### PR TITLE
common: fix format strings for off_t and uint64_t

### DIFF
--- a/src/blk.c
+++ b/src/blk.c
@@ -115,11 +115,12 @@ nsread(void *ns, int lane, void *buf, size_t count, off_t off)
 {
 	struct pmemblk *pbp = (struct pmemblk *)ns;
 
-	LOG(13, "pbp %p lane %d count %zu off %zu", pbp, lane, count, off);
+	LOG(13, "pbp %p lane %d count %zu off %lld",
+			pbp, lane, count, (long long)off);
 
 	if (off + count > pbp->datasize) {
-		LOG(1, "offset + count (%zu) past end of data area (%zu)",
-				off + count, pbp->datasize);
+		LOG(1, "offset + count (%lld) past end of data area (%zu)",
+				(long long)off + count, pbp->datasize);
 		errno = EINVAL;
 		return -1;
 	}
@@ -140,11 +141,12 @@ nswrite(void *ns, int lane, const void *buf, size_t count, off_t off)
 {
 	struct pmemblk *pbp = (struct pmemblk *)ns;
 
-	LOG(13, "pbp %p lane %d count %zu off %zu", pbp, lane, count, off);
+	LOG(13, "pbp %p lane %d count %zu off %lld",
+			pbp, lane, count, (long long)off);
 
 	if (off + count > pbp->datasize) {
-		LOG(1, "offset + count (%zu) past end of data area (%zu)",
-				off + count, pbp->datasize);
+		LOG(1, "offset + count (%lld) past end of data area (%zu)",
+				(long long)off + count, pbp->datasize);
 		errno = EINVAL;
 		return -1;
 	}
@@ -191,11 +193,12 @@ nsmap(void *ns, int lane, void **addrp, size_t len, off_t off)
 {
 	struct pmemblk *pbp = (struct pmemblk *)ns;
 
-	LOG(12, "pbp %p lane %d len %zu off %zu", pbp, lane, len, off);
+	LOG(12, "pbp %p lane %d len %zu off %lld",
+			pbp, lane, len, (long long)off);
 
 	if (off + len >= pbp->datasize) {
-		LOG(1, "offset + len (%zu) past end of data area (%zu)",
-				off + len, pbp->datasize - 1);
+		LOG(1, "offset + len (%lld) past end of data area (%zu)",
+				(long long)off + len, pbp->datasize - 1);
 		errno = EINVAL;
 		return -1;
 	}
@@ -266,8 +269,8 @@ pmemblk_map_common(int fd, size_t bsize, int rdonly)
 	}
 
 	if (stbuf.st_size < PMEMBLK_MIN_POOL) {
-		LOG(1, "size %zu smaller than %zu",
-				stbuf.st_size, PMEMBLK_MIN_POOL);
+		LOG(1, "size %lld smaller than %zu",
+				(long long)stbuf.st_size, PMEMBLK_MIN_POOL);
 		errno = EINVAL;
 		return NULL;
 	}
@@ -479,7 +482,7 @@ pmemblk_nblock(PMEMblk *pbp)
 int
 pmemblk_read(PMEMblk *pbp, void *buf, off_t blockno)
 {
-	LOG(3, "pbp %p buf %p blockno %zu", pbp, buf, blockno);
+	LOG(3, "pbp %p buf %p blockno %lld", pbp, buf, (long long)blockno);
 
 	int lane = lane_enter(pbp);
 
@@ -499,7 +502,7 @@ pmemblk_read(PMEMblk *pbp, void *buf, off_t blockno)
 int
 pmemblk_write(PMEMblk *pbp, const void *buf, off_t blockno)
 {
-	LOG(3, "pbp %p buf %p blockno %zu", pbp, buf, blockno);
+	LOG(3, "pbp %p buf %p blockno %lld", pbp, buf, (long long)blockno);
 
 	if (pbp->rdonly) {
 		LOG(1, "EROFS (pool is read-only)");
@@ -525,7 +528,7 @@ pmemblk_write(PMEMblk *pbp, const void *buf, off_t blockno)
 int
 pmemblk_set_zero(PMEMblk *pbp, off_t blockno)
 {
-	LOG(3, "pbp %p blockno %zu", pbp, blockno);
+	LOG(3, "pbp %p blockno %lld", pbp, (long long)blockno);
 
 	if (pbp->rdonly) {
 		LOG(1, "EROFS (pool is read-only)");
@@ -551,7 +554,7 @@ pmemblk_set_zero(PMEMblk *pbp, off_t blockno)
 int
 pmemblk_set_error(PMEMblk *pbp, off_t blockno)
 {
-	LOG(3, "pbp %p blockno %zu", pbp, blockno);
+	LOG(3, "pbp %p blockno %lld", pbp, (long long)blockno);
 
 	if (pbp->rdonly) {
 		LOG(1, "EROFS (pool is read-only)");

--- a/src/btt_layout.h
+++ b/src/btt_layout.h
@@ -112,8 +112,8 @@ struct btt_flog {
 /*
  * BTT layout properties...
  */
-#define	BTT_MIN_SIZE ((size_t)(1ul << 20) * 512)
-#define	BTT_MAX_ARENA ((size_t)(1ul << 39)) /* 512GB per arena */
+#define	BTT_MIN_SIZE ((1u << 20) * 512)
+#define	BTT_MAX_ARENA (1ull << 39) /* 512GB per arena */
 #define	BTT_MIN_LBA 512
 #define	BTT_INTERNAL_LBA_ALIGNMENT 256
 #define	BTT_DEFAULT_NFREE 256

--- a/src/log.c
+++ b/src/log.c
@@ -88,8 +88,8 @@ pmemlog_map_common(int fd, int rdonly)
 	}
 
 	if (stbuf.st_size < PMEMLOG_MIN_POOL) {
-		LOG(1, "size %zu smaller than %zu",
-				stbuf.st_size, PMEMLOG_MIN_POOL);
+		LOG(1, "size %lld smaller than %zu",
+				(long long)stbuf.st_size, PMEMLOG_MIN_POOL);
 		errno = EINVAL;
 		return NULL;
 	}
@@ -131,22 +131,22 @@ pmemlog_map_common(int fd, int rdonly)
 		if ((hdr_start != roundup(sizeof (*plp),
 					LOG_FORMAT_DATA_ALIGN)) ||
 			(hdr_end != stbuf.st_size) || (hdr_start > hdr_end)) {
-			LOG(1, "wrong start/end offsets (start: %zu end: %zu), "
-				"pool size %zu",
-				hdr_start, hdr_end, stbuf.st_size);
+			LOG(1, "wrong start/end offsets (start: %ju end: %ju), "
+				"pool size %lld",
+				hdr_start, hdr_end, (long long)stbuf.st_size);
 			errno = EINVAL;
 			goto err;
 		}
 
 		if ((hdr_write > hdr_end) || (hdr_write < hdr_start)) {
 			LOG(1, "wrong write offset "
-				"(start: %zu end: %zu write: %zu)",
+				"(start: %ju end: %ju write: %ju)",
 				hdr_start, hdr_end, hdr_write);
 			errno = EINVAL;
 			goto err;
 		}
 
-		LOG(3, "start: %zu, end: %zu, write: %zu",
+		LOG(3, "start: %ju, end: %ju, write: %ju",
 			hdr_start, hdr_end, hdr_write);
 
 		int retval = util_feature_check(&hdr, LOG_FORMAT_INCOMPAT,
@@ -480,7 +480,7 @@ pmemlog_tell(PMEMlog *plp)
 	}
 
 	off_t wp = le64toh(plp->write_offset) - le64toh(plp->start_offset);
-	LOG(4, "write offset %zu", wp);
+	LOG(4, "write offset %lld", (long long)wp);
 
 	if (pthread_rwlock_unlock(plp->rwlockp))
 		LOG(1, "!pthread_rwlock_unlock");

--- a/src/trn.c
+++ b/src/trn.c
@@ -83,8 +83,8 @@ pmemtrn_map(int fd)
 	}
 
 	if (stbuf.st_size < PMEMTRN_MIN_POOL) {
-		LOG(1, "size %zu smaller than %zu",
-				stbuf.st_size, PMEMTRN_MIN_POOL);
+		LOG(1, "size %lld smaller than %zu",
+				(long long)stbuf.st_size, PMEMTRN_MIN_POOL);
 		errno = EINVAL;
 		return NULL;
 	}


### PR DESCRIPTION
This also fixes some warnings when using 32-bit compiler.
`uint64_t` - `"%ju"`
`off_t` - `"%lld"` + cast to `(long long)` 
