### PR TITLE
test: fixes for checking PMEM_FS_DIR and NON_PMEM_FS_DIR

### DIFF
--- a/src/test/RUNTESTLIB.PS1
+++ b/src/test/RUNTESTLIB.PS1
@@ -92,14 +92,6 @@ class Config {
             # "any" as either pmem or non-pmem with "-f"
             #
             $this.forcefs = $true
-
-            $fstype.Split() | % {
-                if ($fs.Split().Contains($_)) {
-                    $this.fstype += $_ + " ";
-                } else {
-                    Write-Host "SKIP: $_ directory not defined"
-                }
-            }
             $this.fstype = $fstype
         } else {
             $this.fstype = $fs
@@ -318,6 +310,13 @@ function runtest {
     } # for runscripts
 }
 
+function isDir {
+    if (-Not $args[0]) {
+        return $false
+    }
+    return Test-Path $args[0] -PathType Container
+}
+
 if (-Not (Test-Path "./testconfig.ps1")) {
     throw $MyInvocation.MyCommand.Name + " stopping because no testconfig.ps1 is found.
 To create one:
@@ -326,7 +325,26 @@ and edit testconfig.ps1 to describe the local machine configuration.
 "
 }
 
+# need to manually clear variables, if definition of a variable was removed
+# from testconfig RUNTEST would use previously exported value
+$Env:PMEM_FS_DIR=""
+$Env:NON_PMEM_FS_DIR=""
+
 . .\testconfig.ps1
+
+if ($Env:PMEM_FS_DIR -And (-Not (isDir($Env:PMEM_FS_DIR)))) {
+	throw "error: PMEM_FS_DIR=$Env:PMEM_FS_DIR doesn't exist"
+}
+
+if ($Env:NON_PMEM_FS_DIR -And (-Not (isDir($Env:NON_PMEM_FS_DIR)))) {
+	throw "error: NON_PMEM_FS_DIR=$Env:NON_PMEM_FS_DIR doesn't exist"
+}
+
+$PMEMDETECT="..\x64\Debug\pmemdetect.exe"
+
+if (-Not (Test-Path $PMEMDETECT)) {
+    $PMEMDETECT="..\x64\Release\pmemdetect.exe"
+}
 
 if (isDir($Env:PMEM_FS_DIR)) {
     if ($Env:PMEM_FS_DIR_FORCE_PMEM -eq "1") {

--- a/src/test/RUNTESTS
+++ b/src/test/RUNTESTS
@@ -348,21 +348,19 @@ runtest() {
 		for fs in $fss
 		do
 			# don't bother trying when fs-type isn't available...
-			[ "$fs" = pmem -a -z "$PMEM_FS_DIR" ] && {
+			if [ "$fs" == "pmem" ] && [ -z "$PMEM_FS_DIR" ] && [ "$fstype" == "all" ]; then
 				pmem_skip=1
 				continue
-			}
+			fi
 
-			[ "$fs" = non-pmem -a -z "$NON_PMEM_FS_DIR" ] && {
+			if [ "$fs" == "non-pmem" ] && [ -z "$NON_PMEM_FS_DIR" ] && [ "$fstype" == "all" ]; then
 				non_pmem_skip=1
 				continue
-			}
+			fi
 
-			[ "$fs" = any -a -z "$PMEM_FS_DIR" -a -z "$NON_PMEM_FS_DIR" ] && {
+			if [ "$fs" == "any" ] && [ -z "$PMEM_FS_DIR" ] && [ -z "$NON_PMEM_FS_DIR" ] && [ "$fstype" == "all" ]; then
 				continue
-			}
-
-
+			fi
 			# for each build-type being tested...
 			for build in $builds
 			do
@@ -449,6 +447,16 @@ if [ "$PMEM_FS_DIR_FORCE_PMEM" = "1" ]; then
 		echo "If you want to ignore this error, please set PMEM_FS_DIR_FORCE_PMEM=2."
 		exit 1
 	fi
+fi
+
+if [ -v PMEM_FS_DIR ] && [ ! -d "$PMEM_FS_DIR" ]; then
+	echo "error: PMEM_FS_DIR=$PMEM_FS_DIR doesn't exist"
+	exit 1
+fi
+
+if [ -v NON_PMEM_FS_DIR ] && [ ! -d "$NON_PMEM_FS_DIR" ]; then
+	echo "error: NON_PMEM_FS_DIR=$NON_PMEM_FS_DIR doesn't exist"
+	exit 1
 fi
 
 if [ -d "$PMEM_FS_DIR" ]; then
@@ -741,8 +749,10 @@ else
 		runtest $testdir
 	done
 fi
+
 [ "$pmem_skip" ] && echo "SKIPPED fs-type \"pmem\" runs: testconfig.sh doesn't set PMEM_FS_DIR"
 [ "$non_pmem_skip" ] && echo "SKIPPED fs-type \"non-pmem\" runs: testconfig.sh doesn't set NON_PMEM_FS_DIR"
+
 if [ "$fail_count" != "0" ]; then
 	echo "$(tput setaf 1)$fail_count tests failed:$(tput sgr0) $fail_list"
 	exit $keep_going_exit_code

--- a/src/test/unittest/unittest.ps1
+++ b/src/test/unittest/unittest.ps1
@@ -60,11 +60,7 @@ function isDir {
     if (-Not $args[0]) {
         return $false
     }
-    if ((Get-Item $args[0] -ErrorAction SilentlyContinue) -is [System.IO.DirectoryInfo]) {
-        return $true
-    } Else {
-        return $false
-    }
+    return Test-Path $args[0] -PathType Container
 }
 
 # force dir w/wildcard to fail if no match
@@ -1082,7 +1078,6 @@ $PMEMPOOL="$Env:EXE_DIR\pmempool$Env:EXESUFFIX"
 $PMEMSPOIL="$Env:EXE_DIR\pmemspoil$Env:EXESUFFIX"
 $PMEMWRITE="$Env:EXE_DIR\pmemwrite$Env:EXESUFFIX"
 $PMEMALLOC="$Env:EXE_DIR\pmemalloc$Env:EXESUFFIX"
-$PMEMDETECT="$Env:EXE_DIR\pmemdetect$Env:EXESUFFIX"
 $PMEMOBJCLI="$Env:EXE_DIR\pmemobjcli$Env:EXESUFFIX"
 $DDMAP="$Env:EXE_DIR\ddmap$Env:EXESUFFIX"
 $BTTCREATE="$Env:EXE_DIR\bttcreate$Env:EXESUFFIX"
@@ -1146,13 +1141,21 @@ if ($DIR) {
     # choose based on FS env variable
     switch ($Env:FS) {
         'pmem' {
+            # if a variable is set - it must point to a valid directory
+            if (-Not $Env:PMEM_FS_DIR) {
+                fatal "${Env:UNITTEST_NAME}: PMEM_FS_DIR not set"
+            }
             sv -Name DIR ($Env:PMEM_FS_DIR + $tail)
             if ($Env:PMEM_FS_DIR_FORCE_PMEM -eq "1") {
                 $Env:PMEM_IS_PMEM_FORCE = "1"
             }
         }
         'non-pmem' {
-             sv -Name DIR ($Env:NON_PMEM_FS_DIR + $tail)
+            # if a variable is set - it must point to a valid directory
+            if (-Not $Env:NON_PMEM_FS_DIR) {
+                fatal "${Env:UNITTEST_NAME}: NON_PMEM_FS_DIR not set"
+            }
+            sv -Name DIR ($Env:NON_PMEM_FS_DIR + $tail)
         }
         'any' {
              if ($Env:PMEM_FS_DIR) {

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -193,12 +193,20 @@ else
 	case "$FS"
 	in
 	pmem)
+		# if a variable is set - it must point to a valid directory
+		if [ "$PMEM_FS_DIR" == "" ]; then
+			fatal "$UNITTEST_NAME: PMEM_FS_DIR is not set"
+		fi
 		DIR=$PMEM_FS_DIR/$DIRSUFFIX/$curtestdir$UNITTEST_NUM$SUFFIX
 		if [ "$PMEM_FS_DIR_FORCE_PMEM" = "1" ] || [ "$PMEM_FS_DIR_FORCE_PMEM" = "2" ]; then
 			export PMEM_IS_PMEM_FORCE=1
 		fi
 		;;
 	non-pmem)
+		# if a variable is set - it must point to a valid directory
+		if [ "$NON_PMEM_FS_DIR" == "" ]; then
+			fatal "$UNITTEST_NAME: NON_PMEM_FS_DIR is not set"
+		fi
 		DIR=$NON_PMEM_FS_DIR/$DIRSUFFIX/$curtestdir$UNITTEST_NUM$SUFFIX
 		;;
 	any)


### PR DESCRIPTION
If PMEM_FS_DIR (or NON_PMEM_FS_DIR) is set it must point to
valid directory. If RUNTEST is run with -f pmem/non-pmem
PMEM_FS_DIR/NON_PMEM_FS_DIR must be specified and valid.

Ref: pmem/issues#751
Ref: pmem/issues#790
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2620)
<!-- Reviewable:end -->
