### PR TITLE
util: remove invalid pool file of util_pool_create()

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -471,6 +471,7 @@ err:
 	int oerrno = errno;
 	if (fd != -1)
 		(void) close(fd);
+	unlink(path);
 	errno = oerrno;
 	return -1;
 }


### PR DESCRIPTION
If someone tries to create a pool of size greater than the maximum
available space, posix_fallocate() fails but it leaves an invalid
file which should be removed.
