### PR TITLE
obj: add Wswitch-default warning flag

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -69,6 +69,9 @@ endif
 ifeq ($(call check_flag, -Wfloat-equal), y)
 DEFAULT_CFLAGS += -Wfloat-equal
 endif
+ifeq ($(call check_flag, -Wswitch-default), y)
+DEFAULT_CFLAGS += -Wswitch-default
+endif
 endif
 
 ifeq ($(DEBUG),1)

--- a/src/jemalloc/jemalloc.mk
+++ b/src/jemalloc/jemalloc.mk
@@ -81,6 +81,7 @@ CFLAGS_FILTER += -Wshadow
 CFLAGS_FILTER += -Wdisabled-macro-expansion
 CFLAGS_FILTER += -Wlanguage-extension-token
 CFLAGS_FILTER += -Wfloat-equal
+CFLAGS_FILTER += -Wswitch-default
 JEMALLOC_CFLAGS=$(filter-out $(CFLAGS_FILTER), $(CFLAGS))
 ifeq ($(shell uname -s),FreeBSD)
 JEMALLOC_CFLAGS += -I/usr/local/include

--- a/src/libpmemobj/ctl.c
+++ b/src/libpmemobj/ctl.c
@@ -695,6 +695,10 @@ ctl_arg_integer(const void *arg, void *dest, size_t dest_size)
 				return -1;
 			*(uint8_t *)dest = (uint8_t)val;
 			break;
+		default:
+			ERR("invalid destination size %zu", dest_size);
+			errno = EINVAL;
+			return -1;
 	}
 
 	return 0;

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -670,6 +670,10 @@ heap_reclaim_zone_garbage(struct palloc_heap *heap, struct bucket *bucket,
 				heap_chunk_write_footer(hdr,
 					hdr->size_idx);
 				break;
+			case CHUNK_TYPE_RUN:
+				break;
+			default:
+				ASSERT(0);
 		}
 
 		i += hdr->size_idx;

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -1597,7 +1597,7 @@ pmemobj_tx_process(void)
 	case TX_STAGE_FINALLY:
 		tx->stage = TX_STAGE_NONE;
 		break;
-	case MAX_TX_STAGE:
+	default:
 		ASSERT(0);
 	}
 }

--- a/src/test/tools/ctrld/ctrld.c
+++ b/src/test/tools/ctrld/ctrld.c
@@ -649,6 +649,8 @@ convert_timeout(char *str)
 	case 'd':
 		ftimeout *= S_DAY;
 		break;
+	default:
+		break;
 	}
 	return (unsigned)ftimeout;
 }

--- a/src/test/tools/pmemobjcli/pmemobjcli.c
+++ b/src/test/tools/pmemobjcli/pmemobjcli.c
@@ -380,7 +380,7 @@ parse_stage(void)
 		case TX_STAGE_FINALLY:
 			stage = "TX_STAGE_FINALLY";
 		break;
-		case MAX_TX_STAGE:
+		default:
 			assert(0); /* unreachable */
 		break;
 	}

--- a/src/test/unittest/Makefile
+++ b/src/test/unittest/Makefile
@@ -72,6 +72,9 @@ endif
 ifeq ($(call check_flag, -Wfloat-equal), y)
 CFLAGS += -Wfloat-equal
 endif
+ifeq ($(call check_flag, -Wswitch-default), y)
+CFLAGS += -Wswitch-default
+endif
 endif
 
 ifeq ($(USE_LIBUNWIND),1)

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -66,6 +66,9 @@ endif
 ifeq ($(call check_flag, -Wfloat-equal), y)
 CFLAGS += -Wfloat-equal
 endif
+ifeq ($(call check_flag, -Wswitch-default), y)
+CFLAGS += -Wswitch-default
+endif
 endif
 
 ifeq ($(DEBUG),1)

--- a/src/tools/pmempool/check.c
+++ b/src/tools/pmempool/check.c
@@ -326,6 +326,10 @@ pmempool_check_func(char *appname, int argc, char *argv[])
 			outv_err("checking consistency failed\n");
 		ret = -1;
 		break;
+	default:
+		outv_err("status unknown\n");
+		ret = -1;
+		break;
 	}
 
 	return ret;

--- a/src/tools/pmempool/output.c
+++ b/src/tools/pmempool/output.c
@@ -806,6 +806,8 @@ out_get_arch_machine_str(uint16_t machine)
 		return "AMD X86-64";
 	case PMDK_MACHINE_AARCH64:
 		return "Aarch64";
+	default:
+		break;
 	}
 
 	int ret = snprintf(str_buff, STR_MAX, "unknown %u", machine);

--- a/src/tools/pmempool/rm.c
+++ b/src/tools/pmempool/rm.c
@@ -142,6 +142,9 @@ rm_file(const char *file)
 	case ASK_SOMETIMES:
 		cask = write_protected ? '?' : 'y';
 		break;
+	default:
+		outv_err("unknown state");
+		return 1;
 	}
 
 	const char *pre_msg = write_protected ? "write-protected " : "";
@@ -177,6 +180,9 @@ remove_remote(const char *target, const char *pool_set)
 	case ASK_SOMETIMES:
 		cask = 'y';
 		break;
+	default:
+		outv_err("unknown state");
+		return 1;
 	}
 
 	char ans = ask_Yn(cask, "remove remote pool '%s' on '%s'?",

--- a/utils/check_license/Makefile
+++ b/utils/check_license/Makefile
@@ -54,6 +54,9 @@ endif
 ifeq ($(call check_flag, -Wfloat-equal), y)
 CFLAGS += -Wfloat-equal
 endif
+ifeq ($(call check_flag, -Wswitch-default), y)
+CFLAGS += -Wswitch-default
+endif
 
 TARGET=check-license
 


### PR DESCRIPTION
Intention of this PR is to extend diagnostic during compilation.
Wswitch-default is responsible to point a place where switch statement do not have a default case, which might lead to complex logical errors and resultant weaknesses.
This warning is currently disabled in project.
In any case any feedback will be appreciated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2858)
<!-- Reviewable:end -->
