### PR TITLE
pool: mark also part as broken

### DIFF
--- a/src/libpmempool/replica.c
+++ b/src/libpmempool/replica.c
@@ -543,7 +543,7 @@ check_badblocks(struct pool_set *set, struct poolset_health_status *set_hs)
 {
 	LOG(3, "set %p, set_hs %p", set, set_hs);
 
-	for (unsigned r = 0; r < set->nreplicas; ++r) {\
+	for (unsigned r = 0; r < set->nreplicas; ++r) {
 		struct pool_replica *rep = set->replica[r];
 		struct replica_health_status *rep_hs = set_hs->replica[r];
 
@@ -568,6 +568,7 @@ check_badblocks(struct pool_set *set, struct poolset_health_status *set_hs)
 
 			if (ret > 0) {
 				/* bad blocks were found */
+				rep_hs->part[p] |= IS_BROKEN;
 				rep_hs->flags |= IS_BROKEN;
 			}
 		}


### PR DESCRIPTION
If bad blocks were found only the replica was marked as broken,
but each part containing bad blocks should also be marked as broken.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2806)
<!-- Reviewable:end -->
