### PR TITLE
vmem: (win) call jemalloc ctor/dtor from DllMain

### DIFF
--- a/src/jemalloc/src/jemalloc.c
+++ b/src/jemalloc/src/jemalloc.c
@@ -3122,7 +3122,7 @@ je_malloc_usable_size(JEMALLOC_USABLE_SIZE_CONST void *ptr)
  * a library constructor that runs before jemalloc's runs.
  */
 JEMALLOC_ATTR(constructor(102))
-static void
+void
 jemalloc_constructor(void)
 {
 
@@ -3130,9 +3130,11 @@ jemalloc_constructor(void)
 }
 
 JEMALLOC_ATTR(destructor(101))
-static void
+void
 jemalloc_destructor(void)
 {
+	if (base_pool_initialized == false)
+		return;
 
 	tcache_thread_cleanup(tcache_tsd_get());
 	arenas_cleanup(arenas_tsd_get());

--- a/src/libvmem/libvmem_main.c
+++ b/src/libvmem/libvmem_main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017, Intel Corporation
+ * Copyright 2015-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,11 +41,16 @@
 void vmem_init(void);
 void vmem_fini(void);
 
+void jemalloc_constructor(void);
+void jemalloc_destructor(void);
+
+
 int APIENTRY
 DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 {
 	switch (dwReason) {
 	case DLL_PROCESS_ATTACH:
+		jemalloc_constructor();
 		vmem_init();
 		break;
 
@@ -55,6 +60,7 @@ DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 
 	case DLL_PROCESS_DETACH:
 		vmem_fini();
+		jemalloc_destructor();
 		break;
 	}
 	return TRUE;

--- a/src/libvmem/vmem.c
+++ b/src/libvmem/vmem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -145,6 +145,10 @@ vmem_fini(void)
 	LOG(3, NULL);
 	util_mutex_destroy(&Pool_lock);
 	util_mutex_destroy(&Vmem_init_lock);
+
+	/* set up jemalloc messages back to stderr */
+	je_vmem_malloc_message = NULL;
+
 	common_fini();
 }
 


### PR DESCRIPTION
... to fix memory leaks in libvmem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2601)
<!-- Reviewable:end -->
