### PR TITLE
fix slab-allocator example bugs.

### DIFF
--- a/src/examples/libpmemobj/slab_allocator/main.c
+++ b/src/examples/libpmemobj/slab_allocator/main.c
@@ -46,9 +46,9 @@
 #include "slab_allocator.h"
 
 POBJ_LAYOUT_BEGIN(slab_allocator);
-POBJ_LAYOUT_ROOT(slab_allocator, struct foo);
+POBJ_LAYOUT_ROOT(slab_allocator, struct root);
 POBJ_LAYOUT_TOID(slab_allocator, struct bar);
-POBJ_LAYOUT_TOID(slab_allocator, struct root);
+POBJ_LAYOUT_TOID(slab_allocator, struct foo);
 POBJ_LAYOUT_END(slab_allocator);
 
 struct foo {


### PR DESCRIPTION
 I think you wrote "struct foo" and "struct root" upside down.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2515)
<!-- Reviewable:end -->
