### PR TITLE
tests: improve reporting of performance indicators

### DIFF
--- a/src/test/obj_persist_count/obj_persist_count.c
+++ b/src/test/obj_persist_count/obj_persist_count.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017, Intel Corporation
+ * Copyright 2015-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,41 +39,179 @@
 #include "pmalloc.h"
 #include "unittest.h"
 
-static struct {
-	int n_persist;
-	int n_msync;
-	int n_flush;
+struct ops_counter {
+	int n_cl_stores;
 	int n_drain;
-} ops_counter;
+	int n_pmem_persist;
+	int n_pmem_msync;
+	int n_pmem_flush;
+	int n_pmem_drain;
+	int n_flush_from_pmem_memcpy;
+	int n_flush_from_pmem_memset;
+	int n_drain_from_pmem_memcpy;
+	int n_drain_from_pmem_memset;
+	int n_pot_cache_misses;
+};
+
+struct ops_counter ops_counter;
+struct ops_counter tx_counter;
+
+#define FLUSH_ALIGN ((uintptr_t)64)
+
+static int
+stores_aligned(const void *addr, size_t len, uintptr_t alignment)
+{
+	uintptr_t start = (uintptr_t)addr & ~(alignment - 1);
+	uintptr_t end = ((uintptr_t)addr + len + alignment - 1) &
+			~(alignment - 1);
+	/* count number of potential cache misses */
+	if (alignment == FLUSH_ALIGN) {
+		if (start != (uintptr_t)addr)
+			ops_counter.n_pot_cache_misses++;
+		if (end != ((uintptr_t)addr + len) && start + alignment != end)
+			ops_counter.n_pot_cache_misses++;
+	} else {
+		stores_aligned(addr, len, FLUSH_ALIGN);
+	}
+	return (int)(end - start);
+}
+
+static void
+flush_cl(const void *addr, size_t len)
+{
+	ops_counter.n_cl_stores +=
+			stores_aligned(addr, len, FLUSH_ALIGN) / FLUSH_ALIGN;
+}
+
+static void
+flush_msync(const void *addr, size_t len)
+{
+	ops_counter.n_cl_stores +=
+			stores_aligned(addr, len, Pagesize) / FLUSH_ALIGN;
+}
 
 FUNC_MOCK(pmem_persist, void, const void *addr, size_t len)
 	FUNC_MOCK_RUN_DEFAULT {
-		ops_counter.n_persist++;
+		ops_counter.n_pmem_persist++;
+		flush_cl(addr, len);
+		ops_counter.n_drain++;
+
 		_FUNC_REAL(pmem_persist)(addr, len);
 	}
 FUNC_MOCK_END
 
 FUNC_MOCK(pmem_msync, int, const void *addr, size_t len)
 	FUNC_MOCK_RUN_DEFAULT {
-		ops_counter.n_msync++;
+		ops_counter.n_pmem_msync++;
+		flush_msync(addr, len);
+		ops_counter.n_drain++;
+
 		return _FUNC_REAL(pmem_msync)(addr, len);
 	}
 FUNC_MOCK_END
 
 FUNC_MOCK(pmem_flush, void, const void *addr, size_t len)
 	FUNC_MOCK_RUN_DEFAULT {
-		ops_counter.n_flush++;
+		ops_counter.n_pmem_flush++;
+		flush_cl(addr, len);
 		_FUNC_REAL(pmem_flush)(addr, len);
 	}
 FUNC_MOCK_END
 
 FUNC_MOCK(pmem_drain, void, void)
 	FUNC_MOCK_RUN_DEFAULT {
+		ops_counter.n_pmem_drain++;
 		ops_counter.n_drain++;
 		_FUNC_REAL(pmem_drain)();
 	}
 FUNC_MOCK_END
 
+_FUNC_REAL_DECL(pmem_memmove, void *, int flags, void *dest, const void *src,
+		size_t len);
+
+static void
+memcpy_nodrain_count(void *dest, const void *src, size_t len)
+{
+	int cl_stores = stores_aligned(dest, len, FLUSH_ALIGN) / FLUSH_ALIGN;
+	ops_counter.n_flush_from_pmem_memcpy += cl_stores;
+	ops_counter.n_cl_stores += cl_stores;
+}
+
+static void
+memcpy_persist_count(void *dest, const void *src, size_t len)
+{
+	memcpy_nodrain_count(dest, src, len);
+
+	ops_counter.n_drain_from_pmem_memcpy++;
+	ops_counter.n_drain++;
+}
+
+FUNC_MOCK(pmem_memcpy_persist, void *, void *dest, const void *src, size_t len)
+	FUNC_MOCK_RUN_DEFAULT {
+		memcpy_persist_count(dest, src, len);
+
+		return _FUNC_REAL(pmem_memcpy_persist)(dest, src, len);
+	}
+FUNC_MOCK_END
+
+FUNC_MOCK(pmem_memcpy_nodrain, void *, void *dest, const void *src, size_t len)
+	FUNC_MOCK_RUN_DEFAULT {
+		memcpy_nodrain_count(dest, src, len);
+
+		return _FUNC_REAL(pmem_memcpy_nodrain)(dest, src, len);
+	}
+FUNC_MOCK_END
+
+FUNC_MOCK(pmem_memmove_persist, void *, void *dest, const void *src, size_t len)
+	FUNC_MOCK_RUN_DEFAULT {
+		memcpy_persist_count(dest, src, len);
+
+		return _FUNC_REAL(pmem_memmove_persist)(dest, src, len);
+	}
+FUNC_MOCK_END
+
+FUNC_MOCK(pmem_memmove_nodrain, void *, void *dest, const void *src, size_t len)
+	FUNC_MOCK_RUN_DEFAULT {
+		memcpy_nodrain_count(dest, src, len);
+
+		return _FUNC_REAL(pmem_memmove_nodrain)(dest, src, len);
+	}
+FUNC_MOCK_END
+
+_FUNC_REAL_DECL(pmem_memset, void *, int flags, void *dest, int c, size_t len);
+
+static void
+memset_nodrain_count(void *dest, size_t len)
+{
+	int cl_set = stores_aligned(dest, len, FLUSH_ALIGN) / FLUSH_ALIGN;
+	ops_counter.n_flush_from_pmem_memset += cl_set;
+	ops_counter.n_cl_stores += cl_set;
+}
+
+static void
+memset_persist_count(void *dest, size_t len)
+{
+	memset_nodrain_count(dest, len);
+
+	ops_counter.n_drain_from_pmem_memset++;
+	ops_counter.n_drain++;
+}
+
+FUNC_MOCK(pmem_memset_persist, void *, void *dest, int c, size_t len)
+	FUNC_MOCK_RUN_DEFAULT {
+		memset_persist_count(dest, len);
+
+		return _FUNC_REAL(pmem_memset_persist)(dest, c, len);
+	}
+FUNC_MOCK_END
+
+FUNC_MOCK(pmem_memset_nodrain, void *, void *dest, int c, size_t len)
+	FUNC_MOCK_RUN_DEFAULT {
+		memset_nodrain_count(dest, len);
+
+		return _FUNC_REAL(pmem_memset_nodrain)(dest, c, len);
+	}
+FUNC_MOCK_END
 
 /*
  * reset_counters -- zero all counters
@@ -88,12 +226,24 @@ reset_counters(void)
  * print_reset_counters -- print and then zero all counters
  */
 static void
-print_reset_counters(const char *task)
+print_reset_counters(const char *task, int tx)
 {
-	UT_OUT("%d\t;%d\t;%d\t;%d\t;%s",
-		ops_counter.n_persist, ops_counter.n_msync,
-		ops_counter.n_flush, ops_counter.n_drain, task);
-
+#define CNT(name) (ops_counter.name - tx * tx_counter.name)
+	UT_OUT(
+		"%-14s %-7d %-10d %-12d %-10d %-10d %-10d %-15d %-17d %-15d %-17d %-23d",
+		task,
+		CNT(n_cl_stores),
+		CNT(n_drain),
+		CNT(n_pmem_persist),
+		CNT(n_pmem_msync),
+		CNT(n_pmem_flush),
+		CNT(n_pmem_drain),
+		CNT(n_flush_from_pmem_memcpy),
+		CNT(n_drain_from_pmem_memcpy),
+		CNT(n_flush_from_pmem_memset),
+		CNT(n_drain_from_pmem_memset),
+		CNT(n_pot_cache_misses));
+#undef CNT
 	reset_counters();
 }
 
@@ -120,9 +270,23 @@ main(int argc, char *argv[])
 			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
 		UT_FATAL("!pmemobj_create: %s", path);
 
-	UT_OUT("persist\t;msync\t;flush\t;drain\t;task");
+	UT_OUT(
+		"%-14s %-7s %-10s %-12s %-10s %-10s %-10s %-15s %-17s %-15s %-17s %-23s",
+		"task",
+		"cl(all)",
+		"drain(all)",
+		"pmem_persist",
+		"pmem_msync",
+		"pmem_flush",
+		"pmem_drain",
+		"pmem_memcpy_cls",
+		"pmem_memcpy_drain",
+		"pmem_memset_cls",
+		"pmem_memset_drain",
+		"potential_cache_misses");
 
-	print_reset_counters("pool_create");
+
+	print_reset_counters("pool_create", 0);
 
 	/* allocate one structure to create a run */
 	pmemobj_alloc(pop, NULL, sizeof(struct foo), 0, NULL, NULL);
@@ -130,62 +294,67 @@ main(int argc, char *argv[])
 
 	PMEMoid root = pmemobj_root(pop, sizeof(struct foo));
 	UT_ASSERT(!OID_IS_NULL(root));
-	print_reset_counters("root_alloc");
+	print_reset_counters("root_alloc", 0);
 
 	PMEMoid oid;
 	int ret = pmemobj_alloc(pop, &oid, sizeof(struct foo), 0, NULL, NULL);
 	UT_ASSERTeq(ret, 0);
-	print_reset_counters("atomic_alloc");
+	print_reset_counters("atomic_alloc", 0);
 
 	pmemobj_free(&oid);
-	print_reset_counters("atomic_free");
+	print_reset_counters("atomic_free", 0);
 
 	struct foo *f = pmemobj_direct(root);
+
+	TX_BEGIN(pop) {
+	} TX_END
+	memcpy(&tx_counter, &ops_counter, sizeof(ops_counter));
+	print_reset_counters("tx_begin_end", 0);
 
 	TX_BEGIN(pop) {
 		f->bar = pmemobj_tx_alloc(sizeof(struct foo), 0);
 		UT_ASSERT(!OID_IS_NULL(f->bar));
 	} TX_END
-	print_reset_counters("tx_alloc");
+	print_reset_counters("tx_alloc", 1);
 
 	TX_BEGIN(pop) {
 		f->bar2 = pmemobj_tx_alloc(sizeof(struct foo), 0);
 		UT_ASSERT(!OID_IS_NULL(f->bar2));
 	} TX_END
-	print_reset_counters("tx_alloc_next");
+	print_reset_counters("tx_alloc_next", 1);
 
 	TX_BEGIN(pop) {
 		pmemobj_tx_free(f->bar);
 	} TX_END
-	print_reset_counters("tx_free");
+	print_reset_counters("tx_free", 1);
 
 	TX_BEGIN(pop) {
 		pmemobj_tx_free(f->bar2);
 	} TX_END
-	print_reset_counters("tx_free_next");
+	print_reset_counters("tx_free_next", 1);
 
 	TX_BEGIN(pop) {
 		pmemobj_tx_add_range_direct(&f->val, sizeof(f->val));
 	} TX_END
-	print_reset_counters("tx_add");
+	print_reset_counters("tx_add", 1);
 
 	TX_BEGIN(pop) {
 		pmemobj_tx_add_range_direct(&f->val, sizeof(f->val));
 	} TX_END
-	print_reset_counters("tx_add_next");
+	print_reset_counters("tx_add_next", 1);
 
 	pmalloc(pop, &f->dest, sizeof(f->val), 0, 0);
-	print_reset_counters("pmalloc");
+	print_reset_counters("pmalloc", 0);
 
 	pfree(pop, &f->dest);
-	print_reset_counters("pfree");
+	print_reset_counters("pfree", 0);
 
 	uint64_t stack_var;
 	pmalloc(pop, &stack_var, sizeof(f->val), 0, 0);
-	print_reset_counters("pmalloc_stack");
+	print_reset_counters("pmalloc_stack", 0);
 
 	pfree(pop, &stack_var);
-	print_reset_counters("pfree_stack");
+	print_reset_counters("pfree_stack", 0);
 
 	pmemobj_close(pop);
 

--- a/src/test/obj_persist_count/out0.log.match
+++ b/src/test/obj_persist_count/out0.log.match
@@ -1,18 +1,19 @@
 obj_persist_count$(nW)TEST0: START: obj_persist_count
  $(nW)obj_persist_count$(nW) $(nW)testfile
-persist	;msync	;flush	;drain	;task
-0	;14	;0	;0	;pool_create
-0	;8	;0	;0	;root_alloc
-0	;2	;0	;0	;atomic_alloc
-0	;1	;0	;0	;atomic_free
-0	;8	;0	;0	;tx_alloc
-0	;7	;0	;0	;tx_alloc_next
-0	;9	;0	;0	;tx_free
-0	;8	;0	;0	;tx_free_next
-0	;21	;0	;0	;tx_add
-0	;6	;0	;0	;tx_add_next
-0	;6	;0	;0	;pmalloc
-0	;5	;0	;0	;pfree
-0	;2	;0	;0	;pmalloc_stack
-0	;1	;0	;0	;pfree_stack
+task           cl(all) drain(all) pmem_persist pmem_msync pmem_flush pmem_drain pmem_memcpy_cls pmem_memcpy_drain pmem_memset_cls pmem_memset_drain potential_cache_misses 
+pool_create    49984   14         0            14         0          0          0               0                 0               0                 8                      
+root_alloc     512     8          0            8          0          0          0               0                 0               0                 5                      
+atomic_alloc   128     2          0            2          0          0          0               0                 0               0                 1                      
+atomic_free    64      1          0            1          0          0          0               0                 0               0                 1                      
+tx_begin_end   128     2          0            2          0          0          0               0                 0               0                 0                      
+tx_alloc       384     6          0            6          0          0          0               0                 0               0                 5                      
+tx_alloc_next  320     5          0            5          0          0          0               0                 0               0                 4                      
+tx_free        448     7          0            7          0          0          0               0                 0               0                 6                      
+tx_free_next   384     6          0            6          0          0          0               0                 0               0                 5                      
+tx_add         1728    19         0            19         0          0          0               0                 0               0                 17                     
+tx_add_next    256     4          0            4          0          0          0               0                 0               0                 4                      
+pmalloc        384     6          0            6          0          0          0               0                 0               0                 4                      
+pfree          320     5          0            5          0          0          0               0                 0               0                 4                      
+pmalloc_stack  128     2          0            2          0          0          0               0                 0               0                 1                      
+pfree_stack    64      1          0            1          0          0          0               0                 0               0                 1                      
 obj_persist_count$(nW)TEST0: DONE

--- a/src/test/obj_persist_count/out1.log.match
+++ b/src/test/obj_persist_count/out1.log.match
@@ -1,18 +1,19 @@
 obj_persist_count$(nW)TEST1: START: obj_persist_count
  $(nW)obj_persist_count$(nW) $(nW)testfile
-persist	;msync	;flush	;drain	;task
-10	;0	;0	;0	;pool_create
-4	;0	;3	;1	;root_alloc
-1	;0	;1	;1	;atomic_alloc
-1	;0	;0	;1	;atomic_free
-6	;0	;2	;2	;tx_alloc
-5	;0	;2	;2	;tx_alloc_next
-8	;0	;1	;2	;tx_free
-7	;0	;1	;2	;tx_free_next
-15	;0	;3	;2	;tx_add
-3	;0	;1	;1	;tx_add_next
-4	;0	;2	;1	;pmalloc
-4	;0	;1	;1	;pfree
-1	;0	;1	;1	;pmalloc_stack
-1	;0	;0	;1	;pfree_stack
+task           cl(all) drain(all) pmem_persist pmem_msync pmem_flush pmem_drain pmem_memcpy_cls pmem_memcpy_drain pmem_memset_cls pmem_memset_drain potential_cache_misses 
+pool_create    49282   14         10           0          0          0          0               0                 49163           4                 8                      
+root_alloc     9       6          4            0          3          1          0               0                 2               1                 5                      
+atomic_alloc   2       2          1            0          1          1          0               0                 0               0                 1                      
+atomic_free    1       2          1            0          0          1          0               0                 0               0                 1                      
+tx_begin_end   2       3          2            0          0          1          0               0                 0               0                 0                      
+tx_alloc       7       5          4            0          2          1          0               0                 0               0                 5                      
+tx_alloc_next  6       4          3            0          2          1          0               0                 0               0                 4                      
+tx_free        7       7          6            0          1          1          0               0                 0               0                 6                      
+tx_free_next   6       6          5            0          1          1          0               0                 0               0                 5                      
+tx_add         538     17         13           0          3          1          1               1                 516             2                 17                     
+tx_add_next    4       3          1            0          1          0          1               1                 1               1                 4                      
+pmalloc        6       5          4            0          2          1          0               0                 0               0                 4                      
+pfree          5       5          4            0          1          1          0               0                 0               0                 4                      
+pmalloc_stack  2       2          1            0          1          1          0               0                 0               0                 1                      
+pfree_stack    1       2          1            0          0          1          0               0                 0               0                 1                      
 obj_persist_count$(nW)TEST1: DONE


### PR DESCRIPTION
1) measure impact of an empty transaction
2) count cachelines stored and drains from memcpy/memmove/memset
3) count overall number of cachelines stored and drains
4) exclude transaction start overhead from transactional operations
5) count number of potential cache misses, by looking at the address
   and length of the operation, assuming that there was a store
   before and cache was empty
6) stop using tabs in output

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2546)
<!-- Reviewable:end -->
