### PR TITLE
test: pmem_has_auto_flush add os_stat mock

### DIFF
--- a/src/test/pmem_has_auto_flush/mocks_posix.c
+++ b/src/test/pmem_has_auto_flush/mocks_posix.c
@@ -80,3 +80,19 @@ FUNC_MOCK_RUN_DEFAULT {
 	return _FUNC_REAL(fs_new)(path2);
 }
 FUNC_MOCK_END
+
+/*
+ * os_stat -- os_stat mock to handle sysfs path
+ */
+FUNC_MOCK(os_stat, int, const char *path, os_stat_t *buf)
+FUNC_MOCK_RUN_DEFAULT {
+	if (!strstr(path, BUS_DEVICE_PATH))
+		return _FUNC_REAL(os_stat)(path, buf);
+
+	const char *prefix = os_getenv("BUS_DEVICE_PATH");
+	char path2[PATH_MAX] = { 0 };
+	strcat(path2, prefix);
+	strcat(path2, path + strlen(BUS_DEVICE_PATH));
+	return _FUNC_REAL(os_stat)(path2, buf);
+}
+FUNC_MOCK_END


### PR DESCRIPTION
There is mock for `fs_new` and `open`, but that is not enough.
Before `fs_new` and `open` `os_auto_flush()` calls `os_stat` and checks return value.
This patch fix `pmem_has_auto_flush/TEST6 ` on machines where `"/sys/bus/nd/devices"` does not exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2712)
<!-- Reviewable:end -->
