### PR TITLE
rpmem: fixed removing remote pool

### DIFF
--- a/src/librpmem/rpmem.c
+++ b/src/librpmem/rpmem.c
@@ -494,7 +494,7 @@ rpmem_create(const char *target, const char *pool_set_name,
 err_monitor:
 	rpmem_common_fip_fini(rpp);
 err_fip_init:
-	rpmem_obc_close(rpp->obc);
+	rpmem_obc_close(rpp->obc, RPMEM_CLOSE_FLAGS_REMOVE);
 err_obc_create:
 	rpmem_common_fini(rpp, 0);
 err_common_init:
@@ -568,7 +568,7 @@ rpmem_open(const char *target, const char *pool_set_name,
 err_monitor:
 	rpmem_common_fip_fini(rpp);
 err_fip_init:
-	rpmem_obc_close(rpp->obc);
+	rpmem_obc_close(rpp->obc, 0);
 err_obc_create:
 	rpmem_common_fini(rpp, 0);
 err_common_init:
@@ -589,7 +589,7 @@ rpmem_close(RPMEMpool *rpp)
 
 	rpmem_fip_close(rpp->fip);
 
-	int ret = rpmem_obc_close(rpp->obc);
+	int ret = rpmem_obc_close(rpp->obc, 0);
 	if (ret)
 		ERR("!close request failed");
 

--- a/src/librpmem/rpmem_obc.c
+++ b/src/librpmem/rpmem_obc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -665,7 +665,7 @@ err_notconnected:
  * closed using rpmem_obc_disconnect function.
  */
 int
-rpmem_obc_close(struct rpmem_obc *rpc)
+rpmem_obc_close(struct rpmem_obc *rpc, int flags)
 {
 	if (!rpmem_obc_is_connected(rpc)) {
 		errno = ENOTCONN;
@@ -674,6 +674,7 @@ rpmem_obc_close(struct rpmem_obc *rpc)
 
 	struct rpmem_msg_close msg;
 	rpmem_obc_set_msg_hdr(&msg.hdr, RPMEM_MSG_TYPE_CLOSE, sizeof(msg));
+	msg.flags = (uint32_t)flags;
 
 	RPMEM_LOG(INFO, "sending close request message");
 

--- a/src/librpmem/rpmem_obc.h
+++ b/src/librpmem/rpmem_obc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -60,5 +60,4 @@ int rpmem_obc_open(struct rpmem_obc *rpc,
 		struct rpmem_pool_attr *pool_attr);
 int rpmem_obc_set_attr(struct rpmem_obc *rpc,
 		const struct rpmem_pool_attr *pool_attr);
-int rpmem_obc_remove(struct rpmem_obc *rpc, const char *pool_desc);
-int rpmem_obc_close(struct rpmem_obc *rpc);
+int rpmem_obc_close(struct rpmem_obc *rpc, int flags);

--- a/src/rpmem_common/rpmem_common.h
+++ b/src/rpmem_common/rpmem_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -129,6 +129,7 @@ struct rpmem_resp_attr {
 #define RPMEM_MAX_NODE		(255 + 1)  /* see gethostname(2) + 1 for '\0' */
 #define RPMEM_MAX_SERVICE	(NI_MAXSERV + 1)  /* + 1 for '\0' */
 #define RPMEM_HDR_SIZE		4096
+#define RPMEM_CLOSE_FLAGS_REMOVE 0x1
 
 struct rpmem_target_info {
 	char user[RPMEM_MAX_USER];

--- a/src/rpmem_common/rpmem_proto.h
+++ b/src/rpmem_common/rpmem_proto.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -193,7 +193,7 @@ struct rpmem_msg_open_resp {
  */
 struct rpmem_msg_close {
 	struct rpmem_msg_hdr hdr;	/* message header */
-	/* no more fields */
+	uint32_t flags;				/* flags */
 } PACKED;
 
 /*

--- a/src/test/rpmem_obc/rpmem_obc_test_close.c
+++ b/src/test/rpmem_obc/rpmem_obc_test_close.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -84,7 +84,7 @@ client_close_errno(char *target, int ex_errno)
 
 	client_connect_wait(rpc, target);
 
-	ret = rpmem_obc_close(rpc);
+	ret = rpmem_obc_close(rpc, 0);
 	if (ex_errno) {
 		UT_ASSERTne(ret, 0);
 		UT_ASSERTeq(errno, ex_errno);
@@ -165,7 +165,7 @@ client_close_error(char *target)
 
 		client_connect_wait(rpc, target);
 
-		ret = rpmem_obc_close(rpc);
+		ret = rpmem_obc_close(rpc, 0);
 		UT_ASSERTne(ret, 0);
 		UT_ASSERTeq(errno, ex_errno);
 

--- a/src/test/rpmem_obc/rpmem_obc_test_misc.c
+++ b/src/test/rpmem_obc/rpmem_obc_test_misc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -79,7 +79,7 @@ client_enotconn(const struct test_case *tc, int argc, char *argv[])
 	UT_ASSERTne(ret, 0);
 	UT_ASSERTeq(errno, ENOTCONN);
 
-	ret = rpmem_obc_close(rpc);
+	ret = rpmem_obc_close(rpc, 0);
 	UT_ASSERTne(ret, 0);
 	UT_ASSERTeq(errno, ENOTCONN);
 
@@ -204,7 +204,7 @@ client_monitor(const struct test_case *tc, int argc, char *argv[])
 		ret = rpmem_obc_monitor(rpc, 1);
 		UT_ASSERTeq(ret, 1);
 
-		ret = rpmem_obc_close(rpc);
+		ret = rpmem_obc_close(rpc, 0);
 		UT_ASSERTeq(ret, 0);
 
 		ret = rpmem_obc_monitor(rpc, 0);

--- a/src/test/rpmem_obc_int/rpmem_obc_int.c
+++ b/src/test/rpmem_obc_int/rpmem_obc_int.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -143,7 +143,7 @@ client_create(const struct test_case *tc, int argc, char *argv[])
 	ret = rpmem_obc_monitor(rpc, 1);
 	UT_ASSERTeq(ret, 1);
 
-	ret = rpmem_obc_close(rpc);
+	ret = rpmem_obc_close(rpc, 0);
 	UT_ASSERTeq(ret, 0);
 
 	ret = rpmem_obc_disconnect(rpc);
@@ -201,7 +201,7 @@ client_open(const struct test_case *tc, int argc, char *argv[])
 	ret = rpmem_obc_monitor(rpc, 1);
 	UT_ASSERTeq(ret, 1);
 
-	ret = rpmem_obc_close(rpc);
+	ret = rpmem_obc_close(rpc, 0);
 	UT_ASSERTeq(ret, 0);
 
 	ret = rpmem_obc_disconnect(rpc);
@@ -249,7 +249,7 @@ client_set_attr(const struct test_case *tc, int argc, char *argv[])
 	ret = rpmem_obc_monitor(rpc, 1);
 	UT_ASSERTeq(ret, 1);
 
-	ret = rpmem_obc_close(rpc);
+	ret = rpmem_obc_close(rpc, 0);
 	UT_ASSERTeq(ret, 0);
 
 	ret = rpmem_obc_disconnect(rpc);
@@ -329,7 +329,7 @@ req_set_attr(struct rpmemd_obc *obc, void *arg,
  * req_close -- process close request
  */
 static int
-req_close(struct rpmemd_obc *obc, void *arg)
+req_close(struct rpmemd_obc *obc, void *arg, int flags)
 {
 	UT_ASSERTne(arg, NULL);
 

--- a/src/test/rpmem_proto/rpmem_proto.c
+++ b/src/test/rpmem_proto/rpmem_proto.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -130,6 +130,7 @@ main(int argc, char *argv[])
 
 	ASSERT_ALIGNED_BEGIN(struct rpmem_msg_close);
 	ASSERT_ALIGNED_FIELD(struct rpmem_msg_close, hdr);
+	ASSERT_ALIGNED_FIELD(struct rpmem_msg_close, flags);
 	ASSERT_ALIGNED_CHECK(struct rpmem_msg_close);
 
 	ASSERT_ALIGNED_BEGIN(struct rpmem_msg_close_resp);

--- a/src/test/rpmemd_obc/rpmemd_obc_test_common.c
+++ b/src/test/rpmemd_obc/rpmemd_obc_test_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -202,7 +202,7 @@ req_cb_open(struct rpmemd_obc *obc, void *arg,
  * struct req_cb_arg.
  */
 static int
-req_cb_close(struct rpmemd_obc *obc, void *arg)
+req_cb_close(struct rpmemd_obc *obc, void *arg, int flags)
 {
 	UT_ASSERTne(arg, NULL);
 

--- a/src/tools/rpmemd/rpmemd.c
+++ b/src/tools/rpmemd/rpmemd.c
@@ -603,7 +603,7 @@ err_pool_opened:
  * rpmemd_req_close -- handle close request
  */
 static int
-rpmemd_req_close(struct rpmemd_obc *obc, void *arg)
+rpmemd_req_close(struct rpmemd_obc *obc, void *arg, int flags)
 {
 	RPMEMD_ASSERT(arg != NULL);
 	RPMEMD_LOG(NOTICE, "close request");
@@ -629,7 +629,8 @@ rpmemd_req_close(struct rpmemd_obc *obc, void *arg)
 		rpmemd_fip_fini(rpmemd->fip);
 	}
 
-	int remove = rpmemd->created && status;
+	int remove = rpmemd->created &&
+			(status || (flags & RPMEM_CLOSE_FLAGS_REMOVE));
 	if (rpmemd_close_pool(rpmemd, remove))
 		RPMEMD_LOG(ERR, "closing pool failed");
 

--- a/src/tools/rpmemd/rpmemd_obc.c
+++ b/src/tools/rpmemd/rpmemd_obc.c
@@ -291,7 +291,8 @@ rpmemd_obc_process_close(struct rpmemd_obc *obc,
 	struct rpmemd_obc_requests *req_cb, void *arg,
 	struct rpmem_msg_hdr *hdrp)
 {
-	return req_cb->close(obc, arg);
+	struct rpmem_msg_close *msg = (struct rpmem_msg_close *)hdrp;
+	return req_cb->close(obc, arg, (int)msg->flags);
 }
 
 /*

--- a/src/tools/rpmemd/rpmemd_obc.h
+++ b/src/tools/rpmemd/rpmemd_obc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,7 +45,7 @@ struct rpmemd_obc_requests {
 			const struct rpmem_pool_attr *pool_attr);
 	int (*open)(struct rpmemd_obc *obc, void *arg,
 			const struct rpmem_req_attr *req);
-	int (*close)(struct rpmemd_obc *obc, void *arg);
+	int (*close)(struct rpmemd_obc *obc, void *arg, int flags);
 	int (*set_attr)(struct rpmemd_obc *obc, void *arg,
 			const struct rpmem_pool_attr *pool_attr);
 };


### PR DESCRIPTION
Ref: pmem/issues#721

This patch introduces flag to rpmem_obc_close which can specify whether to remove pool after closing.
It's needed because in some cases (when there is an error on client side), server thinks that connection
was established and doesn't call cleanup routine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2589)
<!-- Reviewable:end -->
