### PR TITLE
blk: fix offsets in BTT Info header

### DIFF
--- a/src/blk.c
+++ b/src/blk.c
@@ -117,9 +117,9 @@ nsread(void *ns, int lane, void *buf, size_t count, off_t off)
 
 	LOG(13, "pbp %p lane %d count %zu off %zu", pbp, lane, count, off);
 
-	if (off + count >= pbp->datasize) {
+	if (off + count > pbp->datasize) {
 		LOG(1, "offset + count (%zu) past end of data area (%zu)",
-				off + count, pbp->datasize - 1);
+				off + count, pbp->datasize);
 		errno = EINVAL;
 		return -1;
 	}
@@ -142,9 +142,9 @@ nswrite(void *ns, int lane, const void *buf, size_t count, off_t off)
 
 	LOG(13, "pbp %p lane %d count %zu off %zu", pbp, lane, count, off);
 
-	if (off + count >= pbp->datasize) {
+	if (off + count > pbp->datasize) {
 		LOG(1, "offset + count (%zu) past end of data area (%zu)",
-				off + count, pbp->datasize - 1);
+				off + count, pbp->datasize);
 		errno = EINVAL;
 		return -1;
 	}

--- a/src/btt.c
+++ b/src/btt.c
@@ -788,7 +788,7 @@ write_layout(struct btt *bttp, int lane, int write)
 		 * all relative to the beginning of the arena.
 		 */
 		uint64_t nextoff;
-		if (rawsize)
+		if (rawsize >= BTT_MIN_SIZE)
 			nextoff = arena_rawsize;
 		else
 			nextoff = 0;
@@ -912,7 +912,7 @@ write_layout(struct btt *bttp, int lane, int write)
 					sizeof (info), arena_off) < 0)
 			return -1;
 		if ((*bttp->ns_cbp->nswrite)(bttp->ns, lane, &info,
-					sizeof (info), arena_off + nextoff) < 0)
+					sizeof (info), arena_off + infooff) < 0)
 			return -1;
 
 		arena_off += nextoff;


### PR DESCRIPTION
- store backup of BTT Info header on valid position
- do not store offset to next arena if remaining size if less than
  BTT_MIN_SIZE
- fix offset and count checking in nswrite and nsread
