### PR TITLE
common: fix library dependencies (1.3.x)

### DIFF
--- a/src/libpmempool/Makefile
+++ b/src/libpmempool/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -86,7 +86,7 @@ LIBPMEMLOG_PRIV_FUNCS=log_convert2h log_convert2le
 
 include ../Makefile.inc
 
-LIBS += -lpmem -ldl
+LIBS += -pthread -lpmem -ldl
 CFLAGS += -DUSE_LIBDL
 CFLAGS += -DUSE_RPMEM
 

--- a/src/librpmem/Makefile
+++ b/src/librpmem/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -61,6 +61,7 @@ endif
 include ../Makefile.inc
 
 ifeq ($(BUILD_RPMEM),y)
+LIBS += -pthread
 LIBS += $(shell $(PKG_CONFIG) --libs libfabric)
 CFLAGS += $(shell $(PKG_CONFIG) --cflags libfabric)
 CFLAGS += -I. -I../rpmem_common

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -1,4 +1,4 @@
-# Copyright 2014-2017, Intel Corporation
+# Copyright 2014-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -91,8 +91,6 @@ PMEMLOG_PRIV_OBJ=$(LIBSDIR_PRIV)/libpmemlog/libpmemlog_unscoped.o
 PMEMOBJ_PRIV_OBJ=$(LIBSDIR_PRIV)/libpmemobj/libpmemobj_unscoped.o
 PMEMBLK_PRIV_OBJ=$(LIBSDIR_PRIV)/libpmemblk/libpmemblk_unscoped.o
 
-LIBS += -pthread
-
 # XXX: required by clock_gettime(), if glibc version < 2.17
 # The os_clock_gettime() function is now in OS abstraction layer,
 # linked to all the librariess, unit tests and benchmarks.
@@ -109,29 +107,31 @@ DYNAMIC_LIBS += $(LIBSDIR_DEBUG)/libpmemcommon.a
 STATIC_DEBUG_LIBS += $(LIBSDIR_DEBUG)/libpmemcommon.a
 STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libpmemcommon.a
 CFLAGS += -I$(TOP)/src/common
-LIBS += -ldl
 endif
 
 ifeq ($(LIBPMEMPOOL), y)
+LIBPMEM=y
 DYNAMIC_LIBS += -lpmempool
 STATIC_DEBUG_LIBS += $(LIBSDIR_DEBUG)/libpmempool.a
 STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libpmempool.a
 endif
 
 ifeq ($(LIBPMEMBLK), y)
+LIBPMEM=y
 DYNAMIC_LIBS += -lpmemblk
 STATIC_DEBUG_LIBS += $(LIBSDIR_DEBUG)/libpmemblk.a
 STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libpmemblk.a
 endif
 
 ifeq ($(LIBPMEMLOG), y)
+LIBPMEM=y
 DYNAMIC_LIBS += -lpmemlog
 STATIC_DEBUG_LIBS += $(LIBSDIR_DEBUG)/libpmemlog.a
 STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libpmemlog.a
 endif
 
 ifeq ($(LIBPMEMOBJ), y)
-LIBS += -ldl
+LIBPMEM=y
 DYNAMIC_LIBS += -lpmemobj
 STATIC_DEBUG_LIBS += $(LIBSDIR_DEBUG)/libpmemobj.a
 STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libpmemobj.a
@@ -148,6 +148,18 @@ DYNAMIC_LIBS += -lvmem
 STATIC_DEBUG_LIBS += $(LIBSDIR_DEBUG)/libvmem.a
 STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libvmem.a
 endif
+
+
+# If any of these libraries is required, we need to link libpthread
+ifneq ($(LIBPMEMCOMMON)$(LIBPMEM)$(LIBPMEMPOOL)$(LIBPMEMBLK)$(LIBPMEMLOG)$(LIBPMEMOBJ)$(LIBVMEM),)
+LIBS += -pthread
+endif
+
+# If any of these libraries is required, we need to link libdl
+ifneq ($(LIBPMEMCOMMON)$(LIBPMEMOBJ),)
+LIBS += -ldl
+endif
+
 
 ifeq ($(TOOLS_COMMON), y)
 vpath %.c $(TOP)/src/tools/pmempool

--- a/src/tools/rpmemd/Makefile
+++ b/src/tools/rpmemd/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -60,6 +60,8 @@ ifneq ($(DEBUG),)
 CFLAGS += -DDEBUG
 endif
 CFLAGS += $(shell $(PKG_CONFIG) --cflags libfabric)
+
+LIBS += -pthread
 LIBS += $(shell $(PKG_CONFIG) --libs libfabric)
 
 INSTALL_TARGET=y


### PR DESCRIPTION
Adds explicit dependency on libptherad to libpmempool and librpmem.
Fixes required libs evaluation when linking tools.

Ref: pmem/issues#767

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2558)
<!-- Reviewable:end -->
