### PR TITLE
ARM port for NVML libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,16 @@ If you want to build/install experimental packages run:
 	$ make EXPERIMENTAL=y [install,rpm,dpkg]
 ```
 
+Also there is initial support for 64-bit ARM processors provided.
+Currently only supported for aarch64. Currently examples, tools and benchmarks
+and some packages may not get built on ARM cores. But the build will build
+lipmem, libvmem libpmemblk libpmemlog libpmemobj libpmempool, libvmmalloc,
+libpmemcto succesfully.
+
+To trigger the build on a ARM processor
+```
+    $ make EXTRA_CFLAGS="-DAARCH64" BUILD_AARCH64=y
+```
 
 ### Contacts ###
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -37,8 +37,15 @@ include $(TOP)/src/common.inc
 include $(TOP)/src/version.inc
 
 TARGETS = libpmem libvmem libpmemblk libpmemlog libpmemobj libpmempool\
-	libpmemcto libvmmalloc tools
+		  libpmemcto libvmmalloc tools
 ALL_TARGETS = $(TARGETS) common librpmem examples benchmarks
+
+ifeq ($(BUILD_AARCH64),y)
+	TARGETS = libpmem libvmem libpmemblk libpmemlog libpmemobj libpmempool\
+		  libvmmalloc libpmemcto
+	ALL_TARGETS = $(TARGET) common
+endif
+
 SCOPE_DIRS = $(TARGETS) common librpmem rpmem_common
 
 DEBUG_RELEASE_TARGETS = common libpmem libvmem libpmemblk libpmemlog libpmemobj\

--- a/src/common/arm_cacheops.h
+++ b/src/common/arm_cacheops.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014-2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*
+ * ARM inline assembly to flush and invalidate caches
+ * clwb => dc cvac
+ * clflush | clflushopt => dc civac
+ * fence => dmb ish
+ */
+
+#ifndef AARCH64_CACHEOPS_H
+#define AARCH64_CACHEOPS_H
+
+#include <stdlib.h>
+
+static inline void
+arm_clean_va_to_poc(void const *p __attribute__((unused)))
+{
+	asm volatile("dc cvac, %0" : : "r" (p) : "memory");
+}
+
+static inline void
+arm_data_memory_barrier(void)
+{
+	asm volatile("dmb ish" : : : "memory");
+}
+
+static inline void
+arm_clean_and_invalidate_va_to_poc(const void *addr)
+{
+	asm volatile("dc civac, %0" : : "r" (addr) : "memory");
+}
+#endif

--- a/src/libpmem/cpu.c
+++ b/src/libpmem/cpu.c
@@ -32,6 +32,10 @@
 
 /*
  * cpu.c -- CPU features detection
+ *
+ * These routines do not work AARCH64 platforms, and need new detection
+ * routiones to be added. Currently to ensure msync is not used and ARM
+ * FLUSH instructions are used PMEM_IS_PMEM_FORCE=1 needs to be used.
  */
 
 /*
@@ -78,10 +82,6 @@ cpuid(unsigned func, unsigned subfunc, unsigned cpuinfo[4])
 #define cpuid(func, subfunc, cpuinfo)\
 	do { (void)(func); (void)(subfunc); (void)(cpuinfo); } while (0)
 
-#endif
-
-#ifndef bit_SSE2
-#define bit_SSE2	(1 << 26)
 #endif
 
 #ifndef bit_CLFLUSH


### PR DESCRIPTION
This patch
-- Adds neon mneomonics for NVML to make it work on ARM (neon_sse.h)
	-- Add a new vairable AARCH64 to pick ARM build
	-- Currently cflushopt and clwb don't have any replacement.
-- Adding changes to Makefiles to skip building tools and examples
-- Trigger ARM compilation on ARM machines using
   "make EXTRA_CFLAGS=-DAARCH64 BUILD_AARCH64=y DEBUG=0"

Tested with Raspberry P\i Cortex A53 Processors.

Signed-off-by: Vishwanath Venkatesan <vishwanath.venkatesan@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2206)
<!-- Reviewable:end -->
