### PR TITLE
rpmem: register whole pool in RDMA

### DIFF
--- a/src/common/set.c
+++ b/src/common/set.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017, Intel Corporation
+ * Copyright 2015-2018, Intel Corporation
  * Copyright (c) 2016, Microsoft Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1932,16 +1932,10 @@ util_poolset_remote_replica_open(struct pool_set *set, unsigned repidx,
 	}
 #endif
 
-	/*
-	 * The pool header is not visible on the remote node from the local host
-	 * perspective, so we replicate the pool without the pool header.
-	 */
-	void *pool_addr = (void *)((uintptr_t)set->replica[0]->part[0].addr +
-								POOL_HDR_SIZE);
-	size_t pool_size = set->poolsize - POOL_HDR_SIZE;
+	void *pool_addr = (void *)((uintptr_t)set->replica[0]->part[0].addr);
 
 	return util_poolset_remote_open(set->replica[repidx], repidx, minsize,
-			create, pool_addr, pool_size, nlanes);
+			create, pool_addr, set->poolsize, nlanes);
 }
 
 /*

--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -176,7 +176,7 @@ struct pmemobjpool {
 
 	/* remote replica section */
 	void *rpp;	/* RPMEMpool opaque handle if it is a remote replica */
-	uintptr_t remote_base;	/* beginning of the pool's descriptor */
+	uintptr_t remote_base;	/* beginning of the remote pool */
 	char *node_addr;	/* address of a remote node */
 	char *pool_desc;	/* descriptor of a poolset */
 

--- a/src/libpmempool/replica.c
+++ b/src/libpmempool/replica.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -85,8 +85,7 @@ replica_get_part_data_len(struct pool_set *set_in, unsigned repn,
 		unsigned partn)
 {
 	size_t hdrsize = (set_in->options & OPTION_NO_HDRS) ? 0 : Mmap_align;
-	return MMAP_ALIGN_DOWN(
-			set_in->replica[repn]->part[partn].filesize) -
+	return MMAP_ALIGN_DOWN(set_in->replica[repn]->part[partn].filesize) -
 			((partn == 0) ? POOL_HDR_SIZE : hdrsize);
 }
 
@@ -337,7 +336,7 @@ replica_check_store_size(struct pool_set *set,
 	if (rep->remote) {
 		memcpy(&pop.hdr, rep->part[0].hdr, sizeof(pop.hdr));
 		void *descr = (void *)((uintptr_t)&pop + POOL_HDR_SIZE);
-		if (Rpmem_read(rep->remote->rpp, descr, 0,
+		if (Rpmem_read(rep->remote->rpp, descr, POOL_HDR_SIZE,
 			sizeof(pop) - POOL_HDR_SIZE, 0)) {
 			return -1;
 		}

--- a/src/libpmempool/sync.c
+++ b/src/libpmempool/sync.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -353,8 +353,8 @@ copy_data_to_broken_parts(struct pool_set *set, unsigned healthy_replica,
 			void *dst_addr = ADDR_SUM(part->addr, fpoff);
 
 			if (rep->remote) {
-				int ret = Rpmem_persist(rep->remote->rpp,
-						off - POOL_HDR_SIZE, len, 0);
+				int ret = Rpmem_persist(rep->remote->rpp, off,
+						len, 0);
 				if (ret) {
 					LOG(1, "Copying data to remote node "
 						"failed -- '%s' on '%s'",
@@ -364,8 +364,7 @@ copy_data_to_broken_parts(struct pool_set *set, unsigned healthy_replica,
 				}
 			} else if (rep_h->remote) {
 				int ret = Rpmem_read(rep_h->remote->rpp,
-						dst_addr,
-						off - POOL_HDR_SIZE, len, 0);
+						dst_addr, off, len, 0);
 				if (ret) {
 					LOG(1, "Reading data from remote node "
 						"failed -- '%s' on '%s'",

--- a/src/librpmem/rpmem.c
+++ b/src/librpmem/rpmem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -612,6 +612,13 @@ rpmem_persist(RPMEMpool *rpp, size_t offset, size_t length, unsigned lane)
 		return -1;
 	}
 
+	if (offset < RPMEM_HDR_SIZE) {
+		ERR("offset (%zu) in pool is less than %d bytes", offset,
+				RPMEM_HDR_SIZE);
+		errno = EINVAL;
+		return -1;
+	}
+
 	int ret = rpmem_fip_persist(rpp->fip, offset, length, lane);
 	if (unlikely(ret)) {
 		ERR("persist operation failed");
@@ -642,6 +649,10 @@ rpmem_read(RPMEMpool *rpp, void *buff, size_t offset,
 		errno = rpp->error;
 		return -1;
 	}
+
+	if (offset < RPMEM_HDR_SIZE)
+		LOG(1, "reading from pool at offset (%zu) less than %d bytes",
+				offset, RPMEM_HDR_SIZE);
 
 	int ret = rpmem_fip_read(rpp->fip, buff, length, offset, lane);
 	if (unlikely(ret)) {

--- a/src/rpmem_common/rpmem_common.h
+++ b/src/rpmem_common/rpmem_common.h
@@ -128,6 +128,7 @@ struct rpmem_resp_attr {
 #define RPMEM_MAX_USER		(32 + 1)   /* see useradd(8) + 1 for '\0' */
 #define RPMEM_MAX_NODE		(255 + 1)  /* see gethostname(2) + 1 for '\0' */
 #define RPMEM_MAX_SERVICE	(NI_MAXSERV + 1)  /* + 1 for '\0' */
+#define RPMEM_HDR_SIZE		4096
 
 struct rpmem_target_info {
 	char user[RPMEM_MAX_USER];

--- a/src/test/rpmem_basic/TEST13
+++ b/src/test/rpmem_basic/TEST13
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016-2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/rpmem_basic/TEST13 -- unit test for rpmem_persist
+#
+# case: invalid offset provided to rpmem_persist()
+#
+export UNITTEST_NAME=rpmem_basic/TEST13
+export UNITTEST_NUM=13
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+
+. setup.sh
+
+setup
+
+create_poolset $DIR/pool0.set 8M:$PART_DIR/pool0.part0 8M:$PART_DIR/pool0.part1
+run_on_node 0 "rm -rf ${NODE_DIR[0]}$POOLS_DIR ${NODE_DIR[0]}$POOLS_PART && mkdir -p ${NODE_DIR[0]}$POOLS_DIR && mkdir -p ${NODE_DIR[0]}$POOLS_PART"
+copy_files_to_node 0 ${NODE_DIR[0]}$POOLS_DIR $DIR/pool0.set
+
+expect_normal_exit run_on_node 1 ./rpmem_basic$EXESUFFIX\
+	test_create 0 pool0.set ${NODE_ADDR[0]} mem 8M test_close 0
+
+expect_normal_exit run_on_node 1 ./rpmem_basic$EXESUFFIX\
+	test_open 0 pool0.set ${NODE_ADDR[0]} pool 8M init\
+	test_persist_illegal 0\
+	test_close 0
+
+pass

--- a/src/tools/rpmemd/rpmemd.c
+++ b/src/tools/rpmemd/rpmemd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -180,7 +180,7 @@ rpmemd_check_pool(struct rpmemd *rpmemd, const struct rpmem_req_attr *req,
 		return -1;
 	}
 
-	if (rpmemd->pool->pool_size - POOL_HDR_SIZE < req->pool_size) {
+	if (rpmemd->pool->pool_size < req->pool_size) {
 		RPMEMD_LOG(ERR, "requested size is too big");
 		*status = RPMEM_ERR_BADSIZE;
 		return -1;
@@ -200,7 +200,7 @@ rpmemd_common_fip_init(struct rpmemd *rpmemd, const struct rpmem_req_attr *req,
 	void *addr = (void *)((uintptr_t)rpmemd->pool->pool_addr);
 	struct rpmemd_fip_attr fip_attr = {
 		.addr		= addr,
-		.size		= req->pool_size + POOL_HDR_SIZE,
+		.size		= req->pool_size,
 		.nlanes		= req->nlanes,
 		.nthreads	= rpmemd->nthreads,
 		.provider	= req->provider,
@@ -222,9 +222,6 @@ rpmemd_common_fip_init(struct rpmemd *rpmemd, const struct rpmem_req_attr *req,
 		*status = (int)err;
 		goto err_fip_init;
 	}
-
-	/* let user use the pool without header */
-	resp->raddr += POOL_HDR_SIZE;
 
 	return 0;
 err_fip_init:


### PR DESCRIPTION
With this patch, the whole remote and local pools are being registered to RDMA and the first 4KB of the remote pool is protected against writing. This way remote replicas on multiple Device DAX devices with alignment different than 4KB can be used.

This is the continuation of the PR with documentation: https://github.com/pmem/pmdk/pull/2463

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2492)
<!-- Reviewable:end -->

  
  