### PR TITLE
pmem: add a new API pmem_map_fd

### DIFF
--- a/doc/libpmem/pmem_is_pmem.3.md
+++ b/doc/libpmem/pmem_is_pmem.3.md
@@ -46,7 +46,7 @@ date: pmem API version 1.0
 
 # NAME #
 
-**pmem_is_pmem**(), _UW(pmem_map_file),
+**pmem_is_pmem**(), _UW(pmem_map_file), **pmem_map_fd**(),
 **pmem_unmap**() -- check persistency, store persistent data and delete mappings
 
 
@@ -58,6 +58,7 @@ date: pmem API version 1.0
 int pmem_is_pmem(const void *addr, size_t len);
 _UWFUNCR1(void, *pmem_map_file, *path, =q=size_t len, int flags,
 	mode_t mode, size_t *mapped_lenp, int *is_pmemp=e=)
+void *pmem_map_fd(int fd, size_t *mapped_lenp, int *is_pmemp);
 int pmem_unmap(void *addr, size_t len);
 ```
 
@@ -129,6 +130,11 @@ regardless of the flags, equal to either 0 or the exact size of the device.
 
 To delete mappings created with _UW(pmem_map_file), use **pmem_unmap**().
 
+The **pmem_map_fd**() function is same as _UW(pmem_map_file) except that it
+is for the given *fd* file descriptor. The entire file is mapped to memory.
+No matter whether the function succeeds or fails, *fd* remains open after
+the function returns. Note that *fd* should indicate a regular file.
+
 The **pmem_unmap**() function deletes all the mappings for the
 specified address range, and causes further references to addresses
 within the range to generate invalid memory references. It will use the
@@ -145,7 +151,7 @@ from **pmem_is_pmem**() means it is safe to use **pmem_persist**(3)
 and the related functions to make changes durable for that memory
 range.
 
-On success, _UW(pmem_map_file) returns a pointer to the memory-mapped region
+On success, each of _UW(pmem_map_file) and **pmem_map_fd**() returns a pointer to the memory-mapped region
 and sets \**mapped_lenp* and \**is_pmemp* if they are not NULL.
 On error, it returns NULL, sets *errno* appropriately, and does not modify
 \**mapped_lenp* or \**is_pmemp*.

--- a/src/include/libpmem.h
+++ b/src/include/libpmem.h
@@ -88,6 +88,7 @@ void *pmem_map_fileW(const wchar_t *path, size_t len, int flags, mode_t mode,
 	size_t *mapped_lenp, int *is_pmemp);
 #endif
 
+void *pmem_map_fd(int fd, size_t *mapped_lenp, int *is_pmemp);
 int pmem_unmap(void *addr, size_t len);
 int pmem_is_pmem(const void *addr, size_t len);
 void pmem_persist(const void *addr, size_t len);

--- a/src/libpmem/libpmem.def
+++ b/src/libpmem/libpmem.def
@@ -62,6 +62,7 @@ VERSION 1.0
 EXPORTS
 	pmem_map_fileU
 	pmem_map_fileW
+	pmem_map_fd
 	pmem_unmap
 	pmem_is_pmem
 	pmem_persist

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -208,6 +208,7 @@ PMEM_TESTS = \
 	pmem_is_pmem\
 	pmem_is_pmem_linux\
 	pmem_map_file\
+	pmem_map_fd\
 	pmem_memcpy\
 	pmem_memmove\
 	pmem_memset\

--- a/src/test/pmem_map_fd/.gitignore
+++ b/src/test/pmem_map_fd/.gitignore
@@ -1,0 +1,1 @@
+pmem_map_fd

--- a/src/test/pmem_map_fd/Makefile
+++ b/src/test/pmem_map_fd/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2017, Intel Corporation
+# Copyright 2017, Nippon Telegraph and Telephone Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -29,28 +29,15 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+
 #
-# src/libpmem.map -- linker map file for libpmem
+# src/test/pmem_map_fd/Makefile -- build pmem_map_fd() unit test
 #
-LIBPMEM_1.0 {
-	global:
-		pmem_map_file;
-		pmem_map_fd;
-		pmem_unmap;
-		pmem_is_pmem;
-		pmem_persist;
-		pmem_msync;
-		pmem_flush;
-		pmem_drain;
-		pmem_has_hw_drain;
-		pmem_check_version;
-		pmem_errormsg;
-		pmem_memmove_persist;
-		pmem_memcpy_persist;
-		pmem_memset_persist;
-		pmem_memmove_nodrain;
-		pmem_memcpy_nodrain;
-		pmem_memset_nodrain;
-	local:
-		*;
-};
+TARGET = pmem_map_fd
+OBJS = pmem_map_fd.o
+
+LIBPMEM=y
+
+include ../Makefile.inc
+
+LIBS += $(LIBDL)

--- a/src/test/pmem_map_fd/TEST0
+++ b/src/test/pmem_map_fd/TEST0
@@ -1,5 +1,6 @@
+#!/usr/bin/env bash
 #
-# Copyright 2014-2017, Intel Corporation
+# Copyright 2017, Nippon Telegraph and Telephone Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -29,28 +30,35 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+
 #
-# src/libpmem.map -- linker map file for libpmem
+# src/test/pmem_map_fd/TEST0 -- unit test for pmem_map_fd
 #
-LIBPMEM_1.0 {
-	global:
-		pmem_map_file;
-		pmem_map_fd;
-		pmem_unmap;
-		pmem_is_pmem;
-		pmem_persist;
-		pmem_msync;
-		pmem_flush;
-		pmem_drain;
-		pmem_has_hw_drain;
-		pmem_check_version;
-		pmem_errormsg;
-		pmem_memmove_persist;
-		pmem_memcpy_persist;
-		pmem_memset_persist;
-		pmem_memmove_nodrain;
-		pmem_memcpy_nodrain;
-		pmem_memset_nodrain;
-	local:
-		*;
-};
+export UNITTEST_NAME=pmem_map_fd/TEST0
+export UNITTEST_NUM=0
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+configure_valgrind memcheck force-disable
+
+setup
+
+# this test invokes sigsegvs by design
+export ASAN_OPTIONS=handle_segv=0
+
+truncate -s 2G $DIR/testfile1
+
+# <path> <use_mlen> <use_is_pmem>
+
+expect_normal_exit ./pmem_map_fd$EXESUFFIX \
+    $DIR/testfile1 1 1 \
+    $DIR/testfile1 0 0 \
+
+check_files $DIR/testfile1
+
+check
+
+pass

--- a/src/test/pmem_map_fd/out0.log.match
+++ b/src/test/pmem_map_fd/out0.log.match
@@ -1,0 +1,8 @@
+pmem_map_fd/TEST0: START: pmem_map_fd
+ $(nW)/pmem_map_fd$(nW) $(nW)/testfile1 1 1 $(nW)/testfile1 0 0
+$(nW)/testfile1 1 1
+mapped_len 2147483648
+unmap successful
+$(nW)/testfile1 0 0
+unmap successful
+pmem_map_fd/TEST0: DONE

--- a/src/test/pmem_map_fd/pmem_map_fd.c
+++ b/src/test/pmem_map_fd/pmem_map_fd.c
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2017, Nippon Telegraph and Telephone Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * pmem_map_fd.c -- unit test for mapping persistent memory for raw access
+ *
+ * usage: pmem_map_fd file
+ */
+
+#define _GNU_SOURCE
+#include "unittest.h"
+#include <stdlib.h>
+
+#define CHECK_BYTES 4096	/* bytes to compare before/after map call */
+
+static ut_jmp_buf_t Jmp;
+
+/*
+ * signal_handler -- called on SIGSEGV
+ */
+static void
+signal_handler(int sig)
+{
+	ut_siglongjmp(Jmp);
+}
+
+/*
+ * do_check -- check the mapping
+ */
+static void
+do_check(int fd, void *addr, size_t mlen)
+{
+	/* arrange to catch SEGV */
+	struct sigaction v;
+	sigemptyset(&v.sa_mask);
+	v.sa_flags = 0;
+	v.sa_handler = signal_handler;
+	SIGACTION(SIGSEGV, &v, NULL);
+
+	char pat[CHECK_BYTES];
+	char buf[CHECK_BYTES];
+
+	/* write some pattern to the file */
+	memset(pat, 0x5A, CHECK_BYTES);
+	WRITE(fd, pat, CHECK_BYTES);
+
+	if (memcmp(pat, addr, CHECK_BYTES))
+		UT_OUT("first %d bytes do not match", CHECK_BYTES);
+
+	/* fill up mapped region with new pattern */
+	memset(pat, 0xA5, CHECK_BYTES);
+	memcpy(addr, pat, CHECK_BYTES);
+
+	UT_ASSERTeq(pmem_msync(addr, CHECK_BYTES), 0);
+
+	UT_ASSERTeq(pmem_unmap(addr, mlen), 0);
+
+	if (!ut_sigsetjmp(Jmp)) {
+		/* same memcpy from above should now fail */
+		memcpy(addr, pat, CHECK_BYTES);
+	} else {
+		UT_OUT("unmap successful");
+	}
+
+	LSEEK(fd, (os_off_t)0, SEEK_SET);
+	if (READ(fd, buf, CHECK_BYTES) == CHECK_BYTES) {
+		if (memcmp(pat, buf, CHECK_BYTES))
+			UT_OUT("first %d bytes do not match", CHECK_BYTES);
+	}
+}
+
+int
+main(int argc, char *argv[])
+{
+	START(argc, argv, "pmem_map_fd");
+
+	int fd;
+	void *addr;
+	size_t mlen, *mlenp;
+	const char *path;
+	int is_pmem, *is_pmemp, is_pmem_check;
+	int use_mlen, use_is_pmem;
+
+	if (argc < 4)
+		UT_FATAL("usage: %s path use_mlen use_is_pmem ...",
+			argv[0]);
+
+	for (int i = 1; i + 2 < argc; i += 3) {
+		path = argv[i];
+		use_mlen = atoi(argv[i + 1]);
+		use_is_pmem = atoi(argv[i + 2]);
+
+		UT_OUT("%s %d %d", path, use_mlen, use_is_pmem);
+
+		/* assume that path already exists */
+		fd = OPEN(path, O_RDWR);
+
+		mlen = SIZE_MAX;
+		mlenp = (use_mlen) ? &mlen : NULL;
+
+		is_pmemp = (use_is_pmem) ? &is_pmem : NULL;
+
+		addr = pmem_map_fd(fd, mlenp, is_pmemp);
+		if (addr == NULL) {
+			UT_OUT("!pmem_map_fd");
+			CLOSE(fd);
+			continue;
+		}
+
+		os_stat_t stbuf;
+		FSTAT(fd, &stbuf);
+		UT_ASSERT(stbuf.st_size >= 0);
+
+		if (use_mlen) {
+			UT_OUT("mapped_len %zu", mlen);
+			UT_ASSERTeq((size_t)stbuf.st_size, mlen);
+		} else {
+			mlen = (size_t)stbuf.st_size;
+		}
+
+		/* check is_pmem returned from pmem_map_fd */
+		if (use_is_pmem) {
+			is_pmem_check = pmem_is_pmem(addr, mlen);
+			UT_ASSERTeq(is_pmem, is_pmem_check);
+		}
+
+		do_check(fd, addr, mlen); /* this should call pmem_unmap */
+		CLOSE(fd);
+	}
+
+	DONE(NULL);
+}
+
+#ifdef _MSC_VER
+/*
+ * Since libpmem is linked statically, we need to invoke its ctor/dtor.
+ */
+MSVC_CONSTR(libpmem_init)
+MSVC_DESTR(libpmem_fini)
+#endif

--- a/src/test/scope/out1.log.match
+++ b/src/test/scope/out1.log.match
@@ -6,6 +6,7 @@ pmem_errormsg
 pmem_flush
 pmem_has_hw_drain
 pmem_is_pmem
+pmem_map_fd
 pmem_map_file
 pmem_memcpy_nodrain
 pmem_memcpy_persist
@@ -23,6 +24,7 @@ pmem_errormsg
 pmem_flush
 pmem_has_hw_drain
 pmem_is_pmem
+pmem_map_fd
 pmem_map_file
 pmem_memcpy_nodrain
 pmem_memcpy_persist
@@ -40,6 +42,7 @@ pmem_errormsg
 pmem_flush
 pmem_has_hw_drain
 pmem_is_pmem
+pmem_map_fd
 pmem_map_file
 pmem_memcpy_nodrain
 pmem_memcpy_persist
@@ -57,6 +60,7 @@ pmem_errormsg
 pmem_flush
 pmem_has_hw_drain
 pmem_is_pmem
+pmem_map_fd
 pmem_map_file
 pmem_memcpy_nodrain
 pmem_memcpy_persist

--- a/src/test/scope/out1w.log.match
+++ b/src/test/scope/out1w.log.match
@@ -13,6 +13,7 @@ pmem_errormsgW
 pmem_flush
 pmem_has_hw_drain
 pmem_is_pmem
+pmem_map_fd
 pmem_map_fileU
 pmem_map_fileW
 pmem_memcpy_nodrain


### PR DESCRIPTION
The new function is same as pmem_map_file() except that it is for mapping a file descriptor to memory. This would make users happy to apply this library to existing applications that already handle file descriptors.

Signed-off-by: Takashi Menjo &lt;menjo.takashi@lab.ntt.co.jp&gt;

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2370)
<!-- Reviewable:end -->
