### PR TITLE
common: fix Coverity issue

### DIFF
--- a/src/common/set.c
+++ b/src/common/set.c
@@ -3341,6 +3341,7 @@ util_replica_set_attr(struct pool_replica *rep,
 		const struct rpmem_pool_attr *rattr)
 {
 	LOG(3, "rep %p, rattr %p", rep, rattr);
+	ASSERT(rattr != NULL || rep->nhdrs == 0);
 
 	if (rattr != NULL && rep->nhdrs == 0) {
 		ERR(


### PR DESCRIPTION
Coverity warned that dereferencing a null pointer could happen.
CID 187264

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2609)
<!-- Reviewable:end -->
