### PR TITLE
obj: remove one malloc() from add range path

### DIFF
--- a/src/libpmemobj/ravl.h
+++ b/src/libpmemobj/ravl.h
@@ -37,7 +37,7 @@
 #ifndef LIBPMEMOBJ_RAVL_H
 #define LIBPMEMOBJ_RAVL_H 1
 
-#include <stdint.h>
+#include <stddef.h>
 
 struct ravl;
 struct ravl_node;
@@ -54,13 +54,17 @@ enum ravl_predicate {
 
 typedef int ravl_compare(const void *lhs, const void *rhs);
 typedef void ravl_cb(void *data, void *arg);
+typedef void ravl_constr(void *data, size_t data_size, void *arg);
 
 struct ravl *ravl_new(ravl_compare *compare);
+struct ravl *ravl_new_sized(ravl_compare *compare, size_t data_size);
 void ravl_delete(struct ravl *ravl);
 void ravl_delete_cb(struct ravl *ravl, ravl_cb cb, void *arg);
 int ravl_empty(struct ravl *ravl);
 void ravl_clear(struct ravl *ravl);
 int ravl_insert(struct ravl *ravl, const void *data);
+int ravl_emplace(struct ravl *ravl, ravl_constr constr, void *arg);
+int ravl_emplace_copy(struct ravl *ravl, const void *data);
 
 struct ravl_node *ravl_find(struct ravl *ravl, const void *data,
 	enum ravl_predicate predicate_flags);

--- a/src/test/obj_ravl/TEST0
+++ b/src/test/obj_ravl/TEST0
@@ -34,7 +34,7 @@
 #
 # src/test/obj_ravl/TEST0 -- unit test for obj_ravl interface
 #
-export UNITTEST_NAME=obj_ctree/TEST0
+export UNITTEST_NAME=obj_ravl/TEST0
 export UNITTEST_NUM=0
 
 # standard unit test setup

--- a/src/test/obj_ravl/obj_ravl.c
+++ b/src/test/obj_ravl/obj_ravl.c
@@ -185,6 +185,50 @@ test_stress(void)
 	ravl_delete(r);
 }
 
+struct foo {
+	int a;
+	int b;
+	int c;
+};
+
+static int
+cmpfoo(const void *lhs, const void *rhs)
+{
+	const struct foo *l = lhs;
+	const struct foo *r = rhs;
+
+	return (int)((l->a + l->b + l->c) - (r->a + r->b + r->c));
+}
+
+static void
+test_emplace(void)
+{
+	struct ravl *r = ravl_new_sized(cmpfoo, sizeof(struct foo));
+
+	struct foo a = {1, 2, 3};
+	struct foo b = {2, 3, 4};
+	struct foo z = {0, 0, 0};
+
+	ravl_emplace_copy(r, &a);
+	ravl_emplace_copy(r, &b);
+
+	struct ravl_node *n = ravl_find(r, &z, RAVL_PREDICATE_GREATER);
+	struct foo *fn = ravl_data(n);
+	UT_ASSERTeq(fn->a, a.a);
+	UT_ASSERTeq(fn->b, a.b);
+	UT_ASSERTeq(fn->c, a.c);
+	ravl_remove(r, n);
+
+	n = ravl_find(r, &z, RAVL_PREDICATE_GREATER);
+	fn = ravl_data(n);
+	UT_ASSERTeq(fn->a, b.a);
+	UT_ASSERTeq(fn->b, b.b);
+	UT_ASSERTeq(fn->c, b.c);
+	ravl_remove(r, n);
+
+	ravl_delete(r);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -193,6 +237,7 @@ main(int argc, char *argv[])
 	test_predicate();
 	test_misc();
 	test_stress();
+	test_emplace();
 
 	DONE(NULL);
 }


### PR DESCRIPTION
This patch fixes a performance regression introduced in the RAVL patch
by allowing data buffers larger than 8 bytes in ravl_node, which
faciliates storing large data buffers directly in nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2597)
<!-- Reviewable:end -->
