### PR TITLE
common: fix make clean of jemalloc

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -43,7 +43,11 @@ HEADERS_INSTALL = include/libpmem.h include/libvmem.h
 
 SCOPEFILES = *.[ch] include/*.[ch] jemalloc/src/*.[ch]\
 	     $(JEMALLOC_DIR)/include/jemalloc/*.h\
-	     $(JEMALLOC_DIR)/include/jemalloc/internal/*.h
+	     $(JEMALLOC_DIR)/include/jemalloc/internal/*.h\
+	     $(JEMALLOC_DIR)/debug/include/jemalloc/*.h\
+	     $(JEMALLOC_DIR)/debug/include/jemalloc/internal/*.h\
+	     $(JEMALLOC_DIR)/nondebug/include/jemalloc/*.h\
+	     $(JEMALLOC_DIR)/nondebug/include/jemalloc/internal/*.h
 
 all     : TARGET = all
 clean   : TARGET = clean
@@ -66,11 +70,11 @@ clobber:
 
 test: $(VARIANTS)
 	$(MAKE) -C test all
-	$(MAKE) -C $(JEMALLOC_DIR) tests
+	$(MAKE) -C nondebug jemalloc-tests
 
 check: test
 	cd test && ./RUNTESTS
-	$(MAKE) -C $(JEMALLOC_DIR) check
+	$(MAKE) -C nondebug jemalloc-check
 
 cscope:
 	cscope -q -b $(SCOPEFILES)

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -32,13 +32,19 @@
 # src/Makefile.inc -- common Makefile rules for NVM library
 #
 
-JEMALLOC_MAKE_NAME ?= Makefile
 JEMALLOC_OBJROOT ?=
+JEMALLOC_MAKE_NAME = $(JEMALLOC_OBJROOT)/Makefile
 JEMALLOC_MAKE = $(JEMALLOC_DIR)/$(JEMALLOC_MAKE_NAME)
 JEMALLOC_CFG = $(JEMALLOC_DIR)/configure
 JEMALLOC_CFG_AC = $(JEMALLOC_DIR)/configure.ac
 JEMALLOC_LIB_NAME = libjemalloc_pic.a
-JEMALLOC_LIB = $(JEMALLOC_DIR)/$(JEMALLOC_OBJROOT)lib/$(JEMALLOC_LIB_NAME)
+JEMALLOC_LIB = $(JEMALLOC_DIR)/$(JEMALLOC_OBJROOT)/lib/$(JEMALLOC_LIB_NAME)
+
+JEMALLOC_CFG_IN_FILES = $(shell find $(JEMALLOC_DIR) -name "*.in")
+JEMALLOC_CFG_GEN_FILES = $(JEMALLOC_CFG_IN_FILES:.in=)
+JEMALLOC_CFG_OUT_FILES = $(patsubst $(JEMALLOC_DIR)/%, $(JEMALLOC_DIR)/$(JEMALLOC_OBJROOT)/%, $(JEMALLOC_CFG_GEN_FILES))
+JEMALLOC_CFG_OUT_FILES_REL = $(patsubst $(JEMALLOC_DIR)/%, %, $(JEMALLOC_CFG_GEN_FILES))
+.NOTPARALLEL: $(JEMALLOC_CFG_OUT_FILES)
 
 JECONFIG_FILE = ../jemalloc.cfg
 JECONFIG = $(shell cat $(JECONFIG_FILE))
@@ -82,10 +88,14 @@ all: $(TARGETS)
 
 jemalloc: $(JEMALLOC_LIB)
 
-jeconfig $(JEMALLOC_MAKE): $(JEMALLOC_CFG) $(JECONFIG_FILE)
+jeconfig $(JEMALLOC_CFG_OUT_FILES): $(JEMALLOC_CFG) $(JECONFIG_FILE)
 	cd $(JEMALLOC_DIR) && \
 	    ./configure $(JECONFIG) $(EXTRA_JECONFIG)
-	-mv -f $(JEMALLOC_DIR)/Makefile $(JEMALLOC_MAKE)
+	@for FILE in $(JEMALLOC_CFG_OUT_FILES_REL);\
+	do\
+		mkdir -p $$(dirname $(JEMALLOC_DIR)/$(JEMALLOC_OBJROOT)/$$FILE);\
+		mv -vf $(JEMALLOC_DIR)/$$FILE $(JEMALLOC_DIR)/$(JEMALLOC_OBJROOT)/$$FILE;\
+	done
 
 $(JEMALLOC_CFG): $(JEMALLOC_CFG_AC)
 	cd $(JEMALLOC_DIR) && \
@@ -93,8 +103,14 @@ $(JEMALLOC_CFG): $(JEMALLOC_CFG_AC)
 
 $(VMEMOBJS): $(JEMALLOC_LIB)
 
-$(JEMALLOC_LIB): $(JEMALLOC_MAKE)
-	make objroot=$(JEMALLOC_OBJROOT) -f $(JEMALLOC_MAKE_NAME) -C $(JEMALLOC_DIR) all
+$(JEMALLOC_LIB): $(JEMALLOC_CFG_OUT_FILES)
+	make objroot=$(JEMALLOC_OBJROOT)/ -f $(JEMALLOC_MAKE_NAME) -C $(JEMALLOC_DIR) all
+
+jemalloc-tests: jemalloc
+	make objroot=$(JEMALLOC_OBJROOT)/ -f $(JEMALLOC_MAKE_NAME) -C $(JEMALLOC_DIR) tests
+
+jemalloc-check: jemalloc-tests
+	make objroot=$(JEMALLOC_OBJROOT)/ -f $(JEMALLOC_MAKE_NAME) -C $(JEMALLOC_DIR) check
 
 libpmem.a: $(PMEMOBJS)
 	$(LD) -o $*_unscoped.o -r $(PMEMOBJS)
@@ -126,20 +142,26 @@ clean:
 	$(RM) *.o core a.out
 	@if [ -f $(JEMALLOC_MAKE) ];\
 	then\
-		make objroot=$(JEMALLOC_OBJROOT) -f $(JEMALLOC_MAKE_NAME) -C $(JEMALLOC_DIR) clean;\
+		make objroot=$(JEMALLOC_OBJROOT)/ -f $(JEMALLOC_MAKE_NAME) -C $(JEMALLOC_DIR) clean;\
 	fi
 
 clobber: clean
 	$(RM) $(TARGETS) *.so.[0-9]*
-	-make cfgoutputs_out+=$(JEMALLOC_MAKE) objroot=$(JEMALLOC_OBJROOT) -f $(JEMALLOC_MAKE_NAME) -C $(JEMALLOC_DIR) distclean
-	rm -rf $(JEMALLOC_CFG)
+	@if [ -f $(JEMALLOC_MAKE) ];\
+	then\
+		make cfgoutputs_out+=$(JEMALLOC_MAKE) objroot=$(JEMALLOC_OBJROOT)/ -f $(JEMALLOC_MAKE_NAME) -C $(JEMALLOC_DIR) distclean;\
+	fi
+	$(RM) $(JEMALLOC_CFG)
+	$(RM) -r $(JEMALLOC_CFG_GEN_FILES)
+	$(RM) -r $(JEMALLOC_CFG_OUT_FILES)
+	$(RM) -r $(JEMALLOC_DIR)/$(JEMALLOC_OBJROOT)
 
 install: $(TARGETS) $(INSTALL_LINKS)
 	install -d $(LIBS_DESTDIR)
 	install -p -m 0755 $(TARGETS) $(LIBS_DESTDIR)
 	cp -d $(INSTALL_LINKS) $(LIBS_DESTDIR)
 
-.PHONY: all clean clobber jeconfig jemalloc install
+.PHONY: all clean clobber jeconfig jemalloc install jemalloc-tests jemalloc-check
 
 libpmem.o: libpmem.c libpmem.h pmem.h util.h out.h
 blk.o: blk.c libpmem.h pmem.h blk.h util.h out.h

--- a/src/debug/Makefile
+++ b/src/debug/Makefile
@@ -34,7 +34,6 @@
 # src/debug/Makefile -- build the debug versions of the NVM Library
 #
 
-JEMALLOC_MAKE_NAME = Makefile_debug
 JEMALLOC_OBJROOT = debug
 
 VARIANT_DESTDIR = nvml_debug

--- a/src/jemalloc/.gitignore
+++ b/src/jemalloc/.gitignore
@@ -17,8 +17,8 @@
 
 /lib/
 
-/Makefile
-/Makefile_debug
+/debug/
+/nondebug/
 
 /include/jemalloc/internal/jemalloc_internal.h
 /include/jemalloc/internal/jemalloc_internal_defs.h
@@ -71,5 +71,3 @@ test/include/test/jemalloc_test_defs.h
 /test/unit/*.out
 
 /VERSION
-
-/debugsrc/*

--- a/src/jemalloc/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/src/jemalloc/include/jemalloc/internal/jemalloc_internal.h.in
@@ -13,11 +13,11 @@
 #  define JEMALLOC_N(n) jet_##n
 #  include "jemalloc/internal/public_namespace.h"
 #  define JEMALLOC_NO_RENAME
-#  include "../jemalloc@install_suffix@.h"
+#  include "jemalloc/jemalloc@install_suffix@.h"
 #  undef JEMALLOC_NO_RENAME
 #else
 #  define JEMALLOC_N(n) @private_namespace@##n
-#  include "../jemalloc@install_suffix@.h"
+#  include "jemalloc/jemalloc@install_suffix@.h"
 #endif
 #include "jemalloc/internal/private_namespace.h"
 

--- a/src/nondebug/Makefile
+++ b/src/nondebug/Makefile
@@ -34,4 +34,6 @@
 # src/nondebug/Makefile -- build the nondebug versions of the NVM Library
 #
 
+JEMALLOC_OBJROOT = nondebug
+
 include ../Makefile.inc


### PR DESCRIPTION
Headers generated by autotools was overwritten for both variants. After
make clean, these headers was not cleaned and therefore we had headers
from last configure run.
