### PR TITLE
obj: fix pmemobj_open() error handling

### DIFF
--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1112,13 +1112,13 @@ obj_runtime_init(PMEMobjpool *pop, int rdonly, int boot, unsigned nlanes)
 			pop->set->resvsize))
 				!= 0) {
 			ERR("!ctree_insert");
-			goto err;
+			goto err_tree_insert;
 		}
 	}
 
 	if (obj_ctl_init_and_load(pop) != 0) {
 		errno = EINVAL;
-		goto err;
+		goto err_ctl;
 	}
 
 	/*
@@ -1130,6 +1130,11 @@ obj_runtime_init(PMEMobjpool *pop, int rdonly, int boot, unsigned nlanes)
 	RANGE_NONE(pop->addr, sizeof(struct pool_hdr), pop->is_dev_dax);
 
 	return 0;
+
+err_ctl:
+	ctree_remove(pools_tree, (uint64_t)pop, 1);
+err_tree_insert:
+	cuckoo_remove(pools_ht, pop->uuid_lo);
 err:
 	stats_delete(pop, pop->stats);
 	tx_params_delete(pop->tx_params);

--- a/src/test/obj_pool/TEST31
+++ b/src/test/obj_pool/TEST31
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_pool/TEST31 -- unit test for pmemobj_open
+#
+export UNITTEST_NAME=obj_pool/TEST31
+export UNITTEST_NUM=31
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_fs_type any
+require_test_type medium
+
+setup
+umask 0
+
+#
+# TEST31 existing file, file size > min required size, layout is NULL
+#        (valid pool header), reopen after failure
+#
+expect_normal_exit ./obj_pool$EXESUFFIX c $DIR/testfile NULL 20 0640
+
+expect_normal_exit ./obj_pool$EXESUFFIX f $DIR/testfile NULL
+
+check
+
+pass

--- a/src/test/obj_pool/TEST31.PS1
+++ b/src/test/obj_pool/TEST31.PS1
@@ -1,0 +1,66 @@
+#
+# Copyright 2015-2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_pool/TEST31 -- unit test for pmemobj_open
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+
+$Env:UNITTEST_NAME = "obj_pool/TEST31"
+$Env:UNITTEST_NUM = "31"
+
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type any
+require_test_type medium
+
+setup
+
+#
+# TEST31 existing file, file size > min required size, layout is NULL
+#        (valid pool header), reopen after failure
+#
+expect_normal_exit $Env:EXE_DIR\obj_pool$Env:EXESUFFIX `
+    c $DIR\testfile NULL 20 0640
+
+expect_normal_exit $Env:EXE_DIR\obj_pool$Env:EXESUFFIX `
+    f $DIR\testfile NULL
+
+check
+
+pass

--- a/src/test/obj_pool/obj_pool.c
+++ b/src/test/obj_pool/obj_pool.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017, Intel Corporation
+ * Copyright 2015-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -112,7 +112,12 @@ main(int argc, char *argv[])
 	case 'o':
 		pool_open(argv[2], layout);
 		break;
-
+	case 'f':
+		os_setenv("PMEMOBJ_CONF", "invalid-query", 1);
+		pool_open(argv[2], layout);
+		os_unsetenv("PMEMOBJ_CONF");
+		pool_open(argv[2], layout);
+		break;
 	default:
 		UT_FATAL("unknown operation");
 	}

--- a/src/test/obj_pool/out31.log.match
+++ b/src/test/obj_pool/out31.log.match
@@ -1,0 +1,5 @@
+obj_pool$(nW)TEST31: START: obj_pool$(nW)
+ $(nW)obj_pool$(nW) f $(nW)testfile NULL
+$(nW)testfile: pmemobj_open: Invalid argument
+$(nW)testfile: pmemobj_open: Success
+obj_pool$(nW)TEST31: DONE


### PR DESCRIPTION
pmemobj_open() function wasn't cleaning up the global state
after an error resulting in failures of subsequent opens

Ref: pmem/issues#750

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2535)
<!-- Reviewable:end -->
