### PR TITLE
obj: add lazily initialized volatile variables

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -84,7 +84,7 @@ MANPAGES_3_DUMMY = pmem_drain.3 pmem_has_hw_drain.3 pmem_has_auto_flush.3 \
 		   vmem_create_in_region.3 vmem_delete.3 vmem_check.3 vmem_stats_print.3 \
 		   vmem_calloc.3 vmem_realloc.3 vmem_free.3 vmem_aligned_alloc.3 vmem_strdup.3 vmem_wcsdup.3 vmem_malloc_usable_size.3 \
 		   vmem_check_version.3 vmem_errormsg.3 vmem_set_funcs.3 \
-		   oid_equals.3 pmemobj_direct.3 pmemobj_oid.3 pmemobj_type_num.3 pmemobj_pool_by_oid.3 pmemobj_pool_by_ptr.3 \
+		   oid_equals.3 pmemobj_direct.3 pmemobj_oid.3 pmemobj_type_num.3 pmemobj_pool_by_oid.3 pmemobj_pool_by_ptr.3 pmemobj_volatile.3\
 		   pmemobj_zalloc.3 pmemobj_xalloc.3 pmemobj_free.3 pmemobj_realloc.3 pmemobj_zrealloc.3 pmemobj_strdup.3 pmemobj_wcsdup.3 pmemobj_alloc_usable_size.3 \
 		   pobj_new.3 pobj_alloc.3 pobj_znew.3 pobj_zalloc.3 pobj_realloc.3 pobj_zrealloc.3 pobj_free.3 \
 		   pobj_layout_toid.3 pobj_layout_root.3 pobj_layout_name.3 pobj_layout_end.3 pobj_layout_types_num.3 \

--- a/doc/generated/pmemobj_volatile.3
+++ b/doc/generated/pmemobj_volatile.3
@@ -1,0 +1,1 @@
+.so oid_is_null.3

--- a/doc/libpmemobj/oid_is_null.3.md
+++ b/doc/libpmemobj/oid_is_null.3.md
@@ -66,7 +66,7 @@ PMEMoid pmemobj_oid(const void *addr);
 uint64_t pmemobj_type_num(PMEMoid oid);
 PMEMobjpool *pmemobj_pool_by_oid(PMEMoid oid);
 PMEMobjpool *pmemobj_pool_by_ptr(const void *addr);
-void *pmemobj_direct_volatile(PMEMobjpool *pop, struct pmemvlt *vlt,
+void *pmemobj_volatile(PMEMobjpool *pop, struct pmemvlt *vlt, void *ptr,
 	int (*constr)(void *ptr, void *arg), void *arg);
 ```
 
@@ -120,16 +120,19 @@ The **OID_EQUALS**() macro compares two *PMEMoid* objects.
 
 For special cases where volatile (transient) variables need to be stored on
 persistent memory, there's a mechanism composed of *struct pmemvlt* type and
-**pmemobj_direct_volatile()** function. To use it the *struct pmemvlt* need to
-be placed at the beginning of the region of transient data. Macro *PMEMvlt* can
-be used to construct such a region.
-When the **pmemobj_direct_volatile()** function is called on such region,
+**pmemobj_volatile()** function. To use it, the *struct pmemvlt* needs to
+be placed in the neighborhood of transient data region. The *PMEMvlt* macro
+can be used to construct such a region.
+When the **pmemobj_volatile()** function is called on a *struct pmemvlt*,
 it will return the pointer to the data and it will ensure that the provided
 constructor function is called exactly once in the current instance of the
-application.
-The constructor is called with the *ptr* pointer to the data after the
-*struct pmemvlt*, and this function will return the same pointer if the
-constructor returns *0*, otherwise NULL is returned.
+pmemobj pool.
+The constructor is called with the *ptr* pointer to the data, and this function
+will return the same pointer if the constructor returns *0*, otherwise NULL is
+returned.
+For this mechanism to be effective, all accesses to transient variables must
+go through it, otherwise there's a risk of the constructor not being called
+on the first load.
 
 # RETURN VALUE #
 
@@ -181,7 +184,8 @@ struct my_data {
 int
 my_data_constructor(void *ptr, void *arg)
 {
-	uint64_t *foo = 0;
+	uint64_t *foo = ptr;
+	*foo = 0;
 
 	return 0;
 }
@@ -190,7 +194,7 @@ PMEMobjpool *pop = ...;
 
 struct my_data *data = D_RW(...);
 
-uint64_t *foo = pmemobj_direct_volatile(pop, &data->foo.vlt,
+uint64_t *foo = pmemobj_volatile(pop, &data->foo.vlt, &data->foo.value,
 	my_data_constructor, NULL);
 
 assert(*foo == 0);

--- a/src/PMDK.sln
+++ b/src/PMDK.sln
@@ -67,6 +67,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "btree", "examples\libpmemob
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_direct", "test\obj_direct\obj_direct.vcxproj", "{10469175-EEF7-44A0-9961-AC4E45EFD800}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_direct_volatile", "test\obj_direct_volatile\obj_direct_volatile.vcxproj", "{10469175-EEF7-44A0-9961-AC4E45EFD800}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pi", "examples\libpmemobj\pi.vcxproj", "{11D76FBC-DFAA-4B31-9DB0-206E171E3F94}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pmemspoil", "test\tools\pmemspoil\pmemspoil.vcxproj", "{11E158AE-C85A-4A6E-B66A-ED2994709276}"
@@ -836,12 +838,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_cpp_ptr", "test\obj_cpp
 		{CE3F2DFB-8470-4802-AD37-21CAF6CB2681} = {CE3F2DFB-8470-4802-AD37-21CAF6CB2681}
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libpmem", "libpmem", "{E1A205C5-FD08-4356-B69C-B5689F2D6053}"
-	ProjectSection(SolutionItems) = preProject
-		..\doc\libpmem\libpmem.7.md = ..\doc\libpmem\libpmem.7.md
-		..\doc\libpmem\pmem_flush.3.md = ..\doc\libpmem\pmem_flush.3.md
-		..\doc\libpmem\pmem_is_pmem.3.md = ..\doc\libpmem\pmem_is_pmem.3.md
-		..\doc\libpmem\pmem_memmove_persist.3.md = ..\doc\libpmem\pmem_memmove_persist.3.md
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_cpp_v", "test\obj_cpp_v\obj_cpp_v.vcxproj", "{DFEBEBAA-9624-445C-82A0-93363E22D806}"
+	ProjectSection(ProjectDependencies) = postProject
+		{1BAA1617-93AE-4196-8A1A-BD492FB18AEF} = {1BAA1617-93AE-4196-8A1A-BD492FB18AEF}
+		{9E9E3D25-2139-4A5D-9200-18148DDEAD45} = {9E9E3D25-2139-4A5D-9200-18148DDEAD45}
+		{CE3F2DFB-8470-4802-AD37-21CAF6CB2681} = {CE3F2DFB-8470-4802-AD37-21CAF6CB2681}
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{E23BB160-006E-44F2-8FB4-3A2240BBC20C}"
@@ -2272,7 +2273,6 @@ Global
 		{DB68AB21-510B-4BA1-9E6F-E5731D8647BC} = {BFBAB433-860E-4A28-96E3-A4B7AFE3B297}
 		{DEA3CD0A-8781-4ABE-9A7D-00B91132FED0} = {F8373EDD-1B9E-462D-BF23-55638E23E98B}
 		{DFEBEBAA-9624-445C-82A0-93363E22D806} = {42F57B5A-9E6B-44DE-A6D3-7B03B3DFDED7}
-		{E1A205C5-FD08-4356-B69C-B5689F2D6053} = {F18C84B3-7898-4324-9D75-99A6048F442D}
 		{E23BB160-006E-44F2-8FB4-3A2240BBC20C} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
 		{E3229AF7-1FA2-4632-BB0B-B74F709F1A33} = {F42C09CD-ABA5-4DA9-8383-5EA40FA4D763}
 		{E4E2EC33-7902-45D0-9C3C-ADBAFA46874A} = {F8373EDD-1B9E-462D-BF23-55638E23E98B}

--- a/src/examples/libpmemobj++/doc_snippets/persistent.cpp
+++ b/src/examples/libpmemobj++/doc_snippets/persistent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -80,6 +80,37 @@ p_property_example()
 	proot.counter = 12;
 }
 //! [p_property_example]
+
+//! [v_property_example]
+#include <fcntl.h>
+#include <libpmemobj++/persistent_ptr.hpp>
+#include <libpmemobj++/pool.hpp>
+#include <libpmemobj++/v.hpp>
+
+using namespace pmem::obj;
+
+void
+v_property_example()
+{
+	struct foo {
+		foo() : counter(10)
+		{
+		}
+		int counter;
+	};
+
+	// pool root structure
+	struct root {
+		v<foo> f;
+	};
+
+	// create a pmemobj pool
+	auto pop = pool<root>::create("poolfile", "layout", PMEMOBJ_MIN_POOL);
+	auto proot = pop.get_root();
+
+	assert(proot->f.get().counter == 10);
+}
+//! [v_property_example]
 
 //! [persistent_ptr_example]
 #include <fcntl.h>

--- a/src/include/libpmemobj++/detail/volatile.hpp
+++ b/src/include/libpmemobj++/detail/volatile.hpp
@@ -30,76 +30,33 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/*
- * obj_direct_volatile.c -- unit test for pmemobj_direct_volatile()
+/**
+ * @file
+ * Implementation details of volatile variables implementation
  */
-#include "unittest.h"
 
-PMEMobjpool *pop;
+#ifndef LIBPMEMOBJ_VOLATILE_HPP
+#define LIBPMEMOBJ_VOLATILE_HPP
 
-struct test {
-	PMEMvlt(int) count;
-};
+#include <new>
+#include <stddef.h>
 
-#define TEST_OBJECTS 100
-#define TEST_WORKERS 10
-struct test *tests[TEST_OBJECTS];
-
-static int
-test_constructor(void *ptr, void *arg)
+namespace pmem
 {
-	int *count = ptr;
-	util_fetch_and_add32(count, 1);
+
+namespace detail
+{
+
+template <typename T>
+int
+instantiate_volatile_object(void *ptr, void *args)
+{
+	new (ptr) T();
 	return 0;
 }
 
-static void *
-test_worker(void *arg)
-{
-	for (int i = 0; i < TEST_OBJECTS; ++i) {
-		int *count = pmemobj_volatile(pop, &tests[i]->count.vlt,
-			&tests[i]->count.value,
-			test_constructor, NULL);
-		UT_ASSERTne(count, NULL);
-		UT_ASSERTeq(*count, 1);
-	}
-	return NULL;
-}
+} /* namespace detail */
 
-int
-main(int argc, char *argv[])
-{
-	START(argc, argv, "obj_direct_volatile");
+} /* namespace pmem */
 
-	if (argc != 2)
-		UT_FATAL("usage: %s file", argv[0]);
-
-	char *path = argv[1];
-	pop = pmemobj_create(path, "obj_direct_volatile",
-		PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR);
-	if (pop == NULL)
-		UT_FATAL("!pmemobj_create");
-
-	for (int i = 0; i < TEST_OBJECTS; ++i) {
-		PMEMoid oid;
-		pmemobj_zalloc(pop, &oid, sizeof(struct test), 1);
-		UT_ASSERT(!OID_IS_NULL(oid));
-		tests[i] = pmemobj_direct(oid);
-	}
-
-	os_thread_t t[TEST_WORKERS];
-
-	for (int i = 0; i < TEST_WORKERS; ++i) {
-		PTHREAD_CREATE(&t[i], NULL, test_worker, NULL);
-	}
-
-	for (int i = 0; i < TEST_WORKERS; ++i) {
-		PTHREAD_JOIN(&t[i], NULL);
-	}
-
-	for (int i = 0; i < TEST_OBJECTS; ++i) {
-		UT_ASSERTeq(tests[i]->count.value, 1);
-	}
-
-	DONE(NULL);
-}
+#endif /* LIBPMEMOBJ_VOLATILE_HPP */

--- a/src/include/libpmemobj++/v.hpp
+++ b/src/include/libpmemobj++/v.hpp
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * Volatile resides on pmem property template.
+ */
+
+#ifndef PMEMOBJ_V_HPP
+#define PMEMOBJ_V_HPP
+
+#include <memory>
+
+#include "libpmemobj++/detail/common.hpp"
+#include "libpmemobj++/detail/volatile.hpp"
+
+namespace pmem
+{
+
+namespace obj
+{
+
+/**
+ * Volatile resides on pmem class.
+ *
+ * v class is a property-like template class that has to be used for all
+ * volatile variables that reside on persistent memory.
+ * This class ensures that the enclosed type is always properly initialized by
+ * always calling the class default constructor exactly once per instance of the
+ * application.
+ * This class has 8 bytes of storage overhead.
+ * @snippet doc_snippets/persistent.cpp v_property_example
+ */
+template <typename T>
+class v {
+
+public:
+	/**
+	 * Value constructor.
+	 *
+	 * Directly assigns a value to the underlying storage.
+	 *
+	 * @param _val const reference to the value to be assigned.
+	 */
+	v(const T &_val) noexcept : vlt{0}, val{_val}
+	{
+	}
+
+	/**
+	 * Defaulted constructor.
+	 */
+	v() = default;
+
+	/**
+	 * Assignment operator.
+	 */
+	v &
+	operator=(const v &rhs)
+	{
+		this_type(rhs).swap(*this);
+
+		return *this;
+	}
+
+	/**
+	 * Converting assignment operator from a different v<>.
+	 *
+	 * Available only for convertible types.
+	 */
+	template <typename Y, typename = typename std::enable_if<
+				      std::is_convertible<Y, T>::value>::type>
+	v &
+	operator=(const v<Y> &rhs)
+	{
+		this_type(rhs).swap(*this);
+
+		return *this;
+	}
+
+	/**
+	 * Retrieves reference of the object.
+	 *
+	 * @return a reference to the object.
+	 *
+	 */
+	T &
+	get() noexcept
+	{
+		PMEMobjpool *pop = pmemobj_pool_by_ptr(this);
+		if (pop == NULL)
+			return this->val;
+
+		T *value = static_cast<T *>(pmemobj_volatile(
+			pop, &this->vlt, &this->val,
+			pmem::detail::instantiate_volatile_object<T>, NULL));
+
+		return *value;
+	}
+
+	/**
+	 * Conversion operator back to the underlying type.
+	 */
+	operator T() const noexcept
+	{
+		return this->get();
+	}
+
+	/**
+	 * Swaps two v objects of the same type.
+	 */
+	void
+	swap(v &other)
+	{
+		std::swap(this->val, other.val);
+	}
+
+private:
+	struct pmemvlt vlt;
+	T val;
+};
+
+/**
+ * Swaps two v objects of the same type.
+ *
+ * Non-member swap function as required by Swappable concept.
+ * en.cppreference.com/w/cpp/concept/Swappable
+ */
+template <class T>
+inline void
+swap(v<T> &a, v<T> &b)
+{
+	a.swap(b);
+}
+
+} /* namespace obj */
+
+} /* namespace pmem */
+
+#endif /* PMEMOBJ_V_HPP */

--- a/src/include/libpmemobj/base.h
+++ b/src/include/libpmemobj/base.h
@@ -157,7 +157,7 @@ struct {\
 	T value;\
 }
 
-void *pmemobj_direct_volatile(PMEMobjpool *pop, struct pmemvlt *vlt,
+void *pmemobj_volatile(PMEMobjpool *pop, struct pmemvlt *vlt, void *ptr,
 	int (*constr)(void *ptr, void *arg), void *arg);
 
 /*

--- a/src/include/libpmemobj/base.h
+++ b/src/include/libpmemobj/base.h
@@ -147,6 +147,19 @@ void *pmemobj_direct(PMEMoid oid);
 #define pmemobj_direct pmemobj_direct_inline
 #endif
 
+struct pmemvlt {
+	uint64_t runid;
+};
+
+#define PMEMvlt(T)\
+struct {\
+	struct pmemvlt vlt;\
+	T value;\
+}
+
+void *pmemobj_direct_volatile(PMEMobjpool *pop, struct pmemvlt *vlt,
+	int (*constr)(void *ptr, void *arg), void *arg);
+
 /*
  * Returns the OID of the object pointed to by addr.
  */

--- a/src/libpmemobj/libpmemobj.def
+++ b/src/libpmemobj/libpmemobj.def
@@ -123,7 +123,7 @@ EXPORTS
 	pmemobj_flush
 	pmemobj_drain
 	pmemobj_direct
-	pmemobj_direct_volatile
+	pmemobj_volatile
 	pmemobj_oid
 	pmemobj_reserve
 	pmemobj_xreserve

--- a/src/libpmemobj/libpmemobj.def
+++ b/src/libpmemobj/libpmemobj.def
@@ -123,6 +123,7 @@ EXPORTS
 	pmemobj_flush
 	pmemobj_drain
 	pmemobj_direct
+	pmemobj_direct_volatile
 	pmemobj_oid
 	pmemobj_reserve
 	pmemobj_xreserve

--- a/src/libpmemobj/libpmemobj.map
+++ b/src/libpmemobj/libpmemobj.map
@@ -115,7 +115,7 @@ LIBPMEMOBJ_1.0 {
 		pmemobj_xpersist;
 		pmemobj_xflush;
 		pmemobj_direct;
-		pmemobj_direct_volatile;
+		pmemobj_volatile;
 		pmemobj_reserve;
 		pmemobj_xreserve;
 		pmemobj_set_value;

--- a/src/libpmemobj/libpmemobj.map
+++ b/src/libpmemobj/libpmemobj.map
@@ -115,6 +115,7 @@ LIBPMEMOBJ_1.0 {
 		pmemobj_xpersist;
 		pmemobj_xflush;
 		pmemobj_direct;
+		pmemobj_direct_volatile;
 		pmemobj_reserve;
 		pmemobj_xreserve;
 		pmemobj_set_value;

--- a/src/libpmemobj/sync.c
+++ b/src/libpmemobj/sync.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017, Intel Corporation
+ * Copyright 2015-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -59,13 +59,13 @@
 #endif
 
 /*
- * _get_lock -- (internal) atomically initialize and return a lock.
+ * _get_value -- (internal) atomically initialize and return a value.
  *	Returns -1 on error, 0 if the caller is not the lock
  *	initializer, 1 if the caller is the lock initializer.
  */
 static int
-_get_lock(uint64_t pop_runid, volatile uint64_t *runid, void *lock,
-	int (*init_lock)(void *lock, void *arg))
+_get_value(uint64_t pop_runid, volatile uint64_t *runid, void *value, void *arg,
+	int (*init_value)(void *value, void *arg))
 {
 	uint64_t tmp_runid;
 	int initializer = 0;
@@ -80,7 +80,7 @@ _get_lock(uint64_t pop_runid, volatile uint64_t *runid, void *lock,
 
 		initializer = 1;
 
-		if (init_lock(lock, NULL)) {
+		if (init_value(value, arg)) {
 			ERR("error initializing lock");
 			util_fetch_and_and64(runid, 0);
 			return -1;
@@ -117,8 +117,8 @@ get_mutex(PMEMobjpool *pop, PMEMmutex_internal *imp)
 
 	VALGRIND_REMOVE_PMEM_MAPPING(imp, _POBJ_CL_SIZE);
 
-	int initializer = _get_lock(pop->run_id, runid, &imp->PMEMmutex_lock,
-		(void *)os_mutex_init);
+	int initializer = _get_value(pop->run_id, runid, &imp->PMEMmutex_lock,
+		NULL, (void *)os_mutex_init);
 	if (initializer == -1) {
 		return NULL;
 	}
@@ -151,8 +151,8 @@ get_rwlock(PMEMobjpool *pop, PMEMrwlock_internal *irp)
 
 	VALGRIND_REMOVE_PMEM_MAPPING(irp, _POBJ_CL_SIZE);
 
-	int initializer = _get_lock(pop->run_id, runid, &irp->PMEMrwlock_lock,
-		(void *)os_rwlock_init);
+	int initializer = _get_value(pop->run_id, runid, &irp->PMEMrwlock_lock,
+		NULL, (void *)os_rwlock_init);
 	if (initializer == -1) {
 		return NULL;
 	}
@@ -184,8 +184,8 @@ get_cond(PMEMobjpool *pop, PMEMcond_internal *icp)
 
 	VALGRIND_REMOVE_PMEM_MAPPING(icp, _POBJ_CL_SIZE);
 
-	int initializer = _get_lock(pop->run_id, runid, &icp->PMEMcond_cond,
-		(void *)os_cond_init);
+	int initializer = _get_value(pop->run_id, runid, &icp->PMEMcond_cond,
+		NULL, (void *)os_cond_init);
 	if (initializer == -1) {
 		return NULL;
 	}
@@ -639,4 +639,20 @@ pmemobj_cond_wait(PMEMobjpool *pop, PMEMcond *condp,
 	ASSERTeq((uintptr_t)cond % util_alignof(os_cond_t), 0);
 
 	return os_cond_wait(cond, mutex);
+}
+
+/*
+ * pmemobj_direct_volatile -- atomically initialize, record and return a
+ *	generic value
+ */
+void *
+pmemobj_direct_volatile(PMEMobjpool *pop, struct pmemvlt *vlt,
+	int (*constr)(void *ptr, void *arg), void *arg)
+{
+	void *ptr = (char *)vlt + sizeof(struct pmemvlt);
+
+	if (_get_value(pop->run_id, &vlt->runid, ptr, arg, constr) < 0)
+		return NULL;
+
+	return ptr;
 }

--- a/src/libpmemobj/sync.c
+++ b/src/libpmemobj/sync.c
@@ -60,8 +60,8 @@
 
 /*
  * _get_value -- (internal) atomically initialize and return a value.
- *	Returns -1 on error, 0 if the caller is not the lock
- *	initializer, 1 if the caller is the lock initializer.
+ *	Returns -1 on error, 0 if the caller is not the value
+ *	initializer, 1 if the caller is the value initializer.
  */
 static int
 _get_value(uint64_t pop_runid, volatile uint64_t *runid, void *value, void *arg,
@@ -642,14 +642,15 @@ pmemobj_cond_wait(PMEMobjpool *pop, PMEMcond *condp,
 }
 
 /*
- * pmemobj_direct_volatile -- atomically initialize, record and return a
+ * pmemobj_volatile -- atomically initialize, record and return a
  *	generic value
  */
 void *
-pmemobj_direct_volatile(PMEMobjpool *pop, struct pmemvlt *vlt,
+pmemobj_volatile(PMEMobjpool *pop, struct pmemvlt *vlt, void *ptr,
 	int (*constr)(void *ptr, void *arg), void *arg)
 {
-	void *ptr = (char *)vlt + sizeof(struct pmemvlt);
+	LOG(3, "pop %p vlt %p ptr %p constr %p arg %p", pop, vlt, ptr,
+		constr, arg);
 
 	if (_get_value(pop->run_id, &vlt->runid, ptr, arg, constr) < 0)
 		return NULL;

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -164,7 +164,8 @@ OBJ_CPP_TESTS = \
 	obj_cpp_ptr\
 	obj_cpp_ptr_arith\
 	obj_cpp_shared_mutex_posix\
-	obj_cpp_transaction
+	obj_cpp_transaction\
+	obj_cpp_v
 
 OBJ_CPP_ARRAY_TESTS = \
 	obj_cpp_make_persistent_array\

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -88,6 +88,7 @@ OBJ_TESTS = \
 	obj_cuckoo\
 	obj_debug\
 	obj_direct\
+	obj_direct_volatile\
 	obj_extend\
 	obj_first_next\
 	obj_fragmentation\

--- a/src/test/obj_cpp_v/.gitignore
+++ b/src/test/obj_cpp_v/.gitignore
@@ -1,0 +1,1 @@
+obj_cpp_v

--- a/src/test/obj_cpp_v/Makefile
+++ b/src/test/obj_cpp_v/Makefile
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #
 # Copyright 2018, Intel Corporation
 #
@@ -32,17 +31,13 @@
 #
 
 #
-# src/test/obj_direct_volatile/TEST0 -- unit test for direct_volatile
+# src/test/obj_cpp_v/Makefile -- build obj_cpp_v test
 #
+TARGET = obj_cpp_v
+OBJS = obj_cpp_v.o
+COMPILE_LANG = cpp
 
-# standard unit test setup
-. ../unittest/unittest.sh
+LIBPMEM=y
+LIBPMEMOBJ=y
 
-require_test_type medium
-require_fs_type any
-
-setup
-
-expect_normal_exit ./obj_direct_volatile$EXESUFFIX $DIR/test0
-
-pass
+include ../Makefile.inc

--- a/src/test/obj_cpp_v/TEST0
+++ b/src/test/obj_cpp_v/TEST0
@@ -31,18 +31,17 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-#
-# src/test/obj_direct_volatile/TEST0 -- unit test for direct_volatile
-#
-
 # standard unit test setup
 . ../unittest/unittest.sh
 
 require_test_type medium
 require_fs_type any
 
+require_cxx11
+
 setup
 
-expect_normal_exit ./obj_direct_volatile$EXESUFFIX $DIR/test0
+expect_normal_exit\
+    ./obj_cpp_v$EXESUFFIX $DIR/testfile1
 
 pass

--- a/src/test/obj_cpp_v/TEST0.PS1
+++ b/src/test/obj_cpp_v/TEST0.PS1
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #
 # Copyright 2018, Intel Corporation
 #
@@ -30,19 +29,28 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
+# src/test/obj_cpp_v/TEST0 -- unit test for pmem::obj::v<>
 #
-# src/test/obj_direct_volatile/TEST0 -- unit test for direct_volatile
 #
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
 
 # standard unit test setup
-. ../unittest/unittest.sh
+. ..\unittest\unittest.ps1
 
 require_test_type medium
 require_fs_type any
 
 setup
 
-expect_normal_exit ./obj_direct_volatile$EXESUFFIX $DIR/test0
+expect_normal_exit $Env:EXE_DIR\obj_cpp_v$Env:EXESUFFIX `
+    $DIR\testfile
+
+check_files $DIR\testfile
 
 pass

--- a/src/test/obj_cpp_v/obj_cpp_v.vcxproj
+++ b/src/test/obj_cpp_v/obj_cpp_v.vcxproj
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_v\obj_cpp_v.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\libpmemobj\libpmemobj.vcxproj">
+      <Project>{1baa1617-93ae-4196-8a1a-bd492fb18aef}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\libpmem\libpmem.vcxproj">
+      <Project>{9e9e3d25-2139-4a5d-9200-18148ddead45}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\unittest\libut.vcxproj">
+      <Project>{ce3f2dfb-8470-4802-ad37-21caf6cb2681}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{DFEBEBAA-9624-445C-82A0-93363E22D806}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>obj_cpp_ptr</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\test_debug.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\test_release.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link />
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/obj_cpp_v/obj_cpp_v.vcxproj.filters
+++ b/src/test/obj_cpp_v/obj_cpp_v.vcxproj.filters
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Test Scripts">
+      <UniqueIdentifier>{4e4de84d-63e3-45cc-a1f3-fdf5af2b07c3}</UniqueIdentifier>
+      <Extensions>ps1</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_v\obj_cpp_v.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1">
+      <Filter>Test Scripts</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/test/obj_direct_volatile/.gitignore
+++ b/src/test/obj_direct_volatile/.gitignore
@@ -1,0 +1,1 @@
+obj_direct_volatile

--- a/src/test/obj_direct_volatile/Makefile
+++ b/src/test/obj_direct_volatile/Makefile
@@ -33,9 +33,6 @@
 #
 # src/test/obj_direct_volatile/Makefile -- build obj_direct_volatile unit test
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
-
 TARGET = obj_direct_volatile
 OBJS = obj_direct_volatile.o
 
@@ -43,5 +40,3 @@ LIBPMEM=y
 LIBPMEMOBJ=y
 
 include ../Makefile.inc
-
-INCS += -I../../libpmemobj/ -I../../common/

--- a/src/test/obj_direct_volatile/Makefile
+++ b/src/test/obj_direct_volatile/Makefile
@@ -1,0 +1,47 @@
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_direct_volatile/Makefile -- build obj_direct_volatile unit test
+#
+vpath %.c ../../libpmemobj
+vpath %.c ../../common
+
+TARGET = obj_direct_volatile
+OBJS = obj_direct_volatile.o
+
+LIBPMEM=y
+LIBPMEMOBJ=y
+
+include ../Makefile.inc
+
+INCS += -I../../libpmemobj/ -I../../common/

--- a/src/test/obj_direct_volatile/TEST0
+++ b/src/test/obj_direct_volatile/TEST0
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_direct_volatile/TEST0 -- unit test for direct_volatile
+#
+export UNITTEST_NAME=obj_direct/TEST0
+export UNITTEST_NUM=0
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+
+require_fs_type any
+
+setup
+
+expect_normal_exit ./obj_direct_volatile$EXESUFFIX $DIR/test0
+
+pass

--- a/src/test/obj_direct_volatile/TEST0.PS1
+++ b/src/test/obj_direct_volatile/TEST0.PS1
@@ -1,0 +1,57 @@
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_direct_volatile/TEST0 -- unit test for direct_volatile
+#
+
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$ENV:UNITTEST_NAME = "obj_direct_volatile/TEST0"
+$ENV:UNITTEST_NUM = "0"
+
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_test_type medium
+
+require_fs_type any
+
+setup
+
+expect_normal_exit $Env:EXE_DIR\obj_direct_volatile$Env:EXESUFFIX $DIR\test0
+
+pass

--- a/src/test/obj_direct_volatile/TEST0.PS1
+++ b/src/test/obj_direct_volatile/TEST0.PS1
@@ -39,9 +39,6 @@ Param(
     [alias("d")]
     $DIR = ""
     )
-$ENV:UNITTEST_NAME = "obj_direct_volatile/TEST0"
-$ENV:UNITTEST_NUM = "0"
-
 
 # standard unit test setup
 . ..\unittest\unittest.ps1

--- a/src/test/obj_direct_volatile/obj_direct_volatile.c
+++ b/src/test/obj_direct_volatile/obj_direct_volatile.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * obj_direct_volatile.c -- unit test for pmemobj_direct_volatile()
+ */
+#include "obj.h"
+#include "unittest.h"
+
+PMEMobjpool *pop;
+
+struct test {
+	PMEMvlt(int) count;
+};
+
+#define TEST_OBJECTS 100
+#define TEST_WORKERS 10
+struct test *tests[TEST_OBJECTS];
+
+static int
+test_constructor(void *ptr, void *arg)
+{
+	int *count = ptr;
+	util_fetch_and_add32(count, 1);
+	return 0;
+}
+
+static void *
+test_worker(void *arg)
+{
+	for (int i = 0; i < TEST_OBJECTS; ++i) {
+		int *count = pmemobj_direct_volatile(pop, &tests[i]->count.vlt,
+			test_constructor, NULL);
+		UT_ASSERTne(count, NULL);
+		UT_ASSERTeq(*count, 1);
+	}
+	return NULL;
+}
+
+int
+main(int argc, char *argv[])
+{
+	START(argc, argv, "obj_direct_volatile");
+
+	if (argc != 2)
+		UT_FATAL("usage: %s file", argv[0]);
+
+	char *path = argv[1];
+	pop = pmemobj_create(path, "obj_direct_volatile",
+		PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR);
+	if (pop == NULL)
+		UT_FATAL("!pmemobj_create");
+
+	for (int i = 0; i < TEST_OBJECTS; ++i) {
+		PMEMoid oid;
+		pmemobj_zalloc(pop, &oid, sizeof(struct test), 1);
+		UT_ASSERT(!OID_IS_NULL(oid));
+		tests[i] = pmemobj_direct(oid);
+	}
+
+	os_thread_t t[TEST_WORKERS];
+
+	for (int i = 0; i < TEST_WORKERS; ++i) {
+		PTHREAD_CREATE(&t[i], NULL, test_worker, NULL);
+	}
+
+	for (int i = 0; i < TEST_WORKERS; ++i) {
+		PTHREAD_JOIN(&t[i], NULL);
+	}
+
+	for (int i = 0; i < TEST_OBJECTS; ++i) {
+		UT_ASSERTeq(tests[i]->count.value, 1);
+	}
+
+	DONE(NULL);
+}

--- a/src/test/obj_direct_volatile/obj_direct_volatile.vcxproj
+++ b/src/test/obj_direct_volatile/obj_direct_volatile.vcxproj
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="obj_direct_volatile.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\common\libpmemcommon.vcxproj">
+      <Project>{492baa3d-0d5d-478e-9765-500463ae69aa}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\libpmemobj\libpmemobj.vcxproj">
+      <Project>{1baa1617-93ae-4196-8a1a-bd492fb18aef}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\libpmem\libpmem.vcxproj">
+      <Project>{9e9e3d25-2139-4a5d-9200-18148ddead45}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\unittest\libut.vcxproj">
+      <Project>{ce3f2dfb-8470-4802-ad37-21caf6cb2681}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{10469175-EEF7-44A0-9961-AC4E45EFD800}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>obj_direct</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\test_debug.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\test_release.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>Disabled</Optimization>
+      <DisableSpecificWarnings>
+      </DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>$(SolutionDir)\libpmemobj;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <DisableSpecificWarnings>
+      </DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>$(SolutionDir)\libpmemobj;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link />
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/obj_direct_volatile/obj_direct_volatile.vcxproj.filters
+++ b/src/test/obj_direct_volatile/obj_direct_volatile.vcxproj.filters
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Test Scripts">
+      <UniqueIdentifier>{af85130b-199d-4610-834d-707504d99266}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{37b70c4b-e0a5-440e-bbcc-cb86abe6f78b}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="obj_direct_volatile.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1">
+      <Filter>Test Scripts</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/test/scope/out4.log.match
+++ b/src/test/scope/out4.log.match
@@ -18,7 +18,6 @@ pmemobj_ctl_exec
 pmemobj_ctl_get
 pmemobj_ctl_set
 pmemobj_direct
-pmemobj_direct_volatile
 pmemobj_drain
 pmemobj_errormsg
 pmemobj_first
@@ -83,6 +82,7 @@ pmemobj_tx_xalloc
 pmemobj_tx_zalloc
 pmemobj_tx_zrealloc
 pmemobj_type_num
+pmemobj_volatile
 pmemobj_wcsdup
 pmemobj_xalloc
 pmemobj_xflush

--- a/src/test/scope/out4.log.match
+++ b/src/test/scope/out4.log.match
@@ -18,6 +18,7 @@ pmemobj_ctl_exec
 pmemobj_ctl_get
 pmemobj_ctl_set
 pmemobj_direct
+pmemobj_direct_volatile
 pmemobj_drain
 pmemobj_errormsg
 pmemobj_first

--- a/src/test/scope/out4w.log.match
+++ b/src/test/scope/out4w.log.match
@@ -24,7 +24,6 @@ pmemobj_ctl_getW
 pmemobj_ctl_setU
 pmemobj_ctl_setW
 pmemobj_direct
-pmemobj_direct_volatile
 pmemobj_drain
 pmemobj_errormsgU
 pmemobj_errormsgW
@@ -91,6 +90,7 @@ pmemobj_tx_xalloc
 pmemobj_tx_zalloc
 pmemobj_tx_zrealloc
 pmemobj_type_num
+pmemobj_volatile
 pmemobj_wcsdup
 pmemobj_xalloc
 pmemobj_xreserve

--- a/src/test/scope/out4w.log.match
+++ b/src/test/scope/out4w.log.match
@@ -24,6 +24,7 @@ pmemobj_ctl_getW
 pmemobj_ctl_setU
 pmemobj_ctl_setW
 pmemobj_direct
+pmemobj_direct_volatile
 pmemobj_drain
 pmemobj_errormsgU
 pmemobj_errormsgW


### PR DESCRIPTION
This patch adds a new feature that allows arbitrary
volatile (transient) variables to reside on persistent memory.

Ref: pmem/issues#491

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2624)
<!-- Reviewable:end -->
