### PR TITLE
obj: don't compare floats

### DIFF
--- a/src/libpmemobj/alloc_class.c
+++ b/src/libpmemobj/alloc_class.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -445,11 +445,12 @@ alloc_class_find_min_frag(struct alloc_class_collection *ac, size_t n)
 		if (units > RUN_UNIT_MAX_ALLOC)
 			continue;
 
-		float frag = (float)(c->unit_size * units) / (float)real_size;
-		if (frag == 1.f)
+		if (c->unit_size * units == real_size)
 			return c;
 
-		ASSERT(frag >= 1.f);
+		ASSERT(c->unit_size * units > real_size);
+
+		float frag = (float)(c->unit_size * units) / (float)real_size;
 		if (frag < best_frag || best_c == NULL) {
 			best_c = c;
 			best_frag = frag;


### PR DESCRIPTION
This case is probably harmless, but in general comparing floats
for equality may be a source of "funny" bugs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2825)
<!-- Reviewable:end -->
