### PR TITLE
common: create directory structure for rpmbuild

### DIFF
--- a/utils/build-rpm.sh
+++ b/utils/build-rpm.sh
@@ -188,6 +188,9 @@ EOF
 
 tar zcf $PACKAGE_TARBALL $PACKAGE_SOURCE
 
+# Create directory structure for rpmbuild
+mkdir -v BUILD SPECS
+
 rpmbuild --define "_topdir `pwd`"\
          --define "_rpmdir ${OUT_DIR}"\
 	 --define "_srcrpmdir ${OUT_DIR}"\


### PR DESCRIPTION
rpmbuild version 4.4.2.3 requires to create directory
structure before invoking when _topdir is defined.

Fixes: pmem/issues#3
