### PR TITLE
examples: implement publish/reserve example

### DIFF
--- a/src/examples/libpmemobj/ElephantMQ/Makefile
+++ b/src/examples/libpmemobj/ElephantMQ/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018, Intel Corporation
+# Copyright 2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,24 +31,25 @@
 #
 
 #
-# examples/libpmemobj/Makefile -- build the libpmemobj examples
+# examples/libpmemobj/ElephantMQ/Makefile -- builds the message broker example
 #
-PROGS = manpage btree pi lists setjmp
-DIRS = pminvaders pmemlog pmemblk string_store string_store_tx\
-	string_store_tx_type hashmap tree_map pmemobjfs map libart array\
-	linkedlist list_map slab_allocator queue ElephantMQ
+TOP := $(dir $(lastword $(MAKEFILE_LIST)))../../../../
+include $(TOP)/src/common.inc
 
-LIBS = -lpmemobj -lpmem -pthread -lm -pthread
+LIBEVENT := $(call check_package, libevent_pthreads --atleast-version 2.0)
+ifeq ($(LIBEVENT),y)
+PROGS += broker
+else
+$(info NOTE: Skipping ElephantMQ because libevent is missing \
+-- see src/examples/libpmemobj/ElephantMQ/README for details.)
+endif
 
-include ../Makefile.inc
+LIBS = -lpmemobj -lpmem -pthread
 
-map: hashmap tree_map
-pmemobjfs: map
+ifeq ($(LIBEVENT),y)
+LIBS += $(shell $(PKG_CONFIG) --libs libevent_pthreads)
+endif
 
-manpage: manpage.o
-btree: btree.o
-pi: pi.o
-lists: lists.o
+include ../../Makefile.inc
 
-setjmp: CFLAGS += -O2
-setjmp: setjmp.o
+broker: broker.o client.o message.o queue.o topic.o

--- a/src/examples/libpmemobj/ElephantMQ/README
+++ b/src/examples/libpmemobj/ElephantMQ/README
@@ -1,0 +1,130 @@
+This directory contains a message broker implementation, humorously
+named ElephantMQ, that relies on libpmemobj to ensure persistence of queues and
+messages.
+
+Usage:
+$ ./broker <file> <port>
+
+The file must exist and be a libpmemobj pool with layout name "broker". This can
+be done through pmempool:
+
+$ pmempool create obj <file> --layout broker
+
+Once the server is running, clients can connect and talk to the broker with
+the following human readable protocol:
+
+SUB <queue name>
+	Subscribes to queue with the given name. Can only be called once during
+	a client connection.
+
+PUB <data length>\n<data>
+	Publishes a message to the default topic.
+
+BYE
+	Terminates the client connection
+
+SHUTDOWN
+	Terminates the client connection and gracefully shutdowns the server
+
+All messages must be delimited by '\n'.
+
+A queue that has been subscribed to at least once will remain operational in
+the persistent state of the broker and it will continue to receive all published
+messages, even if no client is currently subscribed.
+When a client connects to a previously abandoned queue, all messages are sent
+out. This allows the publishers to operate even in the absence of subscribers.
+
+All queues and messages in those queues survive server restarts and unexpected
+failures.
+
+** Example session **
+$ ./broker /mnt/pmem/messages 9876 &
+
+$ nc 127.0.0.1 9876
+SUB Hello
+PUB 6
+World
+
+** DEPENDENCIES: **
+In order to build ElephantMQ you need to install libevent and libevent-pthreads
+development packages, at least in version 2.0.
+
+** Design **
+
+The message broker was designed with the goal of demonstrating the features of
+libpmemobj. While it is certainly adequate, it should not be looked at as a
+showcase of a good design of this type of software. Many simplifications
+were made to both the protocol and the code to minimize its size and
+complexity.
+
+The primary design consideration was to achieve zero copy persistent messages,
+beginning with `read()` from client's socket directly to reserved persistent
+memory, through reference counted messages in queues, circling back to `write()`
+directly from persistent objects to client's socket.
+
+The second large consideration was achieving scalability through multi-threading
+by relying on transient object reservations in clients' thread pool and atomic
+aggregated publication in common topic worker thread.
+
+
+        +---------------------------------------------------------------+
+        |                        message broker                         |
+
+                                    +-------- reserve > -----+
+                                    |                        |
+     +------------------------+     |  +-------+    +-------------+
+     | connection thread pool |     |  | topic | -- | msg pending |
+     +------------------------+     |  +-------+    +-------------+
+        |                           |      |                 |
+        |                           |      |                 |
+        |           +-- PUB msg > --+	   |   +-- persist --+
+        |           |                      |   |
+        |       +--------+                 |   |   +-------+    +-----+    +-----+
+        +-------| client |- < subscribe > -+--->---| queue | -- | msg | -- | msg |
+        |       +--------+                 |   |   +-------+    +-----+    +-----+
+        |                                  |   |
+        |       +--------+                 |   |   +-------+    +-----+    +-----+
+        +-------| client |- < subscribe > -+--->---| queue | -- | msg | -- | msg |
+        |       +--------+                 |       +-------+    +-----+    +-----+
+        |                                  |
+        +------- ...                       +------- ...
+        .                                  .
+        .                                  .
+        .                                  .
+
+        |                                                               |
+        +---------------------------------------------------------------+
+
+The I/O is non-blocking and handled by libevent. The clients' connections are
+accepted in the main thread and then handed over to one of the worker threads
+running the event loops dedicated to handling client's socket read and write
+events.
+When a client sends a publish request, a new object is reserved through
+`pmemobj_reserve()` function and the data is read into the resulting buffer.
+Once a message is read in its entirety, it's moved to the topic for publication.
+
+For simplicity's sake, there's only one topic to which all clients subscribe by
+default. A topic has its own worker thread that is woken up whenever there's
+a message to be published. When that happens, the thread first collects as many
+pending messages as possible and calls `pmemobj_persist()` on them to make sure
+that the data is safely on the storage. Next, all of the objects are
+atomically published using `pmemobj_publish()` function.
+Once a message is fully persisted and resides safely on pmem, it is pushed into
+each queue in the topic so that it can be sent our to the subscribers' sockets.
+
+Queues are persistent collections of messages. They are also named so that
+clients can reconnect after failure on either side. Once a message is pushed
+into a queue, it won't leave it until a subscriber is connected and the
+message's data is successfully written to client's socket. When a queue is not
+empty and the queue has a connected client, the queue schedules a write event
+to occur in client's thread. The write event is repeated until the client's
+queue is emptied. There can only be one client for each queue.
+
+To avoid having to copy messages for queues a reference counting is used to
+store the messages by pointer instead of by value. It's a transient variable
+in the persistent message that is increased every time the message is pushed
+into a queue and decreased every time the message is popped from it, once
+reference count reaches zero, the message is freed.
+This mechanism relies on atomic instructions and requires recovery at the time
+of the broker startup to recalculate the reference count value and free any
+messages that are not present on any of the queues.

--- a/src/examples/libpmemobj/ElephantMQ/broker.c
+++ b/src/examples/libpmemobj/ElephantMQ/broker.c
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * broker.c - simple message broker implemented using libpmemobj to support
+ *	persistent queues and messages.
+ */
+
+#include <event2/event.h>
+#include <event2/thread.h>
+#include <pthread.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <libpmemobj.h>
+#include "client.h"
+
+#define CONN_BACKLOG 16
+#define NWORKERS 8
+#define NWORKERS_MASK (NWORKERS - 1)
+
+static PMEMobjpool *pop;
+
+/*
+ * event loop worker that is responsible for dispatching read/write events
+ * to client connections. There can be many of these workers running
+ * concurrently to increase throughput of broker.
+ */
+struct worker {
+	pthread_t th;
+	struct event_base *evbase;
+	int running;
+} workers[NWORKERS];
+
+/*
+ * Topic to which messages are sent. For simplicity sake, there's only one topic
+ * in the broker.
+ */
+struct topic *topic;
+
+
+/*
+ * worker_next -- selects the next worker for the client connection in a
+ *	round robin fashion
+ */
+static struct worker *
+worker_next()
+{
+	static uint64_t worker_id = 0;
+
+	return &workers[__sync_fetch_and_add(&worker_id, 1) & NWORKERS_MASK];
+}
+
+/*
+ * worker_func -- worker event loop, handles read and write events
+ */
+static void *
+worker_func(void *arg)
+{
+	struct worker *w = arg;
+	w->evbase = event_base_new();
+	w->running = 1;
+
+	struct timeval heartbeat;
+	heartbeat.tv_sec = 5;
+	heartbeat.tv_usec = 0;
+
+	while (__atomic_load_n(&w->running, __ATOMIC_ACQUIRE)) {
+		event_base_loopexit(w->evbase, &heartbeat);
+
+		if (event_base_dispatch(w->evbase) < 0) {
+			printf("event_base_dispatch %s\n", strerror(errno));
+			break;
+		}
+	}
+
+	event_base_free(w->evbase);
+
+	return NULL;
+}
+
+/*
+ * workers_run -- launches the worker threads
+ */
+static void
+workers_run()
+{
+	evthread_use_pthreads();
+	for (int i = 0; i < NWORKERS; ++i) {
+		struct worker *w = &workers[i];
+		if (pthread_create(&w->th, NULL, worker_func, w) < 0)
+			assert(0);
+	}
+}
+
+/*
+ * workers_stop -- terminates the event loop and waits for the threads to exit
+ */
+static void
+workers_stop()
+{
+	for (int i = 0; i < NWORKERS; ++i) {
+		struct worker *w = &workers[i];
+		w = &workers[i];
+		if (__sync_bool_compare_and_swap(&w->running, 1, 0)) {
+			event_base_loopbreak(w->evbase);
+			pthread_join(w->th, NULL);
+		}
+	}
+}
+
+/*
+ * on_accept -- callback for incoming client connection, creates a new client
+ *	instance which attaches itself to one of the workers
+ */
+static void
+on_accept(evutil_socket_t fd, short ev, void *arg)
+{
+	int cfd;
+	struct sockaddr_in addr;
+
+	socklen_t len = sizeof(addr);
+	if ((cfd = accept(fd, (struct sockaddr *)&addr, &len)) < 0)
+		return;
+
+	if (evutil_make_socket_nonblocking(cfd) < 0)
+		goto err;
+
+	if (client_new(pop, topic, cfd, worker_next()->evbase) == NULL)
+		goto err;
+
+	return;
+err:
+	close(cfd);
+}
+
+/*
+ * server_run -- setups the server socket and the event loop for the accept
+ *	events (reads)
+ *
+ * This function is blocking, terminates only if the event loop is interrupted.
+ */
+static int
+server_run(int port, struct event_base *evbase)
+{
+	evutil_socket_t fd;
+	struct sockaddr_in addr;
+	struct event *ev_accept;
+
+	if ((fd = socket(AF_INET, SOCK_STREAM, 0)) < 0)
+		return -1;
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = INADDR_ANY;
+	addr.sin_port = htons((uint16_t)port);
+	if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0)
+		goto err;
+
+	if (listen(fd, CONN_BACKLOG) < 0)
+		goto err;
+
+	int reuse = 1;
+	setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+
+	if (evutil_make_socket_nonblocking(fd) < 0)
+		goto err;
+
+	ev_accept = event_new(evbase, fd, EV_READ | EV_PERSIST,
+		on_accept, NULL);
+
+	event_add(ev_accept, NULL);
+
+	event_base_dispatch(evbase);
+
+	event_free(ev_accept);
+	event_base_free(evbase);
+
+	close(fd);
+
+	return 0;
+
+err:
+	close(fd);
+	return -1;
+}
+
+/*
+ * main -- broker start
+ */
+int
+main(int argc, char *argv[])
+{
+	if (argc < 3) {
+		printf("usage: %s file-name port\n", argv[0]);
+		return 1;
+	}
+
+	const char *path = argv[1];
+	int port = atoi(argv[2]);
+
+	/* 1. open the pool with queues and messages */
+	pop = pmemobj_open(path, POBJ_LAYOUT_NAME(broker));
+	if (pop == NULL) {
+		fprintf(stderr, "failed to open pool: %s\n",
+				pmemobj_errormsg());
+		return 1;
+	}
+
+	/* 2. recover all existing queues and attached messages */
+	queue_recover_all(pop);
+
+	/* 3. run event loop worker threads */
+	workers_run();
+
+	/*
+	 * The server event loop on which the broker listens for connections.
+	 * Can be used to terminate the application.
+	 */
+	struct event_base *server_evbase = event_base_new();
+
+	/* 4. create transient topic instance */
+	topic = topic_new(pop, "default", server_evbase);
+
+	/* 5. start the server */
+	if (server_run(port, server_evbase) != 0) {
+		fprintf(stderr, "failed to run the server on the given port\n");
+		topic_stop(topic);
+	}
+
+	/* cleanup */
+	workers_stop();
+	topic_delete(topic);
+	event_base_free(server_evbase);
+	pmemobj_close(pop);
+
+	return 0;
+}

--- a/src/examples/libpmemobj/ElephantMQ/client.c
+++ b/src/examples/libpmemobj/ElephantMQ/client.c
@@ -1,0 +1,409 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * client.c - broker client implementation
+ *
+ * This module handles read/write events of individual connections.
+ */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <libpmemobj.h>
+#include "client.h"
+#include "protocol.h"
+
+#define CLIENT_MSG_BUF 128
+
+struct client {
+	PMEMobjpool *pop;
+
+	struct topic *topic; /* the default topic for sub/pub actions */
+
+	int fd; /* client socket */
+	struct event *ev_read;
+	struct event *ev_write;
+
+	char *buf; /* buffer for reads, must either be cmsg or pending->data */
+	size_t buf_len; /* length of the above buffer */
+	size_t buf_offset; /* current read offset into the buffer */
+
+	char cmsg[CLIENT_MSG_BUF]; /* buffer for normal messages */
+
+	struct message_pending *pending; /* buffer to payload messages */
+	size_t write_offset; /* offset for write in pending message */
+
+	struct queue *queue; /* the persistent queue for this client */
+};
+
+/*
+ * on_message_completion -- called whenever a pending message is complete
+ *
+ * Moves the message to the topic for persisting and distribution to all
+ *	subscribing queues.
+ */
+static void
+on_message_completion(struct client *c)
+{
+	c->buf = c->cmsg;
+	c->buf_offset = 0;
+	c->buf_len = CLIENT_MSG_BUF;
+
+	topic_message_schedule(c->topic, c->pending);
+	c->pending = NULL;
+}
+
+/*
+ * cmsg_publish_handler -- handles the PUB client message.
+ */
+static ssize_t
+cmsg_publish_handler(struct client *c, const char *buf, size_t len)
+{
+	/*
+	 * Protocol defines publish as:
+	 * PUB <data length>;\n
+	 *
+	 * Data length is required to create an appropriately sized reservation
+	 * ahead of receiving the entire buffer.
+	 */
+	size_t data_len;
+	if (sscanf(buf, "PUB %lu", &data_len) != 1)
+		return -1;
+
+	/* create a transient pending message */
+	c->pending = message_new(c->pop, data_len);
+	if (c->pending == NULL)
+		return -1;
+
+	TOID(struct message) m = message_get(c->pending);
+	char *nbuf = message_data(m);
+	size_t nlen = message_length(m);
+
+	/*
+	 * Because data needs to be read even in the absence of a pending
+	 * message, and it's impractial to read in single byte buffers, some of
+	 * the already read data might need to be copied into the newly
+	 * reserved pending message.
+	 */
+	size_t buflen = ((uintptr_t)c->buf + c->buf_offset) - (uintptr_t)buf;
+	buflen -= len;
+	size_t overfill = buflen >= nlen ? nlen : buflen;
+	memcpy(nbuf, buf + len, overfill);
+
+	/*
+	 * It might even happen that for small messages the entire payload is
+	 * received in a single read() call.
+	 */
+	if (overfill == nlen) {
+		on_message_completion(c);
+		return (ssize_t)(len + overfill); /* move the loop forward */
+	}
+
+	c->buf = nbuf;
+	c->buf_offset = overfill;
+	c->buf_len = nlen;
+
+	return 0;
+}
+
+/*
+ * cmsg_subscribe_handler -- handles the SUB client message
+ *
+ * Subscribes to the topic with a named queue.
+ */
+static ssize_t
+cmsg_subscribe_handler(struct client *c, const char *buf, size_t len)
+{
+	/*
+	 * Protocol defines subscribe as:
+	 * SUB <queue name>\n
+	 *
+	 * Queues are persistent and so must be named.
+	 */
+	char name[QUEUE_NAME_MAX];
+	if (sscanf(buf, "SUB %s", name) != 1)
+		return -1;
+
+	if (c->queue != NULL)
+		return -1;
+
+	struct queue *q = topic_find_create_queue(c->topic, name);
+	if (q == NULL)
+		return -1;
+
+	/* queues need to add pending writes the client's event loop */
+	if (queue_assign_write_event(q, c->ev_write) != 0)
+		return -1;
+
+	c->queue = q;
+
+	return (ssize_t)len;
+}
+
+/*
+ * cmsg_shutdown_handler -- handler of SHUTDOWN client message.
+ *
+ * Stops the broker.
+ */
+static ssize_t
+cmsg_shutdown_handler(struct client *c, const char *buf, size_t len)
+{
+	topic_stop(c->topic);
+
+	return -1;
+}
+
+/*
+ * cmsg_bye_handler -- handler of BYE client message.
+ *
+ * Disconnects from the broker.
+ */
+static ssize_t
+cmsg_bye_handler(struct client *c, const char *buf, size_t len)
+{
+	return -1;
+}
+
+/*
+ * Client message handlers take tokenized buffers and return how many bytes were
+ * consumed during processing. May return -1 to terminate the connection.
+ */
+typedef ssize_t (*msg_handler)(struct client *client,
+	const char *buf, size_t len);
+
+static msg_handler protocol_impl[MAX_CMSG] = {
+	cmsg_publish_handler,
+	cmsg_subscribe_handler,
+	cmsg_shutdown_handler,
+	cmsg_bye_handler
+};
+
+/*
+ * on_cmsg -- calls the appropriate message handler
+ */
+static ssize_t
+on_cmsg(struct client *c, const char *buf, size_t len)
+{
+	int i;
+	for (i = 0; i < MAX_CMSG; ++i) {
+		if (len >= strlen(cmsg_token[i]) &&
+		    strncmp(cmsg_token[i], buf, strlen(cmsg_token[i])) == 0)
+			break;
+	}
+	if (i == MAX_CMSG) {
+		fprintf(stderr, "unknown or malformed client message\n");
+		return -1;
+	}
+
+	return protocol_impl[i](c, buf, len);
+}
+
+/*
+ * on_payload_read -- handle reads into pending message
+ */
+static int
+on_payload_read(struct client *c, size_t read)
+{
+	TOID(struct message) m = message_get(c->pending);
+	size_t nlen = message_length(m);
+	if (c->buf_offset == nlen) /* if message completed */
+		on_message_completion(c);
+
+	return 0;
+}
+
+/*
+ * on_frame_read -- handle regular reads into cmsg buffer
+ */
+static int
+on_frame_read(struct client *c, size_t read)
+{
+	char *last; /* last byte of the message */
+	char *buf = c->buf;
+	size_t rlen = c->buf_offset; /* remaining data in the buffer */
+	size_t data_len; /* length of the incoming message */
+
+	/* all valid messages are terminated by MSG_END */
+	while ((last = memchr(buf, MSG_END, rlen)) != NULL) {
+		data_len = (size_t)(last - buf + 1);
+		rlen -= data_len;
+
+		ssize_t ret = on_cmsg(c, buf, data_len);
+		if (ret < 0)
+			return -1;
+		else if (ret == 0)
+			break;
+
+		buf += ret;
+	}
+
+	/* if there are leftovers in the buffer, move them to pos 0 */
+	if (rlen != 0)
+		memcpy(c->buf, buf, rlen);
+
+	c->buf_offset = rlen;
+
+	return 0;
+}
+
+/*
+ * on_read -- callback for read events
+ *
+ * Reads data into current buffer and calls the appropriate handler depending
+ * on the application's state.
+ */
+static void
+on_read(evutil_socket_t fd, short ev, void *arg)
+{
+	struct client *c = arg;
+	ssize_t len = -1;
+
+	size_t avail = c->buf_len - c->buf_offset;
+	if (avail == 0) {
+		printf("malformed data\n");
+		goto err;
+	}
+
+	len = read(fd, c->buf + c->buf_offset, avail);
+	if (len <= 0)
+		goto err;
+
+	c->buf_offset += (size_t)len;
+
+	int ret = c->pending == NULL ?
+		on_frame_read(c, (size_t)len) : on_payload_read(c, (size_t)len);
+	if (ret != 0)
+		goto err;
+
+	return;
+
+err:
+	if (len == 0) {
+		printf("client disconnect.\n");
+	} else if (len < 0) {
+		printf("client error: %s\n", strerror(errno));
+	}
+
+	client_delete(c);
+}
+
+/*
+ * on_write -- callback for write events
+ *
+ * Write callback happens in once scenario: there's a pending message on our
+ * current queue. This function takes the message currently at the head of the
+ * queue and attempts to send it to the client's socket.
+ */
+static void
+on_write(evutil_socket_t fd, short ev, void *arg)
+{
+	struct client *client = (struct client *)arg;
+	struct queue *q = client->queue;
+
+	TOID(struct message) msg = queue_peek(q); /* queue's head */
+
+	/* can't rely on being able to write() the entire message */
+	size_t len = message_length(msg) - client->write_offset;
+	ssize_t ret = write(fd, message_data(msg) + client->write_offset, len);
+	if (ret > 0) {
+		if (ret < len) {
+			client->write_offset += (size_t)ret;
+		} else {
+			/* if written the whole message, reset the offset ... */
+			client->write_offset = 0;
+			queue_pop(q); /* ... and pop msg from our queue */
+		}
+	}
+
+	/* if the queue still isn't empty, schedule the write again */
+	if (!queue_empty(q))
+		event_add(client->ev_write, NULL);
+}
+
+/*
+ * client_new -- creates a new client instance
+ */
+struct client *
+client_new(PMEMobjpool *pop, struct topic *topic,
+	int fd, struct event_base *evbase)
+{
+	struct client *c = malloc(sizeof(*c));
+	if (c == NULL)
+		return NULL;
+
+	c->fd = fd;
+
+	/* continuously (EV_PERSIST) wait for read (EV_READ) events */
+	c->ev_read = event_new(evbase, fd, EV_READ | EV_PERSIST,
+		on_read, c);
+	/* wait for write (EV_WRITE) events only when necessary */
+	c->ev_write = event_new(evbase, fd, EV_WRITE,
+		on_write, c);
+
+	c->pending = NULL;
+	c->write_offset = 0;
+
+	c->buf = c->cmsg;
+	c->buf_offset = 0;
+	c->buf_len = CLIENT_MSG_BUF;
+
+	c->queue = NULL;
+	c->topic = topic;
+	c->pop = pop;
+
+	event_add(c->ev_read, NULL);
+
+	return c;
+}
+
+/*
+ * client_delete -- deletes client instance and closes the socket
+ */
+void
+client_delete(struct client *c)
+{
+	if (c->queue != NULL)
+		queue_assign_write_event(c->queue, NULL);
+
+	if (c->pending != NULL)
+		message_pending_delete(c->pending);
+
+	event_del(c->ev_read);
+	event_del(c->ev_write);
+	event_free(c->ev_read);
+	event_free(c->ev_write);
+	close(c->fd);
+
+	free(c);
+}

--- a/src/examples/libpmemobj/ElephantMQ/client.h
+++ b/src/examples/libpmemobj/ElephantMQ/client.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * client.h - broker client interface
+ */
+
+#include <event2/event.h>
+#include <libpmemobj.h>
+#include "topic.h"
+
+struct client;
+
+struct client *client_new(PMEMobjpool *pop, struct topic *topic,
+	int fd, struct event_base *evbase);
+
+void client_delete(struct client *client);

--- a/src/examples/libpmemobj/ElephantMQ/message.c
+++ b/src/examples/libpmemobj/ElephantMQ/message.c
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * message.c - message implementation
+ */
+
+#include <libpmemobj.h>
+#include <stdlib.h>
+#include "message.h"
+
+struct message { /* persistent part of the message */
+	/*
+	 * Reference count used to decide whether or not the message has been
+	 * sent out from all subscribing queues.
+	 * Message after publishing has refc equal 0, and it is increased for
+	 * every queue to which this message is added. Once the message is
+	 * sent out and removed from the queue, the reference count is decreased
+	 * and the object is eventually freed.
+	 * Because of multithreaded nature of the broker, this variable needs to
+	 * be manipulated using atomic operations outside of a persistent
+	 * transaction. For this reason the refc variable is transient and there
+	 * is a recovery process that walks over all the queues and calculates
+	 * on how many queues this message is present.
+	 */
+	int refc;
+
+	size_t len; /* length of data buffer */
+	char data[]; /* payload */
+};
+
+struct message_pending { /* transient part of the message */
+	struct pobj_action act; /* publishable action */
+	TOID(struct message) msg; /* persistent message */
+};
+
+/*
+ * message_new -- creates a new transient message
+ */
+struct message_pending *
+message_new(PMEMobjpool *pop, size_t size)
+{
+	struct message_pending *p = malloc(sizeof(*p));
+	if (p == NULL)
+		goto err;
+
+	/* reserve a buffer large enough to fit the entire payload */
+	p->msg = POBJ_RESERVE_ALLOC(pop, struct message,
+		sizeof(struct message) + size, &p->act);
+	if (TOID_IS_NULL(p->msg))
+		goto err_reserve;
+
+	D_RW(p->msg)->len = size;
+	D_RW(p->msg)->refc = 0;
+
+	return p;
+
+err_reserve:
+	free(p);
+err:
+	return NULL;
+}
+
+/*
+ * message_get -- returns the persistent message from pending
+ */
+TOID(struct message)
+message_get(struct message_pending *pending)
+{
+	return pending->msg;
+}
+
+/*
+ * message_ref -- bumps refrence count of the message
+ */
+void
+message_ref(TOID(struct message) msg)
+{
+	__sync_fetch_and_add(&D_RW(msg)->refc, 1);
+}
+
+/*
+ * message_unref -- decreases refrence count of the message, frees it if 0
+ */
+void
+message_unref(TOID(struct message) msg)
+{
+	if (__sync_sub_and_fetch(&D_RW(msg)->refc, 1) == 0)
+		POBJ_FREE(&msg);
+}
+
+/*
+ * message_data -- returns the message's data buffer
+ */
+void *
+message_data(TOID(struct message) msg)
+{
+	return D_RW(msg)->data;
+}
+
+/*
+ * message_length -- returns the length of the message's data buffer
+ */
+size_t
+message_length(TOID(struct message) msg)
+{
+	return D_RO(msg)->len;
+}
+
+/*
+ * message_pending_publish -- atomically publishes an array of pending messages
+ *
+ * This is not a part of a transaction because we rely on reference counting
+ * to free any messages that might have been published but not added to any of
+ * the queues.
+ */
+void
+message_pending_publish(PMEMobjpool *pop,
+	struct message_pending **pending, size_t npending)
+{
+	struct pobj_action *actv =
+		malloc(sizeof(struct pobj_action) * npending);
+	if (actv == NULL)
+		return;
+
+	for (size_t i = 0; i < npending; ++i) {
+		struct message *m = D_RW(pending[i]->msg);
+		pmemobj_persist(pop, m, sizeof(*m) + m->len);
+
+		actv[i] = pending[i]->act;
+	}
+
+	pmemobj_publish(pop, actv, (int)npending);
+
+	free(actv);
+}
+
+/*
+ * message_pending_delete -- deletes the transient pending message
+ *
+ * The underlying persistent message is left untouched.
+ */
+void
+message_pending_delete(struct message_pending *pending)
+{
+	free(pending);
+}
+
+/*
+ * message_clear_refc_all -- zeroes the reference count of all the messages in
+ *	the pool
+ */
+void
+message_clear_refc_all(PMEMobjpool *pop)
+{
+	TOID(struct message) msg;
+	POBJ_FOREACH_TYPE(pop, msg) {
+		D_RW(msg)->refc = 0;
+	}
+}
+
+/*
+ * message_delete_unref -- deletes all messages in the pool that have reference
+ *	count equal 0
+ */
+void
+message_delete_unref(PMEMobjpool *pop)
+{
+	TOID(struct message) msg;
+	TOID(struct message) nmsg;
+
+	POBJ_FOREACH_SAFE_TYPE(pop, msg, nmsg) {
+		if (D_RO(msg)->refc == 0)
+			POBJ_FREE(&msg);
+	}
+}

--- a/src/examples/libpmemobj/ElephantMQ/message.h
+++ b/src/examples/libpmemobj/ElephantMQ/message.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * message.h - message interface
+ */
+
+#include <stddef.h>
+#include <libpmemobj.h>
+
+TOID_DECLARE(struct message, 100);
+
+struct message;
+struct message_pending;
+
+struct message_pending *message_new(PMEMobjpool *pop, size_t size);
+
+void message_ref(TOID(struct message) msg);
+void message_unref(TOID(struct message) msg);
+
+TOID(struct message) message_get(struct message_pending *pending);
+
+void *message_data(TOID(struct message) msg);
+size_t message_length(TOID(struct message) msg);
+
+void message_pending_publish(PMEMobjpool *pop,
+	struct message_pending **pending, size_t npending);
+
+void message_pending_delete(struct message_pending *pending);
+
+void message_clear_refc_all(PMEMobjpool *pop);
+void message_delete_unref(PMEMobjpool *pop);

--- a/src/examples/libpmemobj/ElephantMQ/protocol.h
+++ b/src/examples/libpmemobj/ElephantMQ/protocol.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * protocol.h - human readable message broker protocol
+ */
+
+/*
+ * All client messages must start with a valid message token and be terminated
+ * by a newline character ('\n'). The message parser is case-sensitive.
+ *
+ * Server responds with newline terminated string literals.
+ * If invalid message token is received, the connection is terminated.
+ */
+enum cmsg {
+	/*
+	 * PUBLISH client message
+	 * Syntax: PUB <data length>\n<data ...>
+	 *
+	 * Data length is limited by PMEMOBJ_MAX_ALLOC_SIZE.
+	 *
+	 * Operation publishes a new message to the default topic. The message
+	 * will be persistently stored and eventually sent out to all
+	 * subscribing connections.
+	 */
+	CMSG_PUBLISH,
+
+	/*
+	 * SUBSCRIBE client message
+	 * Syntax: SUB <queue name>\n
+	 *
+	 * Queue name must be at most 8 bytes.
+	 *
+	 * Operation creates or finds and existing queue with the given name and
+	 * attaches it to the client's connection. Can only be called once
+	 * during a single connection.
+	 * If there are pending messages on the queue, they are all sent
+	 * to the client.
+	 */
+	CMSG_SUBSCRIBE,
+
+	/*
+	 * SHUTDOWN client message
+	 * Syntax: SHUTDOWN\n
+	 *
+	 * Operation terminates the client connection and gracefully shutdowns
+	 * the server.
+	 */
+	CMSG_SHUTDOWN,
+
+	/*
+	 * BYE client message
+	 * Syntax: BYE\n
+	 *
+	 * Operation terminates the client connection.
+	 * No return value.
+	 */
+	CMSG_BYE,
+
+	MAX_CMSG,
+};
+
+static const char *cmsg_token[MAX_CMSG] = {
+	[CMSG_PUBLISH] = "PUB",
+	[CMSG_SUBSCRIBE] = "SUB",
+	[CMSG_SHUTDOWN] = "SHUTDOWN",
+	[CMSG_BYE] = "BYE",
+};
+
+#define MSG_END '\n'

--- a/src/examples/libpmemobj/ElephantMQ/queue.c
+++ b/src/examples/libpmemobj/ElephantMQ/queue.c
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * queue.c - message queue implementation
+ *
+ * A persistent collection of messages to be sent to a client.
+ */
+
+#include <libpmemobj.h>
+#include "queue.h"
+
+/* for simplicity sake, the number of messages in a queue is limited */
+#define QUEUE_MSG_MAX 1024
+#define QUEUE_MSG_MAX_MASK (1024 - 1)
+
+#define QUEUE_TOPIC_MAX 16
+
+struct queue {
+	PMEMmutex lock; /* lock protecting this entire structure */
+
+	char name[QUEUE_NAME_MAX]; /* queue identifier */
+	char topic[QUEUE_TOPIC_MAX]; /* topic to which this queue belongs */
+
+	/* the array of messages to be sent out */
+	size_t front;
+	size_t rear;
+	TOID(struct message) msg[QUEUE_MSG_MAX];
+
+	struct event *ev_write; /* write event of attached client, transient */
+};
+
+/*
+ * queue_foreach_in_topic -- calls a callback for each queue belonging to the
+ *	given topic.
+ *
+ * This is used in recovery process to reset the 'ev_write' variable and rebuild
+ * the topic's queue collection.
+ */
+void
+queue_foreach_in_topic(PMEMobjpool *pop, const char *topic,
+	void (*cb)(struct queue *, void *arg), void *arg)
+{
+	TOID(struct queue) q;
+	POBJ_FOREACH_TYPE(pop, q) {
+		if (strncmp(D_RO(q)->topic, topic, QUEUE_TOPIC_MAX) == 0)
+			cb(D_RW(q), arg);
+	}
+}
+
+struct queue_constructor_args {
+	const char *name;
+	const char *topic;
+};
+
+/*
+ * queue_constructor -- persistent constructor of a new queue
+ */
+static int
+queue_constructor(PMEMobjpool *pop, void *ptr, void *arg)
+{
+	struct queue *q = ptr;
+	struct queue_constructor_args *args = arg;
+
+	memset(q, 0, sizeof(*q));
+	strncpy(q->name, args->name, QUEUE_NAME_MAX);
+	strncpy(q->topic, args->topic, QUEUE_TOPIC_MAX);
+	q->ev_write = NULL;
+	q->front = 0;
+	q->rear = 0;
+
+	pmemobj_persist(pop, q, sizeof(*q));
+
+	return 0;
+}
+
+/*
+ * queue_new -- creates a new persistent queue
+ *
+ * The queues are not linked in any collection other than the implicit one
+ * provided by libpmemobj. This is to avoid having persistent topics.
+ * A real implementation might consider changing it so that a traversal of
+ * queues for recovery is not necessary.
+ */
+struct queue *
+queue_new(PMEMobjpool *pop, const char *name, const char *topic)
+{
+	struct queue_constructor_args args = {name, topic};
+
+	TOID(struct queue) q;
+	POBJ_NEW(pop, &q, struct queue, queue_constructor, &args);
+
+	return D_RW(q);
+}
+
+/*
+ * queue_empty -- returns whether the queue is empty
+ */
+int
+queue_empty(struct queue *queue)
+{
+	return queue->rear == queue->front;
+}
+
+/*
+ * queue_name -- returns the queue's name string
+ */
+const char *
+queue_name(struct queue *queue)
+{
+	return queue->name;
+}
+
+/*
+ * queue_push -- adds an array of messages to the queue, if successful and
+ *	the queue has an attached client, triggers a write event.
+ */
+int
+queue_push(struct queue *queue, PMEMobjpool *pop,
+	struct message_pending **pending, size_t npending)
+{
+	if (QUEUE_MSG_MAX - (queue->rear - queue->front) < npending)
+		return -1;
+
+	TX_BEGIN_PARAM(pop, TX_PARAM_MUTEX, &queue->lock) {
+		size_t pos = queue->rear & QUEUE_MSG_MAX_MASK;
+
+		/* add all of the necessary array fields upfront */
+		pmemobj_tx_add_range_direct(&queue->msg[pos],
+			sizeof(TOID(struct message)) * npending);
+
+		for (int i = 0; i < npending; ++i) {
+			TOID(struct message) msg = message_get(pending[i]);
+			/*
+			 * It doesn't matter when the message's ref count is
+			 * increased because the recovery step will reset
+			 * it regardless of the transaction outcome.
+			 */
+			message_ref(msg);
+
+			queue->msg[pos] = msg;
+		}
+		TX_SET_DIRECT(queue, rear, queue->rear + npending);
+	} TX_ONCOMMIT {
+		if (queue->ev_write != NULL)
+			event_add(queue->ev_write, NULL);
+	} TX_END
+
+	return 0;
+}
+
+/*
+ * queue_peek -- returns the current head of the queue
+ *
+ * Calling thread needs to ensure that nothing will touch the queue's front.
+ */
+TOID(struct message)
+queue_peek(struct queue *queue)
+{
+	if (queue_empty(queue))
+		return TOID_NULL(struct message);
+
+	return queue->msg[queue->front  & QUEUE_MSG_MAX_MASK];
+}
+
+/*
+ * queue_pop -- removes the head of the queue
+ */
+void
+queue_pop(struct queue *queue)
+{
+	PMEMobjpool *pop = pmemobj_pool_by_ptr(queue);
+	TOID(struct message) c = queue->msg[queue->front & QUEUE_MSG_MAX_MASK];
+
+	TX_BEGIN_PARAM(pop, TX_PARAM_MUTEX, &queue->lock) {
+		TX_SET_DIRECT(queue, front, queue->front + 1);
+	} TX_END
+
+	message_unref(c);
+}
+
+/*
+ * queue_assign_write_event -- assigns a client's write event to the queue
+ *
+ * There can be only one assigned event at a time.
+ */
+int
+queue_assign_write_event(struct queue *queue, struct event *e)
+{
+	int ret = -1;
+	PMEMobjpool *pop = pmemobj_pool_by_ptr(queue);
+	pmemobj_mutex_lock(pop, &queue->lock);
+
+	if (queue->ev_write != NULL && e != NULL)
+		goto out;
+
+	queue->ev_write = e;
+	if (!queue_empty(queue) && queue->ev_write != NULL)
+		event_add(queue->ev_write, NULL);
+
+	ret = 0;
+
+out:
+	pmemobj_mutex_unlock(pop, &queue->lock);
+
+	return ret;
+}
+
+/*
+ * queue_ref_messages -- bumps a reference count of every message present
+ *	in the queue
+ */
+static void
+queue_ref_messages(struct queue *queue)
+{
+	for (size_t i = queue->front; i < queue->rear; ++i)
+		message_ref(queue->msg[i]);
+}
+
+/*
+ * queue_recover_all -- recalculate all messages reference count
+ */
+void
+queue_recover_all(PMEMobjpool *pop)
+{
+	/* 1. zero reference count of all messages in the pool */
+	message_clear_refc_all(pop);
+
+	/* 2. for each message in each queue, bump reference count */
+	TOID(struct queue) q;
+	POBJ_FOREACH_TYPE(pop, q) {
+		queue_ref_messages(D_RW(q));
+	}
+
+	/* 3. if there are any messages with refc equal 0, free them */
+	message_delete_unref(pop);
+}

--- a/src/examples/libpmemobj/ElephantMQ/queue.h
+++ b/src/examples/libpmemobj/ElephantMQ/queue.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * queue.h - message queue interface
+ */
+
+#include <libpmemobj.h>
+#include <stddef.h>
+#include <event2/event.h>
+#include "message.h"
+
+#define QUEUE_NAME_MAX 8
+TOID_DECLARE(struct queue, 101);
+
+struct queue;
+
+void queue_foreach_in_topic(PMEMobjpool *pop, const char *topic,
+	void (*cb)(struct queue *, void *arg), void *arg);
+struct queue *queue_new(PMEMobjpool *pop, const char *name, const char *topic);
+
+const char *queue_name(struct queue *queue);
+
+int queue_empty(struct queue *queue);
+
+int queue_assign_write_event(struct queue *queue, struct event *e);
+
+int queue_push(struct queue *queue, PMEMobjpool *pop,
+	struct message_pending **pending, size_t npending);
+
+TOID(struct message) queue_peek(struct queue *queue);
+void queue_pop(struct queue *queue);
+
+void queue_recover_all(PMEMobjpool *pop);

--- a/src/examples/libpmemobj/ElephantMQ/topic.c
+++ b/src/examples/libpmemobj/ElephantMQ/topic.c
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * topic.c - topic implementation
+ *
+ * This is the transient collection of queues. Topic acts as intermediary
+ * between publisher and subscribers. It takes a pending message, turns it
+ * into a fully persisted one, and pushes it out to all interested queues.
+ */
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <assert.h>
+#include "topic.h"
+
+#define TOPIC_PENDING_MAX 1024
+#define TOPIC_QUEUE_MAX 1024
+
+struct topic {
+	PMEMobjpool *pop;
+
+	char name[TOPIC_NAME_MAX]; /* topic identifier */
+	int running;
+
+	/* lock/cond pair for pending messages array */
+	pthread_mutex_t lock;
+	pthread_cond_t cond;
+	pthread_t worker; /* thread for processing of message_pending */
+
+	/* messages waiting to be persisted and sent out to queues */
+	struct message_pending *pending[TOPIC_PENDING_MAX];
+	size_t npending;
+
+	/* collection of associated queues */
+	struct queue *queue[TOPIC_QUEUE_MAX];
+	size_t nqueue;
+
+	struct event_base *base; /* main broker event base, used for closing */
+};
+
+/*
+ * topic_worker -- processes pending messages
+ *
+ * This thread waits for messages, persists them and pushes them out to all
+ * registered queues in the topic.
+ */
+static void *
+topic_worker(void *arg)
+{
+	struct topic *t = arg;
+
+	t->running = 1;
+	struct message_pending *p[POBJ_MAX_ACTIONS];
+	size_t nmsg;
+
+	while (__atomic_load_n(&t->running, __ATOMIC_ACQUIRE)) {
+		pthread_mutex_lock(&t->lock);
+		while (t->npending == 0) {
+			pthread_cond_wait(&t->cond, &t->lock);
+
+			if (!__atomic_load_n(&t->running, __ATOMIC_ACQUIRE))
+				goto out;
+		}
+
+		/* copy over only up to POBJ_MAX_ACTIONS messages */
+		nmsg = t->npending > POBJ_MAX_ACTIONS ?
+			POBJ_MAX_ACTIONS : t->npending;
+		size_t toff = (size_t)(t->npending - nmsg);
+		for (size_t i = 0; i < nmsg; ++i)
+			p[i] = t->pending[toff + i];
+
+		t->npending -= nmsg;
+		pthread_mutex_unlock(&t->lock);
+
+		/* persist and publish all messages */
+		message_pending_publish(t->pop, p, nmsg);
+
+		/* push the message to all registered queues */
+		for (int i = 0; i < t->nqueue; ++i) {
+			queue_push(t->queue[i], t->pop, p, nmsg);
+		}
+
+		/* delete the transient part of the message */
+		for (int i = 0; i < nmsg; ++i)
+			message_pending_delete(p[i]);
+	}
+
+out:
+	return NULL;
+}
+
+/*
+ * topic_recover_queue -- recover the transient state of a queue
+ */
+static void
+topic_recover_queue(struct queue *q, void *arg)
+{
+	struct topic *topic = arg;
+
+	queue_assign_write_event(q, NULL);
+	topic->queue[topic->nqueue++] = q;
+}
+
+/*
+ * topic_recover_queues -- recover all queues belonging to this topic
+ */
+static void
+topic_recover_queues(struct topic *t)
+{
+	queue_foreach_in_topic(t->pop, t->name, topic_recover_queue, t);
+}
+
+/*
+ * topic_new -- creates a new topic instance
+ */
+struct topic *
+topic_new(PMEMobjpool *pop, const char *name, struct event_base *base)
+{
+	struct topic *t = malloc(sizeof(*t));
+	if (t == NULL)
+		return NULL;
+
+	t->pop = pop;
+
+	strncpy(t->name, name, TOPIC_NAME_MAX);
+	pthread_mutex_init(&t->lock, NULL);
+	pthread_cond_init(&t->cond, NULL);
+
+	t->npending = 0;
+	t->nqueue = 0;
+
+	t->running = 0;
+
+	t->base = base;
+
+	if (pthread_create(&t->worker, NULL, topic_worker, t) != 0)
+		assert(0);
+
+	topic_recover_queues(t);
+
+	return t;
+}
+
+/*
+ * topic_stop -- signals the worker to stop and breaks the main event loop
+ */
+void
+topic_stop(struct topic *topic)
+{
+	if (__sync_bool_compare_and_swap(&topic->running, 1, 0)) {
+		pthread_mutex_lock(&topic->lock);
+		pthread_cond_signal(&topic->cond);
+		pthread_mutex_unlock(&topic->lock);
+		event_base_loopbreak(topic->base);
+	}
+}
+
+/*
+ * topic_delete -- deletes the topic instance
+ */
+void
+topic_delete(struct topic *topic)
+{
+	pthread_join(topic->worker, NULL);
+	pthread_cond_destroy(&topic->cond);
+	pthread_mutex_destroy(&topic->lock);
+	free(topic);
+}
+
+/*
+ * topic_message_schedule -- appends the pending message to the array and
+ *	signals the worker thread
+ */
+int
+topic_message_schedule(struct topic *topic, struct message_pending *msg)
+{
+	pthread_mutex_lock(&topic->lock);
+
+	topic->pending[topic->npending++] = msg;
+
+	pthread_cond_signal(&topic->cond);
+	pthread_mutex_unlock(&topic->lock);
+
+	return 0;
+}
+
+/*
+ * topic_find_create_queue -- searches for a queue with the given name in the
+ *	topic, if none exists, creates it
+ */
+struct queue *
+topic_find_create_queue(struct topic *topic, const char *name)
+{
+	struct queue *q = NULL;
+	pthread_mutex_lock(&topic->lock);
+
+	int i;
+	for (i = 0; i < topic->nqueue; ++i) {
+		q = topic->queue[i];
+		if (strncmp(queue_name(q), name, QUEUE_NAME_MAX) == 0)
+			goto out;
+	}
+
+	q = queue_new(topic->pop, name, topic->name);
+	if (q != NULL)
+		topic->queue[topic->nqueue++] = q;
+
+out:
+	pthread_mutex_unlock(&topic->lock);
+	return q;
+}

--- a/src/examples/libpmemobj/ElephantMQ/topic.h
+++ b/src/examples/libpmemobj/ElephantMQ/topic.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * topic.h - topic interface
+ */
+
+#include <libpmemobj.h>
+#include <event2/event.h>
+#include "queue.h"
+
+#define TOPIC_NAME_MAX 16
+
+struct topic;
+
+struct topic *topic_new(PMEMobjpool *pop, const char *name,
+	struct event_base *base);
+struct queue *topic_find_create_queue(struct topic *t, const char *queue_name);
+int topic_message_schedule(struct topic *topic, struct message_pending *msg);
+void topic_delete(struct topic *topic);
+void topic_stop(struct topic *topic);


### PR DESCRIPTION
This patch contains a thorough demonstration of the proper usage of
the publish and reserve API. This shows how to use libpmemobj
transaction model in conjunction with transient object reservation
to achieve a fully scalable multithreaded system.

The example is a very simple message broker that ensures that a
published message will always reach its subscribers, even in the
presence of failures on either side.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2587)
<!-- Reviewable:end -->
