### PR TITLE
common: fix interaction between jemalloc & user.mk

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -184,13 +184,13 @@ check-remote: test
 	$(MAKE) -C test $@
 
 jemalloc jemalloc-clean jemalloc-clobber jemalloc-test jemalloc-check:
-	EXTRA_CFLAGS="$(EXTRA_CFLAGS) -I$(abspath $(TOP))/src/common" $(MAKE) -C jemalloc -f Makefile.libvmem $@
-	EXTRA_CFLAGS="$(EXTRA_CFLAGS) -I$(abspath $(TOP))/src/common" $(MAKE) -C jemalloc -f Makefile.libvmmalloc $@
-	EXTRA_CFLAGS="$(EXTRA_CFLAGS) -I$(abspath $(TOP))/src/common" $(MAKE) -C jemalloc -f Makefile.libpmemcto $@
+	$(MAKE) -C jemalloc -f Makefile.libvmem     $@ EXTRA_CFLAGS="$(EXTRA_CFLAGS) -I$(abspath $(TOP))/src/common"
+	$(MAKE) -C jemalloc -f Makefile.libvmmalloc $@ EXTRA_CFLAGS="$(EXTRA_CFLAGS) -I$(abspath $(TOP))/src/common"
+	$(MAKE) -C jemalloc -f Makefile.libpmemcto  $@ EXTRA_CFLAGS="$(EXTRA_CFLAGS) -I$(abspath $(TOP))/src/common"
 ifeq ($(custom_build),)
-	EXTRA_CFLAGS="$(EXTRA_CFLAGS) -I$(abspath $(TOP))/src/common" $(MAKE) -C jemalloc -f Makefile.libvmem $@ DEBUG=1
-	EXTRA_CFLAGS="$(EXTRA_CFLAGS) -I$(abspath $(TOP))/src/common" $(MAKE) -C jemalloc -f Makefile.libvmmalloc $@ DEBUG=1
-	EXTRA_CFLAGS="$(EXTRA_CFLAGS) -I$(abspath $(TOP))/src/common" $(MAKE) -C jemalloc -f Makefile.libpmemcto $@ DEBUG=1
+	$(MAKE) -C jemalloc -f Makefile.libvmem     $@ DEBUG=1 EXTRA_CFLAGS="$(EXTRA_CFLAGS) -I$(abspath $(TOP))/src/common"
+	$(MAKE) -C jemalloc -f Makefile.libvmmalloc $@ DEBUG=1 EXTRA_CFLAGS="$(EXTRA_CFLAGS) -I$(abspath $(TOP))/src/common"
+	$(MAKE) -C jemalloc -f Makefile.libpmemcto  $@ DEBUG=1 EXTRA_CFLAGS="$(EXTRA_CFLAGS) -I$(abspath $(TOP))/src/common"
 endif
 
 install-cpp:


### PR DESCRIPTION
EXTRA_CFLAGS in user.mk was overwriting EXTRA_CFLAGS set by
src/Makefile, which means jemalloc did not detect Valgrind headers,
and that caused all [vmem|vmmalloc|cto]_valgrind tests to fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2658)
<!-- Reviewable:end -->
