### PR TITLE
obj: add Wfloat-equal warning flag

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -66,6 +66,9 @@ endif
 ifeq ($(call check_flag, -Wmissing-variable-declarations), y)
 DEFAULT_CFLAGS += -Wmissing-variable-declarations
 endif
+ifeq ($(call check_flag, -Wfloat-equal), y)
+DEFAULT_CFLAGS += -Wfloat-equal
+endif
 endif
 
 ifeq ($(DEBUG),1)

--- a/src/jemalloc/jemalloc.mk
+++ b/src/jemalloc/jemalloc.mk
@@ -80,6 +80,7 @@ CFLAGS_FILTER += -Wpedantic
 CFLAGS_FILTER += -Wshadow
 CFLAGS_FILTER += -Wdisabled-macro-expansion
 CFLAGS_FILTER += -Wlanguage-extension-token
+CFLAGS_FILTER += -Wfloat-equal
 JEMALLOC_CFLAGS=$(filter-out $(CFLAGS_FILTER), $(CFLAGS))
 ifeq ($(shell uname -s),FreeBSD)
 JEMALLOC_CFLAGS += -I/usr/local/include

--- a/src/libpmemobj/alloc_class.c
+++ b/src/libpmemobj/alloc_class.c
@@ -519,7 +519,8 @@ alloc_class_collection_new()
 
 			float stepf = (float)n * categories[c].step;
 			size_t stepi = (size_t)stepf;
-			stepi = stepf == stepi ? stepi : stepi + 1;
+			stepi = (stepf - (float)stepi < FLT_EPSILON) ?
+				stepi : stepi + 1;
 
 			n += (stepi + (granularity_mask)) & ~granularity_mask;
 		} while (n <= categories[c].size);

--- a/src/test/unittest/Makefile
+++ b/src/test/unittest/Makefile
@@ -69,6 +69,9 @@ endif
 ifeq ($(call check_flag, -Wmissing-variable-declarations), y)
 CFLAGS += -Wmissing-variable-declarations
 endif
+ifeq ($(call check_flag, -Wfloat-equal), y)
+CFLAGS += -Wfloat-equal
+endif
 endif
 
 ifeq ($(USE_LIBUNWIND),1)

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -63,6 +63,9 @@ endif
 ifeq ($(call check_flag, -Wmissing-variable-declarations), y)
 CFLAGS += -Wmissing-variable-declarations
 endif
+ifeq ($(call check_flag, -Wfloat-equal), y)
+CFLAGS += -Wfloat-equal
+endif
 endif
 
 ifeq ($(DEBUG),1)

--- a/src/tools/pmempool/output.c
+++ b/src/tools/pmempool/output.c
@@ -44,6 +44,7 @@
 #include <err.h>
 #include <endian.h>
 #include <inttypes.h>
+#include <float.h>
 #include "common.h"
 #include "output.h"
 
@@ -289,7 +290,7 @@ out_get_percentage(double perc)
 			return "";
 	} else {
 		int decimal = 0;
-		if (perc >= 100.0 || perc == 0.0)
+		if (perc >= 100.0 || perc < DBL_EPSILON)
 			decimal = 0;
 		else
 			decimal = 6;

--- a/utils/check_license/Makefile
+++ b/utils/check_license/Makefile
@@ -51,6 +51,9 @@ endif
 ifeq ($(call check_flag, -Wmissing-variable-declarations), y)
 CFLAGS += -Wmissing-variable-declarations
 endif
+ifeq ($(call check_flag, -Wfloat-equal), y)
+CFLAGS += -Wfloat-equal
+endif
 
 TARGET=check-license
 


### PR DESCRIPTION
Intention of this PR is to cover the issue with compare floats.
I saw commit:
https://github.com/pmem/pmdk/commit/08654d275c1646dc07da7324d27f0f0f2c1dc911
Wfloat-equal warning is supported by Clang and GCC - it would detect issue from commit above during compilation.

I'm not sure of my changes in alloc_class.c

In any case any feedback will be appreciated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2848)
<!-- Reviewable:end -->
