### PR TITLE
test: fix util_pool_create running on tmpfs file system

### DIFF
--- a/src/test/util_pool_create/TEST0
+++ b/src/test/util_pool_create/TEST0
@@ -75,9 +75,9 @@ expect_normal_exit ./util_pool_create$EXESUFFIX $MIN_POOL \
     $MIN_POOL:$DIR/testlink4\
     $MIN_POOL:$DIR/testfile1\
     0x1000:$DIR/testfile2\
-    0x7FFFFFFFFFFFFFFF:$DIR/testfile3\
     $MIN_POOL:$DIR/testdir2/testfile\
-    $MIN_POOL:$DIR/testfile4
+    $MIN_POOL:$DIR/testfile4\
+    0x7FFFFFFFFFFFFFFF:$DIR/testfile3
 
 rm -f $DIR/testfile[1234]
 rm -f $DIR/testlink[1234]

--- a/src/test/util_pool_create/out0.log.match
+++ b/src/test/util_pool_create/out0.log.match
@@ -1,5 +1,5 @@
 util_pool_create/TEST0: START: util_pool_create
- ./util_pool_create$(*) 0x4000 0x4000:$(*)/testdir1 0x4000:/dev/zero 0x4000:$(*)/testlink1 0x4000:$(*)/testlink2 0x4000:$(*)/testlink3 0x4000:$(*)/testlink4 0x4000:$(*)/testfile1 0x1000:$(*)/testfile2 0x7FFFFFFFFFFFFFFF:$(*)/testfile3 0x4000:$(*)/testdir2/testfile 0x4000:$(*)/testfile4
+ ./util_pool_create$(*) 0x4000 0x4000:$(*)/testdir1 0x4000:/dev/zero 0x4000:$(*)/testlink1 0x4000:$(*)/testlink2 0x4000:$(*)/testlink3 0x4000:$(*)/testlink4 0x4000:$(*)/testfile1 0x1000:$(*)/testfile2 0x4000:$(*)/testdir2/testfile 0x4000:$(*)/testfile4 0x7FFFFFFFFFFFFFFF:$(*)/testfile3
 $(*)/testdir1: util_pool_create: File exists
 /dev/zero: util_pool_create: File exists
 $(*)/testlink1: util_pool_create: File exists
@@ -8,7 +8,7 @@ $(*)/testlink3: util_pool_create: File exists
 $(*)/testlink4: util_pool_create: File exists
 $(*)/testfile1: util_pool_create: File exists
 $(*)/testfile2: util_pool_create: Invalid argument
-$(*)/testfile3: util_pool_create: $(*)
 $(*)/testdir2/testfile: util_pool_create: Permission denied
 $(*)/testfile4: created
+$(*)/testfile3: util_pool_create: $(*)
 util_pool_create/TEST0: Done


### PR DESCRIPTION
Fix the util_pool_create unit test so that it does not fail
when running on the tmpfs file system.
