### PR TITLE
common: change ERR to LOG in some cases

### DIFF
--- a/src/common/file_posix.c
+++ b/src/common/file_posix.c
@@ -328,7 +328,7 @@ util_ddax_region_find(const char *path)
 	}
 
 	if ((dax_reg_id_fd = os_open(dax_region_path, O_RDONLY)) < 0) {
-		ERR("!open(\"%s\", O_RDONLY)", dax_region_path);
+		LOG(1, "!open(\"%s\", O_RDONLY)", dax_region_path);
 		return -1;
 	}
 

--- a/src/common/os_deep_linux.c
+++ b/src/common/os_deep_linux.c
@@ -94,7 +94,7 @@ os_deep_type(const struct map_tracker *mt, void *addr, size_t len)
 		if (os_deep_flush_write(mt->region_id) < 0) {
 			if (errno == ENOENT) {
 				errno = ENOTSUP;
-				ERR("!deep_flush not supported");
+				LOG(1, "!deep_flush not supported");
 			} else {
 				LOG(2, "cannot write to deep_flush"
 					"in region %d", mt->region_id);
@@ -184,7 +184,7 @@ os_part_deep_common(struct pool_set_part *part, void *addr,
 		if (region_id < 0) {
 			if (errno == ENOENT) {
 				errno = ENOTSUP;
-				ERR("!deep_flush not supported");
+				LOG(1, "!deep_flush not supported");
 			} else {
 				LOG(1, "invalid dax_region id %d", region_id);
 			}


### PR DESCRIPTION
In some cases it is expected that there is no deep_flush file. ERR cover other potential errors that occur.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2666)
<!-- Reviewable:end -->
