### PR TITLE
Trivial: Fix Typo at rpmem_deep_persist

### DIFF
--- a/src/librpmem/rpmem.c
+++ b/src/librpmem/rpmem.c
@@ -641,7 +641,7 @@ rpmem_persist(RPMEMpool *rpp, size_t offset, size_t length, unsigned lane)
 }
 
 /*
- * rpmem_deep_persit -- deep flush operation on target node
+ * rpmem_deep_persist -- deep flush operation on target node
  *
  * rpp           -- remote pool handle
  * offset        -- offset in pool


### PR DESCRIPTION
I found a typo at description at rpmem_deep_persist.
So, fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2854)
<!-- Reviewable:end -->
