### PR TITLE
benchmark: rpmem_persist: print bandwidth

### DIFF
--- a/src/benchmarks/benchmark.hpp
+++ b/src/benchmarks/benchmark.hpp
@@ -334,6 +334,7 @@ struct benchmark_info {
 	bool measure_time;
 	bool rm_file;
 	bool allow_poolset;
+	bool print_bandwidth;
 };
 
 void *pmembench_get_priv(struct benchmark *bench);

--- a/src/benchmarks/pmem_memcpy.cpp
+++ b/src/benchmarks/pmem_memcpy.cpp
@@ -526,26 +526,6 @@ pmem_memcpy_exit(struct benchmark *bench, struct benchmark_args *args)
 	return 0;
 }
 
-/*
- * pmem_memcpy_print_extra_headers -- print extra columns
- */
-static void
-pmem_memcpy_print_extra_headers()
-{
-	printf(";bandwidth[MiB/s]");
-}
-
-/*
- * pmem_memcpy_print_extra_values -- print extra values
- */
-static void
-pmem_memcpy_print_extra_values(struct benchmark *bench,
-			       struct benchmark_args *args,
-			       struct total_results *res)
-{
-	printf(";%f", res->nopsps * args->dsize / 1024 / 1024);
-}
-
 /* structure to define command line arguments */
 static struct benchmark_clo pmem_memcpy_clo[8];
 
@@ -639,7 +619,6 @@ pmem_memcpy_constructor(void)
 	pmem_memcpy.opts_size = sizeof(struct pmem_args);
 	pmem_memcpy.rm_file = true;
 	pmem_memcpy.allow_poolset = false;
-	pmem_memcpy.print_extra_headers = pmem_memcpy_print_extra_headers;
-	pmem_memcpy.print_extra_values = pmem_memcpy_print_extra_values;
+	pmem_memcpy.print_bandwidth = true;
 	REGISTER_BENCHMARK(pmem_memcpy);
 };

--- a/src/benchmarks/pmem_memset.cpp
+++ b/src/benchmarks/pmem_memset.cpp
@@ -383,26 +383,6 @@ memset_exit(struct benchmark *bench, struct benchmark_args *args)
 	return 0;
 }
 
-/*
- * pmem_memcpy_print_extra_headers -- print extra columns
- */
-static void
-pmem_memset_print_extra_headers()
-{
-	printf(";bandwidth[MiB/s]");
-}
-
-/*
- * pmem_memcpy_print_extra_values -- print extra values
- */
-static void
-pmem_memset_print_extra_values(struct benchmark *bench,
-			       struct benchmark_args *args,
-			       struct total_results *res)
-{
-	printf(";%f", res->nopsps * args->dsize / 1024 / 1024);
-}
-
 static struct benchmark_clo memset_clo[7];
 /* Stores information about benchmark. */
 static struct benchmark_info memset_info;
@@ -484,7 +464,6 @@ pmem_memset_constructor(void)
 	memset_info.opts_size = sizeof(struct memset_args);
 	memset_info.rm_file = true;
 	memset_info.allow_poolset = false;
-	memset_info.print_extra_headers = pmem_memset_print_extra_headers;
-	memset_info.print_extra_values = pmem_memset_print_extra_values;
+	memset_info.print_bandwidth = true;
 	REGISTER_BENCHMARK(memset_info);
 };

--- a/src/benchmarks/pmembench.cpp
+++ b/src/benchmarks/pmembench.cpp
@@ -432,6 +432,10 @@ pmembench_print_header(struct pmembench *pb, struct benchmark *bench,
 			printf(";%s", bench->clos[i].opt_long);
 		}
 	}
+
+	if (bench->info->print_bandwidth)
+		printf(";bandwidth[MiB/s]");
+
 	if (bench->info->print_extra_headers)
 		bench->info->print_extra_headers();
 	printf("\n");
@@ -458,6 +462,10 @@ pmembench_print_results(struct benchmark *bench, struct benchmark_args *args,
 			printf(";%s", benchmark_clo_str(&bench->clos[i], args,
 							bench->args_size));
 	}
+
+	if (bench->info->print_bandwidth)
+		printf(";%f", res->nopsps * args->dsize / 1024 / 1024);
+
 	if (bench->info->print_extra_values)
 		bench->info->print_extra_values(bench, args, res);
 	printf("\n");

--- a/src/benchmarks/rpmem_persist.cpp
+++ b/src/benchmarks/rpmem_persist.cpp
@@ -575,5 +575,6 @@ pmem_rpmem_persist(void)
 	rpmem_info.opts_size = sizeof(struct rpmem_args);
 	rpmem_info.rm_file = true;
 	rpmem_info.allow_poolset = true;
+	rpmem_info.print_bandwidth = true;
 	REGISTER_BENCHMARK(rpmem_info);
 };


### PR DESCRIPTION
... and make it easier to enable this column in other benchmarks