### PR TITLE
test: require_build_type cleanup

### DIFF
--- a/src/test/obj_ctl_alloc_class/TEST0
+++ b/src/test/obj_ctl_alloc_class/TEST0
@@ -37,6 +37,7 @@
 
 require_test_type short
 require_fs_type any
+require_build_type debug
 
 setup
 

--- a/src/test/obj_debug/Makefile
+++ b/src/test/obj_debug/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_debug/TEST0
+++ b/src/test/obj_debug/TEST0
@@ -39,8 +39,8 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-
-require_build_type debug
+require_build_type debug static-debug
+require_fs_type any
 
 setup
 

--- a/src/test/obj_debug/TEST0.PS1
+++ b/src/test/obj_debug/TEST0.PS1
@@ -44,6 +44,7 @@ Param(
 
 require_test_type medium
 require_build_type debug
+require_fs_type any
 
 setup
 

--- a/src/test/obj_debug/TEST1
+++ b/src/test/obj_debug/TEST1
@@ -39,8 +39,8 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-
-require_build_type debug
+require_build_type debug static-debug
+require_fs_type any
 
 setup
 

--- a/src/test/obj_debug/TEST1.PS1
+++ b/src/test/obj_debug/TEST1.PS1
@@ -44,6 +44,7 @@ Param(
 
 require_test_type medium
 require_build_type debug
+require_fs_type any
 
 setup
 

--- a/src/test/obj_debug/TEST2
+++ b/src/test/obj_debug/TEST2
@@ -39,8 +39,9 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug static-debug
+require_fs_type any
 
-require_build_type debug
 # test causes 5 pmemcheck errors by design
 configure_valgrind pmemcheck force-disable
 setup

--- a/src/test/obj_debug/TEST2.PS1
+++ b/src/test/obj_debug/TEST2.PS1
@@ -44,6 +44,7 @@ Param(
 
 require_test_type medium
 require_build_type debug
+require_fs_type any
 
 setup
 

--- a/src/test/obj_debug/TEST3
+++ b/src/test/obj_debug/TEST3
@@ -39,8 +39,8 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-
-require_build_type debug
+require_build_type debug static-debug
+require_fs_type any
 
 setup
 

--- a/src/test/obj_debug/TEST3.PS1
+++ b/src/test/obj_debug/TEST3.PS1
@@ -44,6 +44,7 @@ Param(
 
 require_test_type medium
 require_build_type debug
+require_fs_type any
 
 setup
 

--- a/src/test/obj_debug/TEST4
+++ b/src/test/obj_debug/TEST4
@@ -39,8 +39,8 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-
-require_build_type debug
+require_build_type debug static-debug
+require_fs_type any
 
 setup
 

--- a/src/test/obj_debug/TEST4.PS1
+++ b/src/test/obj_debug/TEST4.PS1
@@ -44,6 +44,7 @@ Param(
 
 require_test_type medium
 require_build_type debug
+require_fs_type any
 
 setup
 

--- a/src/test/obj_debug/TEST5
+++ b/src/test/obj_debug/TEST5
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2018, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,8 +39,8 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-
-require_build_type debug
+require_build_type debug static-debug
+require_fs_type any
 
 FUNCS=17
 

--- a/src/test/obj_debug/TEST5.PS1
+++ b/src/test/obj_debug/TEST5.PS1
@@ -44,6 +44,7 @@ Param(
 
 require_test_type medium
 require_build_type debug
+require_fs_type any
 
 setup
 

--- a/src/test/obj_list/Makefile
+++ b/src/test/obj_list/Makefile
@@ -36,6 +36,9 @@
 TARGET = obj_list
 OBJS = obj_list.o obj_list_mocks.o obj_list_mocks_palloc.o
 
+BUILD_STATIC_DEBUG=n
+BUILD_STATIC_NONDEBUG=n
+
 LIBPMEM=y
 LIBPMEMOBJ=internal-debug
 

--- a/src/test/obj_list_insert/TEST0
+++ b/src/test/obj_list_insert/TEST0
@@ -41,6 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_insert/TEST0.PS1
+++ b/src/test/obj_list_insert/TEST0.PS1
@@ -45,6 +45,7 @@ Param(
 . ..\unittest\unittest.ps1
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_insert/TEST1
+++ b/src/test/obj_list_insert/TEST1
@@ -41,6 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_insert/TEST1.PS1
+++ b/src/test/obj_list_insert/TEST1.PS1
@@ -45,6 +45,7 @@ Param(
 . ..\unittest\unittest.ps1
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_insert/TEST2
+++ b/src/test/obj_list_insert/TEST2
@@ -41,6 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_insert/TEST2.PS1
+++ b/src/test/obj_list_insert/TEST2.PS1
@@ -45,6 +45,7 @@ Param(
 . ..\unittest\unittest.ps1
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_insert/TEST3
+++ b/src/test/obj_list_insert/TEST3
@@ -41,6 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_insert/TEST3.PS1
+++ b/src/test/obj_list_insert/TEST3.PS1
@@ -45,6 +45,7 @@ Param(
 . ..\unittest\unittest.ps1
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_insert/TEST4
+++ b/src/test/obj_list_insert/TEST4
@@ -41,6 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_insert/TEST4.PS1
+++ b/src/test/obj_list_insert/TEST4.PS1
@@ -45,6 +45,7 @@ Param(
 . ..\unittest\unittest.ps1
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_move/TEST0
+++ b/src/test/obj_list_move/TEST0
@@ -39,6 +39,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_move/TEST0.PS1
+++ b/src/test/obj_list_move/TEST0.PS1
@@ -43,6 +43,7 @@ Param(
 . ..\unittest\unittest.ps1
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_move/TEST1
+++ b/src/test/obj_list_move/TEST1
@@ -39,6 +39,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_move/TEST1.PS1
+++ b/src/test/obj_list_move/TEST1.PS1
@@ -43,6 +43,7 @@ Param(
 . ..\unittest\unittest.ps1
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_move/TEST2
+++ b/src/test/obj_list_move/TEST2
@@ -39,6 +39,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_move/TEST2.PS1
+++ b/src/test/obj_list_move/TEST2.PS1
@@ -43,6 +43,7 @@ Param(
 . ..\unittest\unittest.ps1
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_recovery/TEST0
+++ b/src/test/obj_list_recovery/TEST0
@@ -39,6 +39,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
 
 # exits with locked mutexes
 configure_valgrind helgrind force-disable

--- a/src/test/obj_list_recovery/TEST0.PS1
+++ b/src/test/obj_list_recovery/TEST0.PS1
@@ -43,6 +43,7 @@ Param(
 . ..\unittest\unittest.ps1
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_recovery/TEST1
+++ b/src/test/obj_list_recovery/TEST1
@@ -39,6 +39,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
 
 # exits with locked mutexes
 configure_valgrind helgrind force-disable

--- a/src/test/obj_list_recovery/TEST1.PS1
+++ b/src/test/obj_list_recovery/TEST1.PS1
@@ -43,6 +43,7 @@ Param(
 . ..\unittest\unittest.ps1
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_recovery/TEST2
+++ b/src/test/obj_list_recovery/TEST2
@@ -39,6 +39,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
 
 # exits with locked mutexes
 configure_valgrind helgrind force-disable

--- a/src/test/obj_list_recovery/TEST2.PS1
+++ b/src/test/obj_list_recovery/TEST2.PS1
@@ -43,6 +43,7 @@ Param(
 . ..\unittest\unittest.ps1
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_remove/TEST0
+++ b/src/test/obj_list_remove/TEST0
@@ -42,6 +42,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_remove/TEST0.PS1
+++ b/src/test/obj_list_remove/TEST0.PS1
@@ -46,6 +46,7 @@ Param(
 . ..\unittest\unittest.ps1
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_remove/TEST1
+++ b/src/test/obj_list_remove/TEST1
@@ -42,6 +42,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_remove/TEST1.PS1
+++ b/src/test/obj_list_remove/TEST1.PS1
@@ -46,6 +46,7 @@ Param(
 . ..\unittest\unittest.ps1
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_remove/TEST2
+++ b/src/test/obj_list_remove/TEST2
@@ -41,6 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_remove/TEST2.PS1
+++ b/src/test/obj_list_remove/TEST2.PS1
@@ -45,6 +45,7 @@ Param(
 . ..\unittest\unittest.ps1
 
 require_test_type medium
+require_build_type debug
 
 setup
 

--- a/src/test/obj_list_valgrind/TEST0
+++ b/src/test/obj_list_valgrind/TEST0
@@ -42,6 +42,8 @@
 require_test_type medium
 
 require_fs_type pmem non-pmem
+require_build_type debug
+
 configure_valgrind pmemcheck force-enable ../obj_list/obj_list
 export VALGRIND_OPTS="--mult-stores=yes"
 setup

--- a/src/test/obj_list_valgrind/TEST1
+++ b/src/test/obj_list_valgrind/TEST1
@@ -42,6 +42,8 @@
 require_test_type medium
 
 require_fs_type pmem non-pmem
+require_build_type debug
+
 configure_valgrind pmemcheck force-enable ../obj_list/obj_list
 export VALGRIND_OPTS="--mult-stores=yes"
 setup

--- a/src/test/obj_list_valgrind/TEST2
+++ b/src/test/obj_list_valgrind/TEST2
@@ -42,6 +42,8 @@
 require_test_type medium
 
 require_fs_type pmem non-pmem
+require_build_type debug
+
 configure_valgrind pmemcheck force-enable ../obj_list/obj_list
 export VALGRIND_OPTS="--mult-stores=yes"
 setup

--- a/src/test/obj_list_valgrind/TEST3
+++ b/src/test/obj_list_valgrind/TEST3
@@ -42,6 +42,8 @@
 require_test_type medium
 
 require_fs_type pmem non-pmem
+require_build_type debug
+
 configure_valgrind pmemcheck force-enable ../obj_list/obj_list
 export VALGRIND_OPTS="--mult-stores=yes"
 setup

--- a/src/test/obj_list_valgrind/TEST4
+++ b/src/test/obj_list_valgrind/TEST4
@@ -42,6 +42,8 @@
 require_test_type medium
 
 require_fs_type pmem non-pmem
+require_build_type debug
+
 configure_valgrind pmemcheck force-enable ../obj_list/obj_list
 export VALGRIND_OPTS="--mult-stores=yes"
 setup

--- a/src/test/obj_list_valgrind/TEST5
+++ b/src/test/obj_list_valgrind/TEST5
@@ -42,6 +42,8 @@
 require_test_type medium
 
 require_fs_type pmem non-pmem
+require_build_type debug
+
 configure_valgrind pmemcheck force-enable ../obj_list/obj_list
 export VALGRIND_OPTS="--mult-stores=yes"
 setup

--- a/src/test/out_err/Makefile
+++ b/src/test/out_err/Makefile
@@ -36,6 +36,9 @@
 TARGET = out_err
 OBJS = out_err.o
 
+BUILD_STATIC_DEBUG=n
+BUILD_STATIC_NONDEBUG=n
+
 LIBPMEMCOMMON=y
 include ../Makefile.inc
 

--- a/src/test/rpmem_fip/Makefile
+++ b/src/test/rpmem_fip/Makefile
@@ -58,6 +58,9 @@ OBJS = rpmem_fip_test.o\
 
 endif
 
+BUILD_STATIC_DEBUG=n
+BUILD_STATIC_NONDEBUG=n
+
 LIBPMEMCOMMON=y
 LIBPMEM=y
 

--- a/src/test/rpmem_obc/Makefile
+++ b/src/test/rpmem_obc/Makefile
@@ -50,6 +50,9 @@ OBJS = rpmem_obc_test.o\
        rpmem_obc.o rpmem_util.o rpmem_common.o\
        rpmem_ssh.o rpmem_cmd.o
 
+BUILD_STATIC_DEBUG=n
+BUILD_STATIC_NONDEBUG=n
+
 LIBPMEMCOMMON=y
 include ../Makefile.inc
 

--- a/src/test/rpmem_obc_int/Makefile
+++ b/src/test/rpmem_obc_int/Makefile
@@ -45,6 +45,9 @@ OBJS = rpmem_obc_int.o\
        rpmem_obc.o rpmem_util.o rpmem_common.o\
        rpmemd_obc.o rpmemd_log.o
 
+BUILD_STATIC_DEBUG=n
+BUILD_STATIC_NONDEBUG=n
+
 LIBPMEMCOMMON=y
 include ../Makefile.inc
 

--- a/src/test/rpmem_proto/Makefile
+++ b/src/test/rpmem_proto/Makefile
@@ -37,6 +37,9 @@
 TARGET = rpmem_proto
 OBJS = rpmem_proto.o
 
+BUILD_STATIC_DEBUG=n
+BUILD_STATIC_NONDEBUG=n
+
 include ../Makefile.inc
 
 INCS += -I../../rpmem_common

--- a/src/test/rpmem_proto/TEST0
+++ b/src/test/rpmem_proto/TEST0
@@ -39,7 +39,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-
+require_build_type debug
 require_fs_type none
 
 setup

--- a/src/test/rpmemd_config/Makefile
+++ b/src/test/rpmemd_config/Makefile
@@ -38,6 +38,9 @@ vpath %.c ../../tools/rpmemd
 TARGET = rpmemd_config
 OBJS = rpmemd_config_test.o rpmemd_config.o rpmemd_log.o
 
+BUILD_STATIC_DEBUG=n
+BUILD_STATIC_NONDEBUG=n
+
 include ../Makefile.inc
 
 CFLAGS += -I../../tools/rpmemd

--- a/src/test/rpmemd_config/TEST0
+++ b/src/test/rpmemd_config/TEST0
@@ -37,7 +37,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-
+require_build_type debug
 require_fs_type any
 
 setup

--- a/src/test/rpmemd_config/TEST1
+++ b/src/test/rpmemd_config/TEST1
@@ -37,7 +37,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-
+require_build_type debug
 require_fs_type any
 
 setup

--- a/src/test/rpmemd_config/TEST2
+++ b/src/test/rpmemd_config/TEST2
@@ -37,7 +37,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-
+require_build_type debug
 require_fs_type any
 
 setup

--- a/src/test/rpmemd_config/TEST3
+++ b/src/test/rpmemd_config/TEST3
@@ -37,7 +37,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-
+require_build_type debug
 require_fs_type any
 
 setup

--- a/src/test/rpmemd_config/TEST4
+++ b/src/test/rpmemd_config/TEST4
@@ -37,7 +37,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-
+require_build_type debug
 require_fs_type any
 
 setup

--- a/src/test/rpmemd_dbg/Makefile
+++ b/src/test/rpmemd_dbg/Makefile
@@ -39,6 +39,9 @@ vpath %.c ../rpmemd_log/
 TARGET = rpmemd_dbg
 OBJS = rpmemd_log_test.o rpmemd_log.o
 
+BUILD_STATIC_DEBUG=n
+BUILD_STATIC_NONDEBUG=n
+
 include ../Makefile.inc
 
 CFLAGS += -I../../tools/rpmemd -DDEBUG

--- a/src/test/rpmemd_dbg/TEST0
+++ b/src/test/rpmemd_dbg/TEST0
@@ -40,6 +40,8 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
+require_fs_type none
 
 setup
 

--- a/src/test/rpmemd_dbg/TEST1
+++ b/src/test/rpmemd_dbg/TEST1
@@ -40,6 +40,8 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
+require_fs_type none
 
 setup
 

--- a/src/test/rpmemd_dbg/TEST2
+++ b/src/test/rpmemd_dbg/TEST2
@@ -40,6 +40,8 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
+require_fs_type none
 
 setup
 

--- a/src/test/rpmemd_log/Makefile
+++ b/src/test/rpmemd_log/Makefile
@@ -38,6 +38,9 @@ vpath %.c ../../tools/rpmemd
 TARGET = rpmemd_log
 OBJS = rpmemd_log_test.o rpmemd_log.o
 
+BUILD_STATIC_DEBUG=n
+BUILD_STATIC_NONDEBUG=n
+
 include ../Makefile.inc
 
 CFLAGS += -I../../tools/rpmemd

--- a/src/test/rpmemd_log/TEST0
+++ b/src/test/rpmemd_log/TEST0
@@ -40,6 +40,8 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
+require_fs_type none
 
 setup
 

--- a/src/test/rpmemd_log/TEST1
+++ b/src/test/rpmemd_log/TEST1
@@ -40,6 +40,8 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
+require_fs_type none
 
 setup
 

--- a/src/test/rpmemd_log/TEST2
+++ b/src/test/rpmemd_log/TEST2
@@ -40,6 +40,8 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+require_build_type debug
+require_fs_type none
 
 setup
 

--- a/src/test/rpmemd_obc/Makefile
+++ b/src/test/rpmemd_obc/Makefile
@@ -57,6 +57,9 @@ OBJS = rpmemd_obc_test.o\
        rpmemd_obc_test_set_attr.o\
        rpmemd_obc_test_close.o
 
+BIULD_STATIC_DEBUG=n
+BUILD_STATIC_NONDEBUG=n
+
 LIBPMEMCOMMON=y
 include ../Makefile.inc
 

--- a/src/test/traces/Makefile
+++ b/src/test/traces/Makefile
@@ -36,6 +36,9 @@
 TARGET = traces
 OBJS = traces.o
 
+BUILD_STATIC_DEBUG=n
+BUILD_STATIC_NONDEBUG=n
+
 LIBPMEMCOMMON=y
 include ../Makefile.inc
 CFLAGS += -DDEBUG

--- a/src/test/traces_custom_function/Makefile
+++ b/src/test/traces_custom_function/Makefile
@@ -36,6 +36,9 @@
 TARGET = traces_custom_function
 OBJS = traces_custom_function.o
 
+BUILD_STATIC_DEBUG=n
+BUILD_STATIC_NONDEBUG=n
+
 LIBPMEMCOMMON=y
 include ../Makefile.inc
 CFLAGS += -DDEBUG


### PR DESCRIPTION
Some tests require to be executed on debug build only, i.e. because they
expect debug traces to be logged.  In practice, non-debug version of
such tests is compiled with the same flags as debug build ("-DDEBUG"),
so the same test is executed twice.
Also, there are tests that always link statically to PMDK libraries, so
there is no point in building/executing their static variants.

This patch explicitly disables compilation of static or nondebug
versions of selected tests, as well as adds "require_build_type debug"
to TEST* scripts.

It also adds "require_fs_type any" to speed up test execution, as well
as "require_fs_type none" in tests that actually do not require any
filesystem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2803)
<!-- Reviewable:end -->
