### PR TITLE
common: reorder pool header consistency checks

### DIFF
--- a/src/common/pool_hdr.c
+++ b/src/common/pool_hdr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -75,63 +75,6 @@ util_convert2h_hdr_nocheck(struct pool_hdr *hdrp)
 	hdrp->arch_flags.alignment_desc =
 		le64toh(hdrp->arch_flags.alignment_desc);
 	hdrp->checksum = le64toh(hdrp->checksum);
-}
-
-/*
- * util_convert_hdr -- convert header to host byte order & validate
- *
- * Returns true if header is valid, and all the integer fields are
- * converted to host byte order.  If the header is not valid, this
- * routine returns false and the header passed in is left in an
- * unknown state.
- */
-int
-util_convert_hdr(struct pool_hdr *hdrp)
-{
-	LOG(3, "hdrp %p", hdrp);
-
-	util_convert2h_hdr_nocheck(hdrp);
-
-	/* to be valid, a header must have a major version of at least 1 */
-	if (hdrp->major == 0) {
-		ERR("invalid major version (0)");
-		return 0;
-	}
-
-	/* and to be valid, the fields must checksum correctly */
-	if (!util_checksum(hdrp, sizeof(*hdrp), &hdrp->checksum, 0)) {
-		ERR("invalid checksum of pool header");
-		return 0;
-	}
-
-	LOG(3, "valid header, signature \"%.8s\"", hdrp->signature);
-	return 1;
-}
-
-/*
- * util_convert_hdr_remote -- convert remote header to host byte order
- *                            and validate
- *
- * Returns true if header is valid, and all the integer fields are
- * converted to host byte order.  If the header is not valid, this
- * routine returns false and the header passed in is left in an
- * unknown state.
- */
-int
-util_convert_hdr_remote(struct pool_hdr *hdrp)
-{
-	LOG(3, "hdrp %p", hdrp);
-
-	util_convert2h_hdr_nocheck(hdrp);
-
-	/* and to be valid, the fields must checksum correctly */
-	if (!util_checksum(hdrp, sizeof(*hdrp), &hdrp->checksum, 0)) {
-		ERR("invalid checksum of pool header");
-		return 0;
-	}
-
-	LOG(3, "valid header, signature \"%.8s\"", hdrp->signature);
-	return 1;
 }
 
 /*

--- a/src/common/pool_hdr.h
+++ b/src/common/pool_hdr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -116,8 +116,6 @@ struct pool_hdr {
 
 void util_convert2le_hdr(struct pool_hdr *hdrp);
 void util_convert2h_hdr_nocheck(struct pool_hdr *hdrp);
-int util_convert_hdr(struct pool_hdr *hdrp);
-int util_convert_hdr_remote(struct pool_hdr *hdrp);
 int util_get_arch_flags(struct arch_flags *arch_flags);
 int util_check_arch_flags(const struct arch_flags *arch_flags);
 

--- a/src/test/obj_check/out1.log.match
+++ b/src/test/obj_check/out1.log.match
@@ -1,4 +1,4 @@
 obj_check$(nW)TEST1: START: obj_check
  $(nW)obj_check$(nW) $(nW)testfile
-error: invalid checksum of pool header
+error: wrong pool type: "ERRORBJ"
 obj_check$(nW)TEST1: DONE


### PR DESCRIPTION
This is to produce a valid error message in case the user attempts
to open the pool created by PMDK version 1.4 (or later).
Since the pool header checksum calculation has been modified in
PMDK 1.4, old libraries will fail to open new pools, but the error
message would report the invalid checksum, instead of incompatible
pool format or features.
With this patch, the pool signature, format and compat/incompat
flags are validated before the pool header checksum.
If feature flags or pool format are corrupted, but their value
would pass the check, opening the pool would fail anyway after
checkum validation.  However, if this is a new pool, then error
message would indicate incompatible format/features, not
the wrong checksum.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2671)
<!-- Reviewable:end -->
