### PR TITLE
obj: implement ctl argument versioning mechanism

### DIFF
--- a/doc/libpmemobj/pmemobj_ctl_get.3.md
+++ b/doc/libpmemobj/pmemobj_ctl_get.3.md
@@ -7,7 +7,7 @@ header: PMDK
 date: pmemobj API version 2.2
 ...
 
-[comment]: <> (Copyright 2017, Intel Corporation)
+[comment]: <> (Copyright 2017-2018, Intel Corporation)
 
 [comment]: <> (Redistribution and use in source and binary forms, with or without)
 [comment]: <> (modification, are permitted provided that the following conditions)
@@ -96,6 +96,13 @@ is returned.
 Entry points are the leaves of the CTL namespace structure. Each entry point
 can read from the internal state, write to the internal state,
 exec a function or a combination of these operations.
+
+If an entry point takes a complex structure for its argument, the C `struct`
+will contain `size` of the argument structure as its first field.
+This variable is used for versioning. Normally, setting it takes the form of:
+```
+[arg].size = sizeof(struct [arg_type]);
+```
 
 The entry points are listed in the following format:
 
@@ -234,6 +241,7 @@ This entry point takes a complex argument.
 
 ```
 struct pobj_alloc_class_desc {
+	size_t size;
 	size_t unit_size;
 	unsigned units_per_block;
 	enum pobj_header_type header_type;
@@ -241,7 +249,13 @@ struct pobj_alloc_class_desc {
 };
 ```
 
-The first field, `unit_size`, is an 8-byte unsigned integer that defines the
+The `size` field is the size of the argument structure. Can be set by:
+```
+[class_desc].size = sizeof(struct pobj_alloc_class_desc);
+```
+This field must not be present in a config string.
+
+The first real field, `unit_size`, is an 8-byte unsigned integer that defines the
 allocation class size. While theoretically limited only by
 **PMEMOBJ_MAX_ALLOC_SIZE**, for most workloads this value should be between
 8 bytes and 2 megabytes.
@@ -389,6 +403,8 @@ separated by a ',':
 ```
 first_arg,second_arg
 ```
+
+Complex argument types never contain the size of the argument structure.
 
 In summary, a full configuration sequence looks like this:
 

--- a/src/include/libpmemobj/ctl.h
+++ b/src/include/libpmemobj/ctl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Intel Corporation
+ * Copyright 2017-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -118,6 +118,9 @@ enum pobj_header_type {
  * Description of allocation classes
  */
 struct pobj_alloc_class_desc {
+	/* sizeof this structure */
+	size_t size;
+
 	/*
 	 * The number of bytes in a single unit of allocation. A single
 	 * allocation can span up to 64 units (or 1 in the case of no header).

--- a/src/libpmemobj/pmalloc.c
+++ b/src/libpmemobj/pmalloc.c
@@ -487,6 +487,7 @@ CTL_READ_HANDLER(desc)(PMEMobjpool *pop,
 }
 
 static struct ctl_argument CTL_ARG(desc) = {
+	.sized = 1,
 	.dest_size = sizeof(struct pobj_alloc_class_desc),
 	.parsers = {
 		CTL_ARG_PARSER_STRUCT(struct pobj_alloc_class_desc,

--- a/src/test/obj_ctl_alloc_class/obj_ctl_alloc_class.c
+++ b/src/test/obj_ctl_alloc_class/obj_ctl_alloc_class.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Intel Corporation
+ * Copyright 2017-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -60,6 +60,7 @@ main(int argc, char *argv[])
 	size_t usable_size;
 
 	struct pobj_alloc_class_desc alloc_class_128;
+	alloc_class_128.size = sizeof(struct pobj_alloc_class_desc);
 	alloc_class_128.header_type = POBJ_HEADER_NONE;
 	alloc_class_128.unit_size = 128;
 	alloc_class_128.units_per_block = 1000;
@@ -69,6 +70,7 @@ main(int argc, char *argv[])
 	UT_ASSERTeq(ret, 0);
 
 	struct pobj_alloc_class_desc alloc_class_129;
+	alloc_class_129.size = sizeof(struct pobj_alloc_class_desc);
 	alloc_class_129.header_type = POBJ_HEADER_COMPACT;
 	alloc_class_129.unit_size = 1024;
 	alloc_class_129.units_per_block = 1000;
@@ -158,6 +160,7 @@ main(int argc, char *argv[])
 	UT_ASSERTeq(ret, -1);
 
 	struct pobj_alloc_class_desc alloc_class_new;
+	alloc_class_new.size = sizeof(struct pobj_alloc_class_desc);
 	alloc_class_new.header_type = POBJ_HEADER_NONE;
 	alloc_class_new.unit_size = 777;
 	alloc_class_new.units_per_block = 200;
@@ -168,6 +171,7 @@ main(int argc, char *argv[])
 	UT_ASSERTeq(ret, 0);
 
 	struct pobj_alloc_class_desc alloc_class_fail;
+	alloc_class_fail.size = sizeof(struct pobj_alloc_class_desc);
 	alloc_class_fail.header_type = POBJ_HEADER_NONE;
 	alloc_class_fail.unit_size = 777;
 	alloc_class_fail.units_per_block = 200;
@@ -188,6 +192,7 @@ main(int argc, char *argv[])
 	UT_ASSERTeq(usable_size, 777);
 
 	struct pobj_alloc_class_desc alloc_class_new_huge;
+	alloc_class_new_huge.size = sizeof(struct pobj_alloc_class_desc);
 	alloc_class_new_huge.header_type = POBJ_HEADER_NONE;
 	alloc_class_new_huge.unit_size = (2 << 23);
 	alloc_class_new_huge.units_per_block = 1;
@@ -204,6 +209,7 @@ main(int argc, char *argv[])
 	UT_ASSERTeq(usable_size, (2 << 23));
 
 	struct pobj_alloc_class_desc alloc_class_new_max;
+	alloc_class_new_max.size = sizeof(struct pobj_alloc_class_desc);
 	alloc_class_new_max.header_type = POBJ_HEADER_COMPACT;
 	alloc_class_new_max.unit_size = PMEMOBJ_MAX_ALLOC_SIZE;
 	alloc_class_new_max.units_per_block = 1024;
@@ -218,6 +224,7 @@ main(int argc, char *argv[])
 	UT_ASSERTne(ret, 0);
 
 	struct pobj_alloc_class_desc alloc_class_new_loop;
+	alloc_class_new_loop.size = sizeof(struct pobj_alloc_class_desc);
 	alloc_class_new_loop.header_type = POBJ_HEADER_COMPACT;
 	alloc_class_new_loop.unit_size = 16384;
 	alloc_class_new_loop.units_per_block = 63;


### PR DESCRIPTION
This patch adds sized complex argument parsing that allows us to
require the user to provide us with the size of the argument to
the parser. This is complemented by ability to specify optional
fields inside of a structure.
These two things create a mechanism for ctl entry points
backward compatibilty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2665)
<!-- Reviewable:end -->
