### PR TITLE
test: disable pmemcheck in recovery tests

### DIFF
--- a/src/test/log_recovery/TEST0
+++ b/src/test/log_recovery/TEST0
@@ -46,6 +46,7 @@ require_build_type nondebug static-nondebug
 # exits with locked mutexes
 configure_valgrind helgrind force-disable
 configure_valgrind drd force-disable
+configure_valgrind pmemcheck force-disable
 
 setup
 

--- a/src/test/log_recovery/TEST1
+++ b/src/test/log_recovery/TEST1
@@ -46,6 +46,7 @@ require_build_type nondebug static-nondebug
 # exits with locked mutexes
 configure_valgrind helgrind force-disable
 configure_valgrind drd force-disable
+configure_valgrind pmemcheck force-disable
 
 setup
 

--- a/src/test/obj_recovery/TEST0
+++ b/src/test/obj_recovery/TEST0
@@ -45,6 +45,7 @@ require_no_asan
 # exits with locked mutexes
 configure_valgrind helgrind force-disable
 configure_valgrind drd force-disable
+configure_valgrind pmemcheck force-disable
 
 setup
 

--- a/src/test/obj_recovery/TEST1
+++ b/src/test/obj_recovery/TEST1
@@ -45,6 +45,7 @@ require_no_asan
 # exits with locked mutexes
 configure_valgrind helgrind force-disable
 configure_valgrind drd force-disable
+configure_valgrind pmemcheck force-disable
 
 setup
 

--- a/src/test/obj_recovery/TEST2
+++ b/src/test/obj_recovery/TEST2
@@ -45,6 +45,7 @@ require_no_asan
 # exits with locked mutexes
 configure_valgrind helgrind force-disable
 configure_valgrind drd force-disable
+configure_valgrind pmemcheck force-disable
 
 setup
 

--- a/src/test/obj_recovery/TEST3
+++ b/src/test/obj_recovery/TEST3
@@ -41,6 +41,8 @@
 require_test_type medium
 require_no_asan
 
+configure_valgrind pmemcheck force-disable
+
 setup
 
 # exits in the middle of transaction, so pool cannot be closed

--- a/src/test/obj_recovery/TEST4
+++ b/src/test/obj_recovery/TEST4
@@ -41,6 +41,8 @@
 require_test_type medium
 require_no_asan
 
+configure_valgrind pmemcheck force-disable
+
 setup
 
 # exits in the middle of transaction, so pool cannot be closed

--- a/src/test/obj_recovery/TEST5
+++ b/src/test/obj_recovery/TEST5
@@ -41,6 +41,8 @@
 require_test_type medium
 require_no_asan
 
+configure_valgrind pmemcheck force-disable
+
 setup
 
 # exits in the middle of transaction, so pool cannot be closed

--- a/src/test/obj_recovery/TEST6
+++ b/src/test/obj_recovery/TEST6
@@ -42,6 +42,8 @@
 require_test_type long
 require_no_asan
 
+configure_valgrind pmemcheck force-disable
+
 configure_valgrind memcheck force-enable
 export PMEMOBJ_VG_CHECK_UNDEF=1
 

--- a/src/test/obj_recovery/TEST7
+++ b/src/test/obj_recovery/TEST7
@@ -42,6 +42,8 @@
 require_test_type long
 require_no_asan
 
+configure_valgrind pmemcheck force-disable
+
 configure_valgrind memcheck force-enable
 export PMEMOBJ_VG_CHECK_UNDEF=1
 

--- a/src/test/obj_recovery/TEST8
+++ b/src/test/obj_recovery/TEST8
@@ -42,6 +42,8 @@
 require_test_type long
 require_no_asan
 
+configure_valgrind pmemcheck force-disable
+
 configure_valgrind memcheck force-enable
 export PMEMOBJ_VG_CHECK_UNDEF=1
 


### PR DESCRIPTION
These tests simulate application crash, and intentionally leave some
stores not flushed to persistence.  So, running those tests under
pmemcheck does not make sense.

Ref: pmem/issues#827
Ref: pmem/issues#828

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2701)
<!-- Reviewable:end -->
