### PR TITLE
common: replace REP*/PART*/HDR* macros by functions

### DIFF
--- a/src/common/set.h
+++ b/src/common/set.h
@@ -46,6 +46,7 @@ extern "C" {
 
 #include <sys/types.h>
 
+#include "out.h"
 #include "vec.h"
 #include "pool_hdr.h"
 #include "librpmem.h"
@@ -194,6 +195,7 @@ struct pool_attr {
 static inline unsigned
 REPidx(const struct pool_set *set, unsigned r)
 {
+	ASSERTne(set->nreplicas, 0);
 	return (set->nreplicas + r) % set->nreplicas;
 }
 
@@ -201,6 +203,7 @@ REPidx(const struct pool_set *set, unsigned r)
 static inline unsigned
 REPNidx(const struct pool_set *set, unsigned r)
 {
+	ASSERTne(set->nreplicas, 0);
 	return (set->nreplicas + r + 1) % set->nreplicas;
 }
 
@@ -208,6 +211,7 @@ REPNidx(const struct pool_set *set, unsigned r)
 static inline unsigned
 REPPidx(const struct pool_set *set, unsigned r)
 {
+	ASSERTne(set->nreplicas, 0);
 	return (set->nreplicas + r - 1) % set->nreplicas;
 }
 
@@ -215,6 +219,7 @@ REPPidx(const struct pool_set *set, unsigned r)
 static inline unsigned
 PARTidx(const struct pool_replica *rep, unsigned p)
 {
+	ASSERTne(rep->nparts, 0);
 	return (rep->nparts + p) % rep->nparts;
 }
 
@@ -222,6 +227,7 @@ PARTidx(const struct pool_replica *rep, unsigned p)
 static inline unsigned
 PARTNidx(const struct pool_replica *rep, unsigned p)
 {
+	ASSERTne(rep->nparts, 0);
 	return (rep->nparts + p + 1) % rep->nparts;
 }
 
@@ -229,6 +235,7 @@ PARTNidx(const struct pool_replica *rep, unsigned p)
 static inline unsigned
 PARTPidx(const struct pool_replica *rep, unsigned p)
 {
+	ASSERTne(rep->nparts, 0);
 	return (rep->nparts + p - 1) % rep->nparts;
 }
 
@@ -236,6 +243,7 @@ PARTPidx(const struct pool_replica *rep, unsigned p)
 static inline unsigned
 HDRidx(const struct pool_replica *rep, unsigned p)
 {
+	ASSERTne(rep->nhdrs, 0);
 	return (rep->nhdrs + p) % rep->nhdrs;
 }
 
@@ -243,6 +251,7 @@ HDRidx(const struct pool_replica *rep, unsigned p)
 static inline unsigned
 HDRNidx(const struct pool_replica *rep, unsigned p)
 {
+	ASSERTne(rep->nhdrs, 0);
 	return (rep->nhdrs + p + 1) % rep->nhdrs;
 }
 
@@ -250,6 +259,7 @@ HDRNidx(const struct pool_replica *rep, unsigned p)
 static inline unsigned
 HDRPidx(const struct pool_replica *rep, unsigned p)
 {
+	ASSERTne(rep->nhdrs, 0);
 	return (rep->nhdrs + p - 1) % rep->nhdrs;
 }
 

--- a/src/common/set.h
+++ b/src/common/set.h
@@ -191,49 +191,130 @@ struct pool_attr {
 };
 
 /* get index of the (r)th replica */
-#define REPidx(set, r) (((set)->nreplicas + (r)) % (set)->nreplicas)
+static inline unsigned
+REPidx(const struct pool_set *set, unsigned r)
+{
+	return (set->nreplicas + r) % set->nreplicas;
+}
+
 /* get index of the (r + 1)th replica */
-#define REPNidx(set, r) (((set)->nreplicas + (r) + 1) % (set)->nreplicas)
+static inline unsigned
+REPNidx(const struct pool_set *set, unsigned r)
+{
+	return (set->nreplicas + r + 1) % set->nreplicas;
+}
+
 /* get index of the (r - 1)th replica */
-#define REPPidx(set, r) (((set)->nreplicas + (r) - 1) % (set)->nreplicas)
+static inline unsigned
+REPPidx(const struct pool_set *set, unsigned r)
+{
+	return (set->nreplicas + r - 1) % set->nreplicas;
+}
 
 /* get index of the (r)th part */
-#define PARTidx(rep, p) (((rep)->nparts + (p)) % (rep)->nparts)
+static inline unsigned
+PARTidx(const struct pool_replica *rep, unsigned p)
+{
+	return (rep->nparts + p) % rep->nparts;
+}
+
 /* get index of the (r + 1)th part */
-#define PARTNidx(rep, p) (((rep)->nparts + (p) + 1) % (rep)->nparts)
+static inline unsigned
+PARTNidx(const struct pool_replica *rep, unsigned p)
+{
+	return (rep->nparts + p + 1) % rep->nparts;
+}
+
 /* get index of the (r - 1)th part */
-#define PARTPidx(rep, p) (((rep)->nparts + (p) - 1) % (rep)->nparts)
+static inline unsigned
+PARTPidx(const struct pool_replica *rep, unsigned p)
+{
+	return (rep->nparts + p - 1) % rep->nparts;
+}
 
 /* get index of the (r)th part */
-#define HDRidx(rep, p) (((rep)->nhdrs + (p)) % (rep)->nhdrs)
+static inline unsigned
+HDRidx(const struct pool_replica *rep, unsigned p)
+{
+	return (rep->nhdrs + p) % rep->nhdrs;
+}
+
 /* get index of the (r + 1)th part */
-#define HDRNidx(rep, p) (((rep)->nhdrs + (p) + 1) % (rep)->nhdrs)
+static inline unsigned
+HDRNidx(const struct pool_replica *rep, unsigned p)
+{
+	return (rep->nhdrs + p + 1) % rep->nhdrs;
+}
+
 /* get index of the (r - 1)th part */
-#define HDRPidx(rep, p) (((rep)->nhdrs + (p) - 1) % (rep)->nhdrs)
+static inline unsigned
+HDRPidx(const struct pool_replica *rep, unsigned p)
+{
+	return (rep->nhdrs + p - 1) % rep->nhdrs;
+}
 
 /* get (r)th replica */
-#define REP(set, r)\
-	((set)->replica[REPidx(set, r)])
+static inline struct pool_replica *
+REP(const struct pool_set *set, unsigned r)
+{
+	return set->replica[REPidx(set, r)];
+}
+
 /* get (r + 1)th replica */
-#define REPN(set, r)\
-	((set)->replica[REPNidx(set, r)])
+static inline struct pool_replica *
+REPN(const struct pool_set *set, unsigned r)
+{
+	return set->replica[REPNidx(set, r)];
+}
+
 /* get (r - 1)th replica */
-#define REPP(set, r)\
-	((set)->replica[REPPidx(set, r)])
+static inline struct pool_replica *
+REPP(const struct pool_set *set, unsigned r)
+{
+	return set->replica[REPPidx(set, r)];
+}
 
-#define PART(rep, p)\
-	((rep)->part[PARTidx(rep, p)])
-#define PARTN(rep, p)\
-	((rep)->part[PARTNidx(rep, p)])
-#define PARTP(rep, p)\
-	((rep)->part[PARTPidx(rep, p)])
+/* get (p)th part */
+static inline struct pool_set_part *
+PART(struct pool_replica *rep, unsigned p)
+{
+	return &rep->part[PARTidx(rep, p)];
+}
 
-#define HDR(rep, p)\
-	((struct pool_hdr *)(((rep)->part[HDRidx(rep, p)]).hdr))
-#define HDRN(rep, p)\
-	((struct pool_hdr *)(((rep)->part[HDRNidx(rep, p)]).hdr))
-#define HDRP(rep, p)\
-	((struct pool_hdr *)(((rep)->part[HDRPidx(rep, p)]).hdr))
+/* get (p + 1)th part */
+static inline struct pool_set_part *
+PARTN(struct pool_replica *rep, unsigned p)
+{
+	return &rep->part[PARTNidx(rep, p)];
+}
+
+/* get (p - 1)th part */
+static inline struct pool_set_part *
+PARTP(struct pool_replica *rep, unsigned p)
+{
+	return &rep->part[PARTPidx(rep, p)];
+}
+
+/* get (p)th header */
+static inline struct pool_hdr *
+HDR(struct pool_replica *rep, unsigned p)
+{
+	return (struct pool_hdr *)(rep->part[HDRidx(rep, p)].hdr);
+}
+
+/* get (p + 1)th header */
+static inline struct pool_hdr *
+HDRN(struct pool_replica *rep, unsigned p)
+{
+	return (struct pool_hdr *)(rep->part[HDRNidx(rep, p)].hdr);
+}
+
+/* get (p - 1)th header */
+static inline struct pool_hdr *
+HDRP(struct pool_replica *rep, unsigned p)
+{
+	return (struct pool_hdr *)(rep->part[HDRPidx(rep, p)].hdr);
+}
 
 extern int Prefault_at_open;
 extern int Prefault_at_create;

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -461,7 +461,7 @@ char *util_concat_str(const char *s1, const char *s2);
 #elif defined(_MSC_VER)
 #define COMPILE_ERROR_ON(cond) C_ASSERT(!(cond))
 /* XXX - can't be done with C_ASSERT() unless we have __builtin_constant_p() */
-#define ASSERT_COMPILE_ERROR_ON(cond)
+#define ASSERT_COMPILE_ERROR_ON(cond) do {} while (0)
 #else
 #define COMPILE_ERROR_ON(cond) ((void)sizeof(char[(cond) ? -1 : 1]))
 #define ASSERT_COMPILE_ERROR_ON(cond) COMPILE_ERROR_ON(cond)

--- a/src/libpmemcto/cto.c
+++ b/src/libpmemcto/cto.c
@@ -236,7 +236,7 @@ cto_runtime_init(PMEMctopool *pcp, int rdonly, int is_pmem)
 
 	/* reset consistency flag */
 	pcp->consistent = 0;
-	os_part_deep_common(&PART(REP(pcp->set, 0), 0),
+	os_part_deep_common(PART(REP(pcp->set, 0), 0),
 			&pcp->consistent, sizeof(pcp->consistent), 1);
 
 	/*
@@ -624,13 +624,13 @@ pmemcto_close(PMEMctopool *pcp)
 	/* so far, there could be only one replica in CTO pool set */
 	struct pool_replica *rep = REP(pcp->set, 0);
 	for (unsigned p = 0; p < rep->nparts; p++) {
-		struct pool_set_part *part = &PART(rep, p);
+		struct pool_set_part *part = PART(rep, p);
 		os_part_deep_common(part, part->addr, part->size, 1);
 	}
 
 	/* set consistency flag */
 	pcp->consistent = 1;
-	os_part_deep_common(&PART(REP(pcp->set, 0), 0),
+	os_part_deep_common(PART(REP(pcp->set, 0), 0),
 			&pcp->consistent, sizeof(pcp->consistent), 1);
 
 

--- a/src/libpmempool/check_sds.c
+++ b/src/libpmempool/check_sds.c
@@ -84,7 +84,7 @@ check_shutdown_state(struct pool_set *set)
 		struct shutdown_state curr_sds;
 		shutdown_state_init(&curr_sds, NULL);
 		for (unsigned p = 0; p < rep->nparts; ++p) {
-			shutdown_state_add_part(&curr_sds, PART(rep, p).path,
+			shutdown_state_add_part(&curr_sds, PART(rep, p)->path,
 				NULL);
 		}
 		/* make a copy of sds as we shouldn't modify a pool */

--- a/src/libpmempool/pool.c
+++ b/src/libpmempool/pool.c
@@ -145,7 +145,7 @@ pool_set_read_header(const char *fname, struct pool_hdr *hdr)
 		return -1;
 	}
 	/* open the first part set file to read the pool header values */
-	const struct pool_set_part *part = &PART(REP(set, 0), 0);
+	const struct pool_set_part *part = PART(REP(set, 0), 0);
 	int fdp = util_file_open(part->path, NULL, 0, O_RDONLY);
 	if (fdp < 0) {
 		ERR("cannot open poolset part file");
@@ -1018,7 +1018,7 @@ pool_set_type(struct pool_set *set)
 	struct pool_hdr hdr;
 
 	/* open the first part file to read the pool header values */
-	const struct pool_set_part *part = &PART(REP(set, 0), 0);
+	const struct pool_set_part *part = PART(REP(set, 0), 0);
 
 	if (util_file_pread(part->path, &hdr, sizeof(hdr), 0) !=
 			sizeof(hdr)) {

--- a/src/libpmempool/replica.h
+++ b/src/libpmempool/replica.h
@@ -88,6 +88,7 @@ struct poolset_health_status {
 static inline unsigned
 REP_HEALTHidx(struct poolset_health_status *set, unsigned r)
 {
+	ASSERTne(set->nreplicas, 0);
 	return (set->nreplicas + r) % set->nreplicas;
 }
 
@@ -95,6 +96,7 @@ REP_HEALTHidx(struct poolset_health_status *set, unsigned r)
 static inline unsigned
 REPN_HEALTHidx(struct poolset_health_status *set, unsigned r)
 {
+	ASSERTne(set->nreplicas, 0);
 	return (set->nreplicas + r + 1) % set->nreplicas;
 }
 
@@ -102,6 +104,7 @@ REPN_HEALTHidx(struct poolset_health_status *set, unsigned r)
 static inline unsigned
 PART_HEALTHidx(struct replica_health_status *rep, unsigned p)
 {
+	ASSERTne(rep->nparts, 0);
 	return (rep->nparts + p) % rep->nparts;
 }
 

--- a/src/libpmempool/replica.h
+++ b/src/libpmempool/replica.h
@@ -84,6 +84,41 @@ struct poolset_health_status {
 	struct replica_health_status *replica[];
 };
 
+/* get index of the (r)th replica health status */
+static inline unsigned
+REP_HEALTHidx(struct poolset_health_status *set, unsigned r)
+{
+	return (set->nreplicas + r) % set->nreplicas;
+}
+
+/* get index of the (r + 1)th replica health status */
+static inline unsigned
+REPN_HEALTHidx(struct poolset_health_status *set, unsigned r)
+{
+	return (set->nreplicas + r + 1) % set->nreplicas;
+}
+
+/* get (p)th part health status */
+static inline unsigned
+PART_HEALTHidx(struct replica_health_status *rep, unsigned p)
+{
+	return (rep->nparts + p) % rep->nparts;
+}
+
+/* get (r)th replica health status */
+static inline struct replica_health_status *
+REP_HEALTH(struct poolset_health_status *set, unsigned r)
+{
+	return set->replica[REP_HEALTHidx(set, r)];
+}
+
+/* get (p)th part health status */
+static inline unsigned
+PART_HEALTH(struct replica_health_status *rep, unsigned p)
+{
+	return rep->part[PART_HEALTHidx(rep, p)];
+}
+
 size_t replica_get_part_data_len(struct pool_set *set_in, unsigned repn,
 		unsigned partn);
 uint64_t replica_get_part_data_offset(struct pool_set *set_in, unsigned repn,

--- a/src/libpmempool/sync.c
+++ b/src/libpmempool/sync.c
@@ -157,7 +157,7 @@ static int
 is_uuid_already_used(uuid_t uuid, struct pool_set *set, unsigned repn)
 {
 	for (unsigned r = 0; r < repn; ++r) {
-		if (uuidcmp(uuid, PART(REP(set, r), 0).uuid) == 0)
+		if (uuidcmp(uuid, PART(REP(set, r), 0)->uuid) == 0)
 			return 1;
 	}
 	return 0;
@@ -401,9 +401,9 @@ grant_created_parts_perm(struct pool_set *set, unsigned src_repn,
 	/* get permissions of the first part of the source replica */
 	mode_t src_mode;
 	os_stat_t sb;
-	if (os_stat(PART(REP(set, src_repn), 0).path, &sb) != 0) {
+	if (os_stat(PART(REP(set, src_repn), 0)->path, &sb) != 0) {
 		ERR("cannot check file permissions of %s (replica %u, part %u)",
-				PART(REP(set, src_repn), 0).path, src_repn, 0);
+				PART(REP(set, src_repn), 0)->path, src_repn, 0);
 		src_mode = def_mode;
 	} else {
 		src_mode = sb.st_mode;
@@ -420,14 +420,14 @@ grant_created_parts_perm(struct pool_set *set, unsigned src_repn,
 
 		for (unsigned p = 0; p < set_hs->replica[r]->nparts; p++) {
 			/* skip parts which were not created */
-			if (!PART(REP(set, r), p).created)
+			if (!PART(REP(set, r), p)->created)
 				continue;
 
 			LOG(4, "setting permissions for part %u, replica %u",
 					p, r);
 
 			/* set rights to those of existing part files */
-			if (os_chmod(PART(REP(set, r), p).path, src_mode)) {
+			if (os_chmod(PART(REP(set, r), p)->path, src_mode)) {
 				ERR("cannot set permission rights for created"
 					" parts: replica %u, part %u", r, p);
 				errno = EPERM;
@@ -454,30 +454,30 @@ update_parts_linkage(struct pool_set *set, unsigned repn,
 		struct pool_hdr *next_hdrp = HDRN(rep, p);
 
 		/* set uuids in the current part */
-		memcpy(hdrp->prev_part_uuid, PARTP(rep, p).uuid,
+		memcpy(hdrp->prev_part_uuid, PARTP(rep, p)->uuid,
 				POOL_HDR_UUID_LEN);
-		memcpy(hdrp->next_part_uuid, PARTN(rep, p).uuid,
+		memcpy(hdrp->next_part_uuid, PARTN(rep, p)->uuid,
 				POOL_HDR_UUID_LEN);
 		util_checksum(hdrp, sizeof(*hdrp), &hdrp->checksum,
 			1, POOL_HDR_CSUM_END_OFF);
 
 		/* set uuids in the previous part */
-		memcpy(prev_hdrp->next_part_uuid, PART(rep, p).uuid,
+		memcpy(prev_hdrp->next_part_uuid, PART(rep, p)->uuid,
 				POOL_HDR_UUID_LEN);
 		util_checksum(prev_hdrp, sizeof(*prev_hdrp),
 			&prev_hdrp->checksum, 1, POOL_HDR_CSUM_END_OFF);
 
 		/* set uuids in the next part */
-		memcpy(next_hdrp->prev_part_uuid, PART(rep, p).uuid,
+		memcpy(next_hdrp->prev_part_uuid, PART(rep, p)->uuid,
 				POOL_HDR_UUID_LEN);
 		util_checksum(next_hdrp, sizeof(*next_hdrp),
 			&next_hdrp->checksum, 1, POOL_HDR_CSUM_END_OFF);
 
 		/* store pool's header */
-		util_persist(PART(rep, p).is_dev_dax, hdrp, sizeof(*hdrp));
-		util_persist(PARTP(rep, p).is_dev_dax, prev_hdrp,
+		util_persist(PART(rep, p)->is_dev_dax, hdrp, sizeof(*hdrp));
+		util_persist(PARTP(rep, p)->is_dev_dax, prev_hdrp,
 				sizeof(*prev_hdrp));
-		util_persist(PARTN(rep, p).is_dev_dax, next_hdrp,
+		util_persist(PARTN(rep, p)->is_dev_dax, next_hdrp,
 				sizeof(*next_hdrp));
 
 	}
@@ -502,27 +502,27 @@ update_replicas_linkage(struct pool_set *set, unsigned repn)
 	/* set uuids in the current replica */
 	for (unsigned p = 0; p < rep->nhdrs; ++p) {
 		struct pool_hdr *hdrp = HDR(rep, p);
-		memcpy(hdrp->prev_repl_uuid, PART(prev_r, 0).uuid,
+		memcpy(hdrp->prev_repl_uuid, PART(prev_r, 0)->uuid,
 				POOL_HDR_UUID_LEN);
-		memcpy(hdrp->next_repl_uuid, PART(next_r, 0).uuid,
+		memcpy(hdrp->next_repl_uuid, PART(next_r, 0)->uuid,
 				POOL_HDR_UUID_LEN);
 		util_checksum(hdrp, sizeof(*hdrp), &hdrp->checksum,
 			1, POOL_HDR_CSUM_END_OFF);
 
 		/* store pool's header */
-		util_persist(PART(rep, p).is_dev_dax, hdrp, sizeof(*hdrp));
+		util_persist(PART(rep, p)->is_dev_dax, hdrp, sizeof(*hdrp));
 	}
 
 	/* set uuids in the previous replica */
 	for (unsigned p = 0; p < prev_r->nhdrs; ++p) {
 		struct pool_hdr *prev_hdrp = HDR(prev_r, p);
-		memcpy(prev_hdrp->next_repl_uuid, PART(rep, 0).uuid,
+		memcpy(prev_hdrp->next_repl_uuid, PART(rep, 0)->uuid,
 				POOL_HDR_UUID_LEN);
 		util_checksum(prev_hdrp, sizeof(*prev_hdrp),
 			&prev_hdrp->checksum, 1, POOL_HDR_CSUM_END_OFF);
 
 		/* store pool's header */
-		util_persist(PART(prev_r, p).is_dev_dax, prev_hdrp,
+		util_persist(PART(prev_r, p)->is_dev_dax, prev_hdrp,
 				sizeof(*prev_hdrp));
 	}
 
@@ -530,13 +530,13 @@ update_replicas_linkage(struct pool_set *set, unsigned repn)
 	for (unsigned p = 0; p < next_r->nhdrs; ++p) {
 		struct pool_hdr *next_hdrp = HDR(next_r, p);
 
-		memcpy(next_hdrp->prev_repl_uuid, PART(rep, 0).uuid,
+		memcpy(next_hdrp->prev_repl_uuid, PART(rep, 0)->uuid,
 				POOL_HDR_UUID_LEN);
 		util_checksum(next_hdrp, sizeof(*next_hdrp),
 			&next_hdrp->checksum, 1, POOL_HDR_CSUM_END_OFF);
 
 		/* store pool's header */
-		util_persist(PART(next_r, p).is_dev_dax, next_hdrp,
+		util_persist(PART(next_r, p)->is_dev_dax, next_hdrp,
 				sizeof(*next_hdrp));
 	}
 
@@ -559,7 +559,7 @@ update_poolset_uuids(struct pool_set *set, unsigned repn,
 			1, POOL_HDR_CSUM_END_OFF);
 
 		/* store pool's header */
-		util_persist(PART(rep, p).is_dev_dax, hdrp, sizeof(*hdrp));
+		util_persist(PART(rep, p)->is_dev_dax, hdrp, sizeof(*hdrp));
 	}
 	return 0;
 }
@@ -575,7 +575,7 @@ update_remote_headers(struct pool_set *set)
 	for (unsigned r = 0; r < set->nreplicas; ++ r) {
 		/* skip local or just created replicas */
 		if (REP(set, r)->remote == NULL ||
-				PART(REP(set, r), 0).created == 1)
+				PART(REP(set, r), 0)->created == 1)
 			continue;
 
 		if (util_update_remote_header(set, r)) {

--- a/src/tools/pmempool/common.c
+++ b/src/tools/pmempool/common.c
@@ -521,7 +521,7 @@ util_poolset_map(const char *fname, struct pool_set **poolset, int rdonly)
 	os_close(fd);
 
 	/* read the pool header from first pool set file */
-	const char *part0_path = PART(REP(set, 0), 0).path;
+	const char *part0_path = PART(REP(set, 0), 0)->path;
 	struct pool_hdr hdr;
 	if (util_file_pread(part0_path, &hdr, sizeof(hdr), 0) !=
 			sizeof(hdr)) {


### PR DESCRIPTION
This patch is so long, because I had to change the way those macros/functions return value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2799)
<!-- Reviewable:end -->
