### PR TITLE
test: move obj_constructor TEST1 to 'long' group

### DIFF
--- a/src/test/obj_constructor/TEST1
+++ b/src/test/obj_constructor/TEST1
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2015-2017, Intel Corporation
+# Copyright 2015-2018, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -42,7 +42,7 @@ export UNITTEST_NUM=1
 # standard unit test setup
 . ../unittest/unittest.sh
 
-require_test_type medium
+require_test_type long
 
 require_fs_type any
 configure_valgrind memcheck force-enable


### PR DESCRIPTION
The execution of this test takes about 1 minute on a local machine.
On Travis it's about 2-3 times longer, so it timeouts periodically.

Move it to 'long'  until we have a better solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2534)
<!-- Reviewable:end -->
