### PR TITLE
test: Portable line count support

### DIFF
--- a/src/test/pmem_deep_persist/TEST0
+++ b/src/test/pmem_deep_persist/TEST0
@@ -53,8 +53,8 @@ DEEP_PERSIST_SIZE=$(convert_to_bytes 2M)
 
 expect_normal_exit ./pmem_deep_persist$EXESUFFIX $DIR/testfile1 p $DEEP_PERSIST_SIZE 0
 
-$GREP -e "<libpmem>: <15>.*pmem\.c.*pmem_msync.*" pmem$UNITTEST_NUM.log | wc -l > ./grep$UNITTEST_NUM.log
-$GREP -e "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log | wc -l >> ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <15>.*pmem\.c.*pmem_msync.*" pmem$UNITTEST_NUM.log > ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log >> ./grep$UNITTEST_NUM.log
 
 check
 

--- a/src/test/pmem_deep_persist/TEST1
+++ b/src/test/pmem_deep_persist/TEST1
@@ -51,8 +51,8 @@ truncate -s 2M $DIR/testfile1
 
 expect_normal_exit ./pmem_deep_persist$EXESUFFIX $DIR/testfile1 p 0 0
 
-$GREP -e "<libpmem>: <15>.*pmem\.c.*pmem_msync.*" pmem$UNITTEST_NUM.log | wc -l > ./grep$UNITTEST_NUM.log
-$GREP -e "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log | wc -l >> ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <15>.*pmem\.c.*pmem_msync.*" pmem$UNITTEST_NUM.log > ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log >> ./grep$UNITTEST_NUM.log
 
 check
 

--- a/src/test/pmem_deep_persist/TEST2
+++ b/src/test/pmem_deep_persist/TEST2
@@ -50,8 +50,8 @@ create_poolset $DIR/testset AUTO:${DEVICE_DAX_PATH[0]}
 
 expect_normal_exit ./pmem_deep_persist$EXESUFFIX ${DEVICE_DAX_PATH[0]} p -1 0
 
-$GREP -e "<libpmem>: <15>.*pmem\.c.*pmem_msync.*" pmem$UNITTEST_NUM.log | wc -l > ./grep$UNITTEST_NUM.log
-$GREP -e "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log | wc -l >> ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <15>.*pmem\.c.*pmem_msync.*" pmem$UNITTEST_NUM.log > ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log >> ./grep$UNITTEST_NUM.log
 
 check
 

--- a/src/test/pmem_deep_persist/TEST3
+++ b/src/test/pmem_deep_persist/TEST3
@@ -50,8 +50,8 @@ create_poolset $DIR/testset AUTO:${DEVICE_DAX_PATH[0]}
 
 expect_normal_exit ./pmem_deep_persist$EXESUFFIX ${DEVICE_DAX_PATH[0]} m -1 0
 
-$GREP -e "<libpmem>: <1>.*pmem\.c.*pmem_msync.*" pmem$UNITTEST_NUM.log | wc -l > ./grep$UNITTEST_NUM.log
-$GREP -e "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log | wc -l >> ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <1>.*pmem\.c.*pmem_msync.*" pmem$UNITTEST_NUM.log > ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log >> ./grep$UNITTEST_NUM.log
 
 check
 

--- a/src/test/pmem_deep_persist/TEST4
+++ b/src/test/pmem_deep_persist/TEST4
@@ -53,8 +53,8 @@ DEEP_PERSIST_SIZE=$(convert_to_bytes 2M)
 
 expect_normal_exit ./pmem_deep_persist$EXESUFFIX $DIR/testfile1 m $DEEP_PERSIST_SIZE 0
 
-$GREP -e "<libpmem>: <15>.*pmem\.c.*pmem_msync.*" pmem$UNITTEST_NUM.log | wc -l > ./grep$UNITTEST_NUM.log
-$GREP -e "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log | wc -l >> ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <15>.*pmem\.c.*pmem_msync.*" pmem$UNITTEST_NUM.log > ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log >> ./grep$UNITTEST_NUM.log
 
 check
 

--- a/src/test/pmem_deep_persist/TEST5
+++ b/src/test/pmem_deep_persist/TEST5
@@ -53,8 +53,8 @@ create_poolset $DIR/testset1 16M:$DIR/testfile1 16M:$DIR/testfile2 r\
 DEEP_PERSIST_SIZE=$(convert_to_bytes 2M)
 expect_normal_exit ./pmem_deep_persist$EXESUFFIX $DIR/testset1 o $DEEP_PERSIST_SIZE 1024
 
-$GREP -e "<libpmem>: <3>.*part_deep_persist.*" pmem$UNITTEST_NUM.log | wc -l > ./grep$UNITTEST_NUM.log
-$GREP -e "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log | wc -l >> ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <3>.*part_deep_persist.*" pmem$UNITTEST_NUM.log > ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log >> ./grep$UNITTEST_NUM.log
 
 check
 

--- a/src/test/pmem_deep_persist/TEST6
+++ b/src/test/pmem_deep_persist/TEST6
@@ -54,8 +54,8 @@ DEEP_PERSIST_SIZE=$(convert_to_bytes 16M)
 OFFSET=$(convert_to_bytes 8M)
 expect_normal_exit ./pmem_deep_persist$EXESUFFIX $DIR/testset1 o $DEEP_PERSIST_SIZE $OFFSET
 
-$GREP -e "<libpmem>: <3>.*part_deep_persist.*" pmem$UNITTEST_NUM.log | wc -l > ./grep$UNITTEST_NUM.log
-$GREP -e "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log | wc -l >> ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <3>.*part_deep_persist.*" pmem$UNITTEST_NUM.log > ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log >> ./grep$UNITTEST_NUM.log
 
 check
 

--- a/src/test/pmem_deep_persist/TEST7
+++ b/src/test/pmem_deep_persist/TEST7
@@ -53,8 +53,8 @@ DEEP_PERSIST_SIZE=$(convert_to_bytes 20M)
 OFFSET=$(convert_to_bytes 2M)
 expect_normal_exit ./pmem_deep_persist$EXESUFFIX $DIR/testset1 o $DEEP_PERSIST_SIZE $OFFSET
 
-$GREP -e "<libpmem>: <3>.*part_deep_persist.*" pmem$UNITTEST_NUM.log | wc -l > ./grep$UNITTEST_NUM.log
-$GREP -e "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log | wc -l >> ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <3>.*part_deep_persist.*" pmem$UNITTEST_NUM.log > ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log >> ./grep$UNITTEST_NUM.log
 
 check
 

--- a/src/test/pmem_deep_persist/TEST8
+++ b/src/test/pmem_deep_persist/TEST8
@@ -57,8 +57,8 @@ DEEP_PERSIST_SIZE=$(convert_to_bytes 20M)
 OFFSET=0
 expect_normal_exit ./pmem_deep_persist$EXESUFFIX $DIR/testset1 o $DEEP_PERSIST_SIZE $OFFSET
 
-$GREP -e "<libpmem>: <3>.*part_deep_persist.*" pmem$UNITTEST_NUM.log | wc -l > ./grep$UNITTEST_NUM.log
-$GREP -e "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log | wc -l >> ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <3>.*part_deep_persist.*" pmem$UNITTEST_NUM.log > ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log >> ./grep$UNITTEST_NUM.log
 
 check
 

--- a/src/test/pmem_deep_persist/TEST9
+++ b/src/test/pmem_deep_persist/TEST9
@@ -57,8 +57,8 @@ DEEP_PERSIST_SIZE=$(get_devdax_size 0)
 OFFSET=$(convert_to_bytes 20M)
 expect_normal_exit ./pmem_deep_persist$EXESUFFIX $DIR/testset1 o $DEEP_PERSIST_SIZE $OFFSET
 
-$GREP -e "<libpmem>: <3>.*part_deep_persist.*" pmem$UNITTEST_NUM.log | wc -l > ./grep$UNITTEST_NUM.log
-$GREP -e "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log | wc -l >> ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <3>.*part_deep_persist.*" pmem$UNITTEST_NUM.log > ./grep$UNITTEST_NUM.log
+count_lines "<libpmem>: <3>.*deep_flush_write.*" pmem$UNITTEST_NUM.log >> ./grep$UNITTEST_NUM.log
 
 check
 

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -2860,3 +2860,13 @@ minimum() {
 	done
 	echo $min
 }
+
+#
+# count_lines - count number of lines that match pattern $1 in file $2
+#
+function count_lines() {
+	# grep returns 1 on no match
+	disable_exit_on_error
+	$GREP -ce "$1" $2
+	restore_exit_on_error
+}


### PR DESCRIPTION
Add count_lines function in unittest.sh. Use for
pmem_deep_persist tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2592)
<!-- Reviewable:end -->
