### PR TITLE
vmem: do not reinitialize the dss_mtx mutex

### DIFF
--- a/src/jemalloc/include/jemalloc/internal/chunk.h
+++ b/src/jemalloc/include/jemalloc/internal/chunk.h
@@ -46,7 +46,7 @@ void	chunk_unmap(pool_t *pool, void *chunk, size_t size);
 bool	chunk_dalloc_default(void *chunk, size_t size, unsigned arena_ind, pool_t *pool);
 void	chunk_record(pool_t *pool, extent_tree_t *chunks_szad,
 	extent_tree_t *chunks_ad, void *chunk, size_t size, bool zeroed);
-void	chunk_global_boot();
+bool	chunk_global_boot();
 bool	chunk_boot(pool_t *pool);
 void	chunk_prefork(pool_t *pool);
 void	chunk_postfork_parent(pool_t *pool);

--- a/src/jemalloc/src/chunk.c
+++ b/src/jemalloc/src/chunk.c
@@ -396,13 +396,16 @@ chunk_dalloc_default(void *chunk, size_t size, unsigned arena_ind, pool_t *pool)
 	return (false);
 }
 
-void
+bool
 chunk_global_boot() {
+	if (have_dss && chunk_dss_boot())
+		return (true);
 	/* Set variables according to the value of opt_lg_chunk. */
 	chunksize = (ZU(1) << opt_lg_chunk);
 	assert(chunksize >= PAGE);
 	chunksize_mask = chunksize - 1;
 	chunk_npages = (chunksize >> LG_PAGE);	
+	return (false);
 }
 
 bool
@@ -413,8 +416,6 @@ chunk_boot(pool_t *pool)
 			return (true);
 		memset(&pool->stats_chunks, 0, sizeof(chunk_stats_t));
 	}
-	if (have_dss && chunk_dss_boot())
-		return (true);
 	extent_tree_szad_new(&pool->chunks_szad_mmap);
 	extent_tree_ad_new(&pool->chunks_ad_mmap);
 	extent_tree_szad_new(&pool->chunks_szad_dss);

--- a/src/jemalloc/src/jemalloc.c
+++ b/src/jemalloc/src/jemalloc.c
@@ -799,7 +799,10 @@ malloc_init_hard(void)
 	je_base_malloc = base_malloc_default;
 	je_base_free = base_free_default;
 
-	chunk_global_boot();
+	if (chunk_global_boot()) {
+		malloc_mutex_unlock(&init_lock);
+		return (true);
+	}
 
 	if (ctl_boot()) {
 		malloc_mutex_unlock(&init_lock);


### PR DESCRIPTION
The dss_mtx mutex is locked at chunk_dss.c:50
(called from malloc_init_base_pool() at jemalloc.c:362)
before being initialized at chunk_dss.c:167
(called from malloc_init_base_pool() at jemalloc.c:364).

Move call to chunk_dss_boot() to chunk_global_boot()
in order to fix this bug.

Ref: pmem/issues#16
