### PR TITLE
test: sort devices in pmempool_transform TEST22

### DIFF
--- a/src/test/pmempool_transform/TEST22
+++ b/src/test/pmempool_transform/TEST22
@@ -61,6 +61,20 @@ LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in
 POOLSET_OUT=$DIR/poolset.out
 
+# Make sure the total size of devices 2/3 is not smaller than devices 0/1.
+# If this is the case, swap devices.
+SIZE1=$(($(get_devdax_size 0) + $(get_devdax_size 1)))
+SIZE2=$(($(get_devdax_size 2) + $(get_devdax_size 3)))
+
+if [ $SIZE1 -gt $SIZE2 ]; then
+	TMP=${DEVICE_DAX_PATH[0]}
+	DEVICE_DAX_PATH[0]=${DEVICE_DAX_PATH[2]}
+	DEVICE_DAX_PATH[2]=$TMP
+	TMP=${DEVICE_DAX_PATH[1]}
+	DEVICE_DAX_PATH[1]=${DEVICE_DAX_PATH[3]}
+	DEVICE_DAX_PATH[3]=$TMP
+fi
+
 # Create poolset files
 create_poolset $POOLSET_IN \
 	O SINGLEHDR \
@@ -76,7 +90,6 @@ create_poolset $POOLSET_OUT \
 	AUTO:${DEVICE_DAX_PATH[1]}:x
 
 DAX_SIZE[0]=$(get_devdax_size 0)
-
 OFFSET=${DAX_SIZE[0]}
 ROOT_SIZE=$[OFFSET + 1024]
 

--- a/src/test/pmempool_transform/out22.log.match
+++ b/src/test/pmempool_transform/out22.log.match
@@ -10,23 +10,23 @@ part 0:
 path                     : $(nW)
 type                     : device dax
 size                     : $(nW)
-alignment                : 2097152
+alignment                : $(N)
 part 1:
 path                     : $(nW)
 type                     : device dax
 size                     : $(nW)
-alignment                : 2097152
+alignment                : $(N)
 Replica 1 - local, 2 part(s):
 part 0:
 path                     : $(nW)
 type                     : device dax
 size                     : $(nW)
-alignment                : 4096
+alignment                : $(N)
 part 1:
 path                     : $(nW)
 type                     : device dax
 size                     : $(nW)
-alignment                : 4096
+alignment                : $(N)
 
 Poolset options:
 SINGLEHDR
@@ -51,7 +51,7 @@ Part file:
 path                     : $(nW)
 type                     : device dax
 size                     : $(nW)
-alignment                : 4096
+alignment                : $(N)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
@@ -64,7 +64,7 @@ Part file:
 path                     : $(nW)
 type                     : device dax
 size                     : $(nW)
-alignment                : 2097152
+alignment                : $(N)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]


### PR DESCRIPTION
Test requires four Device-DAX devices - two with 4K alignment and two
with 2M alignment.  One pair of devices acts as an input pool set,
while the other pair will become the new replica added to the pool set
using 'pmempool transform' command.  The devices must be arranged in
the way that their internal alignment is the same within given replica
and the total size of the replica being added cannot be smaller than
the size of the original pool.

Ref: pmem/issues#809

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2727)
<!-- Reviewable:end -->
