### PR TITLE
common: Sanitizer changes for llvm4.0/FreeBSD

### DIFF
--- a/src/jemalloc/include/jemalloc/internal/rb.h
+++ b/src/jemalloc/include/jemalloc/internal/rb.h
@@ -22,9 +22,9 @@
 #ifndef RB_H_
 #define	RB_H_
 
-/* XXX Avoid super-slow compile with clang */
+/* XXX Avoid super-slow compile with older versions of clang */
 #define NOSANITIZE
-#ifdef __clang__
+#if (__clang_major__ == 3 && __clang_minor__ < 9)
 #if __has_attribute(__no_sanitize__)
 #undef NOSANITIZE
 #define NOSANITIZE __attribute__((no_sanitize("undefined")))

--- a/src/test/obj_cpp_ptr_arith/TEST0
+++ b/src/test/obj_cpp_ptr_arith/TEST0
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -40,6 +40,9 @@ export UNITTEST_NUM=0
 require_test_type medium
 
 require_cxx11
+
+# XXX Bug: incompatibility between asan and custom library
+require_no_asan
 
 setup
 


### PR DESCRIPTION
Only disable undefined sanitizer in jemalloc rb.h for
clang < 3.9.
Temporarily add require_no_asan to obj_cpp_ptr_arith/TEST0
due to bug.

*All* short and medium tests, including C++ tests, now build and pass with both the
sanitizer and valgrind on FreeBSD 11.1 using the native llvm4.0 compiler (except
tests requiring real DAX or verbs, which build but are skipped).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2533)
<!-- Reviewable:end -->
