### PR TITLE
benchmarks: fix pread and pwrite

### DIFF
--- a/benchmarks/blk_mt/workers.c
+++ b/benchmarks/blk_mt/workers.c
@@ -38,8 +38,10 @@
 #include <stdio.h>
 #include <pthread.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <string.h>
+
+#define	__USE_UNIX98
+#include <unistd.h>
 
 /*
  * r_worker -- read worker function

--- a/benchmarks/log_mt/threads.c
+++ b/benchmarks/log_mt/threads.c
@@ -34,10 +34,13 @@
 #include <sys/time.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
+
 #include <sys/stat.h>
 
 #include "threads.h"
+
+#define	__USE_UNIX98
+#include <unistd.h>
 
 #define	STATE_BUF_LEN 32
 


### PR DESCRIPTION
On some systems the pread and pwrite calls are not declared
due to lack of appropriate feature test macro.
Define __USE_UNIX98 before including unistd.h in order to turn on
pread and pwrite declarations.
