### PR TITLE
common: simplify recreate_broken_parts()

### DIFF
--- a/src/libpmempool/replica.h
+++ b/src/libpmempool/replica.h
@@ -133,7 +133,7 @@ uint64_t replica_get_part_data_offset(struct pool_set *set_in, unsigned repn,
 static inline bool
 is_dry_run(unsigned flags)
 {
-	return PMEMPOOL_DRY_RUN & flags;
+	return flags & PMEMPOOL_DRY_RUN;
 }
 
 int replica_remove_part(struct pool_set *set, unsigned repn, unsigned partn);


### PR DESCRIPTION
Remove the 'flags' argument and the 'is_dry_run(flags)' check,
because this functions is called only once just after this check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2822)
<!-- Reviewable:end -->
