### PR TITLE
common: fix loading more than 8 parts in a dir

### DIFF
--- a/src/common/set.c
+++ b/src/common/set.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017, Intel Corporation
+ * Copyright 2015-2018, Intel Corporation
  * Copyright (c) 2016, Microsoft Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1227,7 +1227,7 @@ util_part_idx_by_file_name(const char *filename)
 
 	int olderrno = errno;
 	errno = 0;
-	long part_idx = strtol(filename, NULL, 0);
+	long part_idx = strtol(filename, NULL, 10);
 	if (errno != 0)
 		return -1;
 

--- a/src/test/obj_extend/TEST1
+++ b/src/test/obj_extend/TEST1
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+export UNITTEST_NAME=obj_extend/TEST1
+export UNITTEST_NUM=1
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_build_type debug
+require_fs_type pmem
+
+setup
+
+RESVSIZE=$(((512 + 8) * 1024 * 1024)) # 512MiB + 8MiB
+GRANULARITY=$((1024 * 1024 * 10)) # 10 megabytes
+
+# prepare pool sets
+create_poolset $DIR/testset2\
+	$RESVSIZE:$DIR/testdir21:d\
+	O NOHDRS
+
+PMEMOBJ_CONF="heap.size.granularity=$GRANULARITY"\
+	expect_normal_exit ./obj_extend$EXESUFFIX $DIR/testset2
+
+pass


### PR DESCRIPTION
The part names in directory sets are padded by leading zeroes.
What else leads with zeroes? Octal values ;) We need to explicitly
tell strtol that we want decimal numbers when deducing the part id
from its file name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2506)
<!-- Reviewable:end -->
