### PR TITLE
pmem: improve pmem_memcpy_nodrain performance

### DIFF
--- a/doc/libpmem/pmem_memmove_persist.3.md
+++ b/doc/libpmem/pmem_memmove_persist.3.md
@@ -124,6 +124,16 @@ The **pmem_memmove_persist**(), **pmem_memcpy_persist**(), **pmem_memset_persist
 functions return the address of the destination.
 
 
+# CAVEATS #
+After calling any of the *\_nodrain* functions (**pmem_memmove_nodrain**(),
+**pmem_memcpy_nodrain**() or **pmem_memset_nodrain**()) you should not expect
+memory to be visible to other threads before calling **pmem_drain**(3) or any
+of the *\_persist* functions.  This is because those functions may use non-temporal
+store instructions, which are weakly ordered. See "Intel 64 and IA-32 Architectures
+Software Developer's Manual", Volume 1, "Caching of Temporal vs. Non-Temporal
+Data" section for details.
+
+
 # SEE ALSO #
 
 **memcpy**(3), **memmove**(3), **memset**(3),

--- a/src/libpmem/pmem.c
+++ b/src/libpmem/pmem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1031,8 +1031,18 @@ memmove_nodrain_movnt(void *pmemdest, const void *src, size_t len)
 		}
 	}
 
-	/* serialize non-temporal store instructions */
-	predrain_memory_barrier();
+	/*
+	 * The call to pmem_*_nodrain() should be followed by pmem_drain()
+	 * to serialize non-temporal store instructions.  (It could be only
+	 * one drain after a sequence of pmem_*_nodrain calls).
+	 * However, on platforms that only support strongly-ordered CLFLUSH
+	 * for flushing the CPU cache (or that are forced to not use
+	 * CLWB/CLFLUSHOPT) there is no need to put any memory barrier after
+	 * the flush, so the pmem_drain() is a no-op function.  In such case,
+	 * we need to put a memory barrier here.
+	 */
+	if (Func_predrain_fence == predrain_fence_empty)
+		predrain_memory_barrier();
 
 	return pmemdest;
 }
@@ -1195,8 +1205,18 @@ memset_nodrain_movnt(void *pmemdest, int c, size_t len)
 		}
 	}
 
-	/* serialize non-temporal store instructions */
-	predrain_memory_barrier();
+	/*
+	 * The call to pmem_*_nodrain() should be followed by pmem_drain()
+	 * to serialize non-temporal store instructions.  (It could be only
+	 * one drain after a sequence of pmem_*_nodrain calls).
+	 * However, on platforms that only support strongly-ordered CLFLUSH
+	 * for flushing the CPU cache (or that are forced to not use
+	 * CLWB/CLFLUSHOPT) there is no need to put any memory barrier after
+	 * the flush, so the pmem_drain() is a no-op function.  In such case,
+	 * we need to put a memory barrier here.
+	 */
+	if (Func_predrain_fence == predrain_fence_empty)
+		predrain_memory_barrier();
 
 	return pmemdest;
 }


### PR DESCRIPTION
Removes unnecessary SFENCE from pmem_memcpy_nodrain() and
pmem_memset_nodrain() functions, since the memory barrier is done by
pmem_drain().  This fence is only required for platforms using
strongly-ordered CLFLUSH, as pmem_drain() is empty in such case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2542)
<!-- Reviewable:end -->
