### PR TITLE
common: fix library dependencies

### DIFF
--- a/src/libpmempool/Makefile
+++ b/src/libpmempool/Makefile
@@ -75,7 +75,7 @@ LIBPMEMBLK_PRIV_FUNCS=btt_info_set btt_arena_datasize btt_flog_size\
 
 include ../Makefile.inc
 
-LIBS += -lpmem $(LIBDL) $(LIBNDCTL)
+LIBS += -pthread -lpmem $(LIBDL) $(LIBNDCTL)
 CFLAGS += -DUSE_LIBDL
 CFLAGS += -DUSE_RPMEM
 

--- a/src/librpmem/Makefile
+++ b/src/librpmem/Makefile
@@ -61,6 +61,7 @@ endif
 include ../Makefile.inc
 
 ifeq ($(BUILD_RPMEM),y)
+LIBS += -pthread
 LIBS += $(shell $(PKG_CONFIG) --libs libfabric)
 CFLAGS += $(shell $(PKG_CONFIG) --cflags libfabric)
 CFLAGS += -I. -I../rpmem_common

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -1,4 +1,4 @@
-# Copyright 2014-2017, Intel Corporation
+# Copyright 2014-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -109,7 +109,7 @@ PMEMOBJ_PRIV_OBJ=$(LIBSDIR_PRIV)/libpmemobj/libpmemobj_unscoped.o
 PMEMBLK_PRIV_OBJ=$(LIBSDIR_PRIV)/libpmemblk/libpmemblk_unscoped.o
 PMEMCTO_PRIV_OBJ=$(LIBSDIR_PRIV)/libpmemcto/libpmemcto_unscoped.o
 
-LIBS += -pthread $(LIBUUID)
+LIBS += $(LIBUUID)
 
 # XXX: required by clock_gettime(), if glibc version < 2.17
 # The os_clock_gettime() function is now in OS abstraction layer,
@@ -127,37 +127,39 @@ DYNAMIC_LIBS += $(LIBSDIR_DEBUG)/libpmemcommon.a
 STATIC_DEBUG_LIBS += $(LIBSDIR_DEBUG)/libpmemcommon.a
 STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libpmemcommon.a
 CFLAGS += -I$(TOP)/src/common
-LIBS += $(LIBDL)
 LIBS += $(LIBNDCTL)
 endif
 
 ifeq ($(LIBPMEMPOOL), y)
+LIBPMEM=y
 DYNAMIC_LIBS += -lpmempool
 STATIC_DEBUG_LIBS += $(LIBSDIR_DEBUG)/libpmempool.a
 STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libpmempool.a
 endif
 
 ifeq ($(LIBPMEMBLK), y)
+LIBPMEM=y
 DYNAMIC_LIBS += -lpmemblk
 STATIC_DEBUG_LIBS += $(LIBSDIR_DEBUG)/libpmemblk.a
 STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libpmemblk.a
 endif
 
 ifeq ($(LIBPMEMLOG), y)
+LIBPMEM=y
 DYNAMIC_LIBS += -lpmemlog
 STATIC_DEBUG_LIBS += $(LIBSDIR_DEBUG)/libpmemlog.a
 STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libpmemlog.a
 endif
 
 ifeq ($(LIBPMEMOBJ), y)
-LIBS += $(LIBDL)
+LIBPMEM=y
 DYNAMIC_LIBS += -lpmemobj
 STATIC_DEBUG_LIBS += $(LIBSDIR_DEBUG)/libpmemobj.a
 STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libpmemobj.a
 endif
 
 ifeq ($(LIBPMEMCTO), y)
-LIBS += $(LIBDL)
+LIBPMEM=y
 DYNAMIC_LIBS += -lpmemcto
 STATIC_DEBUG_LIBS += $(LIBSDIR_DEBUG)/libpmemcto.a
 STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libpmemcto.a
@@ -174,6 +176,18 @@ DYNAMIC_LIBS += -lvmem
 STATIC_DEBUG_LIBS += $(LIBSDIR_DEBUG)/libvmem.a
 STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libvmem.a
 endif
+
+
+# If any of these libraries is required, we need to link libpthread
+ifneq ($(LIBPMEMCOMMON)$(LIBPMEM)$(LIBPMEMPOOL)$(LIBPMEMBLK)$(LIBPMEMLOG)$(LIBPMEMOBJ)$(LIBPMEMCTO)$(LIBVMEM),)
+LIBS += -pthread
+endif
+
+# If any of these libraries is required, we need to link libdl
+ifneq ($(LIBPMEMCOMMON)$(LIBPMEMPOOL)$(LIBPMEMOBJ),)
+LIBS += $(LIBDL)
+endif
+
 
 ifeq ($(TOOLS_COMMON), y)
 vpath %.c $(TOP)/src/tools/pmempool

--- a/src/tools/rpmemd/Makefile
+++ b/src/tools/rpmemd/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -59,6 +59,8 @@ ifneq ($(DEBUG),)
 CFLAGS += -DDEBUG
 endif
 CFLAGS += $(shell $(PKG_CONFIG) --cflags libfabric)
+
+LIBS += -pthread
 LIBS += $(shell $(PKG_CONFIG) --libs libfabric)
 
 INSTALL_TARGET=y


### PR DESCRIPTION
Adds explicit dependency on libptherad to libpmempool and librpmem.
Fixes required libs evaluation when linking tools.

Ref: pmem/issues#767

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2559)
<!-- Reviewable:end -->
