### PR TITLE
test: fix vmmalloc_malloc_hooks

### DIFF
--- a/src/test/vmmalloc_malloc_hooks/grep2.log.match
+++ b/src/test/vmmalloc_malloc_hooks/grep2.log.match
@@ -1,4 +1,4 @@
 <libvmmalloc>: <4> [$(*) malloc]$(W)size 4321
 <libvmmalloc>: <4> [$(*) calloc]$(W)nmemb 1, size 4321
-<libvmmalloc>: <4> [$(*) realloc]$(W)ptr 0x0, size 4321
+<libvmmalloc>: <4> [$(*) realloc]$(W)ptr 0x$(X), size 4321
 <libvmmalloc>: <4> [$(*) memalign]$(W)boundary 16  size 4321

--- a/src/test/vmmalloc_malloc_hooks/out0.log.match
+++ b/src/test/vmmalloc_malloc_hooks/out0.log.match
@@ -1,5 +1,5 @@
 vmmalloc_malloc_hooks/TEST0: START: vmmalloc_malloc_hooks
  ./vmmalloc_malloc_hooks$(nW)
 installing hooks
-malloc 2 realloc 1 memalign 1 free 4
+malloc 3 realloc 1 memalign 1 free 4
 vmmalloc_malloc_hooks/TEST0: DONE

--- a/src/test/vmmalloc_malloc_hooks/vmmalloc_malloc_hooks.c
+++ b/src/test/vmmalloc_malloc_hooks/vmmalloc_malloc_hooks.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -127,7 +127,8 @@ main(int argc, char *argv[])
 	ptr = calloc(1, 4321);
 	free(ptr);
 
-	ptr = realloc(NULL, 4321);
+	ptr = malloc(8);
+	ptr = realloc(ptr, 4321);
 	free(ptr);
 
 	ptr = memalign(16, 4321);


### PR DESCRIPTION
The recent version of gcc (8.0), replaces 'realloc(NULL, size)'
with 'malloc(size)' at compile time.  This changes the behavior
of the test, as the actual realloc() (and its hook) is never called.
To test realloc hook, it must be called with a non-NULL pointer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2575)
<!-- Reviewable:end -->
