### PR TITLE
benchmark: use nullptr instead of NULL

### DIFF
--- a/src/benchmarks/benchmark_worker.cpp
+++ b/src/benchmarks/benchmark_worker.cpp
@@ -72,7 +72,7 @@ worker_state_transition(struct benchmark_worker *worker,
 static void *
 thread_func(void *arg)
 {
-	assert(arg != NULL);
+	assert(arg != nullptr);
 	struct benchmark_worker *worker = (struct benchmark_worker *)arg;
 
 	os_mutex_lock(&worker->lock);
@@ -103,7 +103,7 @@ thread_func(void *arg)
 	worker_state_transition(worker, WORKER_STATE_EXIT, WORKER_STATE_DONE);
 
 	os_mutex_unlock(&worker->lock);
-	return NULL;
+	return nullptr;
 }
 
 /*
@@ -116,7 +116,7 @@ benchmark_worker_alloc(void)
 		(struct benchmark_worker *)calloc(1, sizeof(*w));
 
 	if (!w)
-		return NULL;
+		return nullptr;
 
 	if (os_mutex_init(&w->lock))
 		goto err_free_worker;
@@ -124,7 +124,7 @@ benchmark_worker_alloc(void)
 	if (os_cond_init(&w->cond))
 		goto err_destroy_mutex;
 
-	if (os_thread_create(&w->thread, NULL, thread_func, w))
+	if (os_thread_create(&w->thread, nullptr, thread_func, w))
 		goto err_destroy_cond;
 
 	return w;
@@ -135,7 +135,7 @@ err_destroy_mutex:
 	os_mutex_destroy(&w->lock);
 err_free_worker:
 	free(w);
-	return NULL;
+	return nullptr;
 }
 
 /*
@@ -144,7 +144,7 @@ err_free_worker:
 void
 benchmark_worker_free(struct benchmark_worker *w)
 {
-	os_thread_join(&w->thread, NULL);
+	os_thread_join(&w->thread, nullptr);
 	os_cond_destroy(&w->cond);
 	os_mutex_destroy(&w->lock);
 	free(w);

--- a/src/benchmarks/blk.cpp
+++ b/src/benchmarks/blk.cpp
@@ -383,7 +383,7 @@ static int
 blk_init(struct blk_bench *bb, struct benchmark_args *args)
 {
 	struct blk_args *ba = (struct blk_args *)args->opts;
-	assert(ba != NULL);
+	assert(ba != nullptr);
 
 	bb->type = parse_op_type(ba->type_str);
 	if (bb->type == OP_TYPE_UNKNOWN) {
@@ -436,7 +436,7 @@ blk_init(struct blk_bench *bb, struct benchmark_args *args)
 	 */
 	bb->pbp = pmemblk_create(args->fname, args->dsize, ba->fsize,
 				 args->fmode);
-	if (bb->pbp == NULL) {
+	if (bb->pbp == nullptr) {
 		perror("pmemblk_create");
 		return -1;
 	}
@@ -454,7 +454,7 @@ blk_init(struct blk_bench *bb, struct benchmark_args *args)
 
 	if (bb->type == OP_TYPE_FILE) {
 		pmemblk_close(bb->pbp);
-		bb->pbp = NULL;
+		bb->pbp = nullptr;
 
 		int flags = O_RDWR | O_CREAT | O_SYNC;
 #ifdef _WIN32
@@ -492,13 +492,13 @@ out_close:
 static int
 blk_read_init(struct benchmark *bench, struct benchmark_args *args)
 {
-	assert(bench != NULL);
-	assert(args != NULL);
+	assert(bench != nullptr);
+	assert(args != nullptr);
 
 	int ret;
 	struct blk_bench *bb =
 		(struct blk_bench *)malloc(sizeof(struct blk_bench));
-	if (bb == NULL) {
+	if (bb == nullptr) {
 		perror("malloc");
 		return -1;
 	}
@@ -535,13 +535,13 @@ blk_read_init(struct benchmark *bench, struct benchmark_args *args)
 static int
 blk_write_init(struct benchmark *bench, struct benchmark_args *args)
 {
-	assert(bench != NULL);
-	assert(args != NULL);
+	assert(bench != nullptr);
+	assert(args != nullptr);
 
 	int ret;
 	struct blk_bench *bb =
 		(struct blk_bench *)malloc(sizeof(struct blk_bench));
-	if (bb == NULL) {
+	if (bb == nullptr) {
 		perror("malloc");
 		return -1;
 	}

--- a/src/benchmarks/clo.cpp
+++ b/src/benchmarks/clo.cpp
@@ -76,7 +76,7 @@ clo_parse_flag(struct benchmark_clo *clo, const char *arg,
 	       struct clo_vec *clovec)
 {
 	bool flag = true;
-	if (arg != NULL) {
+	if (arg != nullptr) {
 		if (strcmp(arg, "true") == 0)
 			flag = true;
 		else if (strcmp(arg, "false") == 0)
@@ -96,16 +96,16 @@ clo_parse_str(struct benchmark_clo *clo, const char *arg,
 	      struct clo_vec *clovec)
 {
 	struct clo_vec_vlist *vlist = clo_vec_vlist_alloc();
-	assert(vlist != NULL);
+	assert(vlist != nullptr);
 
 	char *str = strdup(arg);
-	assert(str != NULL);
+	assert(str != nullptr);
 	clo_vec_add_alloc(clovec, str);
 
 	char *next = strtok(str, ",");
 	while (next) {
 		clo_vec_vlist_add(vlist, &next, sizeof(next));
-		next = strtok(NULL, ",");
+		next = strtok(nullptr, ",");
 	}
 
 	int ret = clo_vec_memcpy_list(clovec, clo->off, sizeof(str), vlist);
@@ -380,12 +380,12 @@ clo_parse_range(struct benchmark_clo *clo, const char *arg,
 		struct clo_vec_vlist *vlist)
 {
 	char *str_first = (char *)malloc(strlen(arg) + 1);
-	assert(str_first != NULL);
+	assert(str_first != nullptr);
 	char *str_step = (char *)malloc(strlen(arg) + 1);
-	assert(str_step != NULL);
+	assert(str_step != nullptr);
 	char step_type = '\0';
 	char *str_last = (char *)malloc(strlen(arg) + 1);
-	assert(str_last != NULL);
+	assert(str_last != nullptr);
 
 	int ret = sscanf(arg, "%[^:]:%c%[^:]:%[^:]", str_first, &step_type,
 			 str_step, str_last);
@@ -462,17 +462,17 @@ clo_parse_ranges(struct benchmark_clo *clo, const char *arg,
 		 clo_eval_range_fn eval_range)
 {
 	struct clo_vec_vlist *vlist = clo_vec_vlist_alloc();
-	assert(vlist != NULL);
+	assert(vlist != nullptr);
 
 	int ret = 0;
 	char *args = strdup(arg);
-	assert(args != NULL);
+	assert(args != nullptr);
 
 	char *curr = args;
 	char *next;
 
 	/* iterate through all values separated by comma */
-	while ((next = strchr(curr, ',')) != NULL) {
+	while ((next = strchr(curr, ',')) != nullptr) {
 		*next = '\0';
 		next++;
 
@@ -532,7 +532,7 @@ static const char *
 clo_str_flag(struct benchmark_clo *clo, void *addr, size_t size)
 {
 	if (clo->off + sizeof(bool) > size)
-		return NULL;
+		return nullptr;
 
 	bool flag = *(bool *)((char *)addr + clo->off);
 
@@ -546,7 +546,7 @@ static const char *
 clo_str_str(struct benchmark_clo *clo, void *addr, size_t size)
 {
 	if (clo->off + sizeof(char *) > size)
-		return NULL;
+		return nullptr;
 
 	return *(char **)((char *)addr + clo->off);
 }
@@ -558,7 +558,7 @@ static const char *
 clo_str_int(struct benchmark_clo *clo, void *addr, size_t size)
 {
 	if (clo->off + clo->type_int.size > size)
-		return NULL;
+		return nullptr;
 
 	void *val = (char *)addr + clo->off;
 
@@ -581,10 +581,10 @@ clo_str_int(struct benchmark_clo *clo, void *addr, size_t size)
 				       *(int64_t *)val);
 			break;
 		default:
-			return NULL;
+			return nullptr;
 	}
 	if (ret < 0)
-		return NULL;
+		return nullptr;
 
 	return str_buff;
 }
@@ -596,7 +596,7 @@ static const char *
 clo_str_uint(struct benchmark_clo *clo, void *addr, size_t size)
 {
 	if (clo->off + clo->type_uint.size > size)
-		return NULL;
+		return nullptr;
 
 	void *val = (char *)addr + clo->off;
 
@@ -619,10 +619,10 @@ clo_str_uint(struct benchmark_clo *clo, void *addr, size_t size)
 				       *(uint64_t *)val);
 			break;
 		default:
-			return NULL;
+			return nullptr;
 	}
 	if (ret < 0)
-		return NULL;
+		return nullptr;
 
 	return str_buff;
 }
@@ -660,7 +660,7 @@ clo_get_by_short(struct benchmark_clo *clos, size_t nclo, char opt_short)
 			return &clos[i];
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 /*
@@ -676,7 +676,7 @@ clo_get_by_long(struct benchmark_clo *clos, size_t nclo, const char *opt_long)
 			return &clos[i];
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 /*
@@ -700,7 +700,7 @@ clo_get_optstr(struct benchmark_clo *clos, size_t nclo)
 	size_t optstrlen = nclo * 2 + 1;
 
 	optstr = (char *)calloc(1, optstrlen);
-	assert(optstr != NULL);
+	assert(optstr != nullptr);
 
 	ptr = optstr;
 	for (i = 0; i < nclo; i++) {
@@ -729,7 +729,7 @@ clo_get_long_options(struct benchmark_clo *clos, size_t nclo)
 	struct option *options;
 
 	options = (struct option *)calloc(nclo + 1, sizeof(struct option));
-	assert(options != NULL);
+	assert(options != nullptr);
 
 	for (i = 0; i < nclo; i++) {
 		options[i].name = clos[i].opt_long;
@@ -820,7 +820,7 @@ benchmark_clo_parse(int argc, char *argv[], struct benchmark_clo *clos,
 	/* parse CLOs as long and/or short options */
 	while ((opt = getopt_long(argc, argv, optstr, options, &optindex)) !=
 	       -1) {
-		struct benchmark_clo *clo = NULL;
+		struct benchmark_clo *clo = nullptr;
 		if (opt) {
 			clo = clo_get_by_short(clos, nclos, opt);
 		} else {
@@ -839,7 +839,7 @@ benchmark_clo_parse(int argc, char *argv[], struct benchmark_clo *clos,
 			goto out;
 
 		/* mark CLO as used */
-		clo->used = optarg != NULL || clo->type == CLO_TYPE_FLAG;
+		clo->used = optarg != nullptr || clo->type == CLO_TYPE_FLAG;
 	}
 
 	if (optind < argc) {
@@ -935,7 +935,7 @@ benchmark_override_clos_in_scenario(struct scenario *scenario, int argc,
 	/* parse CLOs as long and/or short options */
 	while ((opt = getopt_long(argc, argv, optstr, options, &optindex)) !=
 	       -1) {
-		struct benchmark_clo *clo = NULL;
+		struct benchmark_clo *clo = nullptr;
 		if (opt) {
 			clo = clo_get_by_short(clos, nclos, opt);
 		} else {
@@ -950,10 +950,10 @@ benchmark_override_clos_in_scenario(struct scenario *scenario, int argc,
 		/* Check if the given clo is defined in the scenario */
 		struct kv *kv = find_kv_in_scenario(clo->opt_long, scenario);
 		if (kv) { /* replace the value in the scenario */
-			if (optarg != NULL && clo->type != CLO_TYPE_FLAG) {
+			if (optarg != nullptr && clo->type != CLO_TYPE_FLAG) {
 				free(kv->value);
 				kv->value = strdup(optarg);
-			} else if (optarg == NULL &&
+			} else if (optarg == nullptr &&
 				   clo->type == CLO_TYPE_FLAG) {
 				free(kv->value);
 				kv->value = strdup(true_str);
@@ -962,10 +962,10 @@ benchmark_override_clos_in_scenario(struct scenario *scenario, int argc,
 				goto out;
 			}
 		} else { /* add a new param to the scenario */
-			if (optarg != NULL && clo->type != CLO_TYPE_FLAG) {
+			if (optarg != nullptr && clo->type != CLO_TYPE_FLAG) {
 				kv = kv_alloc(clo->opt_long, optarg);
 				TAILQ_INSERT_TAIL(&scenario->head, kv, next);
-			} else if (optarg == NULL &&
+			} else if (optarg == nullptr &&
 				   clo->type == CLO_TYPE_FLAG) {
 				kv = kv_alloc(clo->opt_long, true_str);
 				TAILQ_INSERT_TAIL(&scenario->head, kv, next);
@@ -1016,9 +1016,9 @@ int
 clo_get_scenarios(int argc, char *argv[], struct scenarios *available_scenarios,
 		  struct scenarios *found_scenarios)
 {
-	assert(argv != NULL);
-	assert(available_scenarios != NULL);
-	assert(found_scenarios != NULL);
+	assert(argv != nullptr);
+	assert(available_scenarios != nullptr);
+	assert(found_scenarios != nullptr);
 
 	if (argc <= 0) {
 		fprintf(stderr, "clo get scenarios, argc invalid value: %d\n",
@@ -1038,7 +1038,7 @@ clo_get_scenarios(int argc, char *argv[], struct scenarios *available_scenarios,
 		}
 
 		struct scenario *new_scenario = clone_scenario(scenario);
-		assert(new_scenario != NULL);
+		assert(new_scenario != nullptr);
 
 		TAILQ_INSERT_TAIL(&found_scenarios->head, new_scenario, next);
 		tmp_argc--;

--- a/src/benchmarks/clo_vec.cpp
+++ b/src/benchmarks/clo_vec.cpp
@@ -45,7 +45,7 @@ struct clo_vec *
 clo_vec_alloc(size_t size)
 {
 	struct clo_vec *clovec = (struct clo_vec *)malloc(sizeof(*clovec));
-	assert(clovec != NULL);
+	assert(clovec != nullptr);
 
 	/* init list of arguments and allocations */
 	TAILQ_INIT(&clovec->allocs);
@@ -60,10 +60,10 @@ clo_vec_alloc(size_t size)
 	struct clo_vec_args *args =
 		(struct clo_vec_args *)malloc(sizeof(*args));
 
-	assert(args != NULL);
+	assert(args != nullptr);
 
 	args->args = calloc(1, size);
-	assert(args->args != NULL);
+	assert(args->args != nullptr);
 
 	TAILQ_INSERT_TAIL(&clovec->args, args, next);
 
@@ -78,7 +78,7 @@ clo_vec_alloc(size_t size)
 void
 clo_vec_free(struct clo_vec *clovec)
 {
-	assert(clovec != NULL);
+	assert(clovec != nullptr);
 
 	/* free all allocations */
 	while (!TAILQ_EMPTY(&clovec->allocs)) {
@@ -106,7 +106,7 @@ void *
 clo_vec_get_args(struct clo_vec *clovec, size_t i)
 {
 	if (i >= clovec->nargs)
-		return NULL;
+		return nullptr;
 	size_t c = 0;
 	struct clo_vec_args *args;
 	TAILQ_FOREACH(args, &clovec->args, next)
@@ -116,7 +116,7 @@ clo_vec_get_args(struct clo_vec *clovec, size_t i)
 		c++;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 /*
@@ -128,7 +128,7 @@ clo_vec_add_alloc(struct clo_vec *clovec, void *ptr)
 	struct clo_vec_alloc *alloc =
 		(struct clo_vec_alloc *)malloc(sizeof(*alloc));
 
-	assert(alloc != NULL);
+	assert(alloc != nullptr);
 
 	alloc->ptr = ptr;
 	TAILQ_INSERT_TAIL(&clovec->allocs, alloc, next);
@@ -149,15 +149,15 @@ clo_vec_grow(struct clo_vec *clovec, size_t new_len)
 		struct clo_vec_args *args =
 			(struct clo_vec_args *)calloc(1, sizeof(*args));
 
-		assert(args != NULL);
+		assert(args != nullptr);
 
 		TAILQ_INSERT_TAIL(&clovec->args, args, next);
 
 		args->args = malloc(clovec->size);
-		assert(args->args != NULL);
+		assert(args->args != nullptr);
 
 		void *argscpy = clo_vec_get_args(clovec, i % clovec->nargs);
-		assert(argscpy != NULL);
+		assert(argscpy != nullptr);
 
 		memcpy(args->args, argscpy, clovec->size);
 	}
@@ -174,7 +174,7 @@ clo_vec_vlist_alloc(void)
 	struct clo_vec_vlist *list =
 		(struct clo_vec_vlist *)malloc(sizeof(*list));
 
-	assert(list != NULL);
+	assert(list != nullptr);
 
 	list->nvalues = 0;
 	TAILQ_INIT(&list->head);
@@ -188,7 +188,7 @@ clo_vec_vlist_alloc(void)
 void
 clo_vec_vlist_free(struct clo_vec_vlist *list)
 {
-	assert(list != NULL);
+	assert(list != nullptr);
 
 	while (!TAILQ_EMPTY(&list->head)) {
 		struct clo_vec_value *val = TAILQ_FIRST(&list->head);
@@ -208,10 +208,10 @@ clo_vec_vlist_add(struct clo_vec_vlist *list, void *ptr, size_t size)
 {
 	struct clo_vec_value *val =
 		(struct clo_vec_value *)malloc(sizeof(*val));
-	assert(val != NULL);
+	assert(val != nullptr);
 
 	val->ptr = malloc(size);
-	assert(val->ptr != NULL);
+	assert(val->ptr != nullptr);
 
 	memcpy(val->ptr, ptr, size);
 	TAILQ_INSERT_TAIL(&list->head, val, next);

--- a/src/benchmarks/config_reader.cpp
+++ b/src/benchmarks/config_reader.cpp
@@ -60,7 +60,7 @@ struct config_reader *
 config_reader_alloc(void)
 {
 	struct config_reader *cr = (struct config_reader *)malloc(sizeof(*cr));
-	assert(cr != NULL);
+	assert(cr != nullptr);
 
 	cr->key_file = g_key_file_new();
 	if (!cr->key_file)
@@ -70,7 +70,7 @@ config_reader_alloc(void)
 
 err:
 	free(cr);
-	return NULL;
+	return nullptr;
 }
 
 /*
@@ -80,7 +80,7 @@ int
 config_reader_read(struct config_reader *cr, const char *fname)
 {
 	if (g_key_file_load_from_file(cr->key_file, fname, G_KEY_FILE_NONE,
-				      NULL) != TRUE)
+				      nullptr) != TRUE)
 		return -1;
 
 	return 0;
@@ -137,7 +137,7 @@ config_reader_get_scenarios(struct config_reader *cr,
 	gsize ngroups;
 	gsize g;
 	gchar **groups = g_key_file_get_groups(cr->key_file, &ngroups);
-	assert(NULL != groups);
+	assert(nullptr != groups);
 	if (!groups)
 		return -1;
 
@@ -148,12 +148,12 @@ config_reader_get_scenarios(struct config_reader *cr,
 	int has_global =
 		g_key_file_has_group(cr->key_file, SECTION_GLOBAL) == TRUE;
 	gsize ngkeys;
-	gchar **gkeys = NULL;
+	gchar **gkeys = nullptr;
 	struct scenarios *s;
 	if (has_global) {
 		gkeys = g_key_file_get_keys(cr->key_file, SECTION_GLOBAL,
-					    &ngkeys, NULL);
-		assert(NULL != gkeys);
+					    &ngkeys, nullptr);
+		assert(nullptr != gkeys);
 		if (!gkeys) {
 			ret = -1;
 			goto err_groups;
@@ -161,7 +161,7 @@ config_reader_get_scenarios(struct config_reader *cr,
 	}
 
 	s = scenarios_alloc();
-	assert(NULL != s);
+	assert(nullptr != s);
 	if (!s) {
 		ret = -1;
 		goto err_gkeys;
@@ -180,21 +180,22 @@ config_reader_get_scenarios(struct config_reader *cr,
 		 * If not present the benchmark name is the same as the
 		 * name of the section.
 		 */
-		struct scenario *scenario = NULL;
+		struct scenario *scenario = nullptr;
 		if (g_key_file_has_key(cr->key_file, groups[g], KEY_BENCHMARK,
-				       NULL) == FALSE) {
+				       nullptr) == FALSE) {
 			scenario = scenario_alloc(groups[g], groups[g]);
-			assert(scenario != NULL);
+			assert(scenario != nullptr);
 		} else {
-			gchar *benchmark = g_key_file_get_value(
-				cr->key_file, groups[g], KEY_BENCHMARK, NULL);
-			assert(benchmark != NULL);
+			gchar *benchmark =
+				g_key_file_get_value(cr->key_file, groups[g],
+						     KEY_BENCHMARK, nullptr);
+			assert(benchmark != nullptr);
 			if (!benchmark) {
 				ret = -1;
 				goto err_scenarios;
 			}
 			scenario = scenario_alloc(groups[g], benchmark);
-			assert(scenario != NULL);
+			assert(scenario != nullptr);
 			free(benchmark);
 		}
 
@@ -205,7 +206,8 @@ config_reader_get_scenarios(struct config_reader *cr,
 			 */
 			for (k = 0; k < ngkeys; k++) {
 				if (g_key_file_has_key(cr->key_file, groups[g],
-						       gkeys[k], NULL) == TRUE)
+						       gkeys[k],
+						       nullptr) == TRUE)
 					continue;
 
 				if (!is_argument(gkeys[k]))
@@ -213,15 +215,15 @@ config_reader_get_scenarios(struct config_reader *cr,
 
 				char *value = g_key_file_get_value(
 					cr->key_file, SECTION_GLOBAL, gkeys[k],
-					NULL);
-				assert(NULL != value);
+					nullptr);
+				assert(nullptr != value);
 				if (!value) {
 					ret = -1;
 					goto err_scenarios;
 				}
 
 				struct kv *kv = kv_alloc(gkeys[k], value);
-				assert(NULL != kv);
+				assert(nullptr != kv);
 
 				free(value);
 				if (!kv) {
@@ -235,22 +237,23 @@ config_reader_get_scenarios(struct config_reader *cr,
 
 		/* check for group name */
 		if (g_key_file_has_key(cr->key_file, groups[g], KEY_GROUP,
-				       NULL) != FALSE) {
+				       nullptr) != FALSE) {
 			gchar *group = g_key_file_get_value(
-				cr->key_file, groups[g], KEY_GROUP, NULL);
-			assert(group != NULL);
+				cr->key_file, groups[g], KEY_GROUP, nullptr);
+			assert(group != nullptr);
 			scenario_set_group(scenario, group);
 		} else if (g_key_file_has_key(cr->key_file, SECTION_GLOBAL,
-					      KEY_GROUP, NULL) != FALSE) {
-			gchar *group = g_key_file_get_value(
-				cr->key_file, SECTION_GLOBAL, KEY_GROUP, NULL);
+					      KEY_GROUP, nullptr) != FALSE) {
+			gchar *group = g_key_file_get_value(cr->key_file,
+							    SECTION_GLOBAL,
+							    KEY_GROUP, nullptr);
 			scenario_set_group(scenario, group);
 		}
 
 		gsize nkeys;
 		gchar **keys = g_key_file_get_keys(cr->key_file, groups[g],
-						   &nkeys, NULL);
-		assert(NULL != keys);
+						   &nkeys, nullptr);
+		assert(nullptr != keys);
 		if (!keys) {
 			ret = -1;
 			goto err_scenarios;
@@ -263,8 +266,8 @@ config_reader_get_scenarios(struct config_reader *cr,
 			if (!is_argument(keys[k]))
 				continue;
 			char *value = g_key_file_get_value(
-				cr->key_file, groups[g], keys[k], NULL);
-			assert(NULL != value);
+				cr->key_file, groups[g], keys[k], nullptr);
+			assert(nullptr != value);
 			if (!value) {
 				ret = -1;
 				g_strfreev(keys);
@@ -272,7 +275,7 @@ config_reader_get_scenarios(struct config_reader *cr,
 			}
 
 			struct kv *kv = kv_alloc(keys[k], value);
-			assert(NULL != kv);
+			assert(nullptr != kv);
 
 			free(value);
 			if (!kv) {

--- a/src/benchmarks/log.cpp
+++ b/src/benchmarks/log.cpp
@@ -226,7 +226,7 @@ static int
 fileio_appendv(struct benchmark *bench, struct operation_info *info)
 {
 	struct log_bench *lb = (struct log_bench *)pmembench_get_priv(bench);
-	assert(lb != NULL);
+	assert(lb != nullptr);
 
 	struct log_worker_info *worker_info =
 		(struct log_worker_info *)info->worker->priv;
@@ -391,7 +391,7 @@ log_init_worker(struct benchmark *bench, struct benchmark_args *args,
 				r64 % width + lb->args->min_size;
 		}
 	} else {
-		worker_info->rand_sizes = NULL;
+		worker_info->rand_sizes = nullptr;
 	}
 
 	worker_info->vec_sizes = (size_t *)calloc(
@@ -464,8 +464,8 @@ log_init(struct benchmark *bench, struct benchmark_args *args)
 {
 	int ret = 0;
 	assert(bench);
-	assert(args != NULL);
-	assert(args->opts != NULL);
+	assert(args != nullptr);
+	assert(args->opts != nullptr);
 	struct benchmark_info *bench_info;
 	struct log_bench *lb =
 		(struct log_bench *)malloc(sizeof(struct log_bench));
@@ -521,7 +521,7 @@ log_init(struct benchmark *bench, struct benchmark_args *args)
 
 	if (!lb->args->fileio) {
 		if ((lb->plp = pmemlog_create(args->fname, lb->psize,
-					      args->fmode)) == NULL) {
+					      args->fmode)) == nullptr) {
 			perror("pmemlog_create");
 			ret = -1;
 			goto err_free_lb;
@@ -667,7 +667,7 @@ log_constructor(void)
 	log_append_info.init_worker = log_init_worker;
 	log_append_info.free_worker = log_free_worker;
 	/* this will be assigned in log_init */
-	log_append_info.operation = NULL;
+	log_append_info.operation = nullptr;
 	log_append_info.measure_time = true;
 	log_append_info.clos = log_clo;
 	log_append_info.nclos = ARRAY_SIZE(log_clo);

--- a/src/benchmarks/map_bench.cpp
+++ b/src/benchmarks/map_bench.cpp
@@ -175,7 +175,7 @@ parse_map_type(const char *str)
 			return map_types[i].ops;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 /*
@@ -362,7 +362,7 @@ map_common_init_worker(struct benchmark *bench, struct benchmark_args *args,
 	tree = (struct map_bench *)pmembench_get_priv(bench);
 	targs = (struct map_bench_args *)args->opts;
 	if (targs->ext_tx) {
-		int ret = pmemobj_tx_begin(tree->pop, NULL);
+		int ret = pmemobj_tx_begin(tree->pop, nullptr);
 		if (ret) {
 			(void)pmemobj_tx_end();
 			goto err_free_keys;
@@ -585,7 +585,7 @@ map_common_init(struct benchmark *bench, struct benchmark_args *args)
 
 	map_bench->root_oid = map_bench->root.oid;
 
-	if (map_create(map_bench->mapc, &D_RW(map_bench->root)->map, NULL)) {
+	if (map_create(map_bench->mapc, &D_RW(map_bench->root)->map, nullptr)) {
 		perror("map_new");
 		goto err_free_map;
 	}

--- a/src/benchmarks/obj_lanes.cpp
+++ b/src/benchmarks/obj_lanes.cpp
@@ -93,13 +93,13 @@ parse_lane_section(const char *arg)
 static int
 lanes_init(struct benchmark *bench, struct benchmark_args *args)
 {
-	assert(bench != NULL);
-	assert(args != NULL);
-	assert(args->opts != NULL);
+	assert(bench != nullptr);
+	assert(args != nullptr);
+	assert(args->opts != nullptr);
 
 	struct obj_bench *ob =
 		(struct obj_bench *)malloc(sizeof(struct obj_bench));
-	if (ob == NULL) {
+	if (ob == nullptr) {
 		perror("malloc");
 		return -1;
 	}
@@ -115,7 +115,7 @@ lanes_init(struct benchmark *bench, struct benchmark_args *args)
 
 	/* create pmemobj pool */
 	ob->pop = pmemobj_create(args->fname, "obj_lanes", psize, args->fmode);
-	if (ob->pop == NULL) {
+	if (ob->pop == nullptr) {
 		fprintf(stderr, "%s\n", pmemobj_errormsg());
 		goto err;
 	}

--- a/src/benchmarks/obj_locks.cpp
+++ b/src/benchmarks/obj_locks.cpp
@@ -184,15 +184,15 @@ get_lock(uint64_t pop_runid, volatile uint64_t *runid, void *lock,
 		if ((tmp_runid != (pop_runid - 1))) {
 			if (util_bool_compare_and_swap64(runid, tmp_runid,
 							 (pop_runid - 1))) {
-				if (init_lock(&lock, NULL)) {
+				if (init_lock(&lock, nullptr)) {
 					util_fetch_and_and64(runid, 0);
-					return NULL;
+					return nullptr;
 				}
 
 				if (util_bool_compare_and_swap64(
 					    runid, (pop_runid - 1),
 					    pop_runid) == 0) {
-					return NULL;
+					return nullptr;
 				}
 			}
 		}
@@ -209,9 +209,9 @@ get_lock(uint64_t pop_runid, volatile uint64_t *runid, void *lock,
 static int
 volatile_mutex_init(os_mutex_t **mutexp, void *attr)
 {
-	if (*mutexp == NULL) {
+	if (*mutexp == nullptr) {
 		*mutexp = (os_mutex_t *)malloc(sizeof(os_mutex_t));
-		if (*mutexp == NULL) {
+		if (*mutexp == nullptr) {
 			perror("volatile_mutex_init alloc");
 			return ENOMEM;
 		}
@@ -227,7 +227,7 @@ static int
 volatile_mutex_lock(PMEMobjpool *pop, PMEM_volatile_mutex *mutexp)
 {
 	os_mutex_t *mutex = GET_VOLATILE_MUTEX(pop, mutexp);
-	if (mutex == NULL)
+	if (mutex == nullptr)
 		return EINVAL;
 
 	return os_mutex_lock(mutex);
@@ -240,7 +240,7 @@ static int
 volatile_mutex_unlock(PMEMobjpool *pop, PMEM_volatile_mutex *mutexp)
 {
 	os_mutex_t *mutex = (os_mutex_t *)GET_VOLATILE_MUTEX(pop, mutexp);
-	if (mutex == NULL)
+	if (mutex == nullptr)
 		return EINVAL;
 
 	return os_mutex_unlock(mutex);
@@ -253,7 +253,7 @@ static int
 volatile_mutex_destroy(PMEMobjpool *pop, PMEM_volatile_mutex *mutexp)
 {
 	os_mutex_t *mutex = (os_mutex_t *)GET_VOLATILE_MUTEX(pop, mutexp);
-	if (mutex == NULL)
+	if (mutex == nullptr)
 		return EINVAL;
 
 	int ret = os_mutex_destroy(mutex);
@@ -387,9 +387,9 @@ init_bench_mutex(struct mutex_bench *mb)
 	}
 
 	struct my_root *root = D_RW(mb->root);
-	assert(root != NULL);
+	assert(root != nullptr);
 	mb->locks = D_RW(root->locks);
-	assert(mb->locks != NULL);
+	assert(mb->locks != nullptr);
 
 	if (!mb->pa->use_system_threads) {
 		/* initialize PMEM mutexes */
@@ -453,11 +453,12 @@ op_bench_mutex(struct mutex_bench *mb)
 	} else {
 		if (mb->lock_mode == OP_MODE_1BY1) {
 			bench_operation_1by1(os_mutex_lock_wrapper,
-					     os_mutex_unlock_wrapper, mb, NULL);
+					     os_mutex_unlock_wrapper, mb,
+					     nullptr);
 		} else {
 			bench_operation_all_lock(os_mutex_lock_wrapper,
 						 os_mutex_unlock_wrapper, mb,
-						 NULL);
+						 nullptr);
 		}
 	}
 
@@ -471,7 +472,7 @@ static int
 init_bench_rwlock(struct mutex_bench *mb)
 {
 	struct my_root *root = D_RW(mb->root);
-	assert(root != NULL);
+	assert(root != nullptr);
 
 	POBJ_ZALLOC(mb->pop, &root->locks, lock_t,
 		    mb->pa->n_locks * sizeof(lock_t));
@@ -481,7 +482,7 @@ init_bench_rwlock(struct mutex_bench *mb)
 	}
 
 	mb->locks = D_RW(root->locks);
-	assert(mb->locks != NULL);
+	assert(mb->locks != nullptr);
 
 	if (!mb->pa->use_system_threads) {
 		/* initialize PMEM rwlocks */
@@ -551,12 +552,12 @@ op_bench_rwlock(struct mutex_bench *mb)
 			bench_operation_1by1(
 				!mb->pa->use_rdlock ? os_rwlock_wrlock_wrapper
 						    : os_rwlock_rdlock_wrapper,
-				os_rwlock_unlock_wrapper, mb, NULL);
+				os_rwlock_unlock_wrapper, mb, nullptr);
 		} else {
 			bench_operation_all_lock(
 				!mb->pa->use_rdlock ? os_rwlock_wrlock_wrapper
 						    : os_rwlock_rdlock_wrapper,
-				os_rwlock_unlock_wrapper, mb, NULL);
+				os_rwlock_unlock_wrapper, mb, nullptr);
 		}
 	}
 	return 0;
@@ -569,7 +570,7 @@ static int
 init_bench_vmutex(struct mutex_bench *mb)
 {
 	struct my_root *root = D_RW(mb->root);
-	assert(root != NULL);
+	assert(root != nullptr);
 
 	POBJ_ZALLOC(mb->pop, &root->locks, lock_t,
 		    mb->pa->n_locks * sizeof(lock_t));
@@ -579,13 +580,13 @@ init_bench_vmutex(struct mutex_bench *mb)
 	}
 
 	mb->locks = D_RW(root->locks);
-	assert(mb->locks != NULL);
+	assert(mb->locks != nullptr);
 
 	/* initialize PMEM volatile mutexes */
 	for (unsigned i = 0; i < mb->pa->n_locks; i++) {
 		PMEM_volatile_mutex *p = (PMEM_volatile_mutex *)&mb->locks[i];
 		p->volatile_pmemmutex.runid = mb->pa->runid_initial_value;
-		volatile_mutex_init(&p->volatile_pmemmutex.mutexp, NULL);
+		volatile_mutex_init(&p->volatile_pmemmutex.mutexp, nullptr);
 	}
 
 	return 0;
@@ -664,7 +665,7 @@ parse_benchmark_mode(const char *arg)
 	else if (strcmp(arg, "volatile-mutex") == 0)
 		return &benchmark_ops[BENCH_MODE_VOLATILE_MUTEX];
 	else
-		return NULL;
+		return nullptr;
 }
 
 /*
@@ -674,14 +675,14 @@ parse_benchmark_mode(const char *arg)
 static int
 locks_init(struct benchmark *bench, struct benchmark_args *args)
 {
-	assert(bench != NULL);
-	assert(args != NULL);
+	assert(bench != nullptr);
+	assert(args != nullptr);
 
 	int ret = 0;
 	size_t poolsize;
 
 	struct mutex_bench *mb = (struct mutex_bench *)malloc(sizeof(*mb));
-	if (mb == NULL) {
+	if (mb == nullptr) {
 		perror("malloc");
 		return -1;
 	}
@@ -696,7 +697,7 @@ locks_init(struct benchmark *bench, struct benchmark_args *args)
 	}
 
 	mb->ops = parse_benchmark_mode(mb->pa->lock_type);
-	if (mb->ops == NULL) {
+	if (mb->ops == nullptr) {
 		fprintf(stderr, "Invalid benchmark type: %s\n",
 			mb->pa->lock_type);
 		errno = EINVAL;
@@ -719,7 +720,7 @@ locks_init(struct benchmark *bench, struct benchmark_args *args)
 				 POBJ_LAYOUT_NAME(pmembench_lock_layout),
 				 poolsize, args->fmode);
 
-	if (mb->pop == NULL) {
+	if (mb->pop == nullptr) {
 		ret = -1;
 		perror("pmemobj_create");
 		goto err_free_mb;
@@ -750,12 +751,12 @@ err_free_mb:
 static int
 locks_exit(struct benchmark *bench, struct benchmark_args *args)
 {
-	assert(bench != NULL);
-	assert(args != NULL);
+	assert(bench != nullptr);
+	assert(args != nullptr);
 
 	struct mutex_bench *mb =
 		(struct mutex_bench *)pmembench_get_priv(bench);
-	assert(mb != NULL);
+	assert(mb != nullptr);
 
 	mb->ops->bench_exit(mb);
 
@@ -775,10 +776,10 @@ locks_op(struct benchmark *bench, struct operation_info *info)
 {
 	struct mutex_bench *mb =
 		(struct mutex_bench *)pmembench_get_priv(bench);
-	assert(mb != NULL);
-	assert(mb->pop != NULL);
+	assert(mb != nullptr);
+	assert(mb->pop != nullptr);
 	assert(!TOID_IS_NULL(mb->root));
-	assert(mb->locks != NULL);
+	assert(mb->locks != nullptr);
 	assert(mb->lock_mode < OP_MODE_MAX);
 
 	mb->ops->bench_op(mb);

--- a/src/benchmarks/obj_pmalloc.cpp
+++ b/src/benchmarks/obj_pmalloc.cpp
@@ -108,10 +108,10 @@ struct obj_bench {
 static int
 obj_init(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct my_root *root = NULL;
-	assert(bench != NULL);
-	assert(args != NULL);
-	assert(args->opts != NULL);
+	struct my_root *root = nullptr;
+	assert(bench != nullptr);
+	assert(args != nullptr);
+	assert(args->opts != nullptr);
 
 	if (((struct prog_args *)(args->opts))->minsize >= args->dsize) {
 		fprintf(stderr, "Wrong params - allocation size\n");
@@ -120,7 +120,7 @@ obj_init(struct benchmark *bench, struct benchmark_args *args)
 
 	struct obj_bench *ob =
 		(struct obj_bench *)malloc(sizeof(struct obj_bench));
-	if (ob == NULL) {
+	if (ob == nullptr) {
 		perror("malloc");
 		return -1;
 	}
@@ -157,7 +157,7 @@ obj_init(struct benchmark *bench, struct benchmark_args *args)
 
 	ob->pop = pmemobj_create(args->fname, POBJ_LAYOUT_NAME(pmalloc_layout),
 				 poolsize, args->fmode);
-	if (ob->pop == NULL) {
+	if (ob->pop == nullptr) {
 		fprintf(stderr, "%s\n", pmemobj_errormsg());
 		goto free_ob;
 	}
@@ -169,7 +169,7 @@ obj_init(struct benchmark *bench, struct benchmark_args *args)
 	}
 
 	root = D_RW(ob->root);
-	assert(root != NULL);
+	assert(root != nullptr);
 	POBJ_ZALLOC(ob->pop, &root->offs, uint64_t,
 		    n_ops_total * sizeof(PMEMoid));
 	if (TOID_IS_NULL(root->offs)) {
@@ -181,7 +181,7 @@ obj_init(struct benchmark *bench, struct benchmark_args *args)
 	ob->offs = D_RW(root->offs);
 
 	ob->sizes = (size_t *)malloc(n_ops_total * sizeof(size_t));
-	if (ob->sizes == NULL) {
+	if (ob->sizes == nullptr) {
 		fprintf(stderr, "malloc rand size vect err\n");
 		goto free_pop;
 	}
@@ -271,7 +271,7 @@ pmix_worker_init(struct benchmark *bench, struct benchmark_args *args,
 {
 	struct obj_bench *ob = (struct obj_bench *)pmembench_get_priv(bench);
 	struct pmix_worker *w = (struct pmix_worker *)calloc(1, sizeof(*w));
-	if (w == NULL)
+	if (w == nullptr)
 		return -1;
 
 	w->seed = ob->pa->seed;

--- a/src/benchmarks/pmem_flush.cpp
+++ b/src/benchmarks/pmem_flush.cpp
@@ -372,8 +372,8 @@ parse_op_type(const char *arg)
 static int
 pmem_flush_init(struct benchmark *bench, struct benchmark_args *args)
 {
-	assert(bench != NULL);
-	assert(args != NULL);
+	assert(bench != nullptr);
+	assert(args != nullptr);
 	size_t file_size = 0;
 	int flags = 0;
 
@@ -381,10 +381,10 @@ pmem_flush_init(struct benchmark *bench, struct benchmark_args *args)
 
 	struct pmem_bench *pmb =
 		(struct pmem_bench *)malloc(sizeof(struct pmem_bench));
-	assert(pmb != NULL);
+	assert(pmb != nullptr);
 
 	pmb->pargs = (struct pmem_args *)args->opts;
-	assert(pmb->pargs != NULL);
+	assert(pmb->pargs != nullptr);
 
 	int i = parse_op_type(pmb->pargs->operation);
 	if (i == -1) {
@@ -410,7 +410,7 @@ pmem_flush_init(struct benchmark *bench, struct benchmark_args *args)
 	/* populate offsets array */
 	assert(pmb->n_offsets != 0);
 	pmb->offsets = (size_t *)malloc(pmb->n_offsets * sizeof(*pmb->offsets));
-	assert(pmb->offsets != NULL);
+	assert(pmb->offsets != nullptr);
 
 	for (size_t i = 0; i < pmb->n_offsets; ++i)
 		pmb->offsets[i] = func_mode(pmb, i);
@@ -422,14 +422,14 @@ pmem_flush_init(struct benchmark *bench, struct benchmark_args *args)
 
 	/* create a pmem file and memory map it */
 	pmb->pmem_addr = pmem_map_file(args->fname, file_size, flags,
-				       args->fmode, &pmb->pmem_len, NULL);
+				       args->fmode, &pmb->pmem_len, nullptr);
 
-	if (pmb->pmem_addr == NULL) {
+	if (pmb->pmem_addr == nullptr) {
 		perror("pmem_map_file");
 		goto err_free_pmb;
 	}
 
-	pmb->nondirty_addr = mmap(NULL, pmb->fsize, PROT_READ | PROT_WRITE,
+	pmb->nondirty_addr = mmap(nullptr, pmb->fsize, PROT_READ | PROT_WRITE,
 				  MAP_PRIVATE | MAP_ANON, -1, 0);
 
 	if (pmb->nondirty_addr == MAP_FAILED) {
@@ -437,7 +437,7 @@ pmem_flush_init(struct benchmark *bench, struct benchmark_args *args)
 		goto err_unmap1;
 	}
 
-	pmb->invalid_addr = mmap(NULL, pmb->fsize, PROT_READ | PROT_WRITE,
+	pmb->invalid_addr = mmap(nullptr, pmb->fsize, PROT_READ | PROT_WRITE,
 				 MAP_PRIVATE | MAP_ANON, -1, 0);
 
 	if (pmb->invalid_addr == MAP_FAILED) {

--- a/src/benchmarks/pmem_memcpy.cpp
+++ b/src/benchmarks/pmem_memcpy.cpp
@@ -268,7 +268,7 @@ assign_mode_func(char *option)
 		case OP_MODE_RAND:
 			return mode_rand;
 		default:
-			return NULL;
+			return nullptr;
 	}
 }
 
@@ -384,18 +384,18 @@ assign_size(struct pmem_bench *pmb, struct benchmark_args *args,
 static int
 pmem_memcpy_init(struct benchmark *bench, struct benchmark_args *args)
 {
-	assert(bench != NULL);
-	assert(args != NULL);
+	assert(bench != nullptr);
+	assert(args != nullptr);
 	int ret = 0;
 	size_t file_size = 0;
 	int flags = 0;
 
 	struct pmem_bench *pmb =
 		(struct pmem_bench *)malloc(sizeof(struct pmem_bench));
-	assert(pmb != NULL);
+	assert(pmb != nullptr);
 
 	pmb->pargs = (struct pmem_args *)args->opts;
-	assert(pmb->pargs != NULL);
+	assert(pmb->pargs != nullptr);
 
 	pmb->pargs->chunk_size = args->dsize;
 
@@ -410,7 +410,7 @@ pmem_memcpy_init(struct benchmark *bench, struct benchmark_args *args)
 	}
 	pmb->buf =
 		(unsigned char *)util_aligned_malloc(FLUSH_ALIGN, pmb->bsize);
-	if (pmb->buf == NULL) {
+	if (pmb->buf == nullptr) {
 		perror("posix_memalign");
 		ret = -1;
 		goto err_free_pmb;
@@ -421,7 +421,7 @@ pmem_memcpy_init(struct benchmark *bench, struct benchmark_args *args)
 	pmb->rand_offsets = (unsigned *)malloc(pmb->n_rand_offsets *
 					       sizeof(*pmb->rand_offsets));
 
-	if (pmb->rand_offsets == NULL) {
+	if (pmb->rand_offsets == nullptr) {
 		perror("malloc");
 		ret = -1;
 		goto err_free_pmb;
@@ -437,8 +437,8 @@ pmem_memcpy_init(struct benchmark *bench, struct benchmark_args *args)
 
 	/* create a pmem file and memory map it */
 	pmb->pmem_addr = (unsigned char *)pmem_map_file(
-		args->fname, file_size, flags, args->fmode, NULL, NULL);
-	if (pmb->pmem_addr == NULL) {
+		args->fname, file_size, flags, args->fmode, nullptr, nullptr);
+	if (pmb->pmem_addr == nullptr) {
 		perror(args->fname);
 		ret = -1;
 		goto err_free_buf;
@@ -453,7 +453,8 @@ pmem_memcpy_init(struct benchmark *bench, struct benchmark_args *args)
 	}
 
 	/* set proper func_src() and func_dest() depending on benchmark args */
-	if ((pmb->func_src = assign_mode_func(pmb->pargs->src_mode)) == NULL) {
+	if ((pmb->func_src = assign_mode_func(pmb->pargs->src_mode)) ==
+	    nullptr) {
 		fprintf(stderr, "wrong src_mode parameter -- '%s'",
 			pmb->pargs->src_mode);
 		ret = -1;
@@ -461,7 +462,7 @@ pmem_memcpy_init(struct benchmark *bench, struct benchmark_args *args)
 	}
 
 	if ((pmb->func_dest = assign_mode_func(pmb->pargs->dest_mode)) ==
-	    NULL) {
+	    nullptr) {
 		fprintf(stderr, "wrong dest_mode parameter -- '%s'",
 			pmb->pargs->dest_mode);
 		ret = -1;

--- a/src/benchmarks/pmem_memset.cpp
+++ b/src/benchmarks/pmem_memset.cpp
@@ -277,9 +277,9 @@ memset_op(struct benchmark *bench, struct operation_info *info)
 static int
 memset_init(struct benchmark *bench, struct benchmark_args *args)
 {
-	assert(bench != NULL);
-	assert(args != NULL);
-	assert(args->opts != NULL);
+	assert(bench != nullptr);
+	assert(args != nullptr);
+	assert(args->opts != nullptr);
 
 	int ret = 0;
 	size_t size;
@@ -329,7 +329,8 @@ memset_init(struct benchmark *bench, struct benchmark_args *args)
 
 	/* create a pmem file and memory map it */
 	if ((mb->pmem_addr = pmem_map_file(args->fname, file_size, flags,
-					   args->fmode, NULL, NULL)) == NULL) {
+					   args->fmode, nullptr, nullptr)) ==
+	    nullptr) {
 		perror(args->fname);
 		ret = -1;
 		goto err_free_offsets;

--- a/src/benchmarks/pmembench.cpp
+++ b/src/benchmarks/pmembench.cpp
@@ -312,7 +312,7 @@ int
 pmembench_register(struct benchmark_info *bench_info)
 {
 	struct benchmark *bench = (struct benchmark *)calloc(1, sizeof(*bench));
-	assert(bench != NULL);
+	assert(bench != nullptr);
 
 	bench->info = bench_info;
 
@@ -362,7 +362,7 @@ pmembench_merge_clos(struct benchmark *bench)
 
 	struct benchmark_clo *clos = (struct benchmark_clo *)calloc(
 		nclos, sizeof(struct benchmark_clo));
-	assert(clos != NULL);
+	assert(clos != nullptr);
 
 	memcpy(clos, pmembench_clos, pb_nclos * sizeof(struct benchmark_clo));
 
@@ -508,32 +508,32 @@ pmembench_parse_clo(struct pmembench *pb, struct benchmark *bench,
 static int
 pmembench_parse_affinity(const char *list, char **saveptr)
 {
-	char *str = NULL;
+	char *str = nullptr;
 	char *end;
 	int cpu = 0;
 
 	if (*saveptr) {
-		str = strtok(NULL, ";");
-		if (str == NULL) {
+		str = strtok(nullptr, ";");
+		if (str == nullptr) {
 			/* end of list - we have to start over */
 			free(*saveptr);
-			*saveptr = NULL;
+			*saveptr = nullptr;
 		}
 	}
 
 	if (!*saveptr) {
 		*saveptr = strdup(list);
-		if (*saveptr == NULL) {
+		if (*saveptr == nullptr) {
 			perror("strdup");
 			return -1;
 		}
 
 		str = strtok(*saveptr, ";");
-		if (str == NULL)
+		if (str == nullptr)
 			goto err;
 	}
 
-	if ((str == NULL) || (*str == '\0'))
+	if ((str == nullptr) || (*str == '\0'))
 		goto err;
 
 	cpu = strtol(str, &end, 10);
@@ -546,7 +546,7 @@ err:
 	errno = EINVAL;
 	perror("pmembench_parse_affinity");
 	free(*saveptr);
-	*saveptr = NULL;
+	*saveptr = nullptr;
 	return -1;
 }
 
@@ -560,7 +560,7 @@ pmembench_init_workers(struct benchmark_worker **workers, size_t nworkers,
 {
 	size_t i;
 	int ncpus = 0;
-	char *saveptr = NULL;
+	char *saveptr = nullptr;
 	int ret = 0;
 
 	if (args->thread_affinity) {
@@ -683,25 +683,25 @@ results_alloc(size_t nrepeats, size_t nthreads, size_t nops)
 {
 	struct total_results *total =
 		(struct total_results *)malloc(sizeof(*total));
-	assert(total != NULL);
+	assert(total != nullptr);
 	total->nrepeats = nrepeats;
 	total->nthreads = nthreads;
 	total->nops = nops;
 	total->res =
 		(struct bench_results *)malloc(nrepeats * sizeof(*total->res));
-	assert(total->res != NULL);
+	assert(total->res != nullptr);
 
 	for (size_t i = 0; i < nrepeats; i++) {
 		struct bench_results *res = &total->res[i];
 		assert(nthreads != 0);
 		res->thres = (struct thread_results **)malloc(
 			nthreads * sizeof(*res->thres));
-		assert(res->thres != NULL);
+		assert(res->thres != nullptr);
 		for (size_t j = 0; j < nthreads; j++) {
 			res->thres[j] = (struct thread_results *)malloc(
 				sizeof(*res->thres[j]) +
 				nops * sizeof(benchmark_time_t));
-			assert(res->thres[j] != NULL);
+			assert(res->thres[j] != nullptr);
 		}
 	}
 
@@ -745,12 +745,12 @@ get_total_results(struct total_results *tres)
 	/* allocate helper arrays */
 	benchmark_time_t *tbeg =
 		(benchmark_time_t *)malloc(tres->nthreads * sizeof(*tbeg));
-	assert(tbeg != NULL);
+	assert(tbeg != nullptr);
 	benchmark_time_t *tend =
 		(benchmark_time_t *)malloc(tres->nthreads * sizeof(*tend));
-	assert(tend != NULL);
+	assert(tend != nullptr);
 	double *totals = (double *)malloc(tres->nrepeats * sizeof(double));
-	assert(totals != NULL);
+	assert(totals != nullptr);
 
 	/* estimate total penalty of getting time from the system */
 	benchmark_time_t Tget;
@@ -853,7 +853,7 @@ get_total_results(struct total_results *tres)
 	tres->latency.avg /= count;
 
 	uint64_t *ntotals = (uint64_t *)calloc(count, sizeof(uint64_t));
-	assert(ntotals != NULL);
+	assert(ntotals != nullptr);
 	count = 0;
 
 	/* std deviation of latency and percentiles */
@@ -943,7 +943,7 @@ pmembench_print_help_single(struct benchmark *bench)
 	printf("\nArguments:\n");
 	size_t nclos = sizeof(pmembench_clos) / sizeof(struct benchmark_clo);
 	pmembench_print_args(pmembench_clos, nclos);
-	if (info->clos == NULL)
+	if (info->clos == nullptr)
 		return;
 	pmembench_print_args(info->clos, info->nclos);
 }
@@ -1007,7 +1007,7 @@ pmembench_print_help()
 	pmembench_print_args(pmembench_opts, nclos);
 
 	printf("\nAvaliable benchmarks:\n");
-	struct benchmark *bench = NULL;
+	struct benchmark *bench = nullptr;
 	LIST_FOREACH(bench, &benchmarks.head, next)
 	printf("\t%-20s\t\t%s\n", bench->info->name, bench->info->brief);
 	printf("\n$ pmembench <benchmark> --help to print detailed information"
@@ -1028,7 +1028,7 @@ pmembench_get_bench(const char *name)
 			return bench;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 /*
@@ -1040,13 +1040,13 @@ pmembench_parse_opts(struct pmembench *pb)
 	int ret = 0;
 	int argc = ++pb->argc;
 	char **argv = --pb->argv;
-	struct benchmark_opts *opts = NULL;
+	struct benchmark_opts *opts = nullptr;
 	struct clo_vec *clovec;
 	size_t size, n_clos;
 	size = sizeof(struct benchmark_opts);
 	n_clos = ARRAY_SIZE(pmembench_opts);
 	clovec = clo_vec_alloc(size);
-	assert(clovec != NULL);
+	assert(clovec != nullptr);
 
 	if (benchmark_clo_parse(argc, argv, pmembench_opts, n_clos, clovec)) {
 		ret = -1;
@@ -1054,7 +1054,7 @@ pmembench_parse_opts(struct pmembench *pb)
 	}
 
 	opts = (struct benchmark_opts *)clo_vec_get_args(clovec, 0);
-	if (opts == NULL) {
+	if (opts == nullptr) {
 		ret = -1;
 		goto out;
 	}
@@ -1100,7 +1100,7 @@ pmembench_remove_file(const char *path)
 		    strcmp(info.filename, "..") == 0)
 			continue;
 		tmp = (char *)malloc(strlen(path) + strlen(info.filename) + 2);
-		if (tmp == NULL)
+		if (tmp == nullptr)
 			return -1;
 		sprintf(tmp, "%s/%s", path, info.filename);
 		ret = info.is_dir ? pmembench_remove_file(tmp)
@@ -1156,13 +1156,13 @@ pmembench_single_repeat(struct benchmark *bench, struct benchmark_args *args,
 		}
 	}
 
-	assert(bench->info->operation != NULL);
+	assert(bench->info->operation != nullptr);
 	assert(args->n_threads != 0);
 
 	struct benchmark_worker **workers;
 	workers = (struct benchmark_worker **)malloc(
 		args->n_threads * sizeof(struct benchmark_worker *));
-	assert(workers != NULL);
+	assert(workers != nullptr);
 
 	if ((ret = pmembench_init_workers(workers, n_threads, n_ops, bench,
 					  args)) != 0) {
@@ -1236,7 +1236,7 @@ scale_up_min_exe_time(struct benchmark *bench, struct benchmark_args *args,
 		results_free(total_res);
 		*total_results = results_alloc(args->repeats, args->n_threads,
 					       args->n_ops_per_thread);
-		assert(*total_results != NULL);
+		assert(*total_results != nullptr);
 		total_res = *total_results;
 		total_res->nrepeats = 1;
 	} while (1);
@@ -1254,14 +1254,14 @@ pmembench_run(struct pmembench *pb, struct benchmark *bench)
 	char old_wd[PATH_MAX];
 	int ret = 0;
 
-	struct benchmark_args *args = NULL;
-	struct total_results *total_res = NULL;
-	struct latency *stats = NULL;
-	double *workers_times = NULL;
+	struct benchmark_args *args = nullptr;
+	struct total_results *total_res = nullptr;
+	struct latency *stats = nullptr;
+	double *workers_times = nullptr;
 
-	struct clo_vec *clovec = NULL;
+	struct clo_vec *clovec = nullptr;
 
-	assert(bench->info != NULL);
+	assert(bench->info != nullptr);
 	pmembench_merge_clos(bench);
 
 	/*
@@ -1269,9 +1269,9 @@ pmembench_run(struct pmembench *pb, struct benchmark *bench)
 	 * the working directory accordingly.
 	 */
 	char *wd = os_getenv("PMEMBENCH_DIR");
-	if (wd != NULL) {
+	if (wd != nullptr) {
 		/* get current dir name */
-		if (getcwd(old_wd, PATH_MAX) == NULL) {
+		if (getcwd(old_wd, PATH_MAX) == nullptr) {
 			perror("getcwd");
 			ret = -1;
 			goto out_release_clos;
@@ -1303,7 +1303,7 @@ pmembench_run(struct pmembench *pb, struct benchmark *bench)
 	}
 
 	clovec = clo_vec_alloc(bench->args_size);
-	assert(clovec != NULL);
+	assert(clovec != nullptr);
 
 	if (pmembench_parse_clo(pb, bench, clovec)) {
 		warn("%s: parsing command line arguments failed",
@@ -1313,7 +1313,7 @@ pmembench_run(struct pmembench *pb, struct benchmark *bench)
 	}
 
 	args = (struct benchmark_args *)clo_vec_get_args(clovec, 0);
-	if (args == NULL) {
+	if (args == nullptr) {
 		warn("%s: parsing command line arguments failed",
 		     bench->info->name);
 		ret = -1;
@@ -1332,7 +1332,7 @@ pmembench_run(struct pmembench *pb, struct benchmark *bench)
 
 		args = (struct benchmark_args *)clo_vec_get_args(clovec,
 								 args_i);
-		if (args == NULL) {
+		if (args == nullptr) {
 			warn("%s: parsing command line arguments failed",
 			     bench->info->name);
 			ret = -1;
@@ -1370,13 +1370,13 @@ pmembench_run(struct pmembench *pb, struct benchmark *bench)
 
 		stats = (struct latency *)calloc(args->repeats,
 						 sizeof(struct latency));
-		assert(stats != NULL);
+		assert(stats != nullptr);
 		workers_times = (double *)calloc(n_threads * args->repeats,
 						 sizeof(double));
-		assert(workers_times != NULL);
+		assert(workers_times != nullptr);
 		total_res = results_alloc(args->repeats, args->n_threads,
 					  args->n_ops_per_thread);
-		assert(total_res != NULL);
+		assert(total_res != nullptr);
 
 		unsigned i = 0;
 		if (args->min_exe_time != 0 && bench->info->multiops) {
@@ -1404,9 +1404,9 @@ pmembench_run(struct pmembench *pb, struct benchmark *bench)
 		results_free(total_res);
 		free(stats);
 		free(workers_times);
-		total_res = NULL;
-		stats = NULL;
-		workers_times = NULL;
+		total_res = nullptr;
+		stats = nullptr;
+		workers_times = nullptr;
 	}
 out:
 	if (total_res)
@@ -1420,7 +1420,7 @@ out_release_args:
 
 out_old_wd:
 	/* restore the original working directory */
-	if (wd != NULL) { /* Only if PMEMBENCH_DIR env var was defined */
+	if (wd != nullptr) { /* Only if PMEMBENCH_DIR env var was defined */
 		if (chdir(old_wd)) {
 			perror("chdir(old_wd)");
 			ret = -1;
@@ -1451,7 +1451,7 @@ static int
 pmembench_run_scenario(struct pmembench *pb, struct scenario *scenario)
 {
 	struct benchmark *bench = pmembench_get_bench(scenario->benchmark);
-	if (NULL == bench) {
+	if (nullptr == bench) {
 		fprintf(stderr, "unknown benchmark: %s\n", scenario->benchmark);
 		return -1;
 	}
@@ -1480,9 +1480,9 @@ pmembench_run_scenarios(struct pmembench *pb, struct scenarios *ss)
 static int
 pmembench_run_config(struct pmembench *pb, const char *config)
 {
-	struct scenarios *ss = NULL;
+	struct scenarios *ss = nullptr;
 	struct config_reader *cr = config_reader_alloc();
-	assert(cr != NULL);
+	assert(cr != nullptr);
 
 	int ret = 0;
 
@@ -1492,7 +1492,7 @@ pmembench_run_config(struct pmembench *pb, const char *config)
 	if ((ret = config_reader_get_scenarios(cr, &ss)))
 		goto out;
 
-	assert(ss != NULL);
+	assert(ss != nullptr);
 
 	if (pb->argc == 1) {
 		if ((ret = pmembench_run_scenarios(pb, ss)) != 0)
@@ -1509,7 +1509,7 @@ pmembench_run_config(struct pmembench *pb, const char *config)
 				goto out_scenarios;
 		} else { /* scenarios in cmd line */
 			struct scenarios *cmd_ss = scenarios_alloc();
-			assert(cmd_ss != NULL);
+			assert(cmd_ss != nullptr);
 
 			int parsed_scenarios = clo_get_scenarios(
 				tmp_argc, tmp_argv, ss, cmd_ss);
@@ -1563,21 +1563,21 @@ main(int argc, char *argv[])
 	int fexists;
 	struct benchmark *bench;
 	struct pmembench *pb = (struct pmembench *)calloc(1, sizeof(*pb));
-	assert(pb != NULL);
+	assert(pb != nullptr);
 	Get_time_avg = benchmark_get_avg_get_time();
 
 	pb->argc = --argc;
 	pb->argv = ++argv;
 
 	char *bench_name = pb->argv[0];
-	if (NULL == bench_name) {
+	if (nullptr == bench_name) {
 		ret = -1;
 		goto out;
 	}
 
 	fexists = os_access(bench_name, R_OK) == 0;
 	bench = pmembench_get_bench(bench_name);
-	if (NULL != bench)
+	if (nullptr != bench)
 		ret = pmembench_run(pb, bench);
 	else if (fexists)
 		ret = pmembench_run_config(pb, bench_name);

--- a/src/benchmarks/pmemobj_atomic_lists.cpp
+++ b/src/benchmarks/pmemobj_atomic_lists.cpp
@@ -213,7 +213,7 @@ enum type_mode {
 static struct element
 position_head(struct obj_worker *obj_worker, size_t op_idx)
 {
-	struct element head = {0, OID_NULL, false};
+	struct element head = {nullptr, OID_NULL, false};
 	head.before = true;
 	if (!obj_bench.args->queue)
 		head.itemp = POBJ_LIST_FIRST(&obj_worker->head);
@@ -228,7 +228,7 @@ position_head(struct obj_worker *obj_worker, size_t op_idx)
 static struct element
 position_tail(struct obj_worker *obj_worker, size_t op_idx)
 {
-	struct element tail = {0, OID_NULL, false};
+	struct element tail = {nullptr, OID_NULL, false};
 	tail.before = false;
 	if (!obj_bench.args->queue)
 		tail.itemp = POBJ_LIST_LAST(&obj_worker->head, field);
@@ -363,7 +363,7 @@ obj_init_list(struct worker_info *worker, size_t n_oids, size_t list_len)
 	struct obj_worker *obj_worker = (struct obj_worker *)worker->priv;
 	obj_worker->oids =
 		(TOID(struct item) *)calloc(n_oids, sizeof(TOID(struct item)));
-	if (obj_worker->oids == NULL) {
+	if (obj_worker->oids == nullptr) {
 		perror("calloc");
 		return -1;
 	}
@@ -371,8 +371,8 @@ obj_init_list(struct worker_info *worker, size_t n_oids, size_t list_len)
 		size_t type_num = obj_bench.fn_type_num(worker->index, i);
 		size_t size = obj_bench.alloc_sizes[i];
 		PMEMoid *tmp = (PMEMoid *)&obj_worker->oids[i];
-		if (pmemobj_alloc(obj_bench.pop, tmp, size, type_num, NULL,
-				  NULL) != 0)
+		if (pmemobj_alloc(obj_bench.pop, tmp, size, type_num, nullptr,
+				  nullptr) != 0)
 			goto err_oids;
 	}
 	for (i = 0; i < list_len; i++)
@@ -399,7 +399,7 @@ queue_init_list(struct worker_info *worker, size_t n_items, size_t list_len)
 	CIRCLEQ_INIT(&obj_worker->headq);
 	obj_worker->items =
 		(struct item **)malloc(n_items * sizeof(struct item *));
-	if (obj_worker->items == NULL) {
+	if (obj_worker->items == nullptr) {
 		perror("malloc");
 		return -1;
 	}
@@ -407,7 +407,7 @@ queue_init_list(struct worker_info *worker, size_t n_items, size_t list_len)
 	for (i = 0; i < n_items; i++) {
 		size_t size = obj_bench.alloc_sizes[i];
 		obj_worker->items[i] = (struct item *)calloc(1, size);
-		if (obj_worker->items[i] == NULL) {
+		if (obj_worker->items[i] == nullptr) {
 			perror("calloc");
 			goto err;
 		}
@@ -489,9 +489,9 @@ random_positions(void)
 {
 	fn_position_t *positions = (fn_position_t *)calloc(
 		obj_bench.max_len, sizeof(fn_position_t));
-	if (positions == NULL) {
+	if (positions == nullptr) {
 		perror("calloc");
-		return NULL;
+		return nullptr;
 	}
 
 	if (obj_bench.args->seed != 0)
@@ -515,9 +515,9 @@ static size_t *
 random_values(size_t min, size_t max, size_t n_ops, size_t min_range)
 {
 	size_t *randoms = (size_t *)calloc(n_ops, sizeof(size_t));
-	if (randoms == NULL) {
+	if (randoms == nullptr) {
 		perror("calloc");
-		return NULL;
+		return nullptr;
 	}
 	for (size_t i = 0; i < n_ops; i++)
 		randoms[i] = max;
@@ -525,7 +525,7 @@ random_values(size_t min, size_t max, size_t n_ops, size_t min_range)
 		if (min > max) {
 			fprintf(stderr, "Invalid size\n");
 			free(randoms);
-			return NULL;
+			return nullptr;
 		}
 		for (size_t i = 0; i < n_ops; i++)
 			randoms[i] = RRAND(max, min);
@@ -613,7 +613,7 @@ obj_insert_new_op(struct benchmark *bench, struct operation_info *info)
 	tmp = pmemobj_list_insert_new(
 		obj_bench.pop, offsetof(struct item, field), &obj_worker->head,
 		obj_worker->elm.itemp.oid, obj_worker->elm.before, size,
-		type_num, NULL, NULL);
+		type_num, nullptr, nullptr);
 
 	if (OID_IS_NULL(tmp)) {
 		perror("pmemobj_list_insert_new");
@@ -737,17 +737,17 @@ obj_init_worker(struct worker_info *worker, size_t n_elm, size_t list_len)
 {
 	struct obj_worker *obj_worker =
 		(struct obj_worker *)calloc(1, sizeof(struct obj_worker));
-	if (obj_worker == NULL) {
+	if (obj_worker == nullptr) {
 		perror("calloc");
 		return -1;
 	}
 
 	worker->priv = obj_worker;
 	obj_worker->n_elm = obj_bench.max_len;
-	obj_worker->list_move = NULL;
+	obj_worker->list_move = nullptr;
 	if (obj_bench.position_mode == POSITION_MODE_RAND) {
 		obj_worker->fn_positions = random_positions();
-		if (obj_worker->fn_positions == NULL)
+		if (obj_worker->fn_positions == nullptr)
 			goto err;
 	}
 	if (obj_bench.fn_init(worker, n_elm, list_len) != 0)
@@ -808,21 +808,21 @@ obj_move_init_worker(struct benchmark *bench, struct benchmark_args *args,
 	struct obj_worker *obj_worker = (struct obj_worker *)worker->priv;
 	obj_worker->list_move =
 		(struct obj_worker *)calloc(1, sizeof(struct obj_worker));
-	if (obj_worker->list_move == NULL) {
+	if (obj_worker->list_move == nullptr) {
 		perror("calloc");
 		goto free;
 	}
 	size_t i;
 	if (obj_bench.position_mode == POSITION_MODE_RAND) {
 		obj_worker->list_move->fn_positions = random_positions();
-		if (obj_worker->list_move->fn_positions == NULL)
+		if (obj_worker->list_move->fn_positions == nullptr)
 			goto free_list_move;
 	}
 	for (i = 0; i < obj_bench.min_len; i++) {
 		size_t size = obj_bench.alloc_sizes[i];
 		POBJ_LIST_INSERT_NEW_TAIL(obj_bench.pop,
 					  &obj_worker->list_move->head, field,
-					  size, NULL, NULL);
+					  size, nullptr, nullptr);
 		if (TOID_IS_NULL(POBJ_LIST_LAST(&obj_worker->list_move->head,
 						field))) {
 			perror("pmemobj_list_insert_new");
@@ -854,9 +854,9 @@ free:
 static int
 obj_init(struct benchmark *bench, struct benchmark_args *args)
 {
-	assert(bench != NULL);
-	assert(args != NULL);
-	assert(args->opts != NULL);
+	assert(bench != nullptr);
+	assert(args != nullptr);
+	assert(args->opts != nullptr);
 
 	obj_bench.args = (struct obj_list_args *)args->opts;
 	obj_bench.min_len = obj_bench.args->list_len + 1;
@@ -873,7 +873,7 @@ obj_init(struct benchmark *bench, struct benchmark_args *args)
 		: obj_bench.args->min_size;
 	obj_bench.alloc_sizes = random_values(
 		min_size, obj_size, obj_bench.max_len, sizeof(struct item));
-	if (obj_bench.alloc_sizes == NULL)
+	if (obj_bench.alloc_sizes == nullptr)
 		goto free_random_types;
 
 	/* Decide where operations will be performed */
@@ -896,7 +896,7 @@ obj_init(struct benchmark *bench, struct benchmark_args *args)
 		if (obj_bench.type_mode == TYPE_MODE_RAND) {
 			obj_bench.random_types = random_values(
 				1, UINT32_MAX, obj_bench.max_len, 0);
-			if (obj_bench.random_types == NULL)
+			if (obj_bench.random_types == nullptr)
 				return -1;
 		}
 		/*
@@ -921,7 +921,7 @@ obj_init(struct benchmark *bench, struct benchmark_args *args)
 		/* Create pmemobj pool. */
 		if ((obj_bench.pop = pmemobj_create(args->fname, LAYOUT_NAME,
 						    psize, args->fmode)) ==
-		    NULL) {
+		    nullptr) {
 			perror(pmemobj_errormsg());
 			goto free_all;
 		}

--- a/src/benchmarks/pmemobj_gen.cpp
+++ b/src/benchmarks/pmemobj_gen.cpp
@@ -253,9 +253,9 @@ rand_sizes(size_t min, size_t max, size_t n_ops)
 {
 	assert(n_ops != 0);
 	size_t *rand_sizes = (size_t *)malloc(n_ops * sizeof(size_t));
-	if (rand_sizes == NULL) {
+	if (rand_sizes == nullptr) {
 		perror("malloc");
-		return NULL;
+		return nullptr;
 	}
 	for (size_t i = 0; i < n_ops; i++) {
 		rand_sizes[i] = RRAND(max, min);
@@ -273,7 +273,7 @@ random_types(struct pobj_bench *bench_priv, struct benchmark_args *args)
 	assert(bench_priv->args_priv->n_objs != 0);
 	bench_priv->random_types = (size_t *)malloc(
 		bench_priv->args_priv->n_objs * sizeof(size_t));
-	if (bench_priv->random_types == NULL) {
+	if (bench_priv->random_types == nullptr) {
 		perror("malloc");
 		return -1;
 	}
@@ -293,16 +293,16 @@ pobj_init(struct benchmark *bench, struct benchmark_args *args)
 	size_t psize;
 	size_t n_objs;
 
-	assert(bench != NULL);
-	assert(args != NULL);
+	assert(bench != nullptr);
+	assert(args != nullptr);
 
 	struct pobj_bench *bench_priv =
 		(struct pobj_bench *)malloc(sizeof(struct pobj_bench));
-	if (bench_priv == NULL) {
+	if (bench_priv == nullptr) {
 		perror("malloc");
 		return -1;
 	}
-	assert(args->opts != NULL);
+	assert(args->opts != nullptr);
 
 	bench_priv->args_priv = (struct pobj_args *)args->opts;
 	bench_priv->args_priv->obj_size = args->dsize;
@@ -344,14 +344,14 @@ pobj_init(struct benchmark *bench, struct benchmark_args *args)
 				goto free_bench_priv;
 			break;
 		default:
-			bench_priv->random_types = NULL;
+			bench_priv->random_types = nullptr;
 	}
 	bench_priv->fn_type_num = type_mode_func[bench_priv->type_mode];
 
 	/* assign size determining function */
 	bench_priv->fn_size =
 		bench_priv->args_priv->range ? range_size : static_size;
-	bench_priv->rand_sizes = NULL;
+	bench_priv->rand_sizes = nullptr;
 	if (bench_priv->args_priv->range) {
 		if (bench_priv->args_priv->min_size > args->dsize) {
 			fprintf(stderr, "Invalid allocation size");
@@ -361,21 +361,21 @@ pobj_init(struct benchmark *bench, struct benchmark_args *args)
 			rand_sizes(bench_priv->args_priv->min_size,
 				   bench_priv->args_priv->obj_size,
 				   bench_priv->args_priv->n_objs);
-		if (bench_priv->rand_sizes == NULL)
+		if (bench_priv->rand_sizes == nullptr)
 			goto free_random_types;
 	}
 
 	assert(bench_priv->n_pools > 0);
 	bench_priv->pop = (PMEMobjpool **)calloc(bench_priv->n_pools,
 						 sizeof(PMEMobjpool *));
-	if (bench_priv->pop == NULL) {
+	if (bench_priv->pop == nullptr) {
 		perror("calloc");
 		goto free_random_sizes;
 	}
 
 	bench_priv->sets = (const char **)calloc(bench_priv->n_pools,
 						 sizeof(const char *));
-	if (bench_priv->sets == NULL) {
+	if (bench_priv->sets == nullptr) {
 		perror("calloc");
 		goto free_pop;
 	}
@@ -390,7 +390,7 @@ pobj_init(struct benchmark *bench, struct benchmark_args *args)
 		for (i = 0; i < bench_priv->n_pools; i++) {
 			bench_priv->sets[i] =
 				(char *)malloc(path_len * sizeof(char));
-			if (bench_priv->sets[i] == NULL) {
+			if (bench_priv->sets[i] == nullptr) {
 				perror("malloc");
 				goto free_sets;
 			}
@@ -404,7 +404,7 @@ pobj_init(struct benchmark *bench, struct benchmark_args *args)
 			bench_priv->pop[i] =
 				pmemobj_create(bench_priv->sets[i], LAYOUT_NAME,
 					       psize, FILE_MODE);
-			if (bench_priv->pop[i] == NULL) {
+			if (bench_priv->pop[i] == nullptr) {
 				perror(pmemobj_errormsg());
 				goto free_sets;
 			}
@@ -420,7 +420,7 @@ pobj_init(struct benchmark *bench, struct benchmark_args *args)
 		bench_priv->sets[0] = args->fname;
 		bench_priv->pop[0] = pmemobj_create(
 			bench_priv->sets[0], LAYOUT_NAME, psize, FILE_MODE);
-		if (bench_priv->pop[0] == NULL) {
+		if (bench_priv->pop[0] == nullptr) {
 			perror(pmemobj_errormsg());
 			goto free_pools;
 		}
@@ -497,7 +497,7 @@ pobj_init_worker(struct benchmark *bench, struct benchmark_args *args,
 		(struct pobj_bench *)pmembench_get_priv(bench);
 	struct pobj_worker *pw =
 		(struct pobj_worker *)calloc(1, sizeof(struct pobj_worker));
-	if (pw == NULL) {
+	if (pw == nullptr) {
 		perror("calloc");
 		return -1;
 	}
@@ -505,7 +505,7 @@ pobj_init_worker(struct benchmark *bench, struct benchmark_args *args,
 	worker->priv = pw;
 	pw->oids = (PMEMoid *)calloc(bench_priv->args_priv->n_objs,
 				     sizeof(PMEMoid));
-	if (pw->oids == NULL) {
+	if (pw->oids == nullptr) {
 		free(pw);
 		perror("calloc");
 		return -1;
@@ -515,8 +515,8 @@ pobj_init_worker(struct benchmark *bench, struct benchmark_args *args,
 	for (i = 0; i < bench_priv->args_priv->n_objs; i++) {
 		size_t size = bench_priv->fn_size(bench_priv, i);
 		size_t type = bench_priv->fn_type_num(bench_priv, idx, i);
-		if (pmemobj_alloc(pop, &pw->oids[i], size, type, NULL, NULL) !=
-		    0) {
+		if (pmemobj_alloc(pop, &pw->oids[i], size, type, nullptr,
+				  nullptr) != 0) {
 			perror("pmemobj_alloc");
 			goto out;
 		}
@@ -540,7 +540,7 @@ pobj_direct_op(struct benchmark *bench, struct operation_info *info)
 		(struct pobj_bench *)pmembench_get_priv(bench);
 	struct pobj_worker *pw = (struct pobj_worker *)info->worker->priv;
 	size_t idx = bench_priv->obj(info->index);
-	if (pmemobj_direct(pw->oids[idx]) == NULL)
+	if (pmemobj_direct(pw->oids[idx]) == nullptr)
 		return -1;
 	return 0;
 }
@@ -556,7 +556,7 @@ pobj_open_op(struct benchmark *bench, struct operation_info *info)
 	size_t idx = bench_priv->pool(info->worker->index);
 	pmemobj_close(bench_priv->pop[idx]);
 	bench_priv->pop[idx] = pmemobj_open(bench_priv->sets[idx], LAYOUT_NAME);
-	if (bench_priv->pop[idx] == NULL)
+	if (bench_priv->pop[idx] == nullptr)
 		return -1;
 	return 0;
 }

--- a/src/benchmarks/pmemobj_persist.cpp
+++ b/src/benchmarks/pmemobj_persist.cpp
@@ -109,7 +109,8 @@ init_objects(struct obj_bench *ob)
 	for (uint64_t i = 0; i < ob->nobjs; i++) {
 		PMEMoid oid;
 		void *ptr;
-		if (pmemobj_alloc(ob->pop, &oid, ob->obj_size, 0, NULL, NULL)) {
+		if (pmemobj_alloc(ob->pop, &oid, ob->obj_size, 0, nullptr,
+				  nullptr)) {
 			perror("pmemobj_alloc");
 			goto err_palloc;
 		}
@@ -168,9 +169,9 @@ obj_persist_op(struct benchmark *bench, struct operation_info *info)
 static int
 obj_persist_init(struct benchmark *bench, struct benchmark_args *args)
 {
-	assert(bench != NULL);
-	assert(args != NULL);
-	assert(args->opts != NULL);
+	assert(bench != nullptr);
+	assert(args != nullptr);
+	assert(args->opts != nullptr);
 
 	struct prog_args *pa = (struct prog_args *)args->opts;
 	size_t poolsize;
@@ -181,7 +182,7 @@ obj_persist_init(struct benchmark *bench, struct benchmark_args *args)
 
 	struct obj_bench *ob =
 		(struct obj_bench *)malloc(sizeof(struct obj_bench));
-	if (ob == NULL) {
+	if (ob == nullptr) {
 		perror("malloc");
 		return -1;
 	}
@@ -217,8 +218,8 @@ obj_persist_init(struct benchmark *bench, struct benchmark_args *args)
 
 	poolsize = PAGE_ALIGNED_UP_SIZE(poolsize);
 
-	ob->pop = pmemobj_create(args->fname, NULL, poolsize, args->fmode);
-	if (ob->pop == NULL) {
+	ob->pop = pmemobj_create(args->fname, nullptr, poolsize, args->fmode);
+	if (ob->pop == nullptr) {
 		fprintf(stderr, "%s\n", pmemobj_errormsg());
 		goto free_ob;
 	}

--- a/src/benchmarks/pmemobj_tx.cpp
+++ b/src/benchmarks/pmemobj_tx.cpp
@@ -258,7 +258,7 @@ alloc_dram(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 {
 	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
 	obj_worker->items[idx] = (char *)malloc(obj_bench->sizes[idx]);
-	if (obj_worker->items[idx] == NULL) {
+	if (obj_worker->items[idx] == nullptr) {
 		perror("malloc");
 		return -1;
 	}
@@ -275,7 +275,8 @@ alloc_pmem(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 	size_t type_num = obj_bench->fn_type_num(obj_bench, worker->index, idx);
 	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
 	if (pmemobj_alloc(obj_bench->pop, &obj_worker->oids[idx].oid,
-			  obj_bench->sizes[idx], type_num, NULL, NULL) != 0) {
+			  obj_bench->sizes[idx], type_num, nullptr,
+			  nullptr) != 0) {
 		perror("pmemobj_alloc");
 		return -1;
 	}
@@ -354,7 +355,7 @@ realloc_dram(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
 	char *tmp = (char *)realloc(obj_worker->items[idx],
 				    obj_bench->resizes[idx]);
-	if (tmp == NULL) {
+	if (tmp == nullptr) {
 		perror("realloc");
 		return -1;
 	}
@@ -631,7 +632,7 @@ parse_lib_mode(const char *arg)
 }
 
 static fn_type_num_t type_num_fn[] = {type_mode_one, type_mode_per_thread,
-				      type_mode_rand, NULL};
+				      type_mode_rand, nullptr};
 
 /*
  * one_num -- returns always the same number.
@@ -685,9 +686,9 @@ rand_values(size_t min, size_t max, size_t n_ops)
 {
 	size_t size = max - min;
 	size_t *sizes = (size_t *)calloc(n_ops, sizeof(size_t));
-	if (sizes == NULL) {
+	if (sizes == nullptr) {
 		perror("calloc");
-		return NULL;
+		return nullptr;
 	}
 	for (size_t i = 0; i < n_ops; i++)
 		sizes[i] = max;
@@ -695,7 +696,7 @@ rand_values(size_t min, size_t max, size_t n_ops)
 		if (min > max) {
 			fprintf(stderr, "Invalid size\n");
 			free(sizes);
-			return NULL;
+			return nullptr;
 		}
 		for (size_t i = 0; i < n_ops; i++)
 			sizes[i] = (rand() % size) + min;
@@ -749,7 +750,7 @@ obj_tx_init_worker(struct benchmark *bench, struct benchmark_args *args,
 		(struct obj_tx_bench *)pmembench_get_priv(bench);
 	struct obj_tx_worker *obj_worker =
 		(struct obj_tx_worker *)calloc(1, sizeof(struct obj_tx_worker));
-	if (obj_worker == NULL) {
+	if (obj_worker == nullptr) {
 		perror("calloc");
 		return -1;
 	}
@@ -762,7 +763,7 @@ obj_tx_init_worker(struct benchmark *bench, struct benchmark_args *args,
 	else
 		obj_worker->items =
 			(char **)calloc(obj_bench->n_objs, sizeof(char *));
-	if (obj_worker->oids == NULL && obj_worker->items == NULL) {
+	if (obj_worker->oids == nullptr && obj_worker->items == nullptr) {
 		free(obj_worker);
 		perror("calloc");
 		return -1;
@@ -927,7 +928,7 @@ obj_tx_realloc_init(struct benchmark *bench, struct benchmark_args *args)
 	obj_bench->resizes =
 		rand_values(obj_bench->obj_args->min_rsize,
 			    obj_bench->obj_args->rsize, args->n_ops_per_thread);
-	if (obj_bench->resizes == NULL) {
+	if (obj_bench->resizes == nullptr) {
 		obj_tx_exit(bench, args);
 		return -1;
 	}
@@ -943,9 +944,9 @@ obj_tx_realloc_init(struct benchmark *bench, struct benchmark_args *args)
 int
 obj_tx_init(struct benchmark *bench, struct benchmark_args *args)
 {
-	assert(bench != NULL);
-	assert(args != NULL);
-	assert(args->opts != NULL);
+	assert(bench != nullptr);
+	assert(args != nullptr);
+	assert(args->opts != nullptr);
 
 	pmembench_set_priv(bench, &obj_bench);
 
@@ -954,7 +955,7 @@ obj_tx_init(struct benchmark *bench, struct benchmark_args *args)
 	obj_bench.obj_args->n_ops = args->n_ops_per_thread;
 	obj_bench.n_objs = args->n_ops_per_thread;
 
-	obj_bench.lib_op = obj_bench.obj_args->lib != NULL
+	obj_bench.lib_op = obj_bench.obj_args->lib != nullptr
 		? parse_lib_mode(obj_bench.obj_args->lib)
 		: LIB_MODE_OBJ_ATOMIC;
 
@@ -1008,13 +1009,13 @@ obj_tx_init(struct benchmark *bench, struct benchmark_args *args)
 	if (obj_bench.type_mode == NUM_MODE_RAND) {
 		obj_bench.random_types =
 			rand_values(1, UINT32_MAX, args->n_ops_per_thread);
-		if (obj_bench.random_types == NULL)
+		if (obj_bench.random_types == nullptr)
 			return -1;
 	}
 	obj_bench.sizes = rand_values(obj_bench.obj_args->min_size,
 				      obj_bench.obj_args->obj_size,
 				      args->n_ops_per_thread);
-	if (obj_bench.sizes == NULL)
+	if (obj_bench.sizes == nullptr)
 		goto free_random_types;
 
 	if (obj_bench.lib_mode == LIB_MODE_DRAM)
@@ -1032,7 +1033,7 @@ obj_tx_init(struct benchmark *bench, struct benchmark_args *args)
 
 	obj_bench.pop =
 		pmemobj_create(args->fname, LAYOUT_NAME, psize, args->fmode);
-	if (obj_bench.pop == NULL) {
+	if (obj_bench.pop == nullptr) {
 		perror("pmemobj_create");
 		goto free_all;
 	}

--- a/src/benchmarks/rpmem_persist.cpp
+++ b/src/benchmarks/rpmem_persist.cpp
@@ -258,7 +258,7 @@ rpmem_map_file(const char *path, struct rpmem_bench *mb, size_t size)
 #endif
 
 	mb->addrp = pmem_map_file(path, size, PMEM_FILE_CREATE, mode,
-				  &mb->mapped_len, NULL);
+				  &mb->mapped_len, nullptr);
 
 	if (!mb->addrp)
 		return -1;
@@ -319,7 +319,7 @@ rpmem_poolset_init(const char *path, struct rpmem_bench *mb,
 	rep = set->replica[0];
 
 	assert(rep);
-	assert(rep->remote == NULL);
+	assert(rep->remote == nullptr);
 	if (rep->nparts != 1) {
 		fprintf(stderr, "Multipart master replicas "
 				"are not supported\n");
@@ -344,13 +344,13 @@ rpmem_poolset_init(const char *path, struct rpmem_bench *mb,
 	/* prepare remote replicas */
 	mb->nreplicas = set->nreplicas - 1;
 	mb->nlanes = (unsigned *)malloc(mb->nreplicas * sizeof(unsigned));
-	if (mb->nlanes == NULL) {
+	if (mb->nlanes == nullptr) {
 		perror("malloc");
 		goto err_unmap_file;
 	}
 
 	mb->rpp = (RPMEMpool **)malloc(mb->nreplicas * sizeof(RPMEMpool *));
-	if (mb->rpp == NULL) {
+	if (mb->rpp == nullptr) {
 		perror("malloc");
 		goto err_free_lanes;
 	}
@@ -452,9 +452,9 @@ rpmem_set_min_size(struct rpmem_bench *mb, enum operation_mode op_mode,
 static int
 rpmem_init(struct benchmark *bench, struct benchmark_args *args)
 {
-	assert(bench != NULL);
-	assert(args != NULL);
-	assert(args->opts != NULL);
+	assert(bench != nullptr);
+	assert(args != nullptr);
+	assert(args->opts != nullptr);
 
 	struct rpmem_bench *mb =
 		(struct rpmem_bench *)malloc(sizeof(struct rpmem_bench));

--- a/src/benchmarks/scenario.cpp
+++ b/src/benchmarks/scenario.cpp
@@ -46,13 +46,13 @@ struct kv *
 kv_alloc(const char *key, const char *value)
 {
 	struct kv *kv = (struct kv *)malloc(sizeof(*kv));
-	assert(kv != NULL);
+	assert(kv != nullptr);
 
 	kv->key = strdup(key);
-	assert(kv->key != NULL);
+	assert(kv->key != nullptr);
 
 	kv->value = strdup(value);
-	assert(kv->value != NULL);
+	assert(kv->value != nullptr);
 
 	return kv;
 }
@@ -63,7 +63,7 @@ kv_alloc(const char *key, const char *value)
 void
 kv_free(struct kv *kv)
 {
-	assert(kv != NULL);
+	assert(kv != nullptr);
 	free(kv->key);
 	free(kv->value);
 	free(kv);
@@ -76,16 +76,16 @@ struct scenario *
 scenario_alloc(const char *name, const char *bench)
 {
 	struct scenario *s = (struct scenario *)malloc(sizeof(*s));
-	assert(s != NULL);
+	assert(s != nullptr);
 
 	TAILQ_INIT(&s->head);
 	s->name = strdup(name);
-	assert(s->name != NULL);
+	assert(s->name != nullptr);
 
 	s->benchmark = strdup(bench);
-	assert(s->benchmark != NULL);
+	assert(s->benchmark != nullptr);
 
-	s->group = NULL;
+	s->group = nullptr;
 
 	return s;
 }
@@ -96,7 +96,7 @@ scenario_alloc(const char *name, const char *bench)
 void
 scenario_free(struct scenario *s)
 {
-	assert(s != NULL);
+	assert(s != nullptr);
 
 	while (!TAILQ_EMPTY(&s->head)) {
 		struct kv *kv = TAILQ_FIRST(&s->head);
@@ -116,7 +116,7 @@ scenario_free(struct scenario *s)
 void
 scenario_set_group(struct scenario *s, const char *group)
 {
-	assert(s != NULL);
+	assert(s != nullptr);
 	s->group = strdup(group);
 }
 
@@ -128,7 +128,7 @@ scenarios_alloc(void)
 {
 	struct scenarios *scenarios =
 		(struct scenarios *)malloc(sizeof(*scenarios));
-	assert(NULL != scenarios);
+	assert(nullptr != scenarios);
 
 	TAILQ_INIT(&scenarios->head);
 
@@ -141,7 +141,7 @@ scenarios_alloc(void)
 void
 scenarios_free(struct scenarios *scenarios)
 {
-	assert(scenarios != NULL);
+	assert(scenarios != nullptr);
 	while (!TAILQ_EMPTY(&scenarios->head)) {
 		struct scenario *sce = TAILQ_FIRST(&scenarios->head);
 		TAILQ_REMOVE(&scenarios->head, sce, next);
@@ -163,7 +163,7 @@ scenarios_get_scenario(struct scenarios *ss, const char *name)
 		if (strcmp(scenario->name, name) == 0)
 			return scenario;
 	}
-	return NULL;
+	return nullptr;
 }
 
 /*
@@ -172,9 +172,9 @@ scenarios_get_scenario(struct scenarios *ss, const char *name)
 bool
 contains_scenarios(int argc, char **argv, struct scenarios *ss)
 {
-	assert(argv != NULL);
+	assert(argv != nullptr);
 	assert(argc > 0);
-	assert(ss != NULL);
+	assert(ss != nullptr);
 
 	for (int i = 0; i < argc; i++) {
 		if (scenarios_get_scenario(ss, argv[i]))
@@ -189,18 +189,18 @@ contains_scenarios(int argc, char **argv, struct scenarios *ss)
 struct scenario *
 clone_scenario(struct scenario *src_scenario)
 {
-	assert(src_scenario != NULL);
+	assert(src_scenario != nullptr);
 
 	struct scenario *new_scenario =
 		scenario_alloc(src_scenario->name, src_scenario->benchmark);
-	assert(new_scenario != NULL);
+	assert(new_scenario != nullptr);
 
 	struct kv *src_kv;
 
 	FOREACH_KV(src_kv, src_scenario)
 	{
 		struct kv *new_kv = kv_alloc(src_kv->key, src_kv->value);
-		assert(new_kv != NULL);
+		assert(new_kv != nullptr);
 
 		TAILQ_INSERT_TAIL(&new_scenario->head, new_kv, next);
 	}
@@ -210,7 +210,7 @@ clone_scenario(struct scenario *src_scenario)
 /*
  * find_kv_in_scenario - find a kv in the given scenario with the given key
  * value. Function returns the pointer to the kv structure containing the key or
- * NULL if it is not found
+ * nullptr if it is not found
  */
 struct kv *
 find_kv_in_scenario(const char *key, const struct scenario *scenario)
@@ -222,5 +222,5 @@ find_kv_in_scenario(const char *key, const struct scenario *scenario)
 		if (strcmp(kv->key, key) == 0)
 			return kv;
 	}
-	return NULL;
+	return nullptr;
 }

--- a/src/benchmarks/vmem.cpp
+++ b/src/benchmarks/vmem.cpp
@@ -114,7 +114,7 @@ vmem_malloc_op(struct vmem_bench *vb, unsigned worker_idx, size_t info_idx)
 	struct item *item = &vb->workers[worker_idx].objs[info_idx];
 	item->buf = vmem_malloc(vb->pools[item->pool_num],
 				vb->alloc_sizes[info_idx]);
-	if (item->buf == NULL) {
+	if (item->buf == nullptr) {
 		perror("vmem_malloc");
 		return -1;
 	}
@@ -129,7 +129,7 @@ stdlib_malloc_op(struct vmem_bench *vb, unsigned worker_idx, size_t info_idx)
 {
 	struct item *item = &vb->workers[worker_idx].objs[info_idx];
 	item->buf = malloc(vb->alloc_sizes[info_idx]);
-	if (item->buf == NULL) {
+	if (item->buf == nullptr) {
 		perror("malloc");
 		return -1;
 	}
@@ -143,9 +143,9 @@ static int
 vmem_free_op(struct vmem_bench *vb, unsigned worker_idx, size_t info_idx)
 {
 	struct item *item = &vb->workers[worker_idx].objs[info_idx];
-	if (item->buf != NULL)
+	if (item->buf != nullptr)
 		vmem_free(vb->pools[item->pool_num], item->buf);
-	item->buf = NULL;
+	item->buf = nullptr;
 	return 0;
 }
 
@@ -156,9 +156,9 @@ static int
 stdlib_free_op(struct vmem_bench *vb, unsigned worker_idx, size_t info_idx)
 {
 	struct item *item = &vb->workers[worker_idx].objs[info_idx];
-	if (item->buf != NULL)
+	if (item->buf != nullptr)
 		free(item->buf);
-	item->buf = NULL;
+	item->buf = nullptr;
 	return 0;
 }
 
@@ -171,7 +171,7 @@ vmem_realloc_op(struct vmem_bench *vb, unsigned worker_idx, size_t info_idx)
 	struct item *item = &vb->workers[worker_idx].objs[info_idx];
 	item->buf = vmem_realloc(vb->pools[item->pool_num], item->buf,
 				 vb->realloc_sizes[info_idx]);
-	if (vb->realloc_sizes[info_idx] != 0 && item->buf == NULL) {
+	if (vb->realloc_sizes[info_idx] != 0 && item->buf == nullptr) {
 		perror("vmem_realloc");
 		return -1;
 	}
@@ -186,7 +186,7 @@ stdlib_realloc_op(struct vmem_bench *vb, unsigned worker_idx, size_t info_idx)
 {
 	struct item *item = &vb->workers[worker_idx].objs[info_idx];
 	item->buf = realloc(item->buf, vb->realloc_sizes[info_idx]);
-	if (vb->realloc_sizes[info_idx] != 0 && item->buf == NULL) {
+	if (vb->realloc_sizes[info_idx] != 0 && item->buf == nullptr) {
 		perror("realloc");
 		return -1;
 	}
@@ -209,7 +209,7 @@ vmem_create_pools(struct vmem_bench *vb, struct benchmark_args *args)
 	vb->pool_size =
 		dsize * args->n_ops_per_thread * args->n_threads / vb->npools;
 	vb->pools = (VMEM **)calloc(vb->npools, sizeof(VMEM *));
-	if (vb->pools == NULL) {
+	if (vb->pools == nullptr) {
 		perror("calloc");
 		return -1;
 	}
@@ -220,7 +220,7 @@ vmem_create_pools(struct vmem_bench *vb, struct benchmark_args *args)
 	vb->pool_size *= FACTOR;
 	for (i = 0; i < vb->npools; i++) {
 		vb->pools[i] = vmem_create(args->fname, vb->pool_size);
-		if (vb->pools[i] == NULL) {
+		if (vb->pools[i] == nullptr) {
 			perror("vmem_create");
 			goto err;
 		}
@@ -418,9 +418,9 @@ vmem_exit(struct benchmark *bench, struct benchmark_args *args)
 		free(vb->workers[i].objs);
 	free(vb->workers);
 	free(vb->alloc_sizes);
-	if (vb->realloc_sizes != NULL)
+	if (vb->realloc_sizes != nullptr)
 		free(vb->realloc_sizes);
-	if (vb->mix_ops != NULL)
+	if (vb->mix_ops != nullptr)
 		free(vb->mix_ops);
 	free(vb);
 	return 0;
@@ -449,19 +449,19 @@ vmem_init(struct benchmark *bench, struct benchmark_args *args)
 {
 	unsigned i;
 	size_t j;
-	assert(bench != NULL);
-	assert(args != NULL);
+	assert(bench != nullptr);
+	assert(args != nullptr);
 
 	struct vmem_bench *vb =
 		(struct vmem_bench *)calloc(1, sizeof(struct vmem_bench));
-	if (vb == NULL) {
+	if (vb == nullptr) {
 		perror("malloc");
 		return -1;
 	}
 	pmembench_set_priv(bench, vb);
 	struct vmem_worker *vw;
 	struct vmem_args *va = (struct vmem_args *)args->opts;
-	vb->alloc_sizes = NULL;
+	vb->alloc_sizes = nullptr;
 	vb->lib_mode = va->stdlib_alloc ? STDLIB_MODE : VMEM_MODE;
 
 	if (util_file_is_device_dax(args->fname) && va->pool_per_thread) {
@@ -492,7 +492,7 @@ vmem_init(struct benchmark *bench, struct benchmark_args *args)
 	/* initializes buffers for operations for every thread */
 	vb->workers = (struct vmem_worker *)calloc(args->n_threads,
 						   sizeof(struct vmem_worker));
-	if (vb->workers == NULL) {
+	if (vb->workers == nullptr) {
 		perror("calloc");
 		goto err;
 	}
@@ -500,7 +500,7 @@ vmem_init(struct benchmark *bench, struct benchmark_args *args)
 		vw = &vb->workers[i];
 		vw->objs = (struct item *)calloc(args->n_ops_per_thread,
 						 sizeof(struct item));
-		if (vw->objs == NULL) {
+		if (vw->objs == nullptr) {
 			perror("calloc");
 			goto err_free_workers;
 		}
@@ -511,7 +511,7 @@ vmem_init(struct benchmark *bench, struct benchmark_args *args)
 	}
 
 	if ((vb->alloc_sizes = (size_t *)malloc(
-		     sizeof(size_t) * args->n_ops_per_thread)) == NULL) {
+		     sizeof(size_t) * args->n_ops_per_thread)) == nullptr) {
 		perror("malloc");
 		goto err_free_buf;
 	}
@@ -566,7 +566,7 @@ vmem_realloc_init(struct benchmark *bench, struct benchmark_args *args)
 		goto err;
 	}
 	if ((vb->realloc_sizes = (size_t *)calloc(args->n_ops_per_thread,
-						  sizeof(size_t))) == NULL) {
+						  sizeof(size_t))) == nullptr) {
 		perror("calloc");
 		goto err;
 	}
@@ -595,7 +595,7 @@ vmem_mix_init(struct benchmark *bench, struct benchmark_args *args)
 	unsigned idx, tmp;
 	struct vmem_bench *vb = (struct vmem_bench *)pmembench_get_priv(bench);
 	if ((vb->mix_ops = (unsigned *)calloc(args->n_ops_per_thread,
-					      sizeof(unsigned))) == NULL) {
+					      sizeof(unsigned))) == nullptr) {
 		perror("calloc");
 		goto err;
 	}
@@ -700,8 +700,8 @@ vmem_persist_constructor(void)
 	vmem_malloc_bench.exit = vmem_exit_free;
 	vmem_malloc_bench.multithread = true;
 	vmem_malloc_bench.multiops = true;
-	vmem_malloc_bench.init_worker = NULL;
-	vmem_malloc_bench.free_worker = NULL;
+	vmem_malloc_bench.init_worker = nullptr;
+	vmem_malloc_bench.free_worker = nullptr;
 	vmem_malloc_bench.operation = malloc_main_op;
 	vmem_malloc_bench.clos = vmem_clo;
 	vmem_malloc_bench.nclos = ARRAY_SIZE(vmem_clo) - 3;
@@ -718,7 +718,7 @@ vmem_persist_constructor(void)
 	vmem_mix_bench.multithread = true;
 	vmem_mix_bench.multiops = true;
 	vmem_mix_bench.init_worker = vmem_init_worker;
-	vmem_mix_bench.free_worker = NULL;
+	vmem_mix_bench.free_worker = nullptr;
 	vmem_mix_bench.operation = vmem_mix_op;
 	vmem_mix_bench.clos = vmem_clo;
 	vmem_mix_bench.nclos = ARRAY_SIZE(vmem_clo) - 3;
@@ -734,7 +734,7 @@ vmem_persist_constructor(void)
 	vmem_free_bench.multithread = true;
 	vmem_free_bench.multiops = true;
 	vmem_free_bench.init_worker = vmem_init_worker;
-	vmem_free_bench.free_worker = NULL;
+	vmem_free_bench.free_worker = nullptr;
 	vmem_free_bench.operation = free_main_op;
 	vmem_free_bench.clos = vmem_clo;
 	vmem_free_bench.nclos = ARRAY_SIZE(vmem_clo) - 2;
@@ -751,7 +751,7 @@ vmem_persist_constructor(void)
 	vmem_realloc_bench.multithread = true;
 	vmem_realloc_bench.multiops = true;
 	vmem_realloc_bench.init_worker = vmem_init_worker;
-	vmem_realloc_bench.free_worker = NULL;
+	vmem_realloc_bench.free_worker = nullptr;
 	vmem_realloc_bench.operation = realloc_main_op;
 	vmem_realloc_bench.clos = vmem_clo;
 	vmem_realloc_bench.nclos = ARRAY_SIZE(vmem_clo);


### PR DESCRIPTION
Intention of this PR is use nullptr in cpp files (benchmark module)
Since commit 3e4400bcddcbe22fd67438a3efe11733da60a57d benchmark module is compiled with |std=c++11| which means it supports nullptr

In any case any feedback will be appreciated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2849)
<!-- Reviewable:end -->
