### PR TITLE
obj: fix large vector reserves

### DIFF
--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -769,6 +769,7 @@ tx_fulfill_reservations(struct tx *tx)
 	int i;
 	for (i = 0; i < lane->actvcnt; ++i) {
 		uint64_t *entry = pvector_push_back(lane->undo.ctx[UNDO_ALLOC]);
+		ASSERTne(entry, NULL);
 
 		/* flush if switched to a new vector array */
 		if ((uintptr_t)fentry + sizesum != (uintptr_t)entry) {
@@ -1091,14 +1092,13 @@ tx_alloc_common(struct tx *tx, size_t size, type_num_t type_num,
 		tx_fulfill_reservations(tx);
 
 	int rs = lane->actvcnt;
+	ASSERT((unsigned)rs < MAX_TX_ALLOC_RESERVATIONS);
 
 	if (pvector_reserve(ctx, pvector_size(ctx) + (unsigned)rs + 1) != 0)
 		goto err_oom;
 
-	uint64_t flags = args.flags;
-
 	if (palloc_reserve(&pop->heap, size, constructor, &args, type_num, 0,
-		CLASS_ID_FROM_FLAG(flags), &lane->alloc_actv[rs]) != 0)
+		CLASS_ID_FROM_FLAG(args.flags), &lane->alloc_actv[rs]) != 0)
 		goto err_oom;
 
 	lane->actvcnt++;
@@ -1109,7 +1109,7 @@ tx_alloc_common(struct tx *tx, size_t size, type_num_t type_num,
 	retoid.pool_uuid_lo = pop->uuid_lo;
 	size = palloc_usable_size(&pop->heap, retoid.off);
 
-	const struct tx_range_def r = {retoid.off, size, flags};
+	const struct tx_range_def r = {retoid.off, size, args.flags};
 	if (tx_lane_ranges_insert_def(lane, &r) != 0)
 		goto err_oom;
 
@@ -1442,6 +1442,8 @@ tx_post_commit_cleanup(PMEMobjpool *pop,
 	/* cleanup cache */
 
 	ASSERTeq(pvector_size(runtime->undo.ctx[UNDO_ALLOC]), 0);
+	ASSERT(pvector_capacity(runtime->undo.ctx[UNDO_ALLOC]) == 8 ||
+		pvector_capacity(runtime->undo.ctx[UNDO_ALLOC]) == 0);
 	ASSERTeq(pvector_size(runtime->undo.ctx[UNDO_SET]), 0);
 	ASSERTeq(pvector_size(runtime->undo.ctx[UNDO_FREE]), 0);
 	ASSERT(pvector_size(runtime->undo.ctx[UNDO_FREE]) == 0 ||

--- a/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
+++ b/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017, Intel Corporation
+ * Copyright 2015-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -199,6 +199,8 @@ tx2_worker(void *arg)
 					pmemobj_tx_add_range(oids[i], j, STEP);
 				}
 			}
+		} TX_ONABORT {
+			UT_ASSERT(0);
 		} TX_END
 
 		TX_BEGIN(a->pop) {

--- a/src/test/obj_pvector/obj_pvector.c
+++ b/src/test/obj_pvector/obj_pvector.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017, Intel Corporation
+ * Copyright 2015-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -70,6 +70,9 @@ main(int argc, char *argv[])
 	struct test_root *r = (struct test_root *)pmemobj_direct(root);
 	UT_ASSERTne(r, NULL);
 
+	size_t embedded_size =
+		sizeof(r->vec.embedded) / sizeof(r->vec.embedded[0]);
+
 	struct pvector_context *ctx = pvector_new(pop, &r->vec);
 
 	uint64_t *val = pvector_push_back(ctx);
@@ -97,7 +100,7 @@ main(int argc, char *argv[])
 		n++;
 	}
 
-	uint64_t removed = pvector_pop_back(ctx, NULL);
+	uint64_t removed = pvector_pop_back(ctx, vec_zero_entry);
 	UT_ASSERTeq(removed, 15);
 
 	n = 0;
@@ -117,7 +120,20 @@ main(int argc, char *argv[])
 	pvector_delete(ctx);
 
 	ctx = pvector_new(pop, &r->vec);
-	for (int i = 0; i < PVECTOR_INSERT_VALUES; ++i) {
+	pvector_reserve(ctx, 128);
+	UT_ASSERT(pvector_capacity(ctx) >= 128);
+	UT_ASSERTeq(pvector_size(ctx), 0);
+	val = pvector_push_back(ctx);
+	*val = 5;
+	UT_ASSERTeq(pvector_size(ctx), 1);
+	pvector_pop_back(ctx, vec_zero_entry);
+	UT_ASSERTeq(pvector_size(ctx), 0);
+	UT_ASSERTeq(pvector_capacity(ctx), embedded_size);
+
+	pvector_delete(ctx);
+
+	ctx = pvector_new(pop, &r->vec);
+	for (uint64_t i = 0; i < PVECTOR_INSERT_VALUES; ++i) {
 		val = pvector_push_back(ctx);
 		UT_ASSERTne(val, NULL);
 		*val = i;
@@ -137,6 +153,7 @@ main(int argc, char *argv[])
 	}
 
 	UT_ASSERTeq(pvector_first(ctx), 0);
+	UT_ASSERTeq(pvector_capacity(ctx), embedded_size);
 
 	pvector_delete(ctx);
 


### PR DESCRIPTION
When pvector_reserve was called with new capacity exceeding that
of a single array, it left a hole in the vector's array that later
interfered with capacity calculations, leading to invalid
dereferences.

pmem/issues#788

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2613)
<!-- Reviewable:end -->
