### PR TITLE
examples: fix pmpong build issue

### DIFF
--- a/src/examples/libpmemobj++/pmpong/Makefile
+++ b/src/examples/libpmemobj++/pmpong/Makefile
@@ -39,7 +39,7 @@ FONTDIR=/usr/local/share/fonts
 else
 FONTDIR=/usr/share/fonts
 endif
-PROGS = pmpong $(shell find $(FONTDIR) -name *.ttf | head -n 1 >| fontConf $<)
+PROGS = pmpong
 else
 $(info NOTE: Skipping pmpong because sfml is missing \
 -- see src/examples/libpmemobj/pmpong/README for details.)
@@ -63,3 +63,8 @@ rm-fontconf:
 clobber: rm-fontconf
 
 clean: rm-fontconf
+
+fontConf:
+	find $(FONTDIR) -name *.ttf | head -n 1 > fontConf
+
+all: fontConf


### PR DESCRIPTION
Avoids this warning on make clobber:
head: cannot open 'clean-progs' for reading: No such file or directory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2653)
<!-- Reviewable:end -->
