### PR TITLE
src/test/Makefile: compile obj_ctl_stats

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -133,7 +133,8 @@ OBJ_TESTS = \
 	obj_tx_strdup\
 	obj_constructor\
 	obj_oid\
-	obj_zones
+	obj_zones\
+	obj_ctl_stats
 
 OBJ_REMOTE_TESTS = \
 	obj_rpmem_basic_integration\


### PR DESCRIPTION
fix following issue
--------
$ ./RUNTESTS -f non-pmem obj_ctl_stats
obj_ctl_stats/TEST0: SETUP (check/non-pmem/debug)
../unittest/unittest.sh: line 739: ./obj_ctl_stats: No such file or directory
--------

Signed-off-by: Li Zhijian <zhijianx.li@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2495)
<!-- Reviewable:end -->
