### PR TITLE
obj: adjust extend size to reservation size

### DIFF
--- a/src/common/set.h
+++ b/src/common/set.h
@@ -282,7 +282,7 @@ int util_pool_open(struct pool_set **setp, const char *path, int cow,
 int util_pool_open_remote(struct pool_set **setp, const char *path, int cow,
 	size_t minpartsize, struct rpmem_pool_attr *rattr);
 
-void *util_pool_extend(struct pool_set *set, size_t size);
+void *util_pool_extend(struct pool_set *set, size_t *size, size_t minpartsize);
 
 void util_remote_init(void);
 void util_remote_fini(void);

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -1208,7 +1208,7 @@ error_bucket_create:
 int
 heap_extend(struct palloc_heap *heap, struct bucket *b, size_t size)
 {
-	void *nptr = util_pool_extend(heap->set, size);
+	void *nptr = util_pool_extend(heap->set, &size, PMEMOBJ_MIN_PART);
 	if (nptr == NULL)
 		return -1;
 

--- a/src/test/obj_extend/TEST7
+++ b/src/test/obj_extend/TEST7
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_extend/TEST7 -- unit test for extending the pool
+# reservation size is not 8MiB + N * 128MiB
+# (pmem/issues#823)
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+
+setup
+
+RESVSIZE=$((512 * 1024 * 1024)) # 512MiB
+ALLOCSIZE=$((10 * 1024 * 1024))
+
+# prepare pool sets
+create_poolset $DIR/testset1\
+	$RESVSIZE:$DIR/testdir10:d\
+	O SINGLEHDR
+
+expect_normal_exit ./obj_extend$EXESUFFIX $DIR/testset1 $ALLOCSIZE
+
+check
+
+pass

--- a/src/test/obj_extend/obj_extend.c
+++ b/src/test/obj_extend/obj_extend.c
@@ -48,8 +48,8 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_extend");
 
-	if (argc != 2)
-		UT_FATAL("usage: %s file-name", argv[0]);
+	if (argc < 2)
+		UT_FATAL("usage: %s file-name [alloc-size]", argv[0]);
 
 	const char *path = argv[1];
 
@@ -61,9 +61,15 @@ main(int argc, char *argv[])
 		exit(0);
 	}
 
+	size_t alloc_size;
+	if (argc > 2)
+		alloc_size = atoi(argv[2]);
+	else
+		alloc_size = ALLOC_SIZE;
+
 	size_t allocated = 0;
 	PMEMoid oid;
-	while (pmemobj_alloc(pop, &oid, ALLOC_SIZE, 0, NULL, NULL) == 0) {
+	while (pmemobj_alloc(pop, &oid, alloc_size, 0, NULL, NULL) == 0) {
 		allocated += pmemobj_alloc_usable_size(oid);
 	}
 

--- a/src/test/util_poolset/util_poolset.c
+++ b/src/test/util_poolset/util_poolset.c
@@ -208,7 +208,8 @@ main(int argc, char *argv[])
 			ret = util_pool_open(&set, fname, 0 /* rdonly */,
 				MIN_PART, &attr, NULL, false, NULL);
 			UT_ASSERTeq(ret, 0);
-			void *nptr = util_pool_extend(set, Extend_size);
+			size_t esize = Extend_size;
+			void *nptr = util_pool_extend(set, &esize, MIN_PART);
 			if (nptr == NULL)
 				UT_OUT("!%s: util_pool_extend", fname);
 			else {


### PR DESCRIPTION
If extending the pool with default growth size would exceed reservation
size, adjust new part size to fit reservation size.  In such case, part
size cannot be smaller than minimum part size for given pool type.

Ref: pmem/issues#823

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2724)
<!-- Reviewable:end -->
