### PR TITLE
test: win: disable sys select include

### DIFF
--- a/src/test/unittest/unittest.h
+++ b/src/test/unittest/unittest.h
@@ -110,12 +110,13 @@ extern "C" {
 #include <sys/mman.h>
 #include <sys/file.h>
 #include <sys/mount.h>
-#include <sys/select.h>
 #include <fcntl.h>
 #include <signal.h>
 #include <errno.h>
 #include <dirent.h>
-
+#ifndef _WIN32
+#include <sys/select.h>
+#endif
 /* XXX: move OS abstraction layer out of common */
 #include "os.h"
 #include "os_thread.h"


### PR DESCRIPTION
This is fix to 1.3.2-rc3
Windows does not support <sys/select.h>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2777)
<!-- Reviewable:end -->
