### PR TITLE
common: add os_major/os_minor

### DIFF
--- a/src/common/file.c
+++ b/src/common/file.c
@@ -76,8 +76,8 @@ device_dax_size(const char *path)
 	}
 
 	char spath[PATH_MAX];
-	snprintf(spath, PATH_MAX, "/sys/dev/char/%d:%d/size",
-		major(st.st_rdev), minor(st.st_rdev));
+	snprintf(spath, PATH_MAX, "/sys/dev/char/%u:%u/size",
+		os_major(st.st_rdev), os_minor(st.st_rdev));
 
 	LOG(4, "device size path \"%s\"", spath);
 
@@ -155,8 +155,8 @@ util_fd_is_device_dax(int fd)
 	}
 
 	char spath[PATH_MAX];
-	snprintf(spath, PATH_MAX, "/sys/dev/char/%d:%d/subsystem",
-		major(st.st_rdev), minor(st.st_rdev));
+	snprintf(spath, PATH_MAX, "/sys/dev/char/%u:%u/subsystem",
+		os_major(st.st_rdev), os_minor(st.st_rdev));
 
 	LOG(4, "device subsystem path \"%s\"", spath);
 

--- a/src/common/file_posix.c
+++ b/src/common/file_posix.c
@@ -220,8 +220,8 @@ device_dax_alignment(const char *path)
 	}
 
 	char spath[PATH_MAX];
-	snprintf(spath, PATH_MAX, "/sys/dev/char/%d:%d/device/align",
-		major(st.st_rdev), minor(st.st_rdev));
+	snprintf(spath, PATH_MAX, "/sys/dev/char/%u:%u/device/align",
+		os_major(st.st_rdev), os_minor(st.st_rdev));
 
 	LOG(4, "device align path \"%s\"", spath);
 
@@ -315,8 +315,8 @@ util_ddax_region_find(const char *path)
 
 	dev_t dev_id = st.st_rdev;
 
-	unsigned major = major(dev_id);
-	unsigned minor = minor(dev_id);
+	unsigned major = os_major(dev_id);
+	unsigned minor = os_minor(dev_id);
 	int ret = snprintf(dax_region_path, PATH_MAX,
 		"/sys/dev/char/%u:%u/device/dax_region/id",
 		major, minor);

--- a/src/common/os.h
+++ b/src/common/os.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Intel Corporation
+ * Copyright 2017-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -68,6 +68,15 @@ extern "C" {
 /* dlopen() */
 #ifdef __FreeBSD__
 #define RTLD_DEEPBIND 0	/* XXX */
+#endif
+
+/* major(), minor() */
+#ifdef __FreeBSD__
+#define os_major (unsigned)major
+#define os_minor (unsigned)minor
+#else
+#define os_major major
+#define os_minor minor
 #endif
 
 #endif /* #ifndef _WIN32 */


### PR DESCRIPTION
Define os_major and os_minor macros for portability
    (Linux is unsigned, FreeBSD is signed).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2659)
<!-- Reviewable:end -->
