### PR TITLE
test: Simulated failure fixes for obj_sds.

### DIFF
--- a/src/test/obj_sds/TEST1
+++ b/src/test/obj_sds/TEST1
@@ -57,7 +57,7 @@ create_poolset $POOLSET \
 			   20M:$DIR/testfile15:x
 
 # the pool not closed but there was no an ADR failure
-expect_normal_exit ./obj_sds 1 1 $POOLSET\
+expect_abnormal_exit ./obj_sds 1 1 $POOLSET\
 				   5 0 7 0 9 0 11 0 12 0
 
 expect_normal_exit ./obj_sds 0 0 $POOLSET\

--- a/src/test/obj_sds/TEST2
+++ b/src/test/obj_sds/TEST2
@@ -57,7 +57,7 @@ create_poolset $POOLSET \
 			   20M:$DIR/testfile15:x
 
 # the pool not closed and ADR failure
-expect_normal_exit ./obj_sds 1 1 $POOLSET\
+expect_abnormal_exit ./obj_sds 1 1 $POOLSET\
 				   5 0 7 0 9 0 11 0 12 0
 
 expect_abnormal_exit ./obj_sds 0 0 $POOLSET\

--- a/src/test/obj_sds/TEST3
+++ b/src/test/obj_sds/TEST3
@@ -57,7 +57,7 @@ create_poolset $POOLSET \
 			   20M:$DIR/testfile15:x
 
 # the pool not closed and ADR failure
-expect_normal_exit ./obj_sds 1 1 $POOLSET\
+expect_abnormal_exit ./obj_sds 1 1 $POOLSET\
 				   5 0 7 0 9 0 11 0 12 0
 
 expect_abnormal_exit ./obj_sds 0 0 $POOLSET\

--- a/src/test/obj_sds/TEST4
+++ b/src/test/obj_sds/TEST4
@@ -57,7 +57,7 @@ create_poolset $POOLSET \
 			   20M:$DIR/testfile15:x
 
 # the pool not closed and part moved to another dimm
-expect_normal_exit ./obj_sds 1 1 $POOLSET\
+expect_abnormal_exit ./obj_sds 1 1 $POOLSET\
 				   5 0 7 0 9 0 11 0 12 0
 
 expect_abnormal_exit ./obj_sds 0 0 $POOLSET\

--- a/src/test/obj_sds/TEST5
+++ b/src/test/obj_sds/TEST5
@@ -57,7 +57,7 @@ create_poolset $POOLSET \
 			   20M:$DIR/testfile15:x
 
 # the pool not closed and part moved to another dimm
-expect_normal_exit ./obj_sds 1 1 $POOLSET\
+expect_abnormal_exit ./obj_sds 1 1 $POOLSET\
 				   5 0 7 0 9 0 11 0 12 0
 
 expect_abnormal_exit ./obj_sds 0 0 $POOLSET\

--- a/src/test/obj_sds/TEST6
+++ b/src/test/obj_sds/TEST6
@@ -62,7 +62,7 @@ expect_normal_exit ./obj_sds 1 0 $POOLSET\
 				   5 0 7 0 9 0 11 0 12 0
 
 # the pool closed and ADR failure
-expect_normal_exit ./obj_sds 0 1 $POOLSET\
+expect_abnormal_exit ./obj_sds 0 1 $POOLSET\
 				   5 1 7 1 9 1 11 0 12 0
 
 PMEMOBJ_LOG_LEVEL=4

--- a/src/test/obj_sds/TEST7
+++ b/src/test/obj_sds/TEST7
@@ -62,7 +62,7 @@ expect_normal_exit ./obj_sds 1 0 $POOLSET\
 				   5 0 7 0 9 0 11 0 12 0
 
 # the pool closed and ADR failure
-expect_normal_exit ./obj_sds 0 1 $POOLSET\
+expect_abnormal_exit ./obj_sds 0 1 $POOLSET\
 				   5 1 7 1 9 1 11 0 12 0
 
 # the pool not closed but SDS is fixed

--- a/src/test/obj_sds/obj_sds.c
+++ b/src/test/obj_sds/obj_sds.c
@@ -36,8 +36,6 @@
 
 #include "unittest.h"
 #include "shutdown_state.h"
-#include "set.h"
-#include "obj.h"
 #include <stdlib.h>
 #include <libpmemobj.h>
 
@@ -87,19 +85,12 @@ main(int argc, char *argv[])
 
 	if (!fail)
 		pmemobj_close(pop);
-#ifdef __FreeBSD__
-	/*
-	 * XXX On FreeBSD, mmap()ing a file does not increment the flock()
-	 *	reference count, so the pool set files are held open until
-	 *	pmemobj_close(). In the simulated failure case we still need
-	 *	to close the files for check_open_files() to succeed.
-	 */
-	else
-		util_poolset_fdclose_always(pop->set);
-#endif
 
 	FREE(uids);
 	FREE(uscs);
+
+	if (fail)
+		exit(1);
 
 	DONE(NULL);
 }


### PR DESCRIPTION
Call exit(1) rather than DONE() when fail is set.
Check for abnormal exit when fail is set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2756)
<!-- Reviewable:end -->
