### PR TITLE
test: fix NODE_DEVICE_DAX_PATH usages

### DIFF
--- a/src/test/libpmempool_rm_remote/TEST3
+++ b/src/test/libpmempool_rm_remote/TEST3
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -55,7 +55,7 @@ init_rpmem_on_node 1 0
 
 create_poolset $DIR/pool.set 8M:${NODE_DIR[1]}pool.1:x \
         m ${NODE_ADDR[0]}:remote.set
-create_poolset $DIR/remote.set AUTO:${NODE_DEVICE_DAX_PATH[0]}
+create_poolset $DIR/remote.set AUTO:$(get_node_devdax_path 0 0)
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/remote.set
 copy_files_to_node 1 ${NODE_DIR[1]} $DIR/pool.set

--- a/src/test/obj_rpmem_basic_integration/TEST12
+++ b/src/test/obj_rpmem_basic_integration/TEST12
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -62,9 +62,9 @@ TEST_SET_LOCAL="testset_local"
 TEST_SET_REMOTE="testset_remote"
 
 # create and upload poolset files
-create_poolset $DIR/$TEST_SET_LOCAL AUTO:${NODE_DEVICE_DAX_PATH[1]}:x \
+create_poolset $DIR/$TEST_SET_LOCAL AUTO:$(get_node_devdax_path 1 0):x \
 	m ${NODE_ADDR[0]}:$TEST_SET_REMOTE
-create_poolset $DIR/$TEST_SET_REMOTE AUTO:${NODE_DEVICE_DAX_PATH[0]}:x
+create_poolset $DIR/$TEST_SET_REMOTE AUTO:$(get_node_devdax_path 0 0):x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$TEST_SET_REMOTE
 copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$TEST_SET_LOCAL

--- a/src/test/testconfig.sh.example
+++ b/src/test/testconfig.sh.example
@@ -143,9 +143,7 @@ TM=1
 
 #
 # NODE_DEVICE_DAX_PATH variable for each remote node which
-# can be used to specify path to device dax on remote node.
-#
-# There can be only one device dax specified for each node.
+# can be used to specify path to multiple device daxes on remote node.
 #
 # All remote tests assume the master replica is present on a node of index 1.
 # So the size of device dax on the node of index 1 should not be bigger than

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2017, Intel Corporation
+# Copyright 2014-2018, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -1049,6 +1049,8 @@ function require_dev_dax_node() {
 
 #
 # get_node_devdax_path -- get path of a Device DAX device on a node
+#
+# usage: get_node_devdax_path <node> <device>
 #
 get_node_devdax_path() {
 	local node=$1
@@ -2836,4 +2838,3 @@ minimum() {
 	done
 	echo $min
 }
-


### PR DESCRIPTION
There can be only one device dax specified for each node.

Ref: pmem/issues#739

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2505)
<!-- Reviewable:end -->
