### PR TITLE
common: add os_badblocks_get_and_clear()

### DIFF
--- a/src/common/badblock_freebsd.c
+++ b/src/common/badblock_freebsd.c
@@ -77,6 +77,18 @@ os_badblocks_get(const char *file, struct badblocks *bbs)
 }
 
 /*
+ * os_badblocks_get_and_clear -- get and clear bad blocks in a file
+ *                               (regular file or dax device)
+ */
+int
+os_badblocks_get_and_clear(const char *file, struct badblocks *bbs)
+{
+	LOG(3, "file %s badblocks %p", file, bbs);
+
+	return 0;
+}
+
+/*
  * os_badblocks_clear -- clears bad blocks in a file
  *                      (regular file or dax device)
  */

--- a/src/common/badblock_linux.c
+++ b/src/common/badblock_linux.c
@@ -329,15 +329,15 @@ os_badblocks_clear_file_cb(struct cb_data_s *p, void *arg)
 }
 
 /*
- * os_badblocks_clear_file -- clears bad blocks in the regular file
- *                            (not in a dax device)
+ * os_badblocks_get_clear_file -- get and clear bad blocks in the regular file
+ *                                (not in a dax device)
  */
 static int
-os_badblocks_clear_file(const char *file)
+os_badblocks_get_clear_file(const char *file, struct badblocks *bbs)
 {
-	LOG(3, "file %s", file);
+	LOG(3, "file %s badblocks %p", file, bbs);
 
-	struct badblocks *bbs;
+	int allocated_bbs = 0;
 	int bb_found = -1;
 	int fd = -1;
 
@@ -346,21 +346,44 @@ os_badblocks_clear_file(const char *file)
 		return -1;
 	}
 
-	bbs = Zalloc(sizeof(struct badblocks));
-	if (bbs == NULL) {
-		ERR("!malloc");
-		goto exit_close;
+	if (bbs) {
+		memset(bbs, 0, sizeof(*bbs));
+	} else {
+		bbs = Zalloc(sizeof(struct badblocks));
+		if (bbs == NULL) {
+			ERR("!malloc");
+			goto exit_close;
+		}
+		allocated_bbs = 1;
 	}
 
 	bb_found = os_badblocks_common(file, bbs,
 					os_badblocks_clear_file_cb, &fd);
-	Free(bbs->bbv);
-	Free(bbs);
+
+	if (allocated_bbs) {
+		Free(bbs->bbv);
+		Free(bbs);
+	}
 
 exit_close:
 	close(fd);
 
 	return bb_found;
+}
+
+/*
+ * os_badblocks_get_and_clear -- get and clear bad blocks in a file
+ *                               (regular file or dax device)
+ */
+int
+os_badblocks_get_and_clear(const char *file, struct badblocks *bbs)
+{
+	LOG(3, "file %s badblocks %p", file, bbs);
+
+	if (util_file_is_device_dax(file))
+		return os_dimm_devdax_get_clear_badblocks(file, bbs);
+
+	return os_badblocks_get_clear_file(file, bbs);
 }
 
 /*
@@ -372,8 +395,5 @@ os_badblocks_clear(const char *file)
 {
 	LOG(3, "file %s", file);
 
-	if (util_file_is_device_dax(file))
-		return os_dimm_devdax_clear_badblocks(file);
-
-	return os_badblocks_clear_file(file);
+	return os_badblocks_get_and_clear(file, NULL);
 }

--- a/src/common/badblock_windows.c
+++ b/src/common/badblock_windows.c
@@ -77,6 +77,18 @@ os_badblocks_get(const char *file, struct badblocks *bbs)
 }
 
 /*
+ * os_badblocks_get_and_clear -- get and clear bad blocks in a file
+ *                               (regular file or dax device)
+ */
+int
+os_badblocks_get_and_clear(const char *file, struct badblocks *bbs)
+{
+	LOG(3, "file %s badblocks %p", file, bbs);
+
+	return 0;
+}
+
+/*
  * os_badblocks_clear -- clears bad blocks in a file
  *                      (regular file or dax device)
  */

--- a/src/common/os_badblock.h
+++ b/src/common/os_badblock.h
@@ -60,6 +60,7 @@ struct badblocks {
 
 long os_badblocks_count(const char *path);
 int os_badblocks_get(const char *file, struct badblocks *bbs);
+int os_badblocks_get_and_clear(const char *file, struct badblocks *bbs);
 int os_badblocks_clear(const char *path);
 int os_badblocks_check_file(const char *path);
 

--- a/src/common/os_dimm.h
+++ b/src/common/os_dimm.h
@@ -42,4 +42,5 @@
 int os_dimm_uid(const char *path, char *uid, size_t *len);
 int os_dimm_usc(const char *path, uint64_t *usc);
 int os_dimm_files_namespace_badblocks(const char *path, struct badblocks *bbs);
+int os_dimm_devdax_get_clear_badblocks(const char *path, struct badblocks *bbs);
 int os_dimm_devdax_clear_badblocks(const char *path);

--- a/src/common/os_dimm_none.c
+++ b/src/common/os_dimm_none.c
@@ -82,6 +82,18 @@ os_dimm_files_namespace_badblocks(const char *path, struct badblocks *bbs)
 }
 
 /*
+ * os_dimm_devdax_get_clear_badblocks -- fake bad block getting
+ *                                       and clearing routine
+ */
+int
+os_dimm_devdax_get_clear_badblocks(const char *path, struct badblocks *bbs)
+{
+	LOG(3, "path %s badblocks %p", path, bbs);
+
+	return 0;
+}
+
+/*
  * os_dimm_devdax_clear_badblocks -- fake bad block clearing routine
  */
 int

--- a/src/common/os_dimm_windows.c
+++ b/src/common/os_dimm_windows.c
@@ -173,6 +173,18 @@ os_dimm_files_namespace_badblocks(const char *path, struct badblocks *bbs)
 }
 
 /*
+ * os_dimm_devdax_get_clear_badblocks -- fake bad block getting
+ *                                       and clearing routine
+ */
+int
+os_dimm_devdax_get_clear_badblocks(const char *path, struct badblocks *bbs)
+{
+	LOG(3, "path %s badblocks %p", path, bbs);
+
+	return 0;
+}
+
+/*
  * os_dimm_devdax_clear_badblocks -- fake bad block clearing routine
  */
 int


### PR DESCRIPTION
The os_badblocks_get_and_clear() function will be needed for
advanced support for bad blocks in pmempool-sync.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2821)
<!-- Reviewable:end -->
