### PR TITLE
common: replace NULL with nullptr

### DIFF
--- a/src/examples/libpmemobj++/map_cli/map_cli.cpp
+++ b/src/examples/libpmemobj++/map_cli/map_cli.cpp
@@ -197,7 +197,7 @@ exec_op(pool_base pop, T &map, queue_op op, char *argv[], int &argn)
 			map->clear();
 			break;
 		case MAP_PRINT:
-			map->foreach (printer<typename K::value_type>, 0);
+			map->foreach (printer<typename K::value_type>, nullptr);
 			break;
 		default:
 			throw std::invalid_argument("invalid queue operation");

--- a/src/examples/libpmemobj++/panaconda/panaconda.cpp
+++ b/src/examples/libpmemobj++/panaconda/panaconda.cpp
@@ -762,7 +762,7 @@ game::game(struct parameters *par)
 
 	init_colors();
 
-	srand(time(0));
+	srand(time(nullptr));
 }
 
 game::~game()
@@ -918,13 +918,13 @@ int
 game::parse_conf_create_dynamic_layout(void)
 {
 	FILE *cfg_file;
-	char *line = NULL;
+	char *line = nullptr;
 	size_t len = 0;
 	unsigned i = 0;
 	ssize_t col_no = 0;
 
 	cfg_file = fopen(params->maze_path.c_str(), "r");
-	if (cfg_file == NULL)
+	if (cfg_file == nullptr)
 		return -1;
 
 	persistent_ptr<game_state> r = state.get_root();

--- a/src/include/libpmemobj++/transaction.hpp
+++ b/src/include/libpmemobj++/transaction.hpp
@@ -106,7 +106,7 @@ public:
 		template <typename... L>
 		manual(obj::pool_base &pop, L &... locks)
 		{
-			if (pmemobj_tx_begin(pop.get_handle(), NULL,
+			if (pmemobj_tx_begin(pop.get_handle(), nullptr,
 					     TX_PARAM_NONE) != 0)
 				throw transaction_error(
 					"failed to start transaction");
@@ -392,8 +392,8 @@ public:
 	static void
 	exec_tx(pool_base &pool, std::function<void()> tx, Locks &... locks)
 	{
-		if (pmemobj_tx_begin(pool.get_handle(), NULL, TX_PARAM_NONE) !=
-		    0)
+		if (pmemobj_tx_begin(pool.get_handle(), nullptr,
+				     TX_PARAM_NONE) != 0)
 			throw transaction_error("failed to start transaction");
 
 		auto err = add_lock(locks...);

--- a/src/test/obj_cpp_cond_var/obj_cpp_cond_var.cpp
+++ b/src/test/obj_cpp_cond_var/obj_cpp_cond_var.cpp
@@ -370,7 +370,7 @@ cond_zero_test(nvobj::pool<struct root> &pop)
 			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
 			      return 0;
 		      },
-		      NULL);
+		      nullptr);
 
 	nvobj::condition_variable *placed_mtx =
 		new (pmemobj_direct(raw_cnd)) nvobj::condition_variable;

--- a/src/test/obj_cpp_cond_var_posix/obj_cpp_cond_var_posix.cpp
+++ b/src/test/obj_cpp_cond_var_posix/obj_cpp_cond_var_posix.cpp
@@ -422,7 +422,7 @@ cond_zero_test(nvobj::pool<struct root> &pop)
 			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
 			      return 0;
 		      },
-		      NULL);
+		      nullptr);
 
 	nvobj::condition_variable *placed_mtx =
 		new (pmemobj_direct(raw_cnd)) nvobj::condition_variable;

--- a/src/test/obj_cpp_mutex/obj_cpp_mutex.cpp
+++ b/src/test/obj_cpp_mutex/obj_cpp_mutex.cpp
@@ -116,7 +116,7 @@ mutex_zero_test(nvobj::pool<struct root> &pop)
 			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
 			      return 0;
 		      },
-		      NULL);
+		      nullptr);
 
 	nvobj::mutex *placed_mtx = new (pmemobj_direct(raw_mutex)) nvobj::mutex;
 	std::unique_lock<nvobj::mutex> lck(*placed_mtx);

--- a/src/test/obj_cpp_mutex_posix/obj_cpp_mutex_posix.cpp
+++ b/src/test/obj_cpp_mutex_posix/obj_cpp_mutex_posix.cpp
@@ -126,7 +126,7 @@ mutex_zero_test(nvobj::pool<struct root> &pop)
 			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
 			      return 0;
 		      },
-		      NULL);
+		      nullptr);
 
 	nvobj::mutex *placed_mtx = new (pmemobj_direct(raw_mutex)) nvobj::mutex;
 	std::unique_lock<nvobj::mutex> lck(*placed_mtx);

--- a/src/test/obj_cpp_shared_mutex/obj_cpp_shared_mutex.cpp
+++ b/src/test/obj_cpp_shared_mutex/obj_cpp_shared_mutex.cpp
@@ -133,7 +133,7 @@ mutex_zero_test(nvobj::pool<struct root> &pop)
 			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
 			      return 0;
 		      },
-		      NULL);
+		      nullptr);
 
 	nvobj::shared_mutex *placed_mtx =
 		new (pmemobj_direct(raw_mutex)) nvobj::shared_mutex;

--- a/src/test/obj_cpp_shared_mutex_posix/obj_cpp_shared_mutex_posix.cpp
+++ b/src/test/obj_cpp_shared_mutex_posix/obj_cpp_shared_mutex_posix.cpp
@@ -142,7 +142,7 @@ mutex_zero_test(nvobj::pool<struct root> &pop)
 			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
 			      return 0;
 		      },
-		      NULL);
+		      nullptr);
 
 	nvobj::shared_mutex *placed_mtx =
 		new (pmemobj_direct(raw_mutex)) nvobj::shared_mutex;

--- a/src/test/obj_cpp_timed_mtx/obj_cpp_timed_mtx.cpp
+++ b/src/test/obj_cpp_timed_mtx/obj_cpp_timed_mtx.cpp
@@ -178,7 +178,7 @@ mutex_zero_test(nvobj::pool<struct root> &pop)
 			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
 			      return 0;
 		      },
-		      NULL);
+		      nullptr);
 
 	nvobj::timed_mutex *placed_mtx =
 		new (pmemobj_direct(raw_mutex)) nvobj::timed_mutex;

--- a/src/test/obj_cpp_timed_mtx_posix/obj_cpp_timed_mtx_posix.cpp
+++ b/src/test/obj_cpp_timed_mtx_posix/obj_cpp_timed_mtx_posix.cpp
@@ -179,7 +179,7 @@ mutex_zero_test(nvobj::pool<struct root> &pop)
 			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
 			      return 0;
 		      },
-		      NULL);
+		      nullptr);
 
 	nvobj::timed_mutex *placed_mtx =
 		new (pmemobj_direct(raw_mutex)) nvobj::timed_mutex;


### PR DESCRIPTION
Intention of this PR is to replace NULL with nullptr.
Test/examples are compiled with -std=c++11, which means nullptr value is supported by these module.
I could prepare additional PR for benchmark module with similar changes and additional for makefile to change the std to c++11, but I don't know if it is possible, because of:
https://github.com/pmem/pmdk/commit/485a455a64ded76f824fe4dd2b5bf6d3087287b7

In any case any feedback will be appreciated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2836)
<!-- Reviewable:end -->
