### PR TITLE
common: zero badblocks structure

### DIFF
--- a/src/common/os_dimm_ndctl.c
+++ b/src/common/os_dimm_ndctl.c
@@ -413,6 +413,8 @@ os_dimm_files_namespace_badblocks_bus(struct ndctl_ctx *ctx,
 		return -1;
 	}
 
+	memset(bbs, 0, sizeof(*bbs));
+
 	if (region == NULL || ndns == NULL)
 		return 0;
 


### PR DESCRIPTION
The bbs 'badblocks' structure has to be zeroed,
because if (region == NULL || ndns == NULL)
then bbs has to contain valid data (zeros).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2819)
<!-- Reviewable:end -->
