### PR TITLE
Simple spelling fixes flagged by the debian packaging lintian tool.

### DIFF
--- a/doc/pmempool/pmempool-info.1.md
+++ b/doc/pmempool/pmempool-info.1.md
@@ -138,7 +138,7 @@ Print sizes in human-readable format with appropriate units (e.g. 4k, 8M, 16G)
 
 Print pool's internal data in mixed format which consists of hexadecimal dump of
 header's data and parsed format displayed in human-readable format. This
-allows to see how data is stored in file.
+allows one to see how data is stored in file.
 
 `-s, --stats`
 

--- a/src/examples/libpmemobj/array/README
+++ b/src/examples/libpmemobj/array/README
@@ -3,7 +3,7 @@ Persistent Memory Development Kit
 This is examples/libpmemobj/array/README.
 
 This directory contains an example application implemented using libpmemobj.
-The array example allows to perform basic operations like allocation,
+The array example allows one to perform basic operations like allocation,
 reallocation and de-allocation on persistent array. User can choose
 size of new or reallocated array. There are also 3 types of elements which
 are supported: int, PMEMoid and TOID with structure containing int variable.

--- a/src/libpmempool/libpmempool.c
+++ b/src/libpmempool/libpmempool.c
@@ -238,7 +238,7 @@ pmempool_check_initU(struct pmempool_check_argsU *args, size_t args_size)
 	 */
 	if (util_flag_isset(args->flags, PMEMPOOL_CHECK_DRY_RUN) &&
 			args->backup_path != NULL) {
-		ERR("dry run does not allow to perform backup");
+		ERR("dry run does not allow one to perform backup");
 		errno = EINVAL;
 		return NULL;
 	}

--- a/src/test/tools/pmemspoil/README
+++ b/src/test/tools/pmemspoil/README
@@ -4,8 +4,8 @@ This is src/test/tools/pmemspoil/README.
 
 This directory contains a simple application for corrupting pool files.
 
-This application may be used for testing purposes. One allows to modify every
-single field in all structures used by Persistent Memory Development Kit.
+This application may be used for testing purposes. It allows one to modify
+every single field in all structures used by Persistent Memory Development Kit.
 
 Usage:
 	$ pmemspoil <file> <field>=<value>...


### PR DESCRIPTION
While packaging nvml, the debian lintian tool flagged some simple spelling mistakes. Many were fixed already in current master, but these are the few that remain with regards to the "allows to" expression.