### PR TITLE
vmem: do not reinitialize the pool[0]->chunks_mtx mutex

### DIFF
--- a/src/jemalloc/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/src/jemalloc/include/jemalloc/internal/jemalloc_internal.h.in
@@ -389,6 +389,7 @@ extern pool_t	*pools[POOLS_MAX];
 extern malloc_mutex_t	pools_lock;
 extern void	*(*je_base_malloc)(size_t);
 extern void	(*je_base_free)(void *);
+extern bool	pools_shared_data_create(void);
 
 arena_t	*arenas_extend(pool_t *pool, unsigned ind);
 void	arenas_cleanup(void *arg);

--- a/src/jemalloc/src/jemalloc.c
+++ b/src/jemalloc/src/jemalloc.c
@@ -126,7 +126,6 @@ typedef struct {
 
 static bool	malloc_init_hard(void);
 static bool	malloc_init_base_pool(void);
-static bool	pools_shared_data_create(void);
 static void	*base_malloc_default(size_t size);
 static void	base_free_default(void *ptr);
 
@@ -358,8 +357,6 @@ malloc_init_base_pool(void)
 	npools++;
 	pools[0] = base_pool;
 	pools[0]->seqno = ++pool_seqno;
-
-	pools_shared_data_create();
 
 	if (pool_new(base_pool, 0)) {
 		malloc_mutex_unlock(&pool_base_lock);
@@ -1407,7 +1404,7 @@ base_free_default(void *ptr)
 
 }
 
-static bool
+bool
 pools_shared_data_create(void)
 {
 	if (malloc_initialized == false && malloc_init_hard())
@@ -1474,11 +1471,6 @@ je_pool_create(void *addr, size_t size, int zeroed)
 	if (pool_id == POOLS_MAX) {
 		malloc_mutex_unlock(&pools_lock);
 		malloc_printf("<jemalloc>: Too many pools\n");
-		return NULL;
-	}
-
-	if (pools_shared_data_create()) {
-		malloc_mutex_unlock(&pools_lock);
 		return NULL;
 	}
 

--- a/src/jemalloc/src/pool.c
+++ b/src/jemalloc/src/pool.c
@@ -29,6 +29,10 @@ bool pool_new(pool_t *pool, unsigned pool_id)
 		return (true);
 	}
 
+	if (pools_shared_data_create()) {
+		return (true);
+	}
+
 	pool->stats_cactive = 0;
 	pool->ctl_stats_active = 0;
 	pool->ctl_stats_allocated = 0;


### PR DESCRIPTION
The pool[0]->chunks_mtx mutex is locked at chunk.c:178
(called from malloc_init_base_pool() at jemalloc.c:362)
before being initialized at chunk.c:415
(called from malloc_init_base_pool() at jemalloc.c:364).

Move a call to pools_shared_data_create() to pool_new()
after a call to chunk_boot() in order to fix this bug.

Ref: pmem/issues#17
