### PR TITLE
pool: fix copy_data_to_broken_parts()

### DIFF
--- a/src/libpmempool/sync.c
+++ b/src/libpmempool/sync.c
@@ -370,9 +370,6 @@ copy_data_to_broken_parts(struct pool_set *set, unsigned healthy_replica,
 					return -1;
 				}
 			} else {
-				if (off + len > poolsize)
-					len = poolsize - off;
-
 				void *src_addr =
 					ADDR_SUM(rep_h->part[0].addr, off);
 


### PR DESCRIPTION
Remove redundant (doubled) calculation of 'len'
left by the b83fbe152c commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2810)
<!-- Reviewable:end -->
