### PR TITLE
rpmem: RPMEM_MAX_NLANES fix

### DIFF
--- a/src/librpmem/rpmem.c
+++ b/src/librpmem/rpmem.c
@@ -459,7 +459,7 @@ rpmem_create(const char *target, const char *pool_set_name,
 
 	struct rpmem_req_attr req = {
 		.pool_size	= pool_size,
-		.nlanes		= *nlanes,
+		.nlanes		= min(*nlanes, Rpmem_max_nlanes),
 		.provider	= rpp->provider,
 		.pool_desc	= pool_set_name,
 	};

--- a/src/rpmem_common/rpmem_fip_common.c
+++ b/src/rpmem_common/rpmem_fip_common.c
@@ -311,10 +311,9 @@ rpmem_fip_rx_size(enum rpmem_persist_method pm, enum rpmem_fip_node node)
 size_t
 rpmem_fip_max_nlanes(struct fi_info *fi)
 {
-	return min(min(min(fi->domain_attr->tx_ctx_cnt,
+	return min(min(fi->domain_attr->tx_ctx_cnt,
 			fi->domain_attr->rx_ctx_cnt),
-			fi->domain_attr->cq_cnt),
-			Rpmem_max_nlanes);
+			fi->domain_attr->cq_cnt);
 }
 
 /*


### PR DESCRIPTION
The number of lanes has to be limited prior to establishing
the out-of-band connection.

Ref: pmem/pmdk#2397

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2466)
<!-- Reviewable:end -->
