### PR TITLE
test: rpmem_basic test requires libfabric fix

### DIFF
--- a/src/test/rpmem_basic/TEST12
+++ b/src/test/rpmem_basic/TEST12
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,12 +43,6 @@ export UNITTEST_NUM=12
 require_test_type medium
 
 SETUP_MANUAL_INIT_RPMEM=1
-# libfabric sockets provider in version below 1.5.0 falls into infinite loop
-# in rpmem_read if rpmemd is terminated. To handle it properly it requires
-# fix https://github.com/ofiwg/libfabric/commit/c975c80ac3250d1ed4100bdd99656fffa60c90c6
-if [ "$RPMEM_PROVIDER" == "sockets" ]; then
-	SETUP_LIBFABRIC_VERSION=1.5.0
-fi
 . setup.sh
 
 PID_FILE=rpmemd.pid

--- a/src/test/rpmem_basic/config.sh
+++ b/src/test/rpmem_basic/config.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -42,3 +42,8 @@ CONF_GLOBAL_RPMEM_PMETHOD=all
 
 CONF_RPMEM_PMETHOD[10]=APM
 CONF_RPMEM_PMETHOD[11]=GPSPM
+
+# Sockets provider does not detect fi_cq_signal so it does not return
+# from fi_cq_sread. It causes this test to hang sporadically.
+# https://github.com/ofiwg/libfabric/pull/3645
+CONF_RPMEM_PROVIDER[12]=verbs


### PR DESCRIPTION
Sockets provider does not detect fi_cq_signal so it does not return
from fi_cq_sread. It causes rpmem_basic/TEST12 to hang sporadically.

Ref: ofiwg/libfabric#3645

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2497)
<!-- Reviewable:end -->
