### PR TITLE
test: win: fix multiple matches issue

### DIFF
--- a/src/test/unittest/unittest.ps1
+++ b/src/test/unittest/unittest.ps1
@@ -636,11 +636,9 @@ function check {
         fail ""
     }
 
-    [string]$listing = Get-ChildItem -File | Where-Object  {$_.Name -match "[^0-9]${Env:UNITTEST_NUM}.log.match"}
+    [string]$listing = Get-ChildItem -File | Where-Object {$_.Name -match "[^0-9]${Env:UNITTEST_NUM}.log.match"}
     if ($listing) {
-        if (Test-Path $listing) {
-            match $listing
-        }
+		match $listing
     }
 }
 

--- a/src/test/util_poolset/TEST0w.PS1
+++ b/src/test/util_poolset/TEST0w.PS1
@@ -108,10 +108,10 @@ create_poolset $DIR\testset24 ${MIN_POOL_STR}:$DIR\testfile241:x ${MIN_POOL_STR}
 create_poolset $DIR\testset25 ${MIN_POOL_STR}:$DIR\testfile251:z ${MIN_POOL_STR}:$DIR\testfile252:x `
     r 3M:$DIR\testfile253:z # fail - replica too small
 create_poolset $DIR\testset26 ${MIN_POOL_STR}:$DIR\testfile261:z 2M:$DIR\testfile262:z `
-    r 7M:$DIR\testfile263 r 5M:$DIR\testfile264 # pass - pmem\non-pmem
+    r 8M:$DIR\testfile263 r 6M:$DIR\testfile264 # pass - pmem\non-pmem
 
-$_1GB = 1024*1024*1024
-$_5MB = 5 * 1024 * 1024
+$_1GB = 1024 * 1024 * 1024
+$_6MB = 6 * 1024 * 1024
 
 expect_normal_exit $Env:EXE_DIR\util_poolset$Env:EXESUFFIX c $MIN_POOL `
     $DIR\testset0 $DIR\testset1 `
@@ -129,7 +129,7 @@ expect_normal_exit $Env:EXE_DIR\util_poolset$Env:EXESUFFIX c $MIN_POOL `
     $DIR\testset22 `
     "-mo:$DIR\testset23" $DIR\testset23 `
     $DIR\testset24 $DIR\testset25 `
-    "-mp:$_5MB" $DIR\testset26
+    "-mp:$_6MB" $DIR\testset26
 
 check_files $DIR\testfile11 `
     $DIR\testfile21 $DIR\testfile22 `

--- a/src/test/util_poolset/TEST5w.PS1
+++ b/src/test/util_poolset/TEST5w.PS1
@@ -68,25 +68,31 @@ create_poolset $DIR\testset4 `
 	${RESVSIZE_STR}:$DIR\testdir41:d ${RESVSIZE_STR}:$DIR\testdir42:d `
 	R ${RESVSIZE_STR}:$DIR\testdir43:d ${RESVSIZE_STR}:$DIR\testdir44:d `
 	O SINGLEHDR
+create_poolset $DIR\testset9 `
+	${RESVSIZE}:$DIR\testdir91:d R ${RESVSIZE}:$DIR\testdir91\testdir92:d `
+	O SINGLEHDR # pass
 
 # create pool sets
 expect_normal_exit $Env:EXE_DIR\util_poolset$Env:EXESUFFIX c $MIN_POOL `
     $DIR\testset1 `
     $DIR\testset2 `
     $DIR\testset3 `
-    $DIR\testset4
+    $DIR\testset4 `
+    $DIR\testset9
 
 expect_normal_exit $Env:EXE_DIR\util_poolset$Env:EXESUFFIX o $MIN_POOL `
     $DIR\testset1 `
     $DIR\testset2 `
     $DIR\testset3 `
-    $DIR\testset4
+    $DIR\testset4 `
+    $DIR\testset9
 
 expect_normal_exit $Env:EXE_DIR\util_poolset$Env:EXESUFFIX e $MIN_POOL `
     $DIR\testset1 `
     $DIR\testset2 `
     $DIR\testset3 `
-    $DIR\testset4
+    $DIR\testset4 `
+    $DIR\testset9
 
 # this should fail in poolsets with only one directory because this would exceed
 # the reservation size
@@ -94,13 +100,15 @@ expect_normal_exit $Env:EXE_DIR\util_poolset$Env:EXESUFFIX e $MIN_POOL `
     $DIR\testset1 `
     $DIR\testset2 `
     $DIR\testset3 `
-    $DIR\testset4
+    $DIR\testset4 `
+    $DIR\testset9
 
 expect_normal_exit $Env:EXE_DIR\util_poolset$Env:EXESUFFIX o $MIN_POOL `
     $DIR\testset1 `
     $DIR\testset2 `
     $DIR\testset3 `
-    $DIR\testset4
+    $DIR\testset4 `
+    $DIR\testset9
 
 sls -Path $Env:TEST_LOG_FILE -Pattern "<1>" | `
     %{[string]$_ -replace '^.* len ',"" -replace '^.*][ ]*',''} `

--- a/src/test/util_poolset/grep0w.log.match
+++ b/src/test/util_poolset/grep0w.log.match
@@ -20,4 +20,4 @@ file size does not match config: $(nW)testfile152, 4194303 != 4194304
 Non-empty file detected
 Non-empty file detected
 open "$(nW)testset23": Permission denied
-net pool size 3145728 smaller than 4194304
+reservation pool size 3145728 smaller than 4194304

--- a/src/test/util_poolset/out0w.log.match
+++ b/src/test/util_poolset/out0w.log.match
@@ -1,5 +1,5 @@
 util_poolset$(nW)TEST0w: START: util_poolset
- $(nW)util_poolset$(nW) c 4194304 $(nW)testset0 $(nW)testset1 $(nW)testset2 $(nW)testset3 $(nW)testset4 $(nW)testset5 $(nW)testset6 -mo:$(nW)testfile72 $(nW)testset7 -mf:1073741824 $(nW)testset8 -mo:$(nW)testfile102 $(nW)testset10 $(nW)testset11 $(nW)testset12 $(nW)testset13 $(nW)testset14 $(nW)testset15 $(nW)testset18 $(nW)testset20 $(nW)testset21 $(nW)testset22 -mo:$(nW)testset23 $(nW)testset23 $(nW)testset24 $(nW)testset25 -mp:5242880 $(nW)testset26
+ $(nW)util_poolset$(nW) c 4194304 $(nW)testset0 $(nW)testset1 $(nW)testset2 $(nW)testset3 $(nW)testset4 $(nW)testset5 $(nW)testset6 -mo:$(nW)testfile72 $(nW)testset7 -mf:1073741824 $(nW)testset8 -mo:$(nW)testfile102 $(nW)testset10 $(nW)testset11 $(nW)testset12 $(nW)testset13 $(nW)testset14 $(nW)testset15 $(nW)testset18 $(nW)testset20 $(nW)testset21 $(nW)testset22 -mo:$(nW)testset23 $(nW)testset23 $(nW)testset24 $(nW)testset25 -mp:6291456 $(nW)testset26
 $(nW)testset0: util_pool_create: No such file or directory
 $(nW)testset1: created: nreps 1 poolsize 4194304 zeroed 1
   replica[0]: nparts 1 nhdrs 1 repsize 4194304 is_pmem 0
@@ -48,13 +48,13 @@ $(nW)testset24: created: nreps 3 poolsize 8323072 zeroed 1
     part[0] path $(nW)testfile244 filesize 6291456 size 6291456
     part[1] path $(nW)testfile245 filesize 2097152 size 2031616
 $(nW)testset25: util_pool_create: Invalid argument
-mocked pmem_is_pmem: 5242880
-$(nW)testset26: created: nreps 3 poolsize 5242880 zeroed 0
+mocked pmem_is_pmem: 6291456
+$(nW)testset26: created: nreps 3 poolsize 6225920 zeroed 0
   replica[0]: nparts 2 nhdrs 2 repsize 6225920 is_pmem 0
     part[0] path $(nW)testfile261 filesize 4194304 size 4194304
     part[1] path $(nW)testfile262 filesize 2097152 size 2031616
-  replica[1]: nparts 1 nhdrs 1 repsize 7340032 is_pmem 0
-    part[0] path $(nW)testfile263 filesize 7340032 size 7340032
-  replica[2]: nparts 1 nhdrs 1 repsize 5242880 is_pmem 1
-    part[0] path $(nW)testfile264 filesize 5242880 size 5242880
+  replica[1]: nparts 1 nhdrs 1 repsize 8388608 is_pmem 0
+    part[0] path $(nW)testfile263 filesize 8388608 size 8388608
+  replica[2]: nparts 1 nhdrs 1 repsize 6291456 is_pmem 1
+    part[0] path $(nW)testfile264 filesize 6291456 size 6291456
 util_poolset$(nW)TEST0w: DONE

--- a/src/test/util_poolset/util_poolset.vcxproj
+++ b/src/test/util_poolset/util_poolset.vcxproj
@@ -62,9 +62,6 @@
     <Link />
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\common\libpmemcommon.vcxproj">
-      <Project>{492baa3d-0d5d-478e-9765-500463ae69aa}</Project>
-    </ProjectReference>
     <ProjectReference Include="..\unittest\libut.vcxproj">
       <Project>{ce3f2dfb-8470-4802-ad37-21caf6cb2681}</Project>
     </ProjectReference>
@@ -72,10 +69,12 @@
   <ItemGroup>
     <ClInclude Include="..\..\libpmem\pmem.h" />
     <ClInclude Include="..\..\libpmem\x86_64\cpu.h" />
+    <ClInclude Include="mocks.h" />
     <ClInclude Include="mocks_windows.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\common\file.c" />
+    <ClCompile Include="..\..\common\set.c" />
     <ClCompile Include="..\..\libpmem\pmem.c">
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">WRAP_REAL_PMEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WRAP_REAL_PMEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -89,7 +88,10 @@
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">_DEBUG;_CONSOLE;%(PreprocessorDefinitions);WRAP_REAL_OPEN;WRAP_REAL_PMEM;WRAP_REAL_FALLOCATE</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NDEBUG;_CONSOLE;%(PreprocessorDefinitions);WRAP_REAL_OPEN;WRAP_REAL_PMEM;WRAP_REAL_FALLOCATE</PreprocessorDefinitions>
     </ClCompile>
-    <ClCompile Include="util_poolset.c" />
+    <ClCompile Include="util_poolset.c">
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">WRAP_REAL_PMEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WRAP_REAL_PMEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="grep0w.log.match" />

--- a/src/test/util_poolset/util_poolset.vcxproj.filters
+++ b/src/test/util_poolset/util_poolset.vcxproj.filters
@@ -28,6 +28,9 @@
     <ClInclude Include="..\..\libpmem\x86_64\cpu.h">
       <Filter>libpmem</Filter>
     </ClInclude>
+    <ClInclude Include="mocks.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="util_poolset.c">
@@ -56,6 +59,12 @@
     </ClCompile>
     <ClCompile Include="..\..\common\file.c">
       <Filter>libpmem</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\libpmem\pmem.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\common\set.c">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/src/test/util_sds/err6.log.match
+++ b/src/test/util_sds/err6.log.match
@@ -1,1 +1,1 @@
-{util_sds.c:$(N) main} util_sds/TEST6: Error: An ADR failure is detected, the pool might be corrupted
+$(*)ADR failure is detected, the pool might be corrupted

--- a/src/test/util_sds/err7.log.match
+++ b/src/test/util_sds/err7.log.match
@@ -1,1 +1,1 @@
-{util_sds.c:$(N) main} util_sds/TEST7: Error: An ADR failure is detected, the pool might be corrupted
+$(*)ADR failure is detected, the pool might be corrupted

--- a/src/test/win_getopt/TEST0.PS1
+++ b/src/test/win_getopt/TEST0.PS1
@@ -39,15 +39,14 @@ Param(
     $DIR = ""
     )
 
-$ERR="stderr$Env:UNITTEST_NUM.log"
-
 . ..\unittest\unittest.ps1
 
 require_test_type medium
-
 require_fs_type none
 
 setup
+
+$ERR="stderr${Env:UNITTEST_NUM}.log"
 
 expect_normal_exit $Env:EXE_DIR\win_getopt$Env:EXESUFFIX nonOption -f -3arg `
 -Barg -b --arg_4=a --arg_G -5 -a -A arg --arg_g -d -1 -e nonOption2 --arg_8 `


### PR DESCRIPTION
This patch fixes multiple matches issue on windows - test check was skipping when test had 2 or more mach files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2802)
<!-- Reviewable:end -->
