### PR TITLE
obj: add unused alignment fields to alloc class

### DIFF
--- a/doc/libpmemobj/pmemobj_ctl_get.3.md
+++ b/doc/libpmemobj/pmemobj_ctl_get.3.md
@@ -7,7 +7,7 @@ header: PMDK
 date: pmemobj API version 2.2
 ...
 
-[comment]: <> (Copyright 2017, Intel Corporation)
+[comment]: <> (Copyright 2017-2018, Intel Corporation)
 
 [comment]: <> (Redistribution and use in source and binary forms, with or without)
 [comment]: <> (modification, are permitted provided that the following conditions)
@@ -235,6 +235,7 @@ This entry point takes a complex argument.
 ```
 struct pobj_alloc_class_desc {
 	size_t unit_size;
+	size_t alignment;
 	unsigned units_per_block;
 	enum pobj_header_type header_type;
 	unsigned class_id;
@@ -245,6 +246,10 @@ The first field, `unit_size`, is an 8-byte unsigned integer that defines the
 allocation class size. While theoretically limited only by
 **PMEMOBJ_MAX_ALLOC_SIZE**, for most workloads this value should be between
 8 bytes and 2 megabytes.
+
+The `alignment` field is currently unsupported and must be set to 0. All objects
+have default alignment of 64 bytes, but the user data alignment is affected
+by the size of the chosen header.
 
 The `units_per_block` field defines how many units a single block of memory
 contains. This value will be rounded up to match the internal size of the
@@ -293,7 +298,7 @@ functions.
 
 Example of a valid alloc class query string:
 ```
-heap.alloc_class.128.desc=500,1000,compact
+heap.alloc_class.128.desc=500,0,1000,compact
 ```
 This query, if executed, will create an allocation class with an id of 128 that
 has a unit size of 500 bytes, has at least 1000 units per block and uses

--- a/src/examples/libpmemobj/slab_allocator/slab_allocator.c
+++ b/src/examples/libpmemobj/slab_allocator/slab_allocator.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Intel Corporation
+ * Copyright 2017-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,6 +56,7 @@ slab_new(PMEMobjpool *pop, size_t size)
 
 	slab->class.header_type = POBJ_HEADER_NONE;
 	slab->class.unit_size = size;
+	slab->class.alignment = 0;
 
 	/* should be a reasonably high number, but not too crazy */
 	slab->class.units_per_block = 1000;

--- a/src/include/libpmemobj/ctl.h
+++ b/src/include/libpmemobj/ctl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Intel Corporation
+ * Copyright 2017-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -130,6 +130,15 @@ struct pobj_alloc_class_desc {
 	 * allocation will be 240 bytes: 2 * 128 - 16 (header).
 	 */
 	size_t unit_size;
+
+	/*
+	 * Currently unsupported. All allocation classes have default alignment
+	 * of 64. User data alignment is affected by the size of a header. For
+	 * compact one this means that the aligment is 48 bytes.
+	 *
+	 * Must be 0.
+	 */
+	size_t alignment;
 
 	/*
 	 * The minimum number of units that must be present in a

--- a/src/libpmemobj/pmalloc.c
+++ b/src/libpmemobj/pmalloc.c
@@ -327,6 +327,12 @@ CTL_WRITE_HANDLER(desc)(PMEMobjpool *pop,
 
 	struct pobj_alloc_class_desc *p = arg;
 
+	if (p->alignment != 0) {
+		ERR("Allocation class alignment is not supported yet");
+		errno = ENOTSUP;
+		return -1;
+	}
+
 	if (p->unit_size <= 0 || p->unit_size > PMEMOBJ_MAX_ALLOC_SIZE ||
 		p->units_per_block <= 0) {
 		errno = EINVAL;
@@ -482,6 +488,7 @@ CTL_READ_HANDLER(desc)(PMEMobjpool *pop,
 	p->header_type = user_htype;
 	p->unit_size = c->unit_size;
 	p->class_id = c->id;
+	p->alignment = 0;
 
 	return 0;
 }
@@ -491,6 +498,8 @@ static struct ctl_argument CTL_ARG(desc) = {
 	.parsers = {
 		CTL_ARG_PARSER_STRUCT(struct pobj_alloc_class_desc,
 			unit_size, ctl_arg_integer),
+		CTL_ARG_PARSER_STRUCT(struct pobj_alloc_class_desc,
+			alignment, ctl_arg_integer),
 		CTL_ARG_PARSER_STRUCT(struct pobj_alloc_class_desc,
 			units_per_block, ctl_arg_integer),
 		CTL_ARG_PARSER_STRUCT(struct pobj_alloc_class_desc,

--- a/src/test/obj_ctl_alloc_class/obj_ctl_alloc_class.c
+++ b/src/test/obj_ctl_alloc_class/obj_ctl_alloc_class.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Intel Corporation
+ * Copyright 2017-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -63,6 +63,7 @@ main(int argc, char *argv[])
 	alloc_class_128.header_type = POBJ_HEADER_NONE;
 	alloc_class_128.unit_size = 128;
 	alloc_class_128.units_per_block = 1000;
+	alloc_class_128.alignment = 0;
 
 	ret = pmemobj_ctl_set(pop, "heap.alloc_class.128.desc",
 		&alloc_class_128);
@@ -72,6 +73,8 @@ main(int argc, char *argv[])
 	alloc_class_129.header_type = POBJ_HEADER_COMPACT;
 	alloc_class_129.unit_size = 1024;
 	alloc_class_129.units_per_block = 1000;
+	alloc_class_129.alignment = 0;
+
 
 	ret = pmemobj_ctl_set(pop, "heap.alloc_class.129.desc",
 		&alloc_class_129);
@@ -162,6 +165,7 @@ main(int argc, char *argv[])
 	alloc_class_new.unit_size = 777;
 	alloc_class_new.units_per_block = 200;
 	alloc_class_new.class_id = 0;
+	alloc_class_new.alignment = 0;
 
 	ret = pmemobj_ctl_set(pop, "heap.alloc_class.new.desc",
 		&alloc_class_new);
@@ -172,6 +176,7 @@ main(int argc, char *argv[])
 	alloc_class_fail.unit_size = 777;
 	alloc_class_fail.units_per_block = 200;
 	alloc_class_fail.class_id = 0;
+	alloc_class_fail.alignment = 0;
 
 	ret = pmemobj_ctl_set(pop, "heap.alloc_class.new.desc",
 		&alloc_class_fail);
@@ -192,6 +197,7 @@ main(int argc, char *argv[])
 	alloc_class_new_huge.unit_size = (2 << 23);
 	alloc_class_new_huge.units_per_block = 1;
 	alloc_class_new_huge.class_id = 0;
+	alloc_class_new_huge.alignment = 0;
 
 	ret = pmemobj_ctl_set(pop, "heap.alloc_class.new.desc",
 		&alloc_class_new_huge);
@@ -208,6 +214,7 @@ main(int argc, char *argv[])
 	alloc_class_new_max.unit_size = PMEMOBJ_MAX_ALLOC_SIZE;
 	alloc_class_new_max.units_per_block = 1024;
 	alloc_class_new_max.class_id = 0;
+	alloc_class_new_max.alignment = 0;
 
 	ret = pmemobj_ctl_set(pop, "heap.alloc_class.new.desc",
 		&alloc_class_new_max);
@@ -222,6 +229,7 @@ main(int argc, char *argv[])
 	alloc_class_new_loop.unit_size = 16384;
 	alloc_class_new_loop.units_per_block = 63;
 	alloc_class_new_loop.class_id = 0;
+	alloc_class_new_loop.alignment = 0;
 
 	ret = pmemobj_ctl_set(pop, "heap.alloc_class.new.desc",
 		&alloc_class_new_loop);

--- a/src/test/obj_ctl_alloc_class_config/alloc_class_config
+++ b/src/test/obj_ctl_alloc_class_config/alloc_class_config
@@ -1,17 +1,20 @@
 heap.alloc_class.128.desc =
 	128, # unit size
+	0, # no alignment
 	1000, # roughly 1k units per run
 	none # don't use the header
 ;
 
 heap.alloc_class.129.desc =
 	1024, # unit size
+	0, # no alignment
 	1000, # roughly 1k units per run
 	compact # use compact headers
 ;
 
 heap.alloc_class.130.desc =
 	2048, # unit size
+	0, # no alignment
 	1000, # roughly 1k units per run
 	legacy # use compact headers
 ;


### PR DESCRIPTION
We need to add the alignment field now so that it's easier to
introduce this feature in the next version of the library

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2675)
<!-- Reviewable:end -->
