### PR TITLE
common: fix possible double free of part path

### DIFF
--- a/src/common/set.c
+++ b/src/common/set.c
@@ -2808,6 +2808,7 @@ err_part_init:
 		struct pool_replica *rep = set->replica[rn];
 		unsigned pidx = rep->nparts - 1;
 		Free((void *)(rep->part[pidx].path));
+		rep->part[pidx].path = NULL;
 		rep->nparts--;
 	}
 
@@ -2891,6 +2892,7 @@ err:
 		if (p->created)
 			os_unlink(p->path);
 		Free((void *)p->path);
+		p->path = NULL;
 	}
 	util_poolset_set_size(set);
 


### PR DESCRIPTION
This is difficult to test for because it requires the posix_fallocate to fail during pool extend.

Ref: pmem/issues#758

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2562)
<!-- Reviewable:end -->
