### PR TITLE
test: do not call DONE() when simulating app crash

### DIFF
--- a/src/test/cto_dirty/TEST0
+++ b/src/test/cto_dirty/TEST0
@@ -44,8 +44,8 @@ require_fs_type any
 
 setup
 
-expect_normal_exit ./cto_dirty$EXESUFFIX $DIR/testfile 1
-expect_abnormal_exit ./cto_dirty$EXESUFFIX $DIR/testfile
+expect_abnormal_exit ./cto_dirty$EXESUFFIX $DIR/testfile 1
+expect_normal_exit ./cto_dirty$EXESUFFIX $DIR/testfile
 
 check
 

--- a/src/test/cto_dirty/TEST0.PS1
+++ b/src/test/cto_dirty/TEST0.PS1
@@ -48,8 +48,8 @@ require_fs_type any
 
 setup
 
-expect_normal_exit $Env:EXE_DIR\cto_dirty$Env:EXESUFFIX $DIR\testfile 1
-expect_abnormal_exit $Env:EXE_DIR\cto_dirty$Env:EXESUFFIX $DIR\testfile
+expect_abnormal_exit $Env:EXE_DIR\cto_dirty$Env:EXESUFFIX $DIR\testfile 1
+expect_normal_exit $Env:EXE_DIR\cto_dirty$Env:EXESUFFIX $DIR\testfile
 
 check
 

--- a/src/test/cto_dirty/TEST1
+++ b/src/test/cto_dirty/TEST1
@@ -44,8 +44,8 @@ require_fs_type any
 
 setup
 
-expect_normal_exit ./cto_dirty$EXESUFFIX $DIR/testfile 2
-expect_abnormal_exit ./cto_dirty$EXESUFFIX $DIR/testfile
+expect_abnormal_exit ./cto_dirty$EXESUFFIX $DIR/testfile 2
+expect_normal_exit ./cto_dirty$EXESUFFIX $DIR/testfile
 
 check
 

--- a/src/test/cto_dirty/TEST1.PS1
+++ b/src/test/cto_dirty/TEST1.PS1
@@ -48,8 +48,8 @@ require_fs_type any
 
 setup
 
-expect_normal_exit $Env:EXE_DIR\cto_dirty$Env:EXESUFFIX $DIR\testfile 2
-expect_abnormal_exit $Env:EXE_DIR\cto_dirty$Env:EXESUFFIX $DIR\testfile
+expect_abnormal_exit $Env:EXE_DIR\cto_dirty$Env:EXESUFFIX $DIR\testfile 2
+expect_normal_exit $Env:EXE_DIR\cto_dirty$Env:EXESUFFIX $DIR\testfile
 
 check
 

--- a/src/test/cto_dirty/cto_dirty.c
+++ b/src/test/cto_dirty/cto_dirty.c
@@ -42,8 +42,7 @@
 
 #define EXIT_ON(x, y) do {\
 	if ((x) == (y)) {\
-		DONE(NULL);\
-		exit(0);\
+		exit(1);\
 	}\
 } while (0)
 
@@ -66,7 +65,7 @@ main(int argc, char *argv[])
 		pcp = pmemcto_open(argv[1], "test");
 		if (pcp == NULL) {
 			UT_ERR("pmemcto_open: %s", pmemcto_errormsg());
-			exit(1);
+			goto end;
 		}
 	}
 
@@ -84,7 +83,6 @@ main(int argc, char *argv[])
 
 	pmemcto_close(pcp);
 
-	EXIT_ON(phase, 3);
-
+end:
 	DONE(NULL);
 }


### PR DESCRIPTION
Modifies test scripts to expect abnormal exit for the first run of the
test program, when the crash is simulated.  Since DONE() macro is no
longer called in case of simulated failure, there should be no problem
with left-over open files reported by check_open_files() on FreeBSD.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2751)
<!-- Reviewable:end -->
