### PR TITLE
vmem: fix race condition between library constructors

### DIFF
--- a/src/jemalloc/src/jemalloc.c
+++ b/src/jemalloc/src/jemalloc.c
@@ -341,7 +341,7 @@ malloc_init_base_pool(void)
 	if (base_pool_initialized)
 		return (false);
 
-	if (malloc_initialized == false && malloc_init_hard())
+	if (malloc_init())
 		return (true);
 
 	malloc_mutex_lock(&pool_base_lock);
@@ -1410,7 +1410,7 @@ base_free_default(void *ptr)
 static bool
 pools_shared_data_create(void)
 {
-	if (malloc_initialized == false && malloc_init_hard())
+	if (malloc_init())
 		return (true);
 
 	assert(je_base_malloc != base_malloc_default || pools[0] != NULL);
@@ -1441,6 +1441,9 @@ void pools_shared_data_destroy(void)
 pool_t *
 je_pool_create(void *addr, size_t size, int zeroed)
 {
+	if (malloc_init())
+		return (NULL);
+
 	if (addr == NULL || size < POOL_MINIMAL_SIZE)
 		return NULL;
 

--- a/src/libvmem.c
+++ b/src/libvmem.c
@@ -49,25 +49,12 @@
 
 
 /*
- * libvmem_init -- load-time initialization for libvmem
- *
- * Called automatically by the run-time loader.
- */
-__attribute__((constructor))
-static void
-libvmem_init(void)
-{
-	out_init(VMEM_LOG_PREFIX, VMEM_LOG_LEVEL_VAR, VMEM_LOG_FILE_VAR);
-	LOG(3, NULL);
-	util_init();
-}
-
-/*
  * vmem_check_version -- see if library meets application version requirements
  */
 const char *
 vmem_check_version(unsigned major_required, unsigned minor_required)
 {
+	vmem_init();
 	LOG(3, "major_required %u minor_required %u",
 			major_required, minor_required);
 
@@ -105,6 +92,7 @@ vmem_set_funcs(
 		char *(*strdup_func)(const char *s),
 		void (*print_func)(const char *s))
 {
+	vmem_init();
 	LOG(3, NULL);
 
 	util_set_alloc_funcs(malloc_func, free_func,

--- a/src/vmem.h
+++ b/src/vmem.h
@@ -54,3 +54,5 @@ struct vmem {
 	size_t size;	/* size of mapped region */
 	int caller_mapped;
 };
+
+void vmem_init(void);


### PR DESCRIPTION
Some applications need to create pool in constructor
called before constructor from vmem.
