### PR TITLE
common: FreeBSD compatibility fixes

### DIFF
--- a/src/common/badblock_freebsd.c
+++ b/src/common/badblock_freebsd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Intel Corporation
+ * Copyright 2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,42 +31,59 @@
  */
 
 /*
- * fs.h -- file system traversal abstraction layer
+ * badblock_freebsd.c - implementation of the FreeBSD bad block API
  */
 
-#ifndef PMDK_FS_H
-#define PMDK_FS_H 1
+#include "out.h"
+#include "os_badblock.h"
 
-#include <unistd.h>
+/*
+ * os_badblocks_check_file -- check if the file contains bad blocks
+ *
+ * Return value:
+ * -1 : an error
+ *  0 : no bad blocks
+ *  1 : bad blocks detected
+ */
+int
+os_badblocks_check_file(const char *file)
+{
+	LOG(3, "file %s", file);
 
-struct fs;
+	return 0;
+}
 
-enum fs_entry_type {
-	FS_ENTRY_FILE,
-	FS_ENTRY_DIRECTORY,
-	FS_ENTRY_SYMLINK,
-	FS_ENTRY_OTHER,
+/*
+ * os_badblocks_count -- returns number of bad blocks in the file
+ *                       or -1 in case of an error
+ */
+long
+os_badblocks_count(const char *file)
+{
+	LOG(3, "file %s", file);
 
-	MAX_FS_ENTRY_TYPES
-};
+	return 0;
+}
 
-struct fs_entry {
-	enum fs_entry_type type;
+/*
+ * os_badblocks_get -- returns list of bad blocks in the file
+ */
+int
+os_badblocks_get(const char *file, struct badblocks *bbs)
+{
+	LOG(3, "file %s", file);
 
-	const char *name;
-	size_t namelen;
+	return 0;
+}
 
-	const char *path;
-	size_t pathlen;
-	/* the depth of the traversal */
-	/* XXX long on FreeBSD. Linux uses short. No harm in it being bigger */
-	long level;
-};
+/*
+ * os_badblocks_clear -- clears bad blocks in a file
+ *                      (regular file or dax device)
+ */
+int
+os_badblocks_clear(const char *file)
+{
+	LOG(3, "file %s", file);
 
-struct fs *fs_new(const char *path);
-void fs_delete(struct fs *f);
-
-/* this call invalidates the previous entry */
-struct fs_entry *fs_read(struct fs *f);
-
-#endif /* PMDK_FS_H */
+	return 0;
+}

--- a/src/common/extent_freebsd.c
+++ b/src/common/extent_freebsd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Intel Corporation
+ * Copyright 2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,42 +31,38 @@
  */
 
 /*
- * fs.h -- file system traversal abstraction layer
+ * extent_freebsd.c - implementation of the FreeBSD fs extent query API
+ * XXX THIS IS CURRENTLY A DUMMY MODULE.
  */
 
-#ifndef PMDK_FS_H
-#define PMDK_FS_H 1
+#include <string.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
 
-#include <unistd.h>
+#include "file.h"
+#include "out.h"
+#include "extent.h"
 
-struct fs;
+/*
+ * os_extents_count -- get number of extents of the given file
+ *                     (and optionally read its block size)
+ */
+long
+os_extents_count(const char *path, struct extents *exts)
+{
+	LOG(3, "path %s extents %p", path, exts);
 
-enum fs_entry_type {
-	FS_ENTRY_FILE,
-	FS_ENTRY_DIRECTORY,
-	FS_ENTRY_SYMLINK,
-	FS_ENTRY_OTHER,
+	return -1;
+}
 
-	MAX_FS_ENTRY_TYPES
-};
+/*
+ * os_extents_get -- get extents of the given file
+ *                   (and optionally read its block size)
+ */
+int
+os_extents_get(const char *path, struct extents *exts)
+{
+	LOG(3, "path %s extents %p", path, exts);
 
-struct fs_entry {
-	enum fs_entry_type type;
-
-	const char *name;
-	size_t namelen;
-
-	const char *path;
-	size_t pathlen;
-	/* the depth of the traversal */
-	/* XXX long on FreeBSD. Linux uses short. No harm in it being bigger */
-	long level;
-};
-
-struct fs *fs_new(const char *path);
-void fs_delete(struct fs *f);
-
-/* this call invalidates the previous entry */
-struct fs_entry *fs_read(struct fs *f);
-
-#endif /* PMDK_FS_H */
+	return -1;
+}

--- a/src/common/pmemcommon.inc
+++ b/src/common/pmemcommon.inc
@@ -32,9 +32,9 @@
 #
 
 SOURCE =\
-	$(COMMON)/badblock_linux.c\
+	$(call osdep, $(COMMON)/badblock,.c)\
 	$(COMMON)/badblock_poolset.c\
-	$(COMMON)/extent_linux.c\
+	$(call osdep, $(COMMON)/extent,.c)\
 	$(COMMON)/file.c\
 	$(COMMON)/file_posix.c\
 	$(COMMON)/fs_posix.c\

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -211,9 +211,9 @@ endif
 
 ifeq ($(LIBPMEMCOMMON), internal-nondebug)
 OBJS +=\
-	$(TOP)/src/nondebug/common/badblock_linux.o\
+	$(call osdep, $(TOP)/src/nondebug/common/badblock,.o)\
 	$(TOP)/src/nondebug/common/badblock_poolset.o\
-	$(TOP)/src/nondebug/common/extent_linux.o\
+	$(call osdep, $(TOP)/src/nondebug/common/extent,.o)\
 	$(TOP)/src/nondebug/common/file.o\
 	$(TOP)/src/nondebug/common/file_posix.o\
 	$(TOP)/src/nondebug/common/fs_posix.o\
@@ -238,9 +238,9 @@ endif
 
 ifeq ($(LIBPMEMCOMMON), internal-debug)
 OBJS +=\
-	$(TOP)/src/debug/common/badblock_linux.o\
+	$(call osdep, $(TOP)/src/debug/common/badblock,.o)\
 	$(TOP)/src/debug/common/badblock_poolset.o\
-	$(TOP)/src/debug/common/extent_linux.o\
+	$(call osdep, $(TOP)/src/debug/common/extent,.o)\
 	$(TOP)/src/debug/common/file.o\
 	$(TOP)/src/debug/common/file_posix.o\
 	$(TOP)/src/debug/common/fs_posix.o\

--- a/src/test/pmem_deep_persist/Makefile
+++ b/src/test/pmem_deep_persist/Makefile
@@ -65,8 +65,8 @@ OBJS = pmem_deep_persist.o\
 	shutdown_state.o\
 	os_dimm_none.o\
 	init.o\
-	extent_linux.o\
-	badblock_linux.o\
+	$(call osdep, extent,.o)\
+	$(call osdep, badblock,.o)\
 	badblock_poolset.o
 # this test does not require ndctl
 # to enable builds we use os_dimm_none

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -115,6 +115,7 @@ VALGRIND_SUPP="--suppressions=../ld.supp --suppressions=../memcheck-libunwind.su
 if [ "$(uname -s)" = "FreeBSD" ]; then
 	DATE="gdate"
 	DD="gdd"
+	FALLOCATE="mkfile"
 	VM_OVERCOMMIT="[ $(sysctl vm.overcommit | awk '{print $2}') == 0 ]"
 	RM_ONEFS="-x"
 	STAT_MODE="-f%Lp"
@@ -125,6 +126,7 @@ if [ "$(uname -s)" = "FreeBSD" ]; then
 else
 	DATE="date"
 	DD="dd"
+	FALLOCATE="fallocate -l"
 	VM_OVERCOMMIT="[ $(cat /proc/sys/vm/overcommit_memory) != 2 ]"
 	RM_ONEFS="--one-file-system"
 	STAT_MODE="-c%a"

--- a/src/test/util_badblock/TEST0
+++ b/src/test/util_badblock/TEST0
@@ -44,7 +44,7 @@ require_fs_type any
 
 setup
 
-fallocate -l 100M $DIR/testfile1
+$FALLOCATE 100M $DIR/testfile1
 
 expect_normal_exit ./util_badblock$EXESUFFIX $DIR/testfile1 l
 

--- a/src/test/util_poolset/grep1.log.match
+++ b/src/test/util_poolset/grep1.log.match
@@ -8,19 +8,19 @@ $(OPT)compiled with support for Valgrind drd
 open "$(nW)/testset0": No such file or directory
 invalid major version (0)
 open "$(nW)/testset2": Permission denied
-stat $(nW)/testfile31: No such file or directory
-checking the file for bad blocks failed -- '$(nW)/testfile31'
-counting bad blocks failed -- '$(nW)/testfile31'
-checking the pool file for bad blocks failed -- '$(nW)/testfile31'
-checking the pool set for bad blocks failed
-WARNING: failed to check pool set for bad blocks -- '$(nW)/testset3'
+$(OPT)stat $(nW)/testfile31: No such file or directory
+$(OPT)checking the file for bad blocks failed -- '$(nW)/testfile31'
+$(OPT)counting bad blocks failed -- '$(nW)/testfile31'
+$(OPT)checking the pool file for bad blocks failed -- '$(nW)/testfile31'
+$(OPT)checking the pool set for bad blocks failed
+$(OPT)WARNING: failed to check pool set for bad blocks -- '$(nW)/testset3'
 open "$(nW)/testfile31": No such file or directory
-stat $(nW)/testfile42: No such file or directory
-checking the file for bad blocks failed -- '$(nW)/testfile42'
-counting bad blocks failed -- '$(nW)/testfile42'
-checking the pool file for bad blocks failed -- '$(nW)/testfile42'
-checking the pool set for bad blocks failed
-WARNING: failed to check pool set for bad blocks -- '$(nW)/testset4'
+$(OPT)stat $(nW)/testfile42: No such file or directory
+$(OPT)checking the file for bad blocks failed -- '$(nW)/testfile42'
+$(OPT)counting bad blocks failed -- '$(nW)/testfile42'
+$(OPT)checking the pool file for bad blocks failed -- '$(nW)/testfile42'
+$(OPT)checking the pool set for bad blocks failed
+$(OPT)WARNING: failed to check pool set for bad blocks -- '$(nW)/testset4'
 open "$(nW)/testfile42": No such file or directory
 size 1048576 smaller than 2097152
 size 1048576 smaller than 2097152

--- a/src/test/vmem_valgrind_region/memcheck2.log.match
+++ b/src/test/vmem_valgrind_region/memcheck2.log.match
@@ -18,7 +18,7 @@ $(OPT)==$(N)==    by 0x$(X): fputs $(*)
 ==$(N)==    by 0x$(X): ut_out (ut.c:$(N))
 ==$(N)==    by 0x$(X): do_iterate (vmem_valgrind_region.c:$(N))
 ==$(N)==    by 0x$(X): main (vmem_valgrind_region.c:$(N))
-$(OPT)==$(N)==  Address 0x$(X) is 54 bytes inside data symbol "Buff_trace"
+$(OPT)==$(N)==  Address 0x$(X) is $(N) bytes inside data symbol "Buff_trace"
 ==$(N)== 
 ==$(N)== 
 ==$(N)== HEAP SUMMARY:

--- a/src/test/vmem_valgrind_region/memcheck4.log.match
+++ b/src/test/vmem_valgrind_region/memcheck4.log.match
@@ -18,7 +18,7 @@ $(OPT)==$(N)==    by 0x$(X): fputs $(*)
 ==$(N)==    by 0x$(X): ut_out (ut.c:$(N))
 ==$(N)==    by 0x$(X): do_iterate (vmem_valgrind_region.c:$(N))
 ==$(N)==    by 0x$(X): main (vmem_valgrind_region.c:$(N))
-$(OPT)==$(N)==  Address 0x$(X) is 54 bytes inside data symbol "Buff_trace"
+$(OPT)==$(N)==  Address 0x$(X) is $(N) bytes inside data symbol "Buff_trace"
 ==$(N)== 
 ==$(N)== Invalid read of size 8
 ==$(N)==    at 0x$(X): do_iterate (vmem_valgrind_region.c:$(N))


### PR DESCRIPTION
Use long for level in fs_entry (common/fs.c).
Add FreeBSD stubs for badblock handling.
Close files in cto_dirty test.
Define FALLOCATE in unittest.sh, use in util_badblock test.
Anonymize offset in vmem_valgrind_region memcheck4.log.match.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2745)
<!-- Reviewable:end -->
