### PR TITLE
common: report actual errors in poolset parser

### DIFF
--- a/src/test/util_poolset_parse/grep0.log.match
+++ b/src/test/util_poolset_parse/grep0.log.match
@@ -38,10 +38,10 @@ $(*)set file format correct ($(nW)pool36$(nW).set)
 $(*)set file format correct ($(nW)pool37$(nW).set)
 $(*)pool38$(nW).set [address of remote node and descriptor of remote pool set expected:7]
 $(*)pool39$(nW).set [incorrect descriptor (must be a relative path):7]
-$(*)pool40$(nW).set [incorrect format of size:2]
-$(*)pool41$(nW).set [incorrect format of size:4]
-$(*)pool42$(nW).set [incorrect format of size:8]
-$(*)pool43$(nW).set [incorrect format of size:8]
+$(*)pool40$(nW).set [cannot determine size of a part:2]
+$(*)pool41$(nW).set [cannot determine size of a part:4]
+$(*)pool42$(nW).set [cannot determine size of a part:8]
+$(*)pool43$(nW).set [cannot determine size of a part:8]
 $(*)set file format correct ($(nW)pool44$(nW).set)
 $(*)set file format correct ($(nW)pool45$(nW).set)
 $(*)set file format correct ($(nW)pool46$(nW).set)

--- a/src/test/util_poolset_parse/grep0w.log.match
+++ b/src/test/util_poolset_parse/grep0w.log.match
@@ -38,10 +38,10 @@ $(*)set file format correct ($(nW)pool36$(nW).set)
 $(*)set file format correct ($(nW)pool37$(nW).set)
 $(*)pool38$(nW).set [address of remote node and descriptor of remote pool set expected:7]
 $(*)pool39$(nW).set [incorrect descriptor (must be a relative path):7]
-$(*)pool40$(nW).set [incorrect format of size:2]
-$(*)pool41$(nW).set [incorrect format of size:4]
-$(*)pool42$(nW).set [incorrect format of size:8]
-$(*)pool43$(nW).set [incorrect format of size:8]
+$(*)pool40$(nW).set [cannot determine size of a part:2]
+$(*)pool41$(nW).set [cannot determine size of a part:4]
+$(*)pool42$(nW).set [cannot determine size of a part:8]
+$(*)pool43$(nW).set [cannot determine size of a part:8]
 $(*)set file format correct ($(nW)pool44$(nW).set)
 $(*)set file format correct ($(nW)pool45$(nW).set)
 $(*)set file format correct ($(nW)pool46$(nW).set)


### PR DESCRIPTION
In some cases, pmempool used to report "Invalid argument" error,
while the actual problem was different, i.e. "Permission denied".

Ref: pmem/issues#815

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2677)
<!-- Reviewable:end -->
