### PR TITLE
pmem: change aarch64 macro and improve makefile for ARM64 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,11 +355,6 @@ are not ported yet and may not get built on ARM cores.
 The support for ARM processors is highly experimental. The libraries
 are only validated to "early access" quality with Cortex-A53 processor.
 
-To trigger the build on an ARM processor, run:
-```
-    $ make EXTRA_CFLAGS="-DAARCH64" BUILD_AARCH64=y
-```
-
 ### Contacts ###
 
 For more information on this library, contact

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2017, Intel Corporation
+# Copyright 2014-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -36,14 +36,15 @@ TOP := $(dir $(lastword $(MAKEFILE_LIST)))..
 include $(TOP)/src/common.inc
 include $(TOP)/src/version.inc
 
+ARCH := $(shell $(CC) -dumpmachine | awk -F'[/-]' '{print $$1}')
 TARGETS = libpmem libvmem libpmemblk libpmemlog libpmemobj libpmempool\
 		  libpmemcto libvmmalloc tools
 ALL_TARGETS = $(TARGETS) common librpmem examples benchmarks
 
-ifeq ($(BUILD_AARCH64),y)
+ifeq ($(ARCH), aarch64)
 	TARGETS = libpmem libvmem libpmemblk libpmemlog libpmemobj libpmempool\
 		  libvmmalloc libpmemcto
-	ALL_TARGETS = $(TARGET) common
+	ALL_TARGETS = $(TARGETS) common
 endif
 
 SCOPE_DIRS = $(TARGETS) common librpmem rpmem_common


### PR DESCRIPTION
This patch changes the build requirement for 
AARCH64. Just regular "make" command is sufficient
to build in ARM processor. This patch also removes additional
CFLAGS required for building in ARM processor.
This patch also fixes a typo in the Makefile for ARM
builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2553)
<!-- Reviewable:end -->
