### PR TITLE
common: zero extents to silent memcheck's error

### DIFF
--- a/src/common/extent_linux.c
+++ b/src/common/extent_linux.c
@@ -179,6 +179,9 @@ os_extents_get(const char *path, struct extents *exts)
 	fmap = newfmap;
 	fmap->fm_extent_count = fmap->fm_mapped_extents;
 
+	memset(fmap->fm_extents, 0, fmap->fm_mapped_extents *
+					sizeof(struct fiemap_extent));
+
 	if (ioctl(fd, FS_IOC_FIEMAP, fmap) != 0) {
 		ERR("!ioctl %d", fd);
 		goto error_free;


### PR DESCRIPTION
Zero array of extents just to silent the memcheck's error:

Conditional jump or move depends on uninitialised value(s)
    test_size (util_extent.c:70)
    main (util_extent.c:85)

Ref: pmem/issues#838

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2757)
<!-- Reviewable:end -->
