### PR TITLE
blk: reduce the minimum BTT size to 16MB

### DIFF
--- a/src/btt_layout.h
+++ b/src/btt_layout.h
@@ -112,7 +112,7 @@ struct btt_flog {
 /*
  * BTT layout properties...
  */
-#define	BTT_MIN_SIZE ((1u << 20) * 512)
+#define	BTT_MIN_SIZE ((1u << 20) * 16)
 #define	BTT_MAX_ARENA (1ull << 39) /* 512GB per arena */
 #define	BTT_MIN_LBA_SIZE (size_t)512
 #define	BTT_INTERNAL_LBA_ALIGNMENT 256

--- a/src/include/libpmemblk.h
+++ b/src/include/libpmemblk.h
@@ -66,7 +66,9 @@ const char *pmemblk_check_version(
 		unsigned major_required,
 		unsigned minor_required);
 
-#define	PMEMBLK_MIN_POOL ((size_t)(1 << 30))	/* min pool size: 1GB */
+/* minimum pool size: 16MB + 8KB (minimum BTT size + header size) */
+#define	PMEMBLK_MIN_POOL ((size_t)((1u << 20) * 16 + (1u << 10) * 8))
+
 #define	PMEMBLK_MIN_BLK ((size_t)512)
 
 PMEMblkpool *pmemblk_open(const char *path, size_t bsize);

--- a/src/test/blk_nblock/TEST0
+++ b/src/test/blk_nblock/TEST0
@@ -85,6 +85,14 @@ truncate -s 514G $DIR/testfile6.528
 truncate -s 514G $DIR/testfile6.4096
 truncate -s 514G $DIR/testfile6.4160
 truncate -s 514G $DIR/testfile6.4224
+# MINIMUM POOL SIZE = 16MB + 8KB
+MIN_POOL_SIZE=$((16*1024*1024 + 8*1024))
+truncate -s $MIN_POOL_SIZE $DIR/testfile7.512
+truncate -s $MIN_POOL_SIZE $DIR/testfile7.520
+truncate -s $MIN_POOL_SIZE $DIR/testfile7.528
+truncate -s $MIN_POOL_SIZE $DIR/testfile7.4096
+truncate -s $MIN_POOL_SIZE $DIR/testfile7.4160
+truncate -s $MIN_POOL_SIZE $DIR/testfile7.4224
 
 # should fail:
 #	512:$DIR/testfile1 (file is too small)
@@ -121,8 +129,14 @@ expect_normal_exit ./blk_nblock$EXESUFFIX\
 	528:$DIR/testfile6.528\
 	4096:$DIR/testfile6.4096\
 	4160:$DIR/testfile6.4160\
-	4224:$DIR/testfile6.4224
-rm $DIR/testfile1 $DIR/testfile[23456].*
+	4224:$DIR/testfile6.4224\
+	512:$DIR/testfile7.512\
+	520:$DIR/testfile7.520\
+	528:$DIR/testfile7.528\
+	4096:$DIR/testfile7.4096\
+	4160:$DIR/testfile7.4160\
+	4224:$DIR/testfile7.4224
+rm $DIR/testfile1 $DIR/testfile[234567].*
 
 check
 

--- a/src/test/blk_nblock/out0.log.match
+++ b/src/test/blk_nblock/out0.log.match
@@ -1,5 +1,5 @@
 blk_nblock/TEST0: START: blk_nblock
- ./blk_nblock$(*) 512:$(*)/testfile1 512:$(*)/testfile2.512 4096:$(*)/testfile2.512 520:$(*)/testfile2.520 528:$(*)/testfile2.528 4096:$(*)/testfile2.4096 4160:$(*)/testfile2.4160 4224:$(*)/testfile2.4224 512:$(*)/testfile3.512 520:$(*)/testfile3.520 528:$(*)/testfile3.528 4096:$(*)/testfile3.4096 4160:$(*)/testfile3.4160 4224:$(*)/testfile3.4224 512:$(*)/testfile4.512 520:$(*)/testfile4.520 528:$(*)/testfile4.528 4096:$(*)/testfile4.4096 4160:$(*)/testfile4.4160 4224:$(*)/testfile4.4224 512:$(*)/testfile5.512 520:$(*)/testfile5.520 528:$(*)/testfile5.528 4096:$(*)/testfile5.4096 4160:$(*)/testfile5.4160 4224:$(*)/testfile5.4224 512:$(*)/testfile6.512 520:$(*)/testfile6.520 528:$(*)/testfile6.528 4096:$(*)/testfile6.4096 4160:$(*)/testfile6.4160 4224:$(*)/testfile6.4224
+ ./blk_nblock$(*) 512:$(*)/testfile1 512:$(*)/testfile2.512 4096:$(*)/testfile2.512 520:$(*)/testfile2.520 528:$(*)/testfile2.528 4096:$(*)/testfile2.4096 4160:$(*)/testfile2.4160 4224:$(*)/testfile2.4224 512:$(*)/testfile3.512 520:$(*)/testfile3.520 528:$(*)/testfile3.528 4096:$(*)/testfile3.4096 4160:$(*)/testfile3.4160 4224:$(*)/testfile3.4224 512:$(*)/testfile4.512 520:$(*)/testfile4.520 528:$(*)/testfile4.528 4096:$(*)/testfile4.4096 4160:$(*)/testfile4.4160 4224:$(*)/testfile4.4224 512:$(*)/testfile5.512 520:$(*)/testfile5.520 528:$(*)/testfile5.528 4096:$(*)/testfile5.4096 4160:$(*)/testfile5.4160 4224:$(*)/testfile5.4224 512:$(*)/testfile6.512 520:$(*)/testfile6.520 528:$(*)/testfile6.528 4096:$(*)/testfile6.4096 4160:$(*)/testfile6.4160 4224:$(*)/testfile6.4224 512:$(*)/testfile7.512 520:$(*)/testfile7.520 528:$(*)/testfile7.528 4096:$(*)/testfile7.4096 4160:$(*)/testfile7.4160 4224:$(*)/testfile7.4224
 $(*)/testfile1: pmemblk_create: Invalid argument
 $(*)/testfile2.512: block size 512 usable blocks: 4161462
 $(*)/testfile2.512: pmemblk_create: Invalid argument
@@ -32,4 +32,10 @@ $(*)/testfile6.528: block size 528 usable blocks: 714900046
 $(*)/testfile6.4096: block size 4096 usable blocks: 134610031
 $(*)/testfile6.4160: block size 4160 usable blocks: 126699035
 $(*)/testfile6.4224: block size 4224 usable blocks: 126699035
+$(*)/testfile7.512: block size 512 usable blocks: 32202
+$(*)/testfile7.520: block size 520 usable blocks: 21439
+$(*)/testfile7.528: block size 528 usable blocks: 21439
+$(*)/testfile7.4096: block size 4096 usable blocks: 3829
+$(*)/testfile7.4160: block size 4160 usable blocks: 3588
+$(*)/testfile7.4224: block size 4224 usable blocks: 3588
 blk_nblock/TEST0: Done

--- a/src/test/blk_rw/TEST0
+++ b/src/test/blk_rw/TEST0
@@ -45,16 +45,17 @@ require_fs_type pmem non-pmem
 
 setup
 
-# single arena case
+# single arena and minimum pmemblk pool file case
+MIN_POOL_SIZE=$((16*1024*1024 + 8*1024))
 rm -f $DIR/testfile1
-truncate -s 2G $DIR/testfile1
+truncate -s $MIN_POOL_SIZE $DIR/testfile1
 #
 # All reads to an unwritten block pool should return zeros.
-# Block 4161478 is out of range and should return EINVAL.
+# Block 32202 is out of range and should return EINVAL.
 # Attempts to zero uninitialized blocks are nops (should succeed).
 #
 expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testfile1 c\
-	r:0 r:1 r:4161461 r:4161462 z:0 z:1 r:0
+	r:0 r:1 r:32201 r:32202 z:0 z:1 r:0
 rm $DIR/testfile1
 
 check

--- a/src/test/blk_rw/out0.log.match
+++ b/src/test/blk_rw/out0.log.match
@@ -1,10 +1,10 @@
 blk_rw/TEST0: START: blk_rw
- ./blk_rw$(*) 512 $(*)/testfile1 c r:0 r:1 r:4161461 r:4161462 z:0 z:1 r:0
-512 block size 512 usable blocks 4161462
+ ./blk_rw$(*) 512 $(*)/testfile1 c r:0 r:1 r:32201 r:32202 z:0 z:1 r:0
+512 block size 512 usable blocks 32202
 read      lba 0: {0}
 read      lba 1: {0}
-read      lba 4161461: {0}
-read      lba 4161462: Invalid argument
+read      lba 32201: {0}
+read      lba 32202: Invalid argument
 set_zero  lba 0
 set_zero  lba 1
 read      lba 0: {0}


### PR DESCRIPTION
Reduce the minimum BTT size to 16MB
and the libpmemblk minimum size to 16MB+8KB.
Update two unit tests.
