### PR TITLE
common: allow appending extra CFLAGS/LDFLAGS via command line

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -67,8 +67,8 @@ vpath %.c ..
 vpath %.h .. ../include
 INCS = -I.. -I../include
 
-CFLAGS += -std=gnu99 -Wall -Werror
-LDFLAGS = -Wl,-z,relro
+CFLAGS += -std=gnu99 -Wall -Werror $(EXTRA_CFLAGS)
+LDFLAGS += -Wl,-z,relro $(EXTRA_LDFLAGS)
 
 LN = ln
 PMEMSOVERSION = 1

--- a/src/debug/Makefile
+++ b/src/debug/Makefile
@@ -34,7 +34,7 @@
 # src/debug/Makefile -- build the debug versions of the NVM Library
 #
 
-CFLAGS = -ggdb -DDEBUG
+CFLAGS += -ggdb -DDEBUG
 JEMALLOC_OBJROOT = debug
 
 VARIANT_DESTDIR = nvml_debug

--- a/src/jemalloc.cfg
+++ b/src/jemalloc.cfg
@@ -3,5 +3,5 @@
 --with-private-namespace=je_vmem_
 --disable-xmalloc
 --disable-munmap
-EXTRA_CFLAGS="-DJEMALLOC_LIBVMEM -Werror"
+EXTRA_CFLAGS="-DJEMALLOC_LIBVMEM"
 

--- a/src/nondebug/Makefile
+++ b/src/nondebug/Makefile
@@ -34,7 +34,7 @@
 # src/nondebug/Makefile -- build the nondebug versions of the NVM Library
 #
 
-CFLAGS = -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
+CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
 JEMALLOC_OBJROOT = nondebug
 
 include ../Makefile.inc


### PR DESCRIPTION
With this change, user may provide the extra flags CFLAGS/LDFLAGS using
the following syntax:

Example #1:

> make EXTRA_CFLAGS=-finstrument-functions <target>

Example #2:

> CFLAGS=-finstrument-functions make <target>
