### PR TITLE
test: fix skip message for missing Device DAX

### DIFF
--- a/src/test/blk_rw/TEST11
+++ b/src/test/blk_rw/TEST11
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +45,6 @@ export UNITTEST_NUM=11
 
 require_test_type medium
 require_fs_type any
-require_dax_devices 2
 require_dax_device_alignments 4096 4096
 
 setup

--- a/src/test/blk_rw/TEST12
+++ b/src/test/blk_rw/TEST12
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -46,7 +46,6 @@ export UNITTEST_NUM=12
 
 require_test_type medium
 require_fs_type any
-require_dax_devices 2
 require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup

--- a/src/test/blk_rw/TEST13
+++ b/src/test/blk_rw/TEST13
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +45,6 @@ export UNITTEST_NUM=13
 
 require_test_type medium
 require_fs_type any
-require_dax_devices 2
 require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup

--- a/src/test/log_basic/TEST10
+++ b/src/test/log_basic/TEST10
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -55,7 +55,6 @@ export UNITTEST_NUM=10
 
 require_test_type medium
 require_fs_type any
-require_dax_devices 2
 require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup

--- a/src/test/log_basic/TEST8
+++ b/src/test/log_basic/TEST8
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -55,7 +55,6 @@ export UNITTEST_NUM=8
 
 require_test_type medium
 require_fs_type any
-require_dax_devices 2
 require_dax_device_alignments 4096 4096
 
 setup

--- a/src/test/log_basic/TEST9
+++ b/src/test/log_basic/TEST9
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -56,7 +56,6 @@ export UNITTEST_NUM=9
 
 require_test_type medium
 require_fs_type any
-require_dax_devices 2
 require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup

--- a/src/test/obj_basic_integration/TEST11
+++ b/src/test/obj_basic_integration/TEST11
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,7 +44,6 @@ export UNITTEST_NUM=11
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_dax_devices 2
 require_dax_device_alignments 4096 4096
 
 setup

--- a/src/test/obj_basic_integration/TEST12
+++ b/src/test/obj_basic_integration/TEST12
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +45,6 @@ export UNITTEST_NUM=12
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_dax_devices 2
 require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup

--- a/src/test/obj_basic_integration/TEST13
+++ b/src/test/obj_basic_integration/TEST13
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +45,6 @@ export UNITTEST_NUM=13
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_dax_devices 2
 require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup

--- a/src/test/pmempool_check/TEST24
+++ b/src/test/pmempool_check/TEST24
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,7 +44,6 @@ export UNITTEST_NUM=24
 require_test_type medium
 require_fs_type any
 
-require_dax_devices 2
 require_dax_device_alignments 4096 4096
 
 # covered by TEST21

--- a/src/test/pmempool_check/TEST25
+++ b/src/test/pmempool_check/TEST25
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,7 +44,6 @@ export UNITTEST_NUM=25
 require_test_type medium
 require_fs_type any
 
-require_dax_devices 2
 require_dax_device_alignments 4096 4096
 
 # memcheck covered by TEST23, pmemcheck takes too long

--- a/src/test/pmempool_check/TEST26
+++ b/src/test/pmempool_check/TEST26
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,7 +44,6 @@ export UNITTEST_NUM=26
 require_test_type medium
 require_fs_type any
 
-require_dax_devices 2
 require_dax_device_alignments 2097152 2097152 # 2MiB
 
 # covered by TEST21

--- a/src/test/pmempool_check/TEST27
+++ b/src/test/pmempool_check/TEST27
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,7 +44,6 @@ export UNITTEST_NUM=27
 require_test_type medium
 require_fs_type any
 
-require_dax_devices 2
 require_dax_device_alignments 2097152 2097152 # 2MiB
 
 # memcheck covered by TEST23, pmemcheck takes too long

--- a/src/test/pmempool_info/TEST19
+++ b/src/test/pmempool_info/TEST19
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +43,6 @@ export UNITTEST_NUM=19
 
 require_test_type medium
 require_fs_type any
-require_dax_devices 2
 require_dax_device_alignments 4096 4096
 
 setup

--- a/src/test/pmempool_info/TEST21
+++ b/src/test/pmempool_info/TEST21
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +43,6 @@ export UNITTEST_NUM=21
 
 require_test_type medium
 require_fs_type any
-require_dax_devices 2
 require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup

--- a/src/test/pmempool_rm/TEST6
+++ b/src/test/pmempool_rm/TEST6
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2015-2017, Intel Corporation
+# Copyright 2015-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +43,6 @@ export UNITTEST_NUM=6
 
 require_test_type medium
 require_fs_type any
-require_dax_devices 2
 require_dax_device_alignments 4096 4096
 
 setup

--- a/src/test/pmempool_rm/TEST8
+++ b/src/test/pmempool_rm/TEST8
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2015-2017, Intel Corporation
+# Copyright 2015-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +43,6 @@ export UNITTEST_NUM=8
 
 require_test_type medium
 require_fs_type any
-require_dax_devices 2
 require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup

--- a/src/test/pmempool_sync/TEST13
+++ b/src/test/pmempool_sync/TEST13
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,8 +47,7 @@ SIZE_2MB=2097152
 require_test_type medium
 require_fs_type any
 
-require_dax_devices 4
-require_dax_device_alignments $SIZE_2MB $SIZE_2MB $SIZE_4KB $SIZE_4KB
+require_dax_device_alignments $SIZE_2MB $SIZE_2MB $SIZE_2MB $SIZE_4KB
 
 setup
 

--- a/src/test/pmempool_sync/TEST14
+++ b/src/test/pmempool_sync/TEST14
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,6 @@ SIZE_2MB=2097152
 require_test_type medium
 require_fs_type any
 
-require_dax_devices 4
 require_dax_device_alignments $SIZE_4KB $SIZE_2MB $SIZE_4KB $SIZE_2MB
 
 setup

--- a/src/test/pmempool_sync/TEST15
+++ b/src/test/pmempool_sync/TEST15
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,6 @@ SIZE_2MB=2097152
 require_test_type medium
 require_fs_type any
 
-require_dax_devices 4
 require_dax_device_alignments $SIZE_2MB $SIZE_4KB $SIZE_2MB $SIZE_4KB
 
 setup

--- a/src/test/pmempool_sync/TEST18
+++ b/src/test/pmempool_sync/TEST18
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,6 @@ SIZE_2MB=2097152
 require_test_type medium
 require_fs_type any
 
-require_dax_devices 4
 require_dax_device_alignments $SIZE_2MB $SIZE_2MB $SIZE_4KB $SIZE_4KB
 
 setup

--- a/src/test/pmempool_sync/TEST19
+++ b/src/test/pmempool_sync/TEST19
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,6 @@ SIZE_2MB=2097152
 require_test_type medium
 require_fs_type any
 
-require_dax_devices 4
 require_dax_device_alignments $SIZE_4KB $SIZE_4KB $SIZE_2MB $SIZE_2MB
 
 setup

--- a/src/test/pmempool_sync/TEST20
+++ b/src/test/pmempool_sync/TEST20
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,6 @@ SIZE_2MB=2097152
 require_test_type medium
 require_fs_type any
 
-require_dax_devices 4
 require_dax_device_alignments $SIZE_4KB $SIZE_2MB $SIZE_2MB $SIZE_4KB
 
 setup

--- a/src/test/pmempool_sync/TEST21
+++ b/src/test/pmempool_sync/TEST21
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,6 @@ SIZE_2MB=2097152
 require_test_type medium
 require_fs_type any
 
-require_dax_devices 4
 require_dax_device_alignments $SIZE_2MB $SIZE_4KB $SIZE_4KB $SIZE_2MB
 
 setup

--- a/src/test/pmempool_sync_remote/TEST10
+++ b/src/test/pmempool_sync_remote/TEST10
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,9 +48,6 @@ require_test_type	medium
 require_fs_type		any
 
 . common.sh
-
-require_node_dax_device 0 2
-require_node_dax_device 1 2
 
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_4KB
 require_node_dax_device_alignments 1 $SIZE_4KB $SIZE_4KB

--- a/src/test/pmempool_sync_remote/TEST11
+++ b/src/test/pmempool_sync_remote/TEST11
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,9 +48,6 @@ require_test_type	medium
 require_fs_type		any
 
 . common.sh
-
-require_node_dax_device 0 2
-require_node_dax_device 1 2
 
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_4KB
 require_node_dax_device_alignments 1 $SIZE_4KB $SIZE_4KB

--- a/src/test/pmempool_sync_remote/TEST12
+++ b/src/test/pmempool_sync_remote/TEST12
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,9 +49,6 @@ require_test_type	medium
 require_fs_type		any
 
 . common.sh
-
-require_node_dax_device 0 2
-require_node_dax_device 1 2
 
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_2MB
 require_node_dax_device_alignments 1 $SIZE_2MB $SIZE_2MB

--- a/src/test/pmempool_sync_remote/TEST13
+++ b/src/test/pmempool_sync_remote/TEST13
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,9 +49,6 @@ require_test_type	medium
 require_fs_type		any
 
 . common.sh
-
-require_node_dax_device 0 2
-require_node_dax_device 1 2
 
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_2MB
 require_node_dax_device_alignments 1 $SIZE_2MB $SIZE_2MB

--- a/src/test/pmempool_sync_remote/TEST14
+++ b/src/test/pmempool_sync_remote/TEST14
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,9 +49,6 @@ require_test_type	medium
 require_fs_type		any
 
 . common.sh
-
-require_node_dax_device 0 2
-require_node_dax_device 1 2
 
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_2MB
 require_node_dax_device_alignments 1 $SIZE_2MB $SIZE_4KB

--- a/src/test/pmempool_sync_remote/TEST15
+++ b/src/test/pmempool_sync_remote/TEST15
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,9 +49,6 @@ require_test_type	medium
 require_fs_type		any
 
 . common.sh
-
-require_node_dax_device 0 2
-require_node_dax_device 1 2
 
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_2MB
 require_node_dax_device_alignments 1 $SIZE_2MB $SIZE_4KB

--- a/src/test/pmempool_sync_remote/TEST16
+++ b/src/test/pmempool_sync_remote/TEST16
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,7 +49,6 @@ require_fs_type		any
 
 . common.sh
 
-require_node_dax_device 0 2
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_4KB
 
 setup

--- a/src/test/pmempool_sync_remote/TEST17
+++ b/src/test/pmempool_sync_remote/TEST17
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,7 +49,6 @@ require_fs_type		any
 
 . common.sh
 
-require_node_dax_device 0 2
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_4KB
 
 setup

--- a/src/test/pmempool_sync_remote/TEST18
+++ b/src/test/pmempool_sync_remote/TEST18
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -50,7 +50,6 @@ require_fs_type		any
 
 . common.sh
 
-require_node_dax_device 0 2
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_2MB
 
 setup

--- a/src/test/pmempool_sync_remote/TEST19
+++ b/src/test/pmempool_sync_remote/TEST19
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -50,7 +50,6 @@ require_fs_type		any
 
 . common.sh
 
-require_node_dax_device 0 2
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_2MB
 
 setup

--- a/src/test/pmempool_transform/TEST11
+++ b/src/test/pmempool_transform/TEST11
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,6 @@ SIZE_2MB=2097152
 require_test_type medium
 require_fs_type any
 
-require_dax_devices 2
 require_dax_device_alignments $SIZE_4KB $SIZE_4KB
 
 setup

--- a/src/test/pmempool_transform/TEST12
+++ b/src/test/pmempool_transform/TEST12
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,6 @@ SIZE_2MB=2097152
 require_test_type medium
 require_fs_type any
 
-require_dax_devices 2
 require_dax_device_alignments $SIZE_2MB $SIZE_2MB
 
 setup

--- a/src/test/pmempool_transform/TEST14
+++ b/src/test/pmempool_transform/TEST14
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,7 +49,6 @@ SIZE_2MB=2097152
 require_test_type medium
 require_fs_type any
 
-require_dax_devices 2
 require_dax_device_alignments $SIZE_4KB $SIZE_4KB
 
 setup

--- a/src/test/pmempool_transform/TEST15
+++ b/src/test/pmempool_transform/TEST15
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,7 +48,6 @@ SIZE_2MB=2097152
 require_test_type medium
 require_fs_type any
 
-require_dax_devices 2
 require_dax_device_alignments $SIZE_4KB $SIZE_4KB
 
 setup

--- a/src/test/pmempool_transform/TEST16
+++ b/src/test/pmempool_transform/TEST16
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,6 @@ SIZE_2MB=2097152
 require_test_type medium
 require_fs_type any
 
-require_dax_devices 2
 require_dax_device_alignments $SIZE_2MB $SIZE_2MB
 
 setup

--- a/src/test/pmempool_transform/TEST18
+++ b/src/test/pmempool_transform/TEST18
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -50,7 +50,6 @@ SIZE_2MB=2097152
 require_test_type medium
 require_fs_type any
 
-require_dax_devices 2
 require_dax_device_alignments $SIZE_4KB $SIZE_4KB
 
 setup

--- a/src/test/pmempool_transform/TEST22
+++ b/src/test/pmempool_transform/TEST22
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -46,7 +46,6 @@ SIZE_2MB=2097152
 require_test_type medium
 require_fs_type any
 
-require_dax_devices 4
 require_dax_device_alignments $SIZE_4KB $SIZE_4KB $SIZE_2MB $SIZE_2MB
 
 setup

--- a/src/test/pmempool_transform_remote/TEST10
+++ b/src/test/pmempool_transform_remote/TEST10
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,9 +48,6 @@ require_test_type	medium
 require_fs_type		any
 
 . common.sh
-
-require_node_dax_device 1 2
-require_node_dax_device 0 2
 
 require_node_dax_device_alignments 1 $SIZE_2MB $SIZE_2MB
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_2MB

--- a/src/test/pmempool_transform_remote/TEST11
+++ b/src/test/pmempool_transform_remote/TEST11
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,8 +47,6 @@ require_test_type	medium
 require_fs_type		any
 
 . common.sh
-
-require_node_dax_device 0 2
 
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_4KB
 

--- a/src/test/pmempool_transform_remote/TEST12
+++ b/src/test/pmempool_transform_remote/TEST12
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,8 +48,6 @@ require_test_type	medium
 require_fs_type		any
 
 . common.sh
-
-require_node_dax_device 0 2
 
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_2MB
 

--- a/src/test/pmempool_transform_remote/TEST13
+++ b/src/test/pmempool_transform_remote/TEST13
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,7 +48,6 @@ require_fs_type		any
 
 . common.sh
 
-require_node_dax_device 1 2
 require_node_dax_device_alignments 1 $SIZE_4KB $SIZE_4KB
 
 setup

--- a/src/test/pmempool_transform_remote/TEST14
+++ b/src/test/pmempool_transform_remote/TEST14
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,7 +49,6 @@ require_fs_type		any
 
 . common.sh
 
-require_node_dax_device 1 2
 require_node_dax_device_alignments 1 $SIZE_2MB $SIZE_2MB
 
 setup

--- a/src/test/pmempool_transform_remote/TEST15
+++ b/src/test/pmempool_transform_remote/TEST15
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,9 +47,6 @@ require_test_type	medium
 require_fs_type		any
 
 . common.sh
-
-require_node_dax_device 1 2
-require_node_dax_device 0 2
 
 require_node_dax_device_alignments 1 $SIZE_4KB $SIZE_4KB
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_4KB

--- a/src/test/pmempool_transform_remote/TEST16
+++ b/src/test/pmempool_transform_remote/TEST16
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,9 +48,6 @@ require_test_type	medium
 require_fs_type		any
 
 . common.sh
-
-require_node_dax_device 1 2
-require_node_dax_device 0 2
 
 require_node_dax_device_alignments 1 $SIZE_2MB $SIZE_2MB
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_2MB

--- a/src/test/pmempool_transform_remote/TEST17
+++ b/src/test/pmempool_transform_remote/TEST17
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,7 +48,6 @@ require_fs_type		any
 
 . common.sh
 
-require_node_dax_device 0 2
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_4KB
 
 setup

--- a/src/test/pmempool_transform_remote/TEST18
+++ b/src/test/pmempool_transform_remote/TEST18
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,7 +49,6 @@ require_fs_type		any
 
 . common.sh
 
-require_node_dax_device 0 2
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_2MB
 
 setup

--- a/src/test/pmempool_transform_remote/TEST19
+++ b/src/test/pmempool_transform_remote/TEST19
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,7 +48,6 @@ require_fs_type		any
 
 . common.sh
 
-require_node_dax_device 1 2
 require_node_dax_device_alignments 1 $SIZE_4KB $SIZE_4KB
 
 setup

--- a/src/test/pmempool_transform_remote/TEST6
+++ b/src/test/pmempool_transform_remote/TEST6
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,9 +47,6 @@ require_test_type	medium
 require_fs_type		any
 
 . common.sh
-
-require_node_dax_device 1 2
-require_node_dax_device 0 2
 
 require_node_dax_device_alignments 1 $SIZE_4KB $SIZE_4KB
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_4KB

--- a/src/test/pmempool_transform_remote/TEST7
+++ b/src/test/pmempool_transform_remote/TEST7
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,9 +48,6 @@ require_test_type	medium
 require_fs_type		any
 
 . common.sh
-
-require_node_dax_device 1 2
-require_node_dax_device 0 2
 
 require_node_dax_device_alignments 1 $SIZE_2MB $SIZE_2MB
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_4KB

--- a/src/test/pmempool_transform_remote/TEST8
+++ b/src/test/pmempool_transform_remote/TEST8
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,9 +48,6 @@ require_test_type	medium
 require_fs_type		any
 
 . common.sh
-
-require_node_dax_device 1 2
-require_node_dax_device 0 2
 
 require_node_dax_device_alignments 1 $SIZE_4KB $SIZE_4KB
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_2MB

--- a/src/test/pmempool_transform_remote/TEST9
+++ b/src/test/pmempool_transform_remote/TEST9
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,9 +48,6 @@ require_test_type	medium
 require_fs_type		any
 
 . common.sh
-
-require_node_dax_device 1 2
-require_node_dax_device 0 2
 
 require_node_dax_device_alignments 1 $SIZE_4KB $SIZE_2MB
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_4KB

--- a/src/test/util_poolset_parse/TEST2
+++ b/src/test/util_poolset_parse/TEST2
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,7 +44,6 @@ require_test_type medium
 
 require_build_type debug
 require_fs_type any
-require_dax_devices 2
 require_dax_device_alignments 4096 4096
 
 setup

--- a/src/test/util_poolset_parse/TEST3
+++ b/src/test/util_poolset_parse/TEST3
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,7 +44,6 @@ require_test_type medium
 
 require_build_type debug
 require_fs_type any
-require_dax_devices 2
 require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup


### PR DESCRIPTION
If given test has some specific requirements for Device DAX
alignment(s), we typically use both 'require_(node_)dax_devices'
and 'require_(node_)dax_device_alignments' functions to specify
required number of devices and required device alignments respectively.
In practice, 'require_(node_)dax_devices' is not need in such case,
as 'require_(node_)dax_device_alignments' validates the number of
DAX devices defined in testconfig.sh, and if any of the requirements
are not fulfilled, it provies the complete information in the skip
message.

Ref: pmem/issues#732

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2537)
<!-- Reviewable:end -->
