### PR TITLE
benchmark: allow benchmarks to reuse files

### DIFF
--- a/src/benchmarks/Makefile
+++ b/src/benchmarks/Makefile
@@ -79,7 +79,8 @@ SRC=pmembench.cpp\
     obj_lanes.cpp\
     map_bench.cpp\
     pmemobj_tx.cpp\
-    pmemobj_atomic_lists.cpp
+    pmemobj_atomic_lists.cpp\
+    poolset_util.cpp
 
 # Configuration file without the .cfg extension
 CONFIGS=pmembench_log\

--- a/src/benchmarks/benchmark.hpp
+++ b/src/benchmarks/benchmark.hpp
@@ -85,6 +85,8 @@ struct benchmark_args {
 	const char *fname;       /* path to test file */
 	size_t fsize;		 /* size of test file */
 	bool is_poolset;	 /* test file is a poolset */
+	bool is_dynamic_poolset; /* test file is directory in which
+				    benchmark creates reusable files */
 	mode_t fmode;		 /* test file's permissions */
 	unsigned n_threads;      /* number of working threads */
 	size_t n_ops_per_thread; /* number of operations per thread */

--- a/src/benchmarks/pmembench.vcxproj
+++ b/src/benchmarks/pmembench.vcxproj
@@ -149,6 +149,7 @@
     <ClCompile Include="pmem_flush.cpp" />
     <ClCompile Include="pmem_memcpy.cpp" />
     <ClCompile Include="pmem_memset.cpp" />
+    <ClCompile Include="poolset_util.cpp" />
     <ClCompile Include="rpmem_persist.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
@@ -166,6 +167,7 @@
     <ClInclude Include="clo.hpp" />
     <ClInclude Include="clo_vec.hpp" />
     <ClInclude Include="config_reader.hpp" />
+    <ClInclude Include="poolset_util.hpp" />
     <ClInclude Include="scenario.hpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/src/benchmarks/pmembench.vcxproj.filters
+++ b/src/benchmarks/pmembench.vcxproj.filters
@@ -151,6 +151,9 @@
     <ClCompile Include="..\libpmemobj\stats.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="poolset_util.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="clo.hpp">
@@ -172,6 +175,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="benchmark_worker.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="poolset_util.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/benchmarks/poolset_util.cpp
+++ b/src/benchmarks/poolset_util.cpp
@@ -1,0 +1,118 @@
+/*
+* Copyright 2018, Intel Corporation
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided with the
+*       distribution.
+*
+*     * Neither the name of the copyright holder nor the names of its
+*       contributors may be used to endorse or promote products derived
+*       from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+* A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+* OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+* SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <cassert>
+#include <fcntl.h>
+#include <file.h>
+
+#include "os.h"
+#include "poolset_util.hpp"
+#include "set.h"
+
+#define PART_TEMPLATE "part."
+#define POOL_PART_SIZE (1UL << 30)
+
+/*
+ * dynamic_poolset_clear -- clears header in first part if it exists
+ */
+static int
+dynamic_poolset_clear(const char *dir)
+{
+	char path[PATH_MAX];
+	int count = snprintf(path, sizeof(path),
+			     "%s" OS_DIR_SEP_STR PART_TEMPLATE "0", dir);
+	assert(count > 0);
+	if ((size_t)count >= sizeof(path)) {
+		fprintf(stderr, "path to a poolset part too long\n");
+		return -1;
+	}
+
+	if (os_access(path, F_OK) != 0)
+		return 0;
+
+	return util_file_zero(path, 0, POOL_HDR_SIZE);
+}
+
+/*
+ * dynamic_poolset_create -- clear pool's header and create new poolset
+ */
+int
+dynamic_poolset_create(const char *path, size_t size)
+{
+	/* buffer for part's path and size */
+	char buff[PATH_MAX + 20];
+
+	int ret;
+	int fd;
+	int count;
+	int curr_part = 0;
+
+	ret = dynamic_poolset_clear(path);
+	if (ret == -1)
+		return -1;
+
+	fd = os_open(POOLSET_PATH, O_RDWR | O_CREAT, 0644);
+	if (fd == -1) {
+		perror("open");
+		return -1;
+	}
+
+	char header[] = "PMEMPOOLSET\nOPTION SINGLEHDR\n";
+
+	ret = util_write_all(fd, header, sizeof(header) - 1);
+	if (ret == -1)
+		goto err;
+
+	while (curr_part * POOL_PART_SIZE < size + POOL_HDR_SIZE) {
+		count = snprintf(buff, sizeof(buff),
+				 "%lu %s" OS_DIR_SEP_STR PART_TEMPLATE "%d\n",
+				 POOL_PART_SIZE, path, curr_part);
+		assert(count > 0);
+		if ((size_t)count >= sizeof(buff)) {
+			fprintf(stderr, "path to a poolset part too long\n");
+			goto err;
+		}
+
+		ret = util_write_all(fd, buff, count);
+		if (ret == -1)
+			goto err;
+
+		curr_part++;
+	}
+
+	close(fd);
+	return 0;
+
+err:
+	close(fd);
+	return -1;
+}

--- a/src/benchmarks/poolset_util.hpp
+++ b/src/benchmarks/poolset_util.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*
+ * poolset_util.hpp -- this file provides interface for creating
+ * poolsets of specified size
+ */
+
+#ifndef POOLSET_UTIL_HPP
+#define POOLSET_UTIL_HPP
+
+#include <stddef.h>
+
+#define POOLSET_PATH "pool.set"
+
+int dynamic_poolset_create(const char *path, size_t size);
+
+#endif

--- a/src/common/file.c
+++ b/src/common/file.c
@@ -609,3 +609,27 @@ util_unlink_flock(const char *path)
 	return ret;
 #endif
 }
+
+/*
+ * util_write_all -- a wrapper for util_write
+ *
+ * writes exactly count bytes from buf to file referred to by fd
+ * returns -1 on error, 0 otherwise
+ */
+int
+util_write_all(int fd, const char *buf, size_t count)
+{
+	ssize_t n_wrote = 0;
+	size_t total = 0;
+
+	while (count > total) {
+		n_wrote = util_write(fd, buf, count - total);
+		if (n_wrote <= 0)
+			return -1;
+
+		buf += (size_t)n_wrote;
+		total += (size_t)n_wrote;
+	}
+
+	return 0;
+}

--- a/src/common/file.h
+++ b/src/common/file.h
@@ -89,6 +89,8 @@ int util_unlink(const char *path);
 int util_unlink_flock(const char *path);
 int util_file_mkdir(const char *path, mode_t mode);
 
+int util_write_all(int fd, const char *buf, size_t count);
+
 #ifndef _WIN32
 #define util_read	read
 #define util_write	write

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -42,6 +42,7 @@
 extern "C" {
 #endif
 
+#include <string.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -144,6 +145,19 @@ static inline void
 util_clrbit(uint8_t *b, uint32_t i)
 {
 	b[i / 8] = (uint8_t)(b[i / 8] & (uint8_t)(~(1 << (i % 8))));
+}
+
+/*
+ * util_safe_strcpy -- copies string from src to dst, returns error
+ * when length of source string (including null-terminator)
+ * is greater than max_length
+ */
+static inline int
+util_safe_strcpy(char *dst, const char *src, size_t max_length)
+{
+	strncpy(dst, src, max_length);
+
+	return dst[max_length - 1] == '\0' ? 0 : -1;
 }
 
 #define util_isset(a, i) isset(a, i)

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -148,13 +148,16 @@ util_clrbit(uint8_t *b, uint32_t i)
 }
 
 /*
- * util_safe_strcpy -- copies string from src to dst, returns error
+ * util_safe_strcpy -- copies string from src to dst, returns -1
  * when length of source string (including null-terminator)
- * is greater than max_length
+ * is greater than max_length, 0 otherwise
  */
 static inline int
 util_safe_strcpy(char *dst, const char *src, size_t max_length)
 {
+	if (max_length == 0)
+		return -1;
+
 	strncpy(dst, src, max_length);
 
 	return dst[max_length - 1] == '\0' ? 0 : -1;


### PR DESCRIPTION
When flag '-p' is specified benchmark expects testfile to be absolute path to directory in which it will create
pool from variable number of parts (depending on benchmark needs). Parts can be resued by multiple runs.

This patch allowed to decrease total time needed by benchmark on windows from 12h to 5h.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2830)
<!-- Reviewable:end -->
