### PR TITLE
common: include linux/falloc.h in badblock_linux.c

### DIFF
--- a/src/common/badblock_linux.c
+++ b/src/common/badblock_linux.c
@@ -36,6 +36,7 @@
 
 #define _GNU_SOURCE
 #include <fcntl.h>
+#include <linux/falloc.h>
 
 #include "file.h"
 #include "os.h"


### PR DESCRIPTION
For unknown reasons it is not included automatically
by fcntl.h on CentOS 7.4 and RHEL 7.3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2735)
<!-- Reviewable:end -->
