### PR TITLE
test: update Valgrind suppression files

### DIFF
--- a/src/test/drd-log.supp
+++ b/src/test/drd-log.supp
@@ -9,9 +9,28 @@
     fun:out_log
 }
 {
+    <debug_log_suppress2>
+    drd:ConflictingAccess
+    fun:*memmove
+    fun:_IO_file_xsputn@@GLIBC*
+    fun:fputs
+    fun:out_print_func
+    fun:out_common
+    fun:out_log
+}
+{
     <ut_log_suppress>
     drd:ConflictingAccess
     fun:*mempcpy
+    fun:_IO_file_xsputn@@GLIBC*
+    fun:fputs
+    ...
+    fun:ut_out
+}
+{
+    <ut_log_suppress2>
+    drd:ConflictingAccess
+    fun:*memmove
     fun:_IO_file_xsputn@@GLIBC*
     fun:fputs
     ...

--- a/src/test/helgrind-log.supp
+++ b/src/test/helgrind-log.supp
@@ -8,3 +8,13 @@
     fun:out_common
     fun:out_log
 }
+{
+    <debug_log_suppress2>
+    Helgrind:Race
+    fun:*memmove
+    fun:_IO_file_xsputn@@GLIBC*
+    fun:fputs
+    fun:out_print_func
+    fun:out_common
+    fun:out_log
+}


### PR DESCRIPTION
Fixes failing tests on Fedora 28/rawhide.
(gcc 8.0, glibc 2.27, valgrind 3.13)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2700)
<!-- Reviewable:end -->
