### PR TITLE
test: add require_dev_dax_region

### DIFF
--- a/src/test/pmem_deep_persist/TEST8
+++ b/src/test/pmem_deep_persist/TEST8
@@ -42,7 +42,7 @@ export UNITTEST_NUM=8
 
 require_test_type medium
 require_fs_type any
-
+require_dev_dax_region
 require_dax_devices 2
 
 setup

--- a/src/test/pmem_deep_persist/TEST9
+++ b/src/test/pmem_deep_persist/TEST9
@@ -42,7 +42,7 @@ export UNITTEST_NUM=9
 
 require_test_type medium
 require_fs_type any
-
+require_dev_dax_region
 require_dax_devices 2
 
 setup

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -981,6 +981,32 @@ function require_test_type() {
 }
 
 #
+# require_dev_dax_region -- check if region id file exist for dev dax
+#
+function require_dev_dax_region() {
+	local prefix="$UNITTEST_NAME: SKIP"
+	local cmd="$PMEMDETECT -r"
+
+	for path in ${DEVICE_DAX_PATH[@]}
+	do
+		disable_exit_on_error
+		out=$($cmd $path 2>&1)
+		ret=$?
+		restore_exit_on_error
+
+		if [ "$ret" == "0" ]; then
+			continue
+		elif [ "$ret" == "1" ]; then
+			msg "$prefix $out"
+			exit 0
+		else
+			fatal "$UNITTEST_NAME: pmemdetect: $out"
+		fi
+	done
+	DEVDAX_TO_LOCK=1
+}
+
+#
 # lock_devdax -- acquire a lock on Device DAXes
 #
 lock_devdax() {


### PR DESCRIPTION
Ref: pmem/issues#802

This patch allows skip test if device dax region id does not exist
(in practice it will skip only for old kernels - second part of pmem issue #802)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2667)
<!-- Reviewable:end -->
