### PR TITLE
rpmem: remote deep flush implementation

### DIFF
--- a/doc/librpmem/rpmem_persist.3.md
+++ b/doc/librpmem/rpmem_persist.3.md
@@ -56,6 +56,8 @@ date: rpmem API version 1.1
 
 int rpmem_persist(RPMEMpool *rpp, size_t offset,
 	size_t length, unsigned lane);
+int rpmem_deep_persist(RPMEMpool *rpp, size_t offset,
+	size_t length, unsigned lane);
 int rpmem_read(RPMEMpool *rpp, void *buff, size_t offset,
 	size_t length, unsigned lane);
 ```
@@ -81,6 +83,11 @@ The **rpmem_persist**() operation is performed using the given *lane* number.
 The lane must be less than the value returned by **rpmem_open**(3) or
 **rpmem_create**(3) through the *nlanes* argument (so it can take a value
 from 0 to *nlanes* - 1).
+
+The **rpmem_deep_persist**() function works in the same way as
+**rpmem_persist**(3) function, but additionaly it flushes the data to the
+lowest possible persistency domain available from software.
+Please see **pmem_deep_persist**(3) for details.
 
 The **rpmem_read**() function reads *length* bytes of data from a remote pool
 at *offset* and copies it to the buffer *buff*. The operation is performed on

--- a/src/common/set.c
+++ b/src/common/set.c
@@ -88,6 +88,8 @@ static RPMEMpool *(*Rpmem_open)(const char *target, const char *pool_set_name,
 int (*Rpmem_close)(RPMEMpool *rpp);
 int (*Rpmem_persist)(RPMEMpool *rpp, size_t offset, size_t length,
 			unsigned lane);
+int (*Rpmem_deep_persist)(RPMEMpool *rpp, size_t offset, size_t length,
+			unsigned lane);
 int (*Rpmem_read)(RPMEMpool *rpp, void *buff, size_t offset,
 		size_t length, unsigned lane);
 int (*Rpmem_remove)(const char *target, const char *pool_set_name, int flags);
@@ -173,6 +175,7 @@ util_remote_unload_core(void)
 	Rpmem_open = NULL;
 	Rpmem_close = NULL;
 	Rpmem_persist = NULL;
+	Rpmem_deep_persist = NULL;
 	Rpmem_read = NULL;
 	Rpmem_remove = NULL;
 	Rpmem_set_attr = NULL;
@@ -213,6 +216,7 @@ util_remote_load(void)
 	CHECK_FUNC_COMPATIBLE(rpmem_open, *Rpmem_open);
 	CHECK_FUNC_COMPATIBLE(rpmem_close, *Rpmem_close);
 	CHECK_FUNC_COMPATIBLE(rpmem_persist, *Rpmem_persist);
+	CHECK_FUNC_COMPATIBLE(rpmem_deep_persist, *Rpmem_deep_persist);
 	CHECK_FUNC_COMPATIBLE(rpmem_read, *Rpmem_read);
 	CHECK_FUNC_COMPATIBLE(rpmem_remove, *Rpmem_remove);
 
@@ -250,6 +254,13 @@ util_remote_load(void)
 	Rpmem_persist = util_dlsym(Rpmem_handle_remote, "rpmem_persist");
 	if (util_dl_check_error(Rpmem_persist, "dlsym")) {
 		ERR("symbol 'rpmem_persist' not found");
+		goto err;
+	}
+
+	Rpmem_deep_persist = util_dlsym(Rpmem_handle_remote,
+			"rpmem_deep_persist");
+	if (util_dl_check_error(Rpmem_deep_persist, "dlsym")) {
+		ERR("symbol 'rpmem_deep_persist' not found");
 		goto err;
 	}
 

--- a/src/common/set.h
+++ b/src/common/set.h
@@ -307,6 +307,8 @@ int util_replica_close_remote(struct pool_replica *rep, unsigned repn,
 
 extern int (*Rpmem_persist)(RPMEMpool *rpp, size_t offset, size_t length,
 								unsigned lane);
+extern int (*Rpmem_deep_persist)(RPMEMpool *rpp, size_t offset, size_t length,
+								unsigned lane);
 extern int (*Rpmem_read)(RPMEMpool *rpp, void *buff, size_t offset,
 				size_t length, unsigned lane);
 extern int (*Rpmem_close)(RPMEMpool *rpp);

--- a/src/include/librpmem.h
+++ b/src/include/librpmem.h
@@ -84,6 +84,8 @@ int rpmem_persist(RPMEMpool *rpp, size_t offset, size_t length,
 		unsigned lane);
 int rpmem_read(RPMEMpool *rpp, void *buff, size_t offset, size_t length,
 		unsigned lane);
+int rpmem_deep_persist(RPMEMpool *rpp, size_t offset, size_t length,
+		unsigned lane);
 
 #define RPMEM_REMOVE_FORCE 0x1
 #define RPMEM_REMOVE_POOL_SET 0x2

--- a/src/librpmem/rpmem_fip.c
+++ b/src/librpmem/rpmem_fip.c
@@ -75,14 +75,14 @@
 	ret;\
 })
 
-#define LANE_UNION_ALIGN_SIZE 64
-#define LANE_UNION_ALIGN __attribute__((aligned(LANE_UNION_ALIGN_SIZE)))
+#define LANE_ALIGN_SIZE 64
+#define LANE_ALIGN __attribute__((aligned(LANE_ALIGN_SIZE)))
 
 #define RPMEM_RAW_BUFF_SIZE 4096
 #define RPMEM_RAW_SIZE 8
 
 typedef int (*rpmem_fip_persist_fn)(struct rpmem_fip *fip, size_t offset,
-		size_t len, unsigned lane);
+		size_t len, unsigned lane, unsigned flags);
 
 typedef int (*rpmem_fip_process_fn)(struct rpmem_fip *fip,
 		void *context, uint64_t flags);
@@ -120,24 +120,15 @@ struct rpmem_fip_lane {
 };
 
 /*
- * rpmem_fip_plane_apm -- persist operation's lane for APM
+ * rpmem_fip_plane -- persist operation's lane
  */
-struct rpmem_fip_plane_apm {
+struct rpmem_fip_plane {
 	struct rpmem_fip_lane base;	/* base lane structure */
 	struct rpmem_fip_rma write;	/* WRITE message */
 	struct rpmem_fip_rma read;	/* READ message */
-};
-
-/*
- * rpmem_fip_plane_gpspm -- persist operation's lane for GPSPM
- */
-struct rpmem_fip_plane_gpspm {
-	struct rpmem_fip_lane base;	/* base lane structure */
-	struct rpmem_fip_rma write;	/* WRITE message */
 	struct rpmem_fip_msg send;	/* SEND message */
 	struct rpmem_fip_msg recv;	/* RECV message */
-
-};
+} LANE_ALIGN;
 
 /*
  * rpmem_fip_rlane -- read operation's lane
@@ -168,11 +159,7 @@ struct rpmem_fip {
 	struct rpmem_fip_ops *ops;
 
 	unsigned nlanes;
-	union {
-		struct rpmem_fip_lane base;
-		struct rpmem_fip_plane_apm apm;
-		struct rpmem_fip_plane_gpspm gpspm;
-	} LANE_UNION_ALIGN *lanes;
+	struct rpmem_fip_plane *lanes;
 
 	os_thread_t monitor;
 
@@ -704,175 +691,10 @@ rpmem_fip_monitor_fini(struct rpmem_fip *fip)
 }
 
 /*
- * rpmem_fip_init_lanes_apm -- (internal) initialize lanes for APM
+ * rpmem_fip_init_lanes_common -- (internal) initialize lanes
  */
 static int
-rpmem_fip_init_lanes_apm(struct rpmem_fip *fip)
-{
-	ASSERTne(Pagesize, 0);
-	int ret;
-
-	ASSERT(IS_PAGE_ALIGNED(RPMEM_RAW_BUFF_SIZE));
-	errno = posix_memalign((void **)&fip->raw_buff, Pagesize,
-			RPMEM_RAW_BUFF_SIZE);
-	if (errno) {
-		RPMEM_LOG(ERR, "!allocating APM RAW buffer");
-		goto err_malloc_raw;
-	}
-
-	/* register read-after-write buffer */
-	ret = fi_mr_reg(fip->domain, fip->raw_buff, RPMEM_RAW_BUFF_SIZE,
-			FI_REMOTE_WRITE, 0, 0, 0, &fip->raw_mr, NULL);
-	if (ret) {
-		RPMEM_FI_ERR(ret, "registering APM read buffer");
-		goto err_fi_raw_mr;
-	}
-
-	/* get read-after-write buffer local descriptor */
-	fip->raw_mr_desc = fi_mr_desc(fip->raw_mr);
-
-	return 0;
-err_fi_raw_mr:
-	free(fip->raw_buff);
-err_malloc_raw:
-	return -1;
-}
-
-/*
- * rpmem_fip_init_mem_lanes_apm -- initialize lanes rma structures
- */
-static int
-rpmem_fip_init_mem_lanes_apm(struct rpmem_fip *fip)
-{
-	/*
-	 * Initialize all required structures for:
-	 * WRITE and READ operations.
-	 *
-	 * If the completion is required the FI_COMPLETION flag and
-	 * appropriate context should be used.
-	 *
-	 * In APM only the READ completion is required.
-	 * The context is a lane structure.
-	 */
-	for (unsigned i = 0; i < fip->nlanes; i++) {
-
-		/* WRITE */
-		rpmem_fip_rma_init(&fip->lanes[i].apm.write,
-				fip->mr_desc, 0,
-				fip->rkey,
-				&fip->lanes[i].apm,
-				0);
-
-		/* READ */
-		rpmem_fip_rma_init(&fip->lanes[i].apm.read,
-				fip->raw_mr_desc, 0,
-				fip->rkey,
-				&fip->lanes[i].apm,
-				FI_COMPLETION);
-	}
-
-	return 0;
-}
-
-/*
- * rpmem_fip_fini_lanes_apm -- (internal) deinitialize lanes for APM
- */
-static void
-rpmem_fip_fini_lanes_apm(struct rpmem_fip *fip)
-{
-	RPMEM_FI_CLOSE(fip->raw_mr, "unregistering APM read buffer");
-	free(fip->raw_buff);
-}
-
-/*
- * rpmem_fip_post_lanes_apm -- (internal) post APM-related buffers
- */
-static int
-rpmem_fip_post_lanes_apm(struct rpmem_fip *fip)
-{
-	/* nothing to do */
-	return 0;
-}
-
-/*
- * rpmem_fip_persist_apm -- (internal) perform persist operation for APM
- */
-static int
-rpmem_fip_persist_apm(struct rpmem_fip *fip, size_t offset,
-	size_t len, unsigned lane)
-{
-	struct rpmem_fip_plane_apm *lanep = &fip->lanes[lane].apm;
-
-	int ret;
-	void *laddr = (void *)((uintptr_t)fip->laddr + offset);
-	uint64_t raddr = fip->raddr + offset;
-
-	rpmem_fip_lane_begin(&lanep->base, FI_READ);
-
-	/* WRITE for requested memory region */
-	ret = rpmem_fip_writemsg(lanep->base.ep,
-			&lanep->write, laddr, len, raddr);
-	if (unlikely(ret)) {
-		RPMEM_FI_ERR(ret, "RMA write");
-		return ret;
-	}
-
-	/* READ to read-after-write buffer */
-	ret = rpmem_fip_readmsg(lanep->base.ep, &lanep->read, fip->raw_buff,
-			RPMEM_RAW_SIZE, fip->raddr);
-	if (unlikely(ret)) {
-		RPMEM_FI_ERR(ret, "RMA read");
-		return ret;
-	}
-
-	/* wait for READ completion */
-	ret = rpmem_fip_lane_wait(fip, &lanep->base, FI_READ);
-	if (unlikely(ret)) {
-		ERR("waiting for READ completion failed");
-		return ret;
-	}
-
-	return ret;
-}
-
-/*
- * rpmem_fip_gpspm_post_resp -- (internal) post persist response message buffer
- */
-static inline int
-rpmem_fip_gpspm_post_resp(struct rpmem_fip *fip,
-	struct rpmem_fip_plane_gpspm *lanep)
-{
-	int ret = rpmem_fip_recvmsg(lanep->base.ep, &lanep->recv);
-	if (unlikely(ret)) {
-		RPMEM_FI_ERR(ret, "posting GPSPM recv buffer");
-		return ret;
-	}
-
-	return 0;
-}
-
-/*
- * rpmem_fip_post_lanes_gpspm -- (internal) post all persist response message
- * buffers
- */
-static int
-rpmem_fip_post_lanes_gpspm(struct rpmem_fip *fip)
-{
-	int ret = 0;
-	for (unsigned i = 0; i < fip->nlanes; i++) {
-		ret = rpmem_fip_gpspm_post_resp(fip, &fip->lanes[i].gpspm);
-		if (ret)
-			break;
-	}
-
-	return ret;
-}
-
-/*
- * rpmem_fip_init_lanes_gpspm -- (internal) initialize lanes for GPSPM
- */
-static int
-rpmem_fip_init_lanes_gpspm(struct rpmem_fip *fip)
+rpmem_fip_init_lanes_common(struct rpmem_fip *fip)
 {
 	ASSERTne(Pagesize, 0);
 
@@ -965,24 +787,24 @@ rpmem_fip_init_mem_lanes_gpspm(struct rpmem_fip *fip)
 	unsigned i;
 	for (i = 0; i < fip->nlanes; i++) {
 		/* WRITE */
-		rpmem_fip_rma_init(&fip->lanes[i].gpspm.write,
+		rpmem_fip_rma_init(&fip->lanes[i].write,
 				fip->mr_desc, 0,
 				fip->rkey,
-				&fip->lanes[i].gpspm,
+				&fip->lanes[i],
 				0);
 
 		/* SEND */
-		rpmem_fip_msg_init(&fip->lanes[i].gpspm.send,
+		rpmem_fip_msg_init(&fip->lanes[i].send,
 				fip->pmsg_mr_desc, 0,
-				&fip->lanes[i].gpspm,
+				&fip->lanes[i],
 				&fip->pmsg[i],
 				sizeof(fip->pmsg[i]),
 				FI_COMPLETION);
 
 		/* RECV */
-		rpmem_fip_msg_init(&fip->lanes[i].gpspm.recv,
+		rpmem_fip_msg_init(&fip->lanes[i].recv,
 				fip->pres_mr_desc, 0,
-				&fip->lanes[i].gpspm.recv,
+				&fip->lanes[i].recv,
 				&fip->pres[i],
 				sizeof(fip->pres[i]),
 				FI_COMPLETION);
@@ -992,10 +814,10 @@ rpmem_fip_init_mem_lanes_gpspm(struct rpmem_fip *fip)
 }
 
 /*
- * rpmem_fip_fini_lanes_gpspm -- (internal) deinitialize lanes for GPSPM
+ * rpmem_fip_fini_lanes_common -- (internal) deinitialize lanes for GPSPM
  */
 static void
-rpmem_fip_fini_lanes_gpspm(struct rpmem_fip *fip)
+rpmem_fip_fini_lanes_common(struct rpmem_fip *fip)
 {
 	RPMEM_FI_CLOSE(fip->pmsg_mr, "unregistering messages buffer");
 	RPMEM_FI_CLOSE(fip->pres_mr, "unregistering messages "
@@ -1004,18 +826,182 @@ rpmem_fip_fini_lanes_gpspm(struct rpmem_fip *fip)
 	free(fip->pres);
 }
 
+
 /*
- * rpmem_fip_persist_gpspm -- (internal) perform persist operation for GPSPM
+ * rpmem_fip_init_lanes_apm -- (internal) initialize lanes for APM
  */
 static int
-rpmem_fip_persist_gpspm(struct rpmem_fip *fip, size_t offset,
+rpmem_fip_init_lanes_apm(struct rpmem_fip *fip)
+{
+	ASSERTne(Pagesize, 0);
+	int ret;
+
+	ret = rpmem_fip_init_lanes_common(fip);
+	if (ret)
+		goto err_init_lanes_common;
+
+	ASSERT(IS_PAGE_ALIGNED(RPMEM_RAW_BUFF_SIZE));
+	errno = posix_memalign((void **)&fip->raw_buff, Pagesize,
+			RPMEM_RAW_BUFF_SIZE);
+	if (errno) {
+		RPMEM_LOG(ERR, "!allocating APM RAW buffer");
+		goto err_malloc_raw;
+	}
+
+	/* register read-after-write buffer */
+	ret = fi_mr_reg(fip->domain, fip->raw_buff, RPMEM_RAW_BUFF_SIZE,
+			FI_REMOTE_WRITE, 0, 0, 0, &fip->raw_mr, NULL);
+	if (ret) {
+		RPMEM_FI_ERR(ret, "registering APM read buffer");
+		goto err_fi_raw_mr;
+	}
+
+	/* get read-after-write buffer local descriptor */
+	fip->raw_mr_desc = fi_mr_desc(fip->raw_mr);
+
+	return 0;
+err_fi_raw_mr:
+	free(fip->raw_buff);
+err_malloc_raw:
+	rpmem_fip_fini_lanes_common(fip);
+err_init_lanes_common:
+	return -1;
+}
+
+/*
+ * rpmem_fip_init_mem_lanes_apm -- initialize lanes rma structures
+ */
+static int
+rpmem_fip_init_mem_lanes_apm(struct rpmem_fip *fip)
+{
+	/*
+	 * Initialize all required structures for:
+	 * WRITE and READ operations.
+	 *
+	 * If the completion is required the FI_COMPLETION flag and
+	 * appropriate context should be used.
+	 *
+	 * In APM only the READ completion is required.
+	 * The context is a lane structure.
+	 */
+	for (unsigned i = 0; i < fip->nlanes; i++) {
+
+		/* WRITE */
+		rpmem_fip_rma_init(&fip->lanes[i].write,
+				fip->mr_desc, 0,
+				fip->rkey,
+				&fip->lanes[i],
+				0);
+
+		/* READ */
+		rpmem_fip_rma_init(&fip->lanes[i].read,
+				fip->raw_mr_desc, 0,
+				fip->rkey,
+				&fip->lanes[i],
+				FI_COMPLETION);
+
+		/* SEND */
+		rpmem_fip_msg_init(&fip->lanes[i].send,
+				fip->pmsg_mr_desc, 0,
+				&fip->lanes[i],
+				&fip->pmsg[i],
+				sizeof(fip->pmsg[i]),
+				FI_COMPLETION);
+
+		/* RECV */
+		rpmem_fip_msg_init(&fip->lanes[i].recv,
+				fip->pres_mr_desc, 0,
+				&fip->lanes[i].recv,
+				&fip->pres[i],
+				sizeof(fip->pres[i]),
+				FI_COMPLETION);
+	}
+
+	return 0;
+}
+
+/*
+ * rpmem_fip_fini_lanes_apm -- (internal) deinitialize lanes for APM
+ */
+static void
+rpmem_fip_fini_lanes_apm(struct rpmem_fip *fip)
+{
+	RPMEM_FI_CLOSE(fip->raw_mr, "unregistering APM read buffer");
+	free(fip->raw_buff);
+
+	rpmem_fip_fini_lanes_common(fip);
+}
+
+/*
+ * rpmem_fip_persist_raw -- (internal) perform persist operation using
+ * READ after WRITE mechanism
+ */
+static int
+rpmem_fip_persist_raw(struct rpmem_fip *fip, size_t offset,
 	size_t len, unsigned lane)
 {
-	struct rpmem_fip_plane_gpspm *lanep = &fip->lanes[lane].gpspm;
+	struct rpmem_fip_plane *lanep = &fip->lanes[lane];
+
+	int ret;
+	void *laddr = (void *)((uintptr_t)fip->laddr + offset);
+	uint64_t raddr = fip->raddr + offset;
+
+	rpmem_fip_lane_begin(&lanep->base, FI_READ);
+
+	/* WRITE for requested memory region */
+	ret = rpmem_fip_writemsg(lanep->base.ep,
+			&lanep->write, laddr, len, raddr);
+	if (unlikely(ret)) {
+		RPMEM_FI_ERR(ret, "RMA write");
+		return ret;
+	}
+
+	/* READ to read-after-write buffer */
+	ret = rpmem_fip_readmsg(lanep->base.ep, &lanep->read, fip->raw_buff,
+			RPMEM_RAW_SIZE, fip->raddr);
+	if (unlikely(ret)) {
+		RPMEM_FI_ERR(ret, "RMA read");
+		return ret;
+	}
+
+	/* wait for READ completion */
+	ret = rpmem_fip_lane_wait(fip, &lanep->base, FI_READ);
+	if (unlikely(ret)) {
+		ERR("waiting for READ completion failed");
+		return ret;
+	}
+
+	return ret;
+}
+
+/*
+ * rpmem_fip_post_resp -- (internal) post persist response message buffer
+ */
+static inline int
+rpmem_fip_post_resp(struct rpmem_fip *fip,
+	struct rpmem_fip_plane *lanep)
+{
+	int ret = rpmem_fip_recvmsg(lanep->base.ep, &lanep->recv);
+	if (unlikely(ret)) {
+		RPMEM_FI_ERR(ret, "posting recv buffer");
+		return ret;
+	}
+
+	return 0;
+}
+
+/*
+ * rpmem_fip_persist_saw -- (internal) perform persist operation using
+ * SEND after WRITE mechanism
+ */
+static int
+rpmem_fip_persist_saw(struct rpmem_fip *fip, size_t offset,
+	size_t len, unsigned lane, unsigned flags)
+{
+	struct rpmem_fip_plane *lanep = &fip->lanes[lane];
 	void *laddr = (void *)((uintptr_t)fip->laddr + offset);
 	uint64_t raddr = fip->raddr + offset;
 	struct rpmem_msg_persist *msg;
-	struct rpmem_fip_plane_gpspm *gpspm = (void *)lanep;
 	int ret;
 
 	ret = rpmem_fip_lane_wait(fip, &lanep->base, FI_SEND);
@@ -1028,19 +1014,20 @@ rpmem_fip_persist_gpspm(struct rpmem_fip *fip, size_t offset,
 
 	/* WRITE for requested memory region */
 	ret = rpmem_fip_writemsg(lanep->base.ep,
-			&gpspm->write, laddr, len, raddr);
+			&lanep->write, laddr, len, raddr);
 	if (unlikely(ret)) {
 		RPMEM_FI_ERR((int)ret, "RMA write");
 		return ret;
 	}
 
 	/* SEND persist message */
-	msg = rpmem_fip_msg_get_pmsg(&gpspm->send);
+	msg = rpmem_fip_msg_get_pmsg(&lanep->send);
+	msg->flags = flags;
 	msg->lane = lane;
 	msg->addr = raddr;
 	msg->size = len;
 
-	ret = rpmem_fip_sendmsg(lanep->base.ep, &gpspm->send);
+	ret = rpmem_fip_sendmsg(lanep->base.ep, &lanep->send);
 	if (unlikely(ret)) {
 		RPMEM_FI_ERR(ret, "MSG send");
 		return ret;
@@ -1053,7 +1040,7 @@ rpmem_fip_persist_gpspm(struct rpmem_fip *fip, size_t offset,
 		return ret;
 	}
 
-	ret = rpmem_fip_gpspm_post_resp(fip, lanep);
+	ret = rpmem_fip_post_resp(fip, lanep);
 	if (unlikely(ret)) {
 		ERR("posting RECV buffer failed");
 		return ret;
@@ -1063,22 +1050,52 @@ rpmem_fip_persist_gpspm(struct rpmem_fip *fip, size_t offset,
 }
 
 /*
+ * rpmem_fip_persist_apm -- (internal) perform persist operation for APM
+ */
+static int
+rpmem_fip_persist_apm(struct rpmem_fip *fip, size_t offset,
+	size_t len, unsigned lane, unsigned flags)
+{
+	if (unlikely(flags & RPMEM_DEEP_PERSIST))
+		return rpmem_fip_persist_saw(fip, offset, len, lane, flags);
+
+	return rpmem_fip_persist_raw(fip, offset, len, lane);
+}
+
+/*
+ * rpmem_fip_post_lanes_common -- (internal) post all persist response message
+ * buffers
+ */
+static int
+rpmem_fip_post_lanes_common(struct rpmem_fip *fip)
+{
+	int ret = 0;
+	for (unsigned i = 0; i < fip->nlanes; i++) {
+		ret = rpmem_fip_post_resp(fip, &fip->lanes[i]);
+		if (ret)
+			break;
+	}
+
+	return ret;
+}
+
+/*
  * rpmem_fip_ops -- some operations specific for persistency method used
  */
 static struct rpmem_fip_ops rpmem_fip_ops[MAX_RPMEM_PM] = {
 	[RPMEM_PM_GPSPM] = {
-		.persist = rpmem_fip_persist_gpspm,
-		.lanes_init = rpmem_fip_init_lanes_gpspm,
+		.persist = rpmem_fip_persist_saw,
+		.lanes_init = rpmem_fip_init_lanes_common,
 		.lanes_init_mem = rpmem_fip_init_mem_lanes_gpspm,
-		.lanes_fini = rpmem_fip_fini_lanes_gpspm,
-		.lanes_post = rpmem_fip_post_lanes_gpspm,
+		.lanes_fini = rpmem_fip_fini_lanes_common,
+		.lanes_post = rpmem_fip_post_lanes_common,
 	},
 	[RPMEM_PM_APM] = {
 		.persist = rpmem_fip_persist_apm,
 		.lanes_init = rpmem_fip_init_lanes_apm,
 		.lanes_init_mem = rpmem_fip_init_mem_lanes_apm,
 		.lanes_fini = rpmem_fip_fini_lanes_apm,
-		.lanes_post = rpmem_fip_post_lanes_apm,
+		.lanes_post = rpmem_fip_post_lanes_common,
 	},
 };
 
@@ -1233,8 +1250,10 @@ close_monitor:
  */
 int
 rpmem_fip_persist(struct rpmem_fip *fip, size_t offset, size_t len,
-	unsigned lane)
+	unsigned lane, unsigned flags)
 {
+	RPMEM_ASSERT((flags & RPMEM_FLAGS_MASK) == 0);
+
 	if (unlikely(rpmem_fip_is_closing(fip)))
 		return ECONNRESET; /* it will be passed to errno */
 
@@ -1255,7 +1274,7 @@ rpmem_fip_persist(struct rpmem_fip *fip, size_t offset, size_t len,
 		size_t tmp_len = len < fip->fi->ep_attr->max_msg_size ?
 			len : fip->fi->ep_attr->max_msg_size;
 
-		ret = fip->ops->persist(fip, offset, tmp_len, lane);
+		ret = fip->ops->persist(fip, offset, tmp_len, lane, flags);
 		if (ret) {
 			RPMEM_LOG(ERR, "persist operation failed");
 			goto err;

--- a/src/librpmem/rpmem_fip.h
+++ b/src/librpmem/rpmem_fip.h
@@ -61,7 +61,7 @@ int rpmem_fip_process_start(struct rpmem_fip *fip);
 int rpmem_fip_process_stop(struct rpmem_fip *fip);
 
 int rpmem_fip_persist(struct rpmem_fip *fip, size_t offset, size_t len,
-		unsigned lane);
+		unsigned lane, unsigned flags);
 
 int rpmem_fip_read(struct rpmem_fip *fip, void *buff,
 		size_t len, size_t off, unsigned lane);

--- a/src/rpmem_common/rpmem_fip_common.c
+++ b/src/rpmem_common/rpmem_fip_common.c
@@ -247,9 +247,10 @@ rpmem_fip_lane_attrs[MAX_RPMEM_FIP_NODE][MAX_RPMEM_PM] = {
 		.n_per_cq = 3,
 	},
 	[RPMEM_FIP_NODE_CLIENT][RPMEM_PM_APM] = {
-		.n_per_sq = 2, /* WRITE + READ */
-		.n_per_rq = 0, /* unused */
-		.n_per_cq = 2,
+		/* WRITE + READ for persist, WRITE + SEND for deep persist */
+		.n_per_sq = 2, /* WRITE + SEND */
+		.n_per_rq = 1, /* RECV */
+		.n_per_cq = 3,
 	},
 	[RPMEM_FIP_NODE_SERVER][RPMEM_PM_GPSPM] = {
 		.n_per_sq = 1, /* SEND */
@@ -257,9 +258,9 @@ rpmem_fip_lane_attrs[MAX_RPMEM_FIP_NODE][MAX_RPMEM_PM] = {
 		.n_per_cq = 3,
 	},
 	[RPMEM_FIP_NODE_SERVER][RPMEM_PM_APM] = {
-		.n_per_sq = 0, /* unused */
-		.n_per_rq = 0, /* unused */
-		.n_per_cq = 1,
+		.n_per_sq = 1, /* SEND */
+		.n_per_rq = 1, /* RECV */
+		.n_per_cq = 3,
 	},
 };
 

--- a/src/rpmem_common/rpmem_proto.h
+++ b/src/rpmem_common/rpmem_proto.h
@@ -207,11 +207,16 @@ struct rpmem_msg_close_resp {
 	/* no more fields */
 } PACKED;
 
+#define RPMEM_PERSIST		0x0
+#define RPMEM_DEEP_PERSIST 0x1
+#define RPMEM_FLAGS_ALL		RPMEM_DEEP_PERSIST
+#define RPMEM_FLAGS_MASK	((uint32_t)(~RPMEM_FLAGS_ALL))
 /*
  * rpmem_msg_persist -- remote persist message
  */
 struct rpmem_msg_persist {
-	uint64_t lane;	/* lane identifier */
+	uint32_t flags; /* lane flags */
+	uint32_t lane;	/* lane identifier */
 	uint64_t addr;	/* remote memory address */
 	uint64_t size;	/* remote memory size */
 };
@@ -220,7 +225,8 @@ struct rpmem_msg_persist {
  * rpmem_msg_persist_resp -- remote persist response message
  */
 struct rpmem_msg_persist_resp {
-	uint64_t lane;	/* lane identifier */
+	uint32_t flags;	/* lane flags */
+	uint32_t lane;	/* lane identifier */
 };
 
 /*

--- a/src/test/rpmem_basic/TEST14
+++ b/src/test/rpmem_basic/TEST14
@@ -1,5 +1,6 @@
+#!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -29,21 +30,40 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+
 #
-# src/librpmem/librpmem.map -- linker map file for librpmem
+# src/test/rpmem_basic/TEST14 -- unit test for rpmem_deep_persist
 #
-LIBRPMEM_1.0 {
-	global:
-		rpmem_create;
-		rpmem_open;
-		rpmem_set_attr;
-		rpmem_close;
-		rpmem_remove;
-		rpmem_persist;
-		rpmem_deep_persist;
-		rpmem_read;
-		rpmem_check_version;
-		rpmem_errormsg;
-	local:
-		*;
-};
+export UNITTEST_NAME=rpmem_basic/TEST14
+export UNITTEST_NUM=14
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+
+. setup.sh
+
+setup
+
+create_poolset $DIR/pool0.set  8M:$PART_DIR/pool0.part0 8M:$PART_DIR/pool0.part1
+
+run_on_node 0 "rm -rf ${NODE_DIR[0]}$POOLS_DIR ${NODE_DIR[0]}$POOLS_PART && mkdir -p ${NODE_DIR[0]}$POOLS_DIR && mkdir -p ${NODE_DIR[0]}$POOLS_PART"
+
+copy_files_to_node 0 ${NODE_DIR[0]}$POOLS_DIR $DIR/pool0.set
+
+expect_normal_exit run_on_node 1 ./rpmem_basic$EXESUFFIX\
+	test_create 0 pool0.set ${NODE_ADDR[0]} mem 8M none test_close 0
+
+expect_normal_exit run_on_node 0 ./rpmem_basic$EXESUFFIX\
+	fill_pool ${NODE_DIR[0]}$POOLS_DIR/pool0.set 1234
+
+expect_normal_exit run_on_node 1 ./rpmem_basic$EXESUFFIX\
+	test_open 0 pool0.set ${NODE_ADDR[0]} pool 8M init none\
+	test_deep_persist 0 4321 8 8\
+	test_close 0
+
+expect_normal_exit run_on_node 0 ./rpmem_basic$EXESUFFIX\
+	check_pool ${NODE_DIR[0]}$POOLS_DIR/pool0.set 4321 8M
+
+pass

--- a/src/test/rpmem_basic/TEST15
+++ b/src/test/rpmem_basic/TEST15
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016-2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/rpmem_basic/TEST15 -- unit test for rpmem_deep_persist
+# with device dax
+#
+export UNITTEST_NAME=rpmem_basic/TEST15
+export UNITTEST_NUM=15
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+
+require_fs_type any
+require_build_type nondebug debug
+
+. setup.sh
+
+require_node_dax_device 0 1
+require_node_dax_device 1 1
+
+setup
+
+LOG=out${UNITTEST_NUM}.log
+LOG_TEMP=out${UNITTEST_NUM}_part.log
+
+create_poolset $DIR/pool0.set AUTO:$(get_node_devdax_path 0 0)
+create_poolset $DIR/pool1.set AUTO:$(get_node_devdax_path 0 0) O SINGLEHDR
+create_poolset $DIR/pool2.set AUTO:$(get_node_devdax_path 0 0) O NOHDRS
+
+expect_normal_exit run_on_node 0 rm -rf $PART_DIR
+expect_normal_exit run_on_node 0 mkdir -p ${RPMEM_POOLSET_DIR[0]}
+expect_normal_exit run_on_node 0 mkdir -p $PART_DIR
+expect_normal_exit copy_files_to_node 0 ${RPMEM_POOLSET_DIR[0]} $DIR/{pool0.set,pool1.set,pool2.set}
+
+expect_normal_exit run_on_node 0 ../pmempool rm -sf ${RPMEM_POOLSET_DIR[0]}/{pool0.set,pool1.set,pool2.set}
+expect_normal_exit run_on_node 1 ../pmempool rm -sf $(get_node_devdax_path 0 0)
+
+# pool0:
+
+expect_normal_exit run_on_node 1 ./rpmem_basic$EXESUFFIX\
+	test_create 0 pool0.set ${NODE_ADDR[0]} $(get_node_devdax_path 1 0) 0 none\
+	test_deep_persist 0 0 1 1\
+	test_close 0\
+	test_open 0 pool0.set ${NODE_ADDR[0]} $(get_node_devdax_path 1 0) 0 init none\
+	test_deep_persist 0 0 8 8\
+	test_close 0\
+	test_remove ${NODE_ADDR[0]} pool0.set 0 0
+run_on_node 1 "cat $LOG >> $LOG_TEMP"
+
+# pool1 (w/ SIGNLEHDR option):
+
+expect_normal_exit run_on_node 1 ./rpmem_basic$EXESUFFIX\
+	test_create 0 pool1.set ${NODE_ADDR[0]} $(get_node_devdax_path 1 0) 0 singlehdr\
+	test_deep_persist 0 0 1 1\
+	test_close 0\
+	test_open 0 pool1.set ${NODE_ADDR[0]} $(get_node_devdax_path 1 0) 0 init singlehdr\
+	test_deep_persist 0 0 8 8\
+	test_close 0\
+	test_remove ${NODE_ADDR[0]} pool1.set 0 0
+run_on_node 1 "cat $LOG >> $LOG_TEMP"
+
+# pool2 (w/ NOHDRS option):
+
+expect_normal_exit run_on_node 1 ./rpmem_basic$EXESUFFIX\
+	test_create 0 pool2.set ${NODE_ADDR[0]} $(get_node_devdax_path 1 0) 0 noattr\
+	test_deep_persist 0 0 1 1\
+	test_close 0\
+	test_open 0 pool2.set ${NODE_ADDR[0]} $(get_node_devdax_path 1 0) 0 init noattr\
+	test_deep_persist 0 0 8 8\
+	test_close 0\
+	test_remove ${NODE_ADDR[0]} pool2.set 0 0
+run_on_node 1 "cat $LOG >> $LOG_TEMP"
+
+run_on_node 1 mv $LOG_TEMP $LOG
+check
+pass

--- a/src/test/rpmem_fip/rpmem_fip_test.c
+++ b/src/test/rpmem_fip/rpmem_fip_test.c
@@ -173,7 +173,7 @@ client_persist_thread(void *arg)
 		memset(&lpool[offset], val, SIZE_PER_LANE);
 
 		ret = rpmem_fip_persist(args->fip, offset,
-				SIZE_PER_LANE, args->lane);
+				SIZE_PER_LANE, args->lane, RPMEM_PERSIST);
 		UT_ASSERTeq(ret, 0);
 	}
 

--- a/src/test/rpmem_proto/rpmem_proto.c
+++ b/src/test/rpmem_proto/rpmem_proto.c
@@ -138,12 +138,14 @@ main(int argc, char *argv[])
 	ASSERT_ALIGNED_CHECK(struct rpmem_msg_close_resp);
 
 	ASSERT_ALIGNED_BEGIN(struct rpmem_msg_persist);
+	ASSERT_ALIGNED_FIELD(struct rpmem_msg_persist, flags);
 	ASSERT_ALIGNED_FIELD(struct rpmem_msg_persist, lane);
 	ASSERT_ALIGNED_FIELD(struct rpmem_msg_persist, addr);
 	ASSERT_ALIGNED_FIELD(struct rpmem_msg_persist, size);
 	ASSERT_ALIGNED_CHECK(struct rpmem_msg_persist);
 
 	ASSERT_ALIGNED_BEGIN(struct rpmem_msg_persist_resp);
+	ASSERT_ALIGNED_FIELD(struct rpmem_msg_persist_resp, flags);
 	ASSERT_ALIGNED_FIELD(struct rpmem_msg_persist_resp, lane);
 	ASSERT_ALIGNED_CHECK(struct rpmem_msg_persist_resp);
 

--- a/src/tools/rpmemd/rpmemd.c
+++ b/src/tools/rpmemd/rpmemd.c
@@ -55,6 +55,7 @@
 #include "os_thread.h"
 #include "util.h"
 #include "uuid.h"
+#include "set.h"
 
 /*
  * rpmemd -- rpmem handle
@@ -190,6 +191,16 @@ rpmemd_check_pool(struct rpmemd *rpmemd, const struct rpmem_req_attr *req,
 }
 
 /*
+ * rpmemd_deep_persist -- perform deep persist operation
+ */
+static int
+rpmemd_deep_persist(const void *addr, size_t size, void *ctx)
+{
+	struct rpmemd *rpmemd = (struct rpmemd *)ctx;
+	return util_replica_deep_persist(addr, size, rpmemd->pool->set, 0);
+}
+
+/*
  * rpmemd_common_fip_init -- initialize fabric provider
  */
 static int
@@ -205,6 +216,8 @@ rpmemd_common_fip_init(struct rpmemd *rpmemd, const struct rpmem_req_attr *req,
 		.nthreads	= rpmemd->nthreads,
 		.provider	= req->provider,
 		.persist_method = rpmemd->persist_method,
+		.deep_persist	= rpmemd_deep_persist,
+		.ctx		= rpmemd
 	};
 
 	const int is_pmem = rpmemd_db_pool_is_pmem(rpmemd->pool);

--- a/src/tools/rpmemd/rpmemd_fip.h
+++ b/src/tools/rpmemd/rpmemd_fip.h
@@ -46,6 +46,8 @@ struct rpmemd_fip_attr {
 	enum rpmem_provider provider;
 	enum rpmem_persist_method persist_method;
 	int (*persist)(const void *addr, size_t len);
+	int (*deep_persist)(const void *addr, size_t len, void *ctx);
+	void *ctx;
 };
 
 struct rpmemd_fip *rpmemd_fip_init(const char *node,


### PR DESCRIPTION
Implementation of remote deep flush function which
performs WPQ flush on the remote node for given address, size and lane
number. The rpmem_deep_flush() function works exactly the same as
rpmem_persist() using GPSPM. It copies the desired data to remote node
using RDMA WRITE operation, then sends the 'deep flush' operation
using RDMA SEND and finally waits for response message.
Since the rpmemd must receive and process the 'deep flush' operation
message it must read the completion queue in APM mode as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2457)
<!-- Reviewable:end -->
