### PR TITLE
vmem: do not unlock ctl_mtx mutex twice

### DIFF
--- a/src/jemalloc/src/ctl.c
+++ b/src/jemalloc/src/ctl.c
@@ -762,7 +762,6 @@ ctl_init_pool(pool_t *pool)
 
 	ret = false;
 label_return:
-	malloc_mutex_unlock(&ctl_mtx);
 	return (ret);
 }
 


### PR DESCRIPTION
The ctl_mtx mutex is unlocked at src/jemalloc/src/ctl.c:785.
