### PR TITLE
rpmem: remove all remaining parts on remote node

### DIFF
--- a/src/test/pmempool_rm_remote/TEST2
+++ b/src/test/pmempool_rm_remote/TEST2
@@ -31,10 +31,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 #
-# pmempool_rm_remotie/TEST1 -- test for cli rm command with remote replica
+# pmempool_rm_remotie/TEST2 -- test for cli rm command with remote replica
 #
-export UNITTEST_NAME=pmempool_rm_remote/TEST1
-export UNITTEST_NUM=1
+export UNITTEST_NAME=pmempool_rm_remote/TEST2
+export UNITTEST_NUM=2
 
 . ../unittest/unittest.sh
 
@@ -82,7 +82,7 @@ check_files_on_node 1 $TEST_SET_LOCAL test_part0 test_part1 test_part2 test_part
 rm_files_from_node 0 ${NODE_DIR[0]}test_part_remote2
 check_no_files_on_node 0 test_part_remote2
 
-expect_abnormal_exit run_on_node 1 ../pmempool rm ${NODE_DIR[1]}$TEST_SET_LOCAL 1>> $OUT 2>&1
+expect_normal_exit run_on_node 1 ../pmempool rm -f ${NODE_DIR[1]}$TEST_SET_LOCAL 1>> $OUT 2>&1
 
 check_no_files_on_node 0 test_part_remote0 test_part_remote1 test_part_remote2 test_part_remote3
 

--- a/src/test/rpmemd_db/rpmemd0.log.match
+++ b/src/test/rpmemd_db/rpmemd0.log.match
@@ -1,1 +1,0 @@
-removing '$(nW)' failed: $(*)

--- a/src/test/rpmemd_db/rpmemd1.log.match
+++ b/src/test/rpmemd_db/rpmemd1.log.match
@@ -3,4 +3,3 @@ duplicate found in pool set file -- $(nW)/pool$(N).set: File exists
 cannot create pool set -- '$(nW)pool1.set': Resource temporarily unavailable
 cannot create pool set -- '$(nW)pool1.set': File exists
 cannot create pool set -- '$(nW)pool1.set': File exists
-removing '$(nW)pool0.set' failed: Invalid argument

--- a/src/test/rpmemd_db/rpmemd_db_test.c
+++ b/src/test/rpmemd_db/rpmemd_db_test.c
@@ -609,29 +609,6 @@ test_remove(const char *root_dir, const char *pool_desc)
 
 	prp = rpmemd_db_pool_create(db, pool_desc, 0, &attr);
 	UT_ASSERTne(prp, NULL);
-
-	struct pool_hdr *pool_hdr = prp->pool_addr;
-	const char *uuid = (char *)pool_hdr->poolset_uuid;
-	const size_t uuid_size = sizeof(pool_hdr->poolset_uuid);
-	strncpy((char *)uuid, "ERROR", uuid_size);
-	util_persist_auto(prp->set->replica[0]->part[0].is_dev_dax, uuid,
-			uuid_size);
-	rpmemd_db_pool_close(db, prp);
-
-	ret = rpmemd_db_pool_remove(db, pool_desc, 0, 0);
-	UT_ASSERTne(ret, 0);
-
-	ret = util_poolset_foreach_part(path, exists_cb, NULL);
-	UT_ASSERTeq(ret, 0);
-
-	ret = rpmemd_db_pool_remove(db, pool_desc, 1, 0);
-	UT_ASSERTeq(ret, 0);
-
-	ret = util_poolset_foreach_part(path, noexists_cb, NULL);
-	UT_ASSERTeq(ret, 0);
-
-	prp = rpmemd_db_pool_create(db, pool_desc, 0, &attr);
-	UT_ASSERTne(prp, NULL);
 	rpmemd_db_pool_close(db, prp);
 
 	ret = rpmemd_db_pool_remove(db, pool_desc, 0, 1);


### PR DESCRIPTION
Remove all existing part files on remote node even if one of them is
missing.

Ref: pmem/issues#599

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2633)
<!-- Reviewable:end -->
