### PR TITLE
vmem: add asserts checking binind

### DIFF
--- a/src/jemalloc/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/src/jemalloc/include/jemalloc/internal/jemalloc_internal.h.in
@@ -832,6 +832,7 @@ u2rz(size_t usize)
 
 	if (usize <= SMALL_MAXCLASS) {
 		size_t binind = small_size2bin(usize);
+		assert(binind < NBINS);
 		ret = arena_bin_info[binind].redzone_size;
 	} else
 		ret = 0;

--- a/src/jemalloc/src/arena.c
+++ b/src/jemalloc/src/arena.c
@@ -1685,6 +1685,7 @@ arena_quarantine_junk_small(void *ptr, size_t usize)
 	assert(usize <= SMALL_MAXCLASS);
 
 	binind = small_size2bin(usize);
+	assert(binind < NBINS);
 	bin_info = &arena_bin_info[binind];
 	arena_redzones_validate(ptr, bin_info, true);
 }
@@ -2241,6 +2242,7 @@ arena_ralloc_no_move(void *ptr, size_t oldsize, size_t size, size_t extra,
 	 */
 	if (oldsize <= arena_maxclass) {
 		if (oldsize <= SMALL_MAXCLASS) {
+			assert(small_size2bin(oldsize) < NBINS);
 			assert(arena_bin_info[small_size2bin(oldsize)].reg_size
 			    == oldsize);
 			if ((size + extra <= SMALL_MAXCLASS &&


### PR DESCRIPTION
Add asserts checking binind when it is
a return value of small_size2bin()
(like in arena.c:1701 and 1858).
It fixes issues reported by Klocwork.
