### PR TITLE
benchmark: use auto in declaration type

### DIFF
--- a/src/benchmarks/benchmark_worker.cpp
+++ b/src/benchmarks/benchmark_worker.cpp
@@ -73,7 +73,7 @@ static void *
 thread_func(void *arg)
 {
 	assert(arg != nullptr);
-	struct benchmark_worker *worker = (struct benchmark_worker *)arg;
+	auto *worker = (struct benchmark_worker *)arg;
 
 	os_mutex_lock(&worker->lock);
 

--- a/src/benchmarks/blk.cpp
+++ b/src/benchmarks/blk.cpp
@@ -155,7 +155,7 @@ blk_do_warmup(struct blk_bench *bb, struct benchmark_args *args)
 {
 	size_t lba;
 	int ret = 0;
-	char *buff = (char *)calloc(1, args->dsize);
+	auto *buff = (char *)calloc(1, args->dsize);
 	if (!buff) {
 		perror("calloc");
 		return -1;
@@ -287,8 +287,8 @@ fileio_write(struct blk_bench *bb, struct benchmark_args *ba,
 static int
 blk_operation(struct benchmark *bench, struct operation_info *info)
 {
-	struct blk_bench *bb = (struct blk_bench *)pmembench_get_priv(bench);
-	struct blk_worker *bworker = (struct blk_worker *)info->worker->priv;
+	auto *bb = (struct blk_bench *)pmembench_get_priv(bench);
+	auto *bworker = (struct blk_worker *)info->worker->priv;
 
 	os_off_t off = bworker->blocks[info->index];
 	return bb->worker(bb, info->args, bworker, off);
@@ -309,8 +309,8 @@ blk_init_worker(struct benchmark *bench, struct benchmark_args *args,
 		return -1;
 	}
 
-	struct blk_bench *bb = (struct blk_bench *)pmembench_get_priv(bench);
-	struct blk_args *bargs = (struct blk_args *)args->opts;
+	auto *bb = (struct blk_bench *)pmembench_get_priv(bench);
+	auto *bargs = (struct blk_args *)args->opts;
 
 	bworker->seed = os_rand_r(&bargs->seed);
 
@@ -370,7 +370,7 @@ static void
 blk_free_worker(struct benchmark *bench, struct benchmark_args *args,
 		struct worker_info *worker)
 {
-	struct blk_worker *bworker = (struct blk_worker *)worker->priv;
+	auto *bworker = (struct blk_worker *)worker->priv;
 	free(bworker->blocks);
 	free(bworker->buff);
 	free(bworker);
@@ -382,7 +382,7 @@ blk_free_worker(struct benchmark *bench, struct benchmark_args *args,
 static int
 blk_init(struct blk_bench *bb, struct benchmark_args *args)
 {
-	struct blk_args *ba = (struct blk_args *)args->opts;
+	auto *ba = (struct blk_args *)args->opts;
 	assert(ba != nullptr);
 
 	bb->type = parse_op_type(ba->type_str);
@@ -496,8 +496,7 @@ blk_read_init(struct benchmark *bench, struct benchmark_args *args)
 	assert(args != nullptr);
 
 	int ret;
-	struct blk_bench *bb =
-		(struct blk_bench *)malloc(sizeof(struct blk_bench));
+	auto *bb = (struct blk_bench *)malloc(sizeof(struct blk_bench));
 	if (bb == nullptr) {
 		perror("malloc");
 		return -1;
@@ -539,8 +538,7 @@ blk_write_init(struct benchmark *bench, struct benchmark_args *args)
 	assert(args != nullptr);
 
 	int ret;
-	struct blk_bench *bb =
-		(struct blk_bench *)malloc(sizeof(struct blk_bench));
+	auto *bb = (struct blk_bench *)malloc(sizeof(struct blk_bench));
 	if (bb == nullptr) {
 		perror("malloc");
 		return -1;
@@ -578,7 +576,7 @@ blk_write_init(struct benchmark *bench, struct benchmark_args *args)
 static int
 blk_exit(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct blk_bench *bb = (struct blk_bench *)pmembench_get_priv(bench);
+	auto *bb = (struct blk_bench *)pmembench_get_priv(bench);
 
 	int result;
 	switch (bb->type) {

--- a/src/benchmarks/clo.cpp
+++ b/src/benchmarks/clo.cpp
@@ -147,10 +147,10 @@ parse_number_base(const char *arg, void *value, int s, int base)
 	char *end;
 	errno = 0;
 	if (s) {
-		int64_t *v = (int64_t *)value;
+		auto *v = (int64_t *)value;
 		*v = strtoll(arg, &end, base);
 	} else {
-		uint64_t *v = (uint64_t *)value;
+		auto *v = (uint64_t *)value;
 		*v = strtoull(arg, &end, base);
 	}
 
@@ -379,12 +379,12 @@ clo_parse_range(struct benchmark_clo *clo, const char *arg,
 		clo_parse_single_fn parse_single, clo_eval_range_fn eval_range,
 		struct clo_vec_vlist *vlist)
 {
-	char *str_first = (char *)malloc(strlen(arg) + 1);
+	auto *str_first = (char *)malloc(strlen(arg) + 1);
 	assert(str_first != nullptr);
-	char *str_step = (char *)malloc(strlen(arg) + 1);
+	auto *str_step = (char *)malloc(strlen(arg) + 1);
 	assert(str_step != nullptr);
 	char step_type = '\0';
-	char *str_last = (char *)malloc(strlen(arg) + 1);
+	auto *str_last = (char *)malloc(strlen(arg) + 1);
 	assert(str_last != nullptr);
 
 	int ret = sscanf(arg, "%[^:]:%c%[^:]:%[^:]", str_first, &step_type,

--- a/src/benchmarks/clo_vec.cpp
+++ b/src/benchmarks/clo_vec.cpp
@@ -234,7 +234,7 @@ clo_vec_memcpy(struct clo_vec *clovec, size_t off, size_t size, void *ptr)
 
 	size_t i;
 	for (i = 0; i < clovec->nargs; i++) {
-		char *args = (char *)clo_vec_get_args(clovec, i);
+		auto *args = (char *)clo_vec_get_args(clovec, i);
 		char *dptr = args + off;
 		memcpy(dptr, ptr, size);
 	}
@@ -268,7 +268,7 @@ clo_vec_memcpy_list(struct clo_vec *clovec, size_t off, size_t size,
 	TAILQ_FOREACH(value, &list->head, next)
 	{
 		for (i = value_i * len; i < (value_i + 1) * len; i++) {
-			char *args = (char *)clo_vec_get_args(clovec, i);
+			auto *args = (char *)clo_vec_get_args(clovec, i);
 			char *dptr = args + off;
 			memcpy(dptr, value->ptr, size);
 		}

--- a/src/benchmarks/log.cpp
+++ b/src/benchmarks/log.cpp
@@ -103,7 +103,7 @@ do_warmup(struct log_bench *lb, size_t nops)
 {
 	int ret = 0;
 	size_t bsize = lb->args->vec_size * lb->args->el_size;
-	char *buf = (char *)calloc(1, bsize);
+	auto *buf = (char *)calloc(1, bsize);
 	if (!buf) {
 		perror("calloc");
 		return -1;
@@ -151,11 +151,10 @@ out:
 static int
 log_append(struct benchmark *bench, struct operation_info *info)
 {
-	struct log_bench *lb = (struct log_bench *)pmembench_get_priv(bench);
+	auto *lb = (struct log_bench *)pmembench_get_priv(bench);
 	assert(lb);
 
-	struct log_worker_info *worker_info =
-		(struct log_worker_info *)info->worker->priv;
+	auto *worker_info = (struct log_worker_info *)info->worker->priv;
 
 	assert(worker_info);
 
@@ -176,11 +175,10 @@ log_append(struct benchmark *bench, struct operation_info *info)
 static int
 log_appendv(struct benchmark *bench, struct operation_info *info)
 {
-	struct log_bench *lb = (struct log_bench *)pmembench_get_priv(bench);
+	auto *lb = (struct log_bench *)pmembench_get_priv(bench);
 	assert(lb);
 
-	struct log_worker_info *worker_info =
-		(struct log_worker_info *)info->worker->priv;
+	auto *worker_info = (struct log_worker_info *)info->worker->priv;
 
 	assert(worker_info);
 
@@ -200,11 +198,10 @@ log_appendv(struct benchmark *bench, struct operation_info *info)
 static int
 fileio_append(struct benchmark *bench, struct operation_info *info)
 {
-	struct log_bench *lb = (struct log_bench *)pmembench_get_priv(bench);
+	auto *lb = (struct log_bench *)pmembench_get_priv(bench);
 	assert(lb);
 
-	struct log_worker_info *worker_info =
-		(struct log_worker_info *)info->worker->priv;
+	auto *worker_info = (struct log_worker_info *)info->worker->priv;
 
 	assert(worker_info);
 
@@ -225,11 +222,10 @@ fileio_append(struct benchmark *bench, struct operation_info *info)
 static int
 fileio_appendv(struct benchmark *bench, struct operation_info *info)
 {
-	struct log_bench *lb = (struct log_bench *)pmembench_get_priv(bench);
+	auto *lb = (struct log_bench *)pmembench_get_priv(bench);
 	assert(lb != nullptr);
 
-	struct log_worker_info *worker_info =
-		(struct log_worker_info *)info->worker->priv;
+	auto *worker_info = (struct log_worker_info *)info->worker->priv;
 
 	assert(worker_info);
 
@@ -250,7 +246,7 @@ fileio_appendv(struct benchmark *bench, struct operation_info *info)
 static int
 log_process_data(const void *buf, size_t len, void *arg)
 {
-	struct log_worker_info *worker_info = (struct log_worker_info *)arg;
+	auto *worker_info = (struct log_worker_info *)arg;
 	size_t left = worker_info->buf_size - worker_info->buf_ptr;
 	if (len > left) {
 		worker_info->buf_ptr = 0;
@@ -298,11 +294,10 @@ fileio_read(int fd, ssize_t len, struct log_worker_info *worker_info)
 static int
 log_read_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct log_bench *lb = (struct log_bench *)pmembench_get_priv(bench);
+	auto *lb = (struct log_bench *)pmembench_get_priv(bench);
 	assert(lb);
 
-	struct log_worker_info *worker_info =
-		(struct log_worker_info *)info->worker->priv;
+	auto *worker_info = (struct log_worker_info *)info->worker->priv;
 
 	assert(worker_info);
 
@@ -333,11 +328,11 @@ log_init_worker(struct benchmark *bench, struct benchmark_args *args,
 		struct worker_info *worker)
 {
 	int ret = 0;
-	struct log_bench *lb = (struct log_bench *)pmembench_get_priv(bench);
+	auto *lb = (struct log_bench *)pmembench_get_priv(bench);
 	size_t i_size, n_vectors;
 	assert(lb);
 
-	struct log_worker_info *worker_info = (struct log_worker_info *)malloc(
+	auto *worker_info = (struct log_worker_info *)malloc(
 		sizeof(struct log_worker_info));
 	if (!worker_info) {
 		perror("malloc");
@@ -383,8 +378,8 @@ log_init_worker(struct benchmark *bench, struct benchmark_args *args,
 
 		/* generate append sizes */
 		for (size_t i = 0; i < n_sizes; i++) {
-			uint32_t hr = (uint32_t)os_rand_r(&worker_info->seed);
-			uint32_t lr = (uint32_t)os_rand_r(&worker_info->seed);
+			auto hr = (uint32_t)os_rand_r(&worker_info->seed);
+			auto lr = (uint32_t)os_rand_r(&worker_info->seed);
 			uint64_t r64 = (uint64_t)hr << 32 | lr;
 			size_t width = lb->args->el_size - lb->args->min_size;
 			worker_info->rand_sizes[i] =
@@ -445,8 +440,7 @@ log_free_worker(struct benchmark *bench, struct benchmark_args *args,
 		struct worker_info *worker)
 {
 
-	struct log_worker_info *worker_info =
-		(struct log_worker_info *)worker->priv;
+	auto *worker_info = (struct log_worker_info *)worker->priv;
 	assert(worker_info);
 
 	free(worker_info->buf);
@@ -467,8 +461,7 @@ log_init(struct benchmark *bench, struct benchmark_args *args)
 	assert(args != nullptr);
 	assert(args->opts != nullptr);
 	struct benchmark_info *bench_info;
-	struct log_bench *lb =
-		(struct log_bench *)malloc(sizeof(struct log_bench));
+	auto *lb = (struct log_bench *)malloc(sizeof(struct log_bench));
 
 	if (!lb) {
 		perror("malloc");
@@ -580,7 +573,7 @@ err_free_lb:
 static int
 log_exit(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct log_bench *lb = (struct log_bench *)pmembench_get_priv(bench);
+	auto *lb = (struct log_bench *)pmembench_get_priv(bench);
 
 	if (!lb->args->fileio)
 		pmemlog_close(lb->plp);

--- a/src/benchmarks/map_bench.cpp
+++ b/src/benchmarks/map_bench.cpp
@@ -219,10 +219,8 @@ map_remove_root_op(struct map_bench *map_bench, uint64_t key)
 static int
 map_remove_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct map_bench *map_bench =
-		(struct map_bench *)pmembench_get_priv(bench);
-	struct map_bench_worker *tworker =
-		(struct map_bench_worker *)info->worker->priv;
+	auto *map_bench = (struct map_bench *)pmembench_get_priv(bench);
+	auto *tworker = (struct map_bench_worker *)info->worker->priv;
 
 	uint64_t key = tworker->keys[info->index];
 
@@ -274,10 +272,8 @@ map_insert_root_op(struct map_bench *map_bench, uint64_t key)
 static int
 map_insert_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct map_bench *map_bench =
-		(struct map_bench *)pmembench_get_priv(bench);
-	struct map_bench_worker *tworker =
-		(struct map_bench_worker *)info->worker->priv;
+	auto *map_bench = (struct map_bench *)pmembench_get_priv(bench);
+	auto *tworker = (struct map_bench_worker *)info->worker->priv;
 	uint64_t key = tworker->keys[info->index];
 
 	mutex_lock_nofail(&map_bench->lock);
@@ -317,10 +313,8 @@ map_get_root_op(struct map_bench *map_bench, uint64_t key)
 static int
 map_get_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct map_bench *map_bench =
-		(struct map_bench *)pmembench_get_priv(bench);
-	struct map_bench_worker *tworker =
-		(struct map_bench_worker *)info->worker->priv;
+	auto *map_bench = (struct map_bench *)pmembench_get_priv(bench);
+	auto *tworker = (struct map_bench_worker *)info->worker->priv;
 
 	uint64_t key = tworker->keys[info->index];
 
@@ -387,9 +381,8 @@ static void
 map_common_free_worker(struct benchmark *bench, struct benchmark_args *args,
 		       struct worker_info *worker)
 {
-	struct map_bench_worker *tworker =
-		(struct map_bench_worker *)worker->priv;
-	struct map_bench_args *targs = (struct map_bench_args *)args->opts;
+	auto *tworker = (struct map_bench_worker *)worker->priv;
+	auto *targs = (struct map_bench_args *)args->opts;
 
 	if (targs->ext_tx) {
 		pmemobj_tx_commit();
@@ -410,10 +403,9 @@ map_insert_init_worker(struct benchmark *bench, struct benchmark_args *args,
 	if (ret)
 		return ret;
 
-	struct map_bench_args *targs = (struct map_bench_args *)args->opts;
+	auto *targs = (struct map_bench_args *)args->opts;
 	assert(targs);
-	struct map_bench_worker *tworker =
-		(struct map_bench_worker *)worker->priv;
+	auto *tworker = (struct map_bench_worker *)worker->priv;
 
 	assert(tworker);
 
@@ -431,12 +423,11 @@ map_global_rand_keys_init(struct benchmark *bench, struct benchmark_args *args,
 			  struct worker_info *worker)
 {
 
-	struct map_bench *tree = (struct map_bench *)pmembench_get_priv(bench);
+	auto *tree = (struct map_bench *)pmembench_get_priv(bench);
 	assert(tree);
-	struct map_bench_args *targs = (struct map_bench_args *)args->opts;
+	auto *targs = (struct map_bench_args *)args->opts;
 	assert(targs);
-	struct map_bench_worker *tworker =
-		(struct map_bench_worker *)worker->priv;
+	auto *tworker = (struct map_bench_worker *)worker->priv;
 
 	assert(tworker);
 	assert(tree->init_nkeys);
@@ -611,7 +602,7 @@ err_free_bench:
 static int
 map_common_exit(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct map_bench *tree = (struct map_bench *)pmembench_get_priv(bench);
+	auto *tree = (struct map_bench *)pmembench_get_priv(bench);
 
 	os_mutex_destroy(&tree->lock);
 	map_ctx_free(tree->mapc);
@@ -626,10 +617,9 @@ map_common_exit(struct benchmark *bench, struct benchmark_args *args)
 static int
 map_keys_init(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct map_bench *map_bench =
-		(struct map_bench *)pmembench_get_priv(bench);
+	auto *map_bench = (struct map_bench *)pmembench_get_priv(bench);
 	assert(map_bench);
-	struct map_bench_args *targs = (struct map_bench_args *)args->opts;
+	auto *targs = (struct map_bench_args *)args->opts;
 	assert(targs);
 
 	assert(map_bench->nkeys != 0);
@@ -691,7 +681,7 @@ map_keys_init(struct benchmark *bench, struct benchmark_args *args)
 static int
 map_keys_exit(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct map_bench *tree = (struct map_bench *)pmembench_get_priv(bench);
+	auto *tree = (struct map_bench *)pmembench_get_priv(bench);
 	free(tree->keys);
 	return 0;
 }

--- a/src/benchmarks/obj_lanes.cpp
+++ b/src/benchmarks/obj_lanes.cpp
@@ -97,8 +97,7 @@ lanes_init(struct benchmark *bench, struct benchmark_args *args)
 	assert(args != nullptr);
 	assert(args->opts != nullptr);
 
-	struct obj_bench *ob =
-		(struct obj_bench *)malloc(sizeof(struct obj_bench));
+	auto *ob = (struct obj_bench *)malloc(sizeof(struct obj_bench));
 	if (ob == nullptr) {
 		perror("malloc");
 		return -1;
@@ -139,7 +138,7 @@ err:
 static int
 lanes_exit(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct obj_bench *ob = (struct obj_bench *)pmembench_get_priv(bench);
+	auto *ob = (struct obj_bench *)pmembench_get_priv(bench);
 
 	pmemobj_close(ob->pop);
 	free(ob);
@@ -153,7 +152,7 @@ lanes_exit(struct benchmark *bench, struct benchmark_args *args)
 static int
 lanes_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct obj_bench *ob = (struct obj_bench *)pmembench_get_priv(bench);
+	auto *ob = (struct obj_bench *)pmembench_get_priv(bench);
 	struct lane_section *section;
 
 	for (int i = 0; i < OPERATION_REPEAT_COUNT; i++) {

--- a/src/benchmarks/obj_locks.cpp
+++ b/src/benchmarks/obj_locks.cpp
@@ -149,7 +149,7 @@ bench_operation_1by1(lock_fun_wrapper flock, lock_fun_wrapper funlock,
 		     struct mutex_bench *mb, PMEMobjpool *pop)
 {
 	for (unsigned i = 0; i < (mb)->pa->n_locks; (i)++) {
-		void *o = (void *)(&(mb)->locks[i]);
+		auto *o = (void *)(&(mb)->locks[i]);
 		flock(pop, o);
 		funlock(pop, o);
 	}
@@ -163,11 +163,11 @@ bench_operation_all_lock(lock_fun_wrapper flock, lock_fun_wrapper funlock,
 			 struct mutex_bench *mb, PMEMobjpool *pop)
 {
 	for (unsigned i = 0; i < (mb)->pa->n_locks; (i)++) {
-		void *o = (void *)(&(mb)->locks[i]);
+		auto *o = (void *)(&(mb)->locks[i]);
 		flock(pop, o);
 	}
 	for (unsigned i = 0; i < (mb)->pa->n_locks; i++) {
-		void *o = (void *)(&(mb)->locks[i]);
+		auto *o = (void *)(&(mb)->locks[i]);
 		funlock(pop, o);
 	}
 }
@@ -226,7 +226,7 @@ volatile_mutex_init(os_mutex_t **mutexp, void *attr)
 static int
 volatile_mutex_lock(PMEMobjpool *pop, PMEM_volatile_mutex *mutexp)
 {
-	os_mutex_t *mutex = GET_VOLATILE_MUTEX(pop, mutexp);
+	auto *mutex = GET_VOLATILE_MUTEX(pop, mutexp);
 	if (mutex == nullptr)
 		return EINVAL;
 
@@ -239,7 +239,7 @@ volatile_mutex_lock(PMEMobjpool *pop, PMEM_volatile_mutex *mutexp)
 static int
 volatile_mutex_unlock(PMEMobjpool *pop, PMEM_volatile_mutex *mutexp)
 {
-	os_mutex_t *mutex = (os_mutex_t *)GET_VOLATILE_MUTEX(pop, mutexp);
+	auto *mutex = (os_mutex_t *)GET_VOLATILE_MUTEX(pop, mutexp);
 	if (mutex == nullptr)
 		return EINVAL;
 
@@ -252,7 +252,7 @@ volatile_mutex_unlock(PMEMobjpool *pop, PMEM_volatile_mutex *mutexp)
 static int
 volatile_mutex_destroy(PMEMobjpool *pop, PMEM_volatile_mutex *mutexp)
 {
-	os_mutex_t *mutex = (os_mutex_t *)GET_VOLATILE_MUTEX(pop, mutexp);
+	auto *mutex = (os_mutex_t *)GET_VOLATILE_MUTEX(pop, mutexp);
 	if (mutex == nullptr)
 		return EINVAL;
 
@@ -394,15 +394,14 @@ init_bench_mutex(struct mutex_bench *mb)
 	if (!mb->pa->use_system_threads) {
 		/* initialize PMEM mutexes */
 		for (unsigned i = 0; i < mb->pa->n_locks; i++) {
-			PMEMmutex_internal *p =
-				(PMEMmutex_internal *)&mb->locks[i];
+			auto *p = (PMEMmutex_internal *)&mb->locks[i];
 			p->pmemmutex.runid = mb->pa->runid_initial_value;
 			os_mutex_init(&p->PMEMmutex_lock);
 		}
 	} else {
 		/* initialize os_thread mutexes */
 		for (unsigned i = 0; i < mb->pa->n_locks; i++) {
-			os_mutex_t *p = (os_mutex_t *)&mb->locks[i];
+			auto *p = (os_mutex_t *)&mb->locks[i];
 			os_mutex_init(p);
 		}
 	}
@@ -419,7 +418,7 @@ exit_bench_mutex(struct mutex_bench *mb)
 	if (mb->pa->use_system_threads) {
 		/* deinitialize os_thread mutex objects */
 		for (unsigned i = 0; i < mb->pa->n_locks; i++) {
-			os_mutex_t *p = (os_mutex_t *)&mb->locks[i];
+			auto *p = (os_mutex_t *)&mb->locks[i];
 			os_mutex_destroy(p);
 		}
 	}
@@ -487,15 +486,14 @@ init_bench_rwlock(struct mutex_bench *mb)
 	if (!mb->pa->use_system_threads) {
 		/* initialize PMEM rwlocks */
 		for (unsigned i = 0; i < mb->pa->n_locks; i++) {
-			PMEMrwlock_internal *p =
-				(PMEMrwlock_internal *)&mb->locks[i];
+			auto *p = (PMEMrwlock_internal *)&mb->locks[i];
 			p->pmemrwlock.runid = mb->pa->runid_initial_value;
 			os_rwlock_init(&p->PMEMrwlock_lock);
 		}
 	} else {
 		/* initialize os_thread rwlocks */
 		for (unsigned i = 0; i < mb->pa->n_locks; i++) {
-			os_rwlock_t *p = (os_rwlock_t *)&mb->locks[i];
+			auto *p = (os_rwlock_t *)&mb->locks[i];
 			os_rwlock_init(p);
 		}
 	}
@@ -512,7 +510,7 @@ exit_bench_rwlock(struct mutex_bench *mb)
 	if (mb->pa->use_system_threads) {
 		/* deinitialize os_thread mutex objects */
 		for (unsigned i = 0; i < mb->pa->n_locks; i++) {
-			os_rwlock_t *p = (os_rwlock_t *)&mb->locks[i];
+			auto *p = (os_rwlock_t *)&mb->locks[i];
 			os_rwlock_destroy(p);
 		}
 	}
@@ -584,7 +582,7 @@ init_bench_vmutex(struct mutex_bench *mb)
 
 	/* initialize PMEM volatile mutexes */
 	for (unsigned i = 0; i < mb->pa->n_locks; i++) {
-		PMEM_volatile_mutex *p = (PMEM_volatile_mutex *)&mb->locks[i];
+		auto *p = (PMEM_volatile_mutex *)&mb->locks[i];
 		p->volatile_pmemmutex.runid = mb->pa->runid_initial_value;
 		volatile_mutex_init(&p->volatile_pmemmutex.mutexp, nullptr);
 	}
@@ -600,7 +598,7 @@ static int
 exit_bench_vmutex(struct mutex_bench *mb)
 {
 	for (unsigned i = 0; i < mb->pa->n_locks; i++) {
-		PMEM_volatile_mutex *p = (PMEM_volatile_mutex *)&mb->locks[i];
+		auto *p = (PMEM_volatile_mutex *)&mb->locks[i];
 		volatile_mutex_destroy(mb->pop, p);
 	}
 
@@ -754,8 +752,7 @@ locks_exit(struct benchmark *bench, struct benchmark_args *args)
 	assert(bench != nullptr);
 	assert(args != nullptr);
 
-	struct mutex_bench *mb =
-		(struct mutex_bench *)pmembench_get_priv(bench);
+	auto *mb = (struct mutex_bench *)pmembench_get_priv(bench);
 	assert(mb != nullptr);
 
 	mb->ops->bench_exit(mb);
@@ -774,8 +771,7 @@ locks_exit(struct benchmark *bench, struct benchmark_args *args)
 static int
 locks_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct mutex_bench *mb =
-		(struct mutex_bench *)pmembench_get_priv(bench);
+	auto *mb = (struct mutex_bench *)pmembench_get_priv(bench);
 	assert(mb != nullptr);
 	assert(mb->pop != nullptr);
 	assert(!TOID_IS_NULL(mb->root));

--- a/src/benchmarks/obj_pmalloc.cpp
+++ b/src/benchmarks/obj_pmalloc.cpp
@@ -118,8 +118,7 @@ obj_init(struct benchmark *bench, struct benchmark_args *args)
 		return -1;
 	}
 
-	struct obj_bench *ob =
-		(struct obj_bench *)malloc(sizeof(struct obj_bench));
+	auto *ob = (struct obj_bench *)malloc(sizeof(struct obj_bench));
 	if (ob == nullptr) {
 		perror("malloc");
 		return -1;
@@ -189,8 +188,8 @@ obj_init(struct benchmark *bench, struct benchmark_args *args)
 	if (ob->pa->use_random_size) {
 		size_t width = args->dsize - ob->pa->minsize;
 		for (size_t i = 0; i < n_ops_total; i++) {
-			uint32_t hr = (uint32_t)os_rand_r(&ob->pa->seed);
-			uint32_t lr = (uint32_t)os_rand_r(&ob->pa->seed);
+			auto hr = (uint32_t)os_rand_r(&ob->pa->seed);
+			auto lr = (uint32_t)os_rand_r(&ob->pa->seed);
 			uint64_t r64 = (uint64_t)hr << 32 | lr;
 			ob->sizes[i] = r64 % width + ob->pa->minsize;
 		}
@@ -216,7 +215,7 @@ free_ob:
 static int
 obj_exit(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct obj_bench *ob = (struct obj_bench *)pmembench_get_priv(bench);
+	auto *ob = (struct obj_bench *)pmembench_get_priv(bench);
 
 	free(ob->sizes);
 
@@ -242,7 +241,7 @@ pmalloc_init(struct benchmark *bench, struct benchmark_args *args)
 static int
 pmalloc_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct obj_bench *ob = (struct obj_bench *)pmembench_get_priv(bench);
+	auto *ob = (struct obj_bench *)pmembench_get_priv(bench);
 
 	uint64_t i = info->index +
 		info->worker->index * info->args->n_ops_per_thread;
@@ -269,8 +268,8 @@ static int
 pmix_worker_init(struct benchmark *bench, struct benchmark_args *args,
 		 struct worker_info *worker)
 {
-	struct obj_bench *ob = (struct obj_bench *)pmembench_get_priv(bench);
 	struct pmix_worker *w = (struct pmix_worker *)calloc(1, sizeof(*w));
+	auto *ob = (struct obj_bench *)pmembench_get_priv(bench);
 	if (w == nullptr)
 		return -1;
 
@@ -288,7 +287,7 @@ static void
 pmix_worker_fini(struct benchmark *bench, struct benchmark_args *args,
 		 struct worker_info *worker)
 {
-	struct pmix_worker *w = (struct pmix_worker *)worker->priv;
+	auto *w = (struct pmix_worker *)worker->priv;
 	free(w);
 }
 
@@ -322,8 +321,8 @@ shuffle_objects(uint64_t *objects, size_t start, size_t nobjects,
 static int
 pmix_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct obj_bench *ob = (struct obj_bench *)pmembench_get_priv(bench);
-	struct pmix_worker *w = (struct pmix_worker *)info->worker->priv;
+	auto *ob = (struct obj_bench *)pmembench_get_priv(bench);
+	auto *w = (struct pmix_worker *)info->worker->priv;
 
 	uint64_t idx = info->worker->index * info->args->n_ops_per_thread;
 
@@ -357,7 +356,7 @@ pmix_op(struct benchmark *bench, struct operation_info *info)
 static int
 pmalloc_exit(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct obj_bench *ob = (struct obj_bench *)pmembench_get_priv(bench);
+	auto *ob = (struct obj_bench *)pmembench_get_priv(bench);
 
 	for (size_t i = 0; i < args->n_ops_per_thread * args->n_threads; i++) {
 		if (ob->offs[i])
@@ -378,7 +377,7 @@ pfree_init(struct benchmark *bench, struct benchmark_args *args)
 	if (ret)
 		return ret;
 
-	struct obj_bench *ob = (struct obj_bench *)pmembench_get_priv(bench);
+	auto *ob = (struct obj_bench *)pmembench_get_priv(bench);
 
 	for (size_t i = 0; i < args->n_ops_per_thread * args->n_threads; i++) {
 		ret = pmalloc(ob->pop, &ob->offs[i], ob->sizes[i], 0, 0);
@@ -404,7 +403,7 @@ pfree_init(struct benchmark *bench, struct benchmark_args *args)
 static int
 pfree_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct obj_bench *ob = (struct obj_bench *)pmembench_get_priv(bench);
+	auto *ob = (struct obj_bench *)pmembench_get_priv(bench);
 
 	uint64_t i = info->index +
 		info->worker->index * info->args->n_ops_per_thread;

--- a/src/benchmarks/pmem_flush.cpp
+++ b/src/benchmarks/pmem_flush.cpp
@@ -379,8 +379,7 @@ pmem_flush_init(struct benchmark *bench, struct benchmark_args *args)
 
 	uint64_t (*func_mode)(struct pmem_bench * pmb, uint64_t index);
 
-	struct pmem_bench *pmb =
-		(struct pmem_bench *)malloc(sizeof(struct pmem_bench));
+	auto *pmb = (struct pmem_bench *)malloc(sizeof(struct pmem_bench));
 	assert(pmb != nullptr);
 
 	pmb->pargs = (struct pmem_args *)args->opts;
@@ -486,7 +485,7 @@ err_free_pmb:
 static int
 pmem_flush_exit(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct pmem_bench *pmb = (struct pmem_bench *)pmembench_get_priv(bench);
+	auto *pmb = (struct pmem_bench *)pmembench_get_priv(bench);
 	pmem_unmap(pmb->pmem_addr, pmb->fsize);
 	munmap(pmb->nondirty_addr, pmb->fsize);
 	free(pmb);
@@ -499,7 +498,7 @@ pmem_flush_exit(struct benchmark *bench, struct benchmark_args *args)
 static int
 pmem_flush_operation(struct benchmark *bench, struct operation_info *info)
 {
-	struct pmem_bench *pmb = (struct pmem_bench *)pmembench_get_priv(bench);
+	auto *pmb = (struct pmem_bench *)pmembench_get_priv(bench);
 
 	size_t op_idx = info->index;
 	assert(op_idx < pmb->n_offsets);

--- a/src/benchmarks/pmem_memcpy.cpp
+++ b/src/benchmarks/pmem_memcpy.cpp
@@ -390,8 +390,7 @@ pmem_memcpy_init(struct benchmark *bench, struct benchmark_args *args)
 	size_t file_size = 0;
 	int flags = 0;
 
-	struct pmem_bench *pmb =
-		(struct pmem_bench *)malloc(sizeof(struct pmem_bench));
+	auto *pmb = (struct pmem_bench *)malloc(sizeof(struct pmem_bench));
 	assert(pmb != nullptr);
 
 	pmb->pargs = (struct pmem_args *)args->opts;
@@ -505,7 +504,7 @@ err_free_pmb:
 static int
 pmem_memcpy_operation(struct benchmark *bench, struct operation_info *info)
 {
-	struct pmem_bench *pmb = (struct pmem_bench *)pmembench_get_priv(bench);
+	auto *pmb = (struct pmem_bench *)pmembench_get_priv(bench);
 
 	size_t src_index = pmb->func_src(pmb, info);
 
@@ -527,7 +526,7 @@ pmem_memcpy_operation(struct benchmark *bench, struct operation_info *info)
 static int
 pmem_memcpy_exit(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct pmem_bench *pmb = (struct pmem_bench *)pmembench_get_priv(bench);
+	auto *pmb = (struct pmem_bench *)pmembench_get_priv(bench);
 	pmem_unmap(pmb->pmem_addr, pmb->fsize);
 	util_aligned_free(pmb->buf);
 	free(pmb->rand_offsets);

--- a/src/benchmarks/pmem_memset.cpp
+++ b/src/benchmarks/pmem_memset.cpp
@@ -254,8 +254,7 @@ warmup_msync(struct memset_bench *mb)
 static int
 memset_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct memset_bench *mb =
-		(struct memset_bench *)pmembench_get_priv(bench);
+	auto *mb = (struct memset_bench *)pmembench_get_priv(bench);
 
 	assert(info->index < mb->n_offsets);
 
@@ -289,8 +288,7 @@ memset_init(struct benchmark *bench, struct benchmark_args *args)
 	int flags = 0;
 
 	int (*warmup_func)(struct memset_bench *) = warmup_persist;
-	struct memset_bench *mb =
-		(struct memset_bench *)malloc(sizeof(struct memset_bench));
+	auto *mb = (struct memset_bench *)malloc(sizeof(struct memset_bench));
 	if (!mb) {
 		perror("malloc");
 		return -1;
@@ -384,8 +382,7 @@ err_free_mb:
 static int
 memset_exit(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct memset_bench *mb =
-		(struct memset_bench *)pmembench_get_priv(bench);
+	auto *mb = (struct memset_bench *)pmembench_get_priv(bench);
 	pmem_unmap(mb->pmem_addr, mb->fsize);
 	free(mb->offsets);
 	free(mb);

--- a/src/benchmarks/pmembench.cpp
+++ b/src/benchmarks/pmembench.cpp
@@ -360,7 +360,7 @@ pmembench_merge_clos(struct benchmark *bench)
 		nclos += bench->info->nclos;
 	}
 
-	struct benchmark_clo *clos = (struct benchmark_clo *)calloc(
+	auto *clos = (struct benchmark_clo *)calloc(
 		nclos, sizeof(struct benchmark_clo));
 	assert(clos != nullptr);
 
@@ -647,8 +647,8 @@ results_store(struct bench_results *res, struct benchmark_worker **workers,
 static int
 compare_time(const void *p1, const void *p2)
 {
-	const benchmark_time_t *t1 = (const benchmark_time_t *)p1;
-	const benchmark_time_t *t2 = (const benchmark_time_t *)p2;
+	const auto *t1 = (const benchmark_time_t *)p1;
+	const auto *t2 = (const benchmark_time_t *)p2;
 
 	return benchmark_time_compare(t1, t2);
 }
@@ -659,8 +659,8 @@ compare_time(const void *p1, const void *p2)
 static int
 compare_doubles(const void *a1, const void *b1)
 {
-	const double *a = (const double *)a1;
-	const double *b = (const double *)b1;
+	const auto *a = (const double *)a1;
+	const auto *b = (const double *)b1;
 	return (*a > *b) - (*a < *b);
 }
 
@@ -670,8 +670,8 @@ compare_doubles(const void *a1, const void *b1)
 static int
 compare_uint64t(const void *a1, const void *b1)
 {
-	const uint64_t *a = (const uint64_t *)a1;
-	const uint64_t *b = (const uint64_t *)b1;
+	const auto *a = (const uint64_t *)a1;
+	const auto *b = (const uint64_t *)b1;
 	return (*a > *b) - (*a < *b);
 }
 
@@ -749,7 +749,7 @@ get_total_results(struct total_results *tres)
 	benchmark_time_t *tend =
 		(benchmark_time_t *)malloc(tres->nthreads * sizeof(*tend));
 	assert(tend != nullptr);
-	double *totals = (double *)malloc(tres->nrepeats * sizeof(double));
+	auto *totals = (double *)malloc(tres->nrepeats * sizeof(double));
 	assert(totals != nullptr);
 
 	/* estimate total penalty of getting time from the system */
@@ -852,7 +852,7 @@ get_total_results(struct total_results *tres)
 	assert(count > 0);
 	tres->latency.avg /= count;
 
-	uint64_t *ntotals = (uint64_t *)calloc(count, sizeof(uint64_t));
+	auto *ntotals = (uint64_t *)calloc(count, sizeof(uint64_t));
 	assert(ntotals != nullptr);
 	count = 0;
 

--- a/src/benchmarks/pmemobj_atomic_lists.cpp
+++ b/src/benchmarks/pmemobj_atomic_lists.cpp
@@ -316,7 +316,7 @@ static fn_position_t rand_positions[] = {position_head, position_tail,
 static void
 get_item(struct benchmark *bench, struct operation_info *info)
 {
-	struct obj_worker *obj_worker = (struct obj_worker *)info->worker->priv;
+	auto *obj_worker = (struct obj_worker *)info->worker->priv;
 	obj_worker->elm = obj_bench.fn_position(obj_worker, info->index);
 }
 
@@ -328,7 +328,7 @@ get_item(struct benchmark *bench, struct operation_info *info)
 static int
 get_move_item(struct benchmark *bench, struct operation_info *info)
 {
-	struct obj_worker *obj_worker = (struct obj_worker *)info->worker->priv;
+	auto *obj_worker = (struct obj_worker *)info->worker->priv;
 	obj_worker->list_move->elm =
 		obj_bench.fn_position(obj_worker->list_move, info->index);
 
@@ -360,7 +360,7 @@ static int
 obj_init_list(struct worker_info *worker, size_t n_oids, size_t list_len)
 {
 	size_t i;
-	struct obj_worker *obj_worker = (struct obj_worker *)worker->priv;
+	auto *obj_worker = (struct obj_worker *)worker->priv;
 	obj_worker->oids =
 		(TOID(struct item) *)calloc(n_oids, sizeof(TOID(struct item)));
 	if (obj_worker->oids == nullptr) {
@@ -370,7 +370,7 @@ obj_init_list(struct worker_info *worker, size_t n_oids, size_t list_len)
 	for (i = 0; i < n_oids; i++) {
 		size_t type_num = obj_bench.fn_type_num(worker->index, i);
 		size_t size = obj_bench.alloc_sizes[i];
-		PMEMoid *tmp = (PMEMoid *)&obj_worker->oids[i];
+		auto *tmp = (PMEMoid *)&obj_worker->oids[i];
 		if (pmemobj_alloc(obj_bench.pop, tmp, size, type_num, nullptr,
 				  nullptr) != 0)
 			goto err_oids;
@@ -395,7 +395,7 @@ static int
 queue_init_list(struct worker_info *worker, size_t n_items, size_t list_len)
 {
 	size_t i;
-	struct obj_worker *obj_worker = (struct obj_worker *)worker->priv;
+	auto *obj_worker = (struct obj_worker *)worker->priv;
 	CIRCLEQ_INIT(&obj_worker->headq);
 	obj_worker->items =
 		(struct item **)malloc(n_items * sizeof(struct item *));
@@ -487,8 +487,8 @@ queue_free_worker_items(struct obj_worker *obj_worker)
 static fn_position_t *
 random_positions(void)
 {
-	fn_position_t *positions = (fn_position_t *)calloc(
-		obj_bench.max_len, sizeof(fn_position_t));
+	auto *positions = (fn_position_t *)calloc(obj_bench.max_len,
+						  sizeof(fn_position_t));
 	if (positions == nullptr) {
 		perror("calloc");
 		return nullptr;
@@ -514,7 +514,7 @@ random_positions(void)
 static size_t *
 random_values(size_t min, size_t max, size_t n_ops, size_t min_range)
 {
-	size_t *randoms = (size_t *)calloc(n_ops, sizeof(size_t));
+	auto *randoms = (size_t *)calloc(n_ops, sizeof(size_t));
 	if (randoms == nullptr) {
 		perror("calloc");
 		return nullptr;
@@ -539,7 +539,7 @@ random_values(size_t min, size_t max, size_t n_ops, size_t min_range)
 static int
 queue_insert_op(struct operation_info *info)
 {
-	struct obj_worker *obj_worker = (struct obj_worker *)info->worker->priv;
+	auto *obj_worker = (struct obj_worker *)info->worker->priv;
 	CIRCLEQ_INSERT_AFTER(&obj_worker->headq, obj_worker->elm.itemq,
 			     obj_worker->items[info->index + obj_bench.min_len],
 			     fieldq);
@@ -553,7 +553,7 @@ queue_insert_op(struct operation_info *info)
 static int
 obj_insert_op(struct operation_info *info)
 {
-	struct obj_worker *obj_worker = (struct obj_worker *)info->worker->priv;
+	auto *obj_worker = (struct obj_worker *)info->worker->priv;
 	POBJ_LIST_INSERT_AFTER(
 		obj_bench.pop, &obj_worker->head, obj_worker->elm.itemp,
 		obj_worker->oids[info->index + obj_bench.min_len], field);
@@ -567,7 +567,7 @@ obj_insert_op(struct operation_info *info)
 static int
 queue_remove_op(struct operation_info *info)
 {
-	struct obj_worker *obj_worker = (struct obj_worker *)info->worker->priv;
+	auto *obj_worker = (struct obj_worker *)info->worker->priv;
 	CIRCLEQ_REMOVE(&obj_worker->headq, obj_worker->elm.itemq, fieldq);
 	return 0;
 }
@@ -579,7 +579,7 @@ queue_remove_op(struct operation_info *info)
 static int
 obj_remove_op(struct operation_info *info)
 {
-	struct obj_worker *obj_worker = (struct obj_worker *)info->worker->priv;
+	auto *obj_worker = (struct obj_worker *)info->worker->priv;
 	POBJ_LIST_REMOVE(obj_bench.pop, &obj_worker->head,
 			 obj_worker->elm.itemp, field);
 	return 0;
@@ -605,7 +605,7 @@ obj_insert_new_op(struct benchmark *bench, struct operation_info *info)
 {
 	get_item(bench, info);
 
-	struct obj_worker *obj_worker = (struct obj_worker *)info->worker->priv;
+	auto *obj_worker = (struct obj_worker *)info->worker->priv;
 	PMEMoid tmp;
 	size_t size = obj_bench.alloc_sizes[info->index];
 	size_t type_num =
@@ -643,7 +643,7 @@ obj_remove_free_op(struct benchmark *bench, struct operation_info *info)
 {
 	get_item(bench, info);
 
-	struct obj_worker *obj_worker = (struct obj_worker *)info->worker->priv;
+	auto *obj_worker = (struct obj_worker *)info->worker->priv;
 	POBJ_LIST_REMOVE_FREE(obj_bench.pop, &obj_worker->head,
 			      obj_worker->elm.itemp, field);
 	return 0;
@@ -658,7 +658,7 @@ obj_move_op(struct benchmark *bench, struct operation_info *info)
 	if (get_move_item(bench, info))
 		return -1;
 
-	struct obj_worker *obj_worker = (struct obj_worker *)info->worker->priv;
+	auto *obj_worker = (struct obj_worker *)info->worker->priv;
 	POBJ_LIST_MOVE_ELEMENT_BEFORE(obj_bench.pop, &obj_worker->head,
 				      &obj_worker->list_move->head,
 				      obj_worker->list_move->elm.itemp,
@@ -685,7 +685,7 @@ static void
 free_worker_list(struct benchmark *bench, struct benchmark_args *args,
 		 struct worker_info *worker)
 {
-	struct obj_worker *obj_worker = (struct obj_worker *)worker->priv;
+	auto *obj_worker = (struct obj_worker *)worker->priv;
 	obj_bench.args->queue ? queue_free_worker_list(obj_worker)
 			      : obj_free_worker_list(obj_worker);
 	free_worker(obj_worker);
@@ -700,8 +700,8 @@ static void
 free_worker_items(struct benchmark *bench, struct benchmark_args *args,
 		  struct worker_info *worker)
 {
-	struct obj_worker *obj_worker = (struct obj_worker *)worker->priv;
-	struct obj_list_args *obj_args = (struct obj_list_args *)args->opts;
+	auto *obj_worker = (struct obj_worker *)worker->priv;
+	auto *obj_args = (struct obj_list_args *)args->opts;
 	obj_args->queue ? queue_free_worker_items(obj_worker)
 			: obj_free_worker_items(obj_worker);
 	free_worker(obj_worker);
@@ -715,7 +715,7 @@ static void
 obj_move_free_worker(struct benchmark *bench, struct benchmark_args *args,
 		     struct worker_info *worker)
 {
-	struct obj_worker *obj_worker = (struct obj_worker *)worker->priv;
+	auto *obj_worker = (struct obj_worker *)worker->priv;
 	while (!POBJ_LIST_EMPTY(&obj_worker->list_move->head))
 		POBJ_LIST_REMOVE_FREE(
 			obj_bench.pop, &obj_worker->list_move->head,
@@ -735,7 +735,7 @@ obj_move_free_worker(struct benchmark *bench, struct benchmark_args *args,
 static int
 obj_init_worker(struct worker_info *worker, size_t n_elm, size_t list_len)
 {
-	struct obj_worker *obj_worker =
+	auto *obj_worker =
 		(struct obj_worker *)calloc(1, sizeof(struct obj_worker));
 	if (obj_worker == nullptr) {
 		perror("calloc");
@@ -805,7 +805,7 @@ obj_move_init_worker(struct benchmark *bench, struct benchmark_args *args,
 	if (obj_init_worker(worker, obj_bench.max_len, obj_bench.max_len) != 0)
 		return -1;
 
-	struct obj_worker *obj_worker = (struct obj_worker *)worker->priv;
+	auto *obj_worker = (struct obj_worker *)worker->priv;
 	obj_worker->list_move =
 		(struct obj_worker *)calloc(1, sizeof(struct obj_worker));
 	if (obj_worker->list_move == nullptr) {

--- a/src/benchmarks/pmemobj_gen.cpp
+++ b/src/benchmarks/pmemobj_gen.cpp
@@ -252,7 +252,7 @@ static size_t *
 rand_sizes(size_t min, size_t max, size_t n_ops)
 {
 	assert(n_ops != 0);
-	size_t *rand_sizes = (size_t *)malloc(n_ops * sizeof(size_t));
+	auto *rand_sizes = (size_t *)malloc(n_ops * sizeof(size_t));
 	if (rand_sizes == nullptr) {
 		perror("malloc");
 		return nullptr;
@@ -296,7 +296,7 @@ pobj_init(struct benchmark *bench, struct benchmark_args *args)
 	assert(bench != nullptr);
 	assert(args != nullptr);
 
-	struct pobj_bench *bench_priv =
+	auto *bench_priv =
 		(struct pobj_bench *)malloc(sizeof(struct pobj_bench));
 	if (bench_priv == nullptr) {
 		perror("malloc");
@@ -453,7 +453,7 @@ free_bench_priv:
 static int
 pobj_direct_init(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct pobj_args *pa = (struct pobj_args *)args->opts;
+	auto *pa = (struct pobj_args *)args->opts;
 	pa->n_objs = pa->one_obj ? 1 : args->n_ops_per_thread;
 	if (pobj_init(bench, args) != 0)
 		return -1;
@@ -467,8 +467,7 @@ static int
 pobj_exit(struct benchmark *bench, struct benchmark_args *args)
 {
 	size_t i;
-	struct pobj_bench *bench_priv =
-		(struct pobj_bench *)pmembench_get_priv(bench);
+	auto *bench_priv = (struct pobj_bench *)pmembench_get_priv(bench);
 	if (bench_priv->n_pools > 1) {
 		for (i = 0; i < bench_priv->n_pools; i++) {
 			pmemobj_close(bench_priv->pop[i]);
@@ -493,10 +492,8 @@ pobj_init_worker(struct benchmark *bench, struct benchmark_args *args,
 		 struct worker_info *worker)
 {
 	size_t i, idx = worker->index;
-	struct pobj_bench *bench_priv =
-		(struct pobj_bench *)pmembench_get_priv(bench);
-	struct pobj_worker *pw =
-		(struct pobj_worker *)calloc(1, sizeof(struct pobj_worker));
+	auto *bench_priv = (struct pobj_bench *)pmembench_get_priv(bench);
+	auto *pw = (struct pobj_worker *)calloc(1, sizeof(struct pobj_worker));
 	if (pw == nullptr) {
 		perror("calloc");
 		return -1;
@@ -536,9 +533,8 @@ out:
 static int
 pobj_direct_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct pobj_bench *bench_priv =
-		(struct pobj_bench *)pmembench_get_priv(bench);
-	struct pobj_worker *pw = (struct pobj_worker *)info->worker->priv;
+	auto *bench_priv = (struct pobj_bench *)pmembench_get_priv(bench);
+	auto *pw = (struct pobj_worker *)info->worker->priv;
 	size_t idx = bench_priv->obj(info->index);
 	if (pmemobj_direct(pw->oids[idx]) == nullptr)
 		return -1;
@@ -551,8 +547,7 @@ pobj_direct_op(struct benchmark *bench, struct operation_info *info)
 static int
 pobj_open_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct pobj_bench *bench_priv =
-		(struct pobj_bench *)pmembench_get_priv(bench);
+	auto *bench_priv = (struct pobj_bench *)pmembench_get_priv(bench);
 	size_t idx = bench_priv->pool(info->worker->index);
 	pmemobj_close(bench_priv->pop[idx]);
 	bench_priv->pop[idx] = pmemobj_open(bench_priv->sets[idx], LAYOUT_NAME);
@@ -568,9 +563,8 @@ static void
 pobj_free_worker(struct benchmark *bench, struct benchmark_args *args,
 		 struct worker_info *worker)
 {
-	struct pobj_worker *pw = (struct pobj_worker *)worker->priv;
-	struct pobj_bench *bench_priv =
-		(struct pobj_bench *)pmembench_get_priv(bench);
+	auto *pw = (struct pobj_worker *)worker->priv;
+	auto *bench_priv = (struct pobj_bench *)pmembench_get_priv(bench);
 	for (size_t i = 0; i < bench_priv->args_priv->n_objs; i++)
 		pmemobj_free(&pw->oids[i]);
 	free(pw->oids);

--- a/src/benchmarks/pmemobj_persist.cpp
+++ b/src/benchmarks/pmemobj_persist.cpp
@@ -150,7 +150,7 @@ do_warmup(struct obj_bench *ob)
 static int
 obj_persist_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct obj_bench *ob = (struct obj_bench *)pmembench_get_priv(bench);
+	auto *ob = (struct obj_bench *)pmembench_get_priv(bench);
 	uint64_t idx = info->worker->index * info->args->n_ops_per_thread +
 		info->index;
 
@@ -173,15 +173,14 @@ obj_persist_init(struct benchmark *bench, struct benchmark_args *args)
 	assert(args != nullptr);
 	assert(args->opts != nullptr);
 
-	struct prog_args *pa = (struct prog_args *)args->opts;
+	auto *pa = (struct prog_args *)args->opts;
 	size_t poolsize;
 	if (pa->minsize >= args->dsize) {
 		fprintf(stderr, "Wrong params - allocation size\n");
 		return -1;
 	}
 
-	struct obj_bench *ob =
-		(struct obj_bench *)malloc(sizeof(struct obj_bench));
+	auto *ob = (struct obj_bench *)malloc(sizeof(struct obj_bench));
 	if (ob == nullptr) {
 		perror("malloc");
 		return -1;
@@ -247,7 +246,7 @@ free_ob:
 static int
 obj_persist_exit(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct obj_bench *ob = (struct obj_bench *)pmembench_get_priv(bench);
+	auto *ob = (struct obj_bench *)pmembench_get_priv(bench);
 
 	for (uint64_t i = 0; i < ob->nobjs; ++i) {
 		pmemobj_free(&ob->oids[i]);

--- a/src/benchmarks/pmemobj_tx.cpp
+++ b/src/benchmarks/pmemobj_tx.cpp
@@ -256,7 +256,7 @@ static int
 alloc_dram(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 	   size_t idx)
 {
-	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
+	auto *obj_worker = (struct obj_tx_worker *)worker->priv;
 	obj_worker->items[idx] = (char *)malloc(obj_bench->sizes[idx]);
 	if (obj_worker->items[idx] == nullptr) {
 		perror("malloc");
@@ -273,7 +273,7 @@ alloc_pmem(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 	   size_t idx)
 {
 	size_t type_num = obj_bench->fn_type_num(obj_bench, worker->index, idx);
-	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
+	auto *obj_worker = (struct obj_tx_worker *)worker->priv;
 	if (pmemobj_alloc(obj_bench->pop, &obj_worker->oids[idx].oid,
 			  obj_bench->sizes[idx], type_num, nullptr,
 			  nullptr) != 0) {
@@ -290,7 +290,7 @@ static int
 alloc_tx(struct obj_tx_bench *obj_bench, struct worker_info *worker, size_t idx)
 {
 	size_t type_num = obj_bench->fn_type_num(obj_bench, worker->index, idx);
-	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
+	auto *obj_worker = (struct obj_tx_worker *)worker->priv;
 	obj_worker->oids[idx].oid = pmemobj_tx_xalloc(
 		obj_bench->sizes[idx], type_num, POBJ_XALLOC_NO_FLUSH);
 	if (OID_IS_NULL(obj_worker->oids[idx].oid)) {
@@ -307,7 +307,7 @@ static int
 free_dram(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 	  size_t idx)
 {
-	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
+	auto *obj_worker = (struct obj_tx_worker *)worker->priv;
 	free(obj_worker->items[idx]);
 	return 0;
 }
@@ -319,7 +319,7 @@ static int
 free_pmem(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 	  size_t idx)
 {
-	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
+	auto *obj_worker = (struct obj_tx_worker *)worker->priv;
 	POBJ_FREE(&obj_worker->oids[idx]);
 	return 0;
 }
@@ -330,7 +330,7 @@ free_pmem(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 static int
 free_tx(struct obj_tx_bench *obj_bench, struct worker_info *worker, size_t idx)
 {
-	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
+	auto *obj_worker = (struct obj_tx_worker *)worker->priv;
 	TX_FREE(obj_worker->oids[idx]);
 	return 0;
 }
@@ -352,8 +352,8 @@ static int
 realloc_dram(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 	     size_t idx)
 {
-	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
-	char *tmp = (char *)realloc(obj_worker->items[idx],
+	auto *obj_worker = (struct obj_tx_worker *)worker->priv;
+	auto *tmp = (char *)realloc(obj_worker->items[idx],
 				    obj_bench->resizes[idx]);
 	if (tmp == nullptr) {
 		perror("realloc");
@@ -370,7 +370,7 @@ static int
 realloc_pmem(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 	     size_t idx)
 {
-	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
+	auto *obj_worker = (struct obj_tx_worker *)worker->priv;
 	size_t type_num = obj_bench->fn_type_num(obj_bench, worker->index, idx);
 	if (obj_bench->obj_args->change_type)
 		type_num++;
@@ -389,7 +389,7 @@ static int
 realloc_tx(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 	   size_t idx)
 {
-	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
+	auto *obj_worker = (struct obj_tx_worker *)worker->priv;
 	size_t type_num = obj_bench->fn_type_num(obj_bench, worker->index, idx);
 	if (obj_bench->obj_args->change_type)
 		type_num++;
@@ -410,7 +410,7 @@ add_range_nested_tx(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 		    size_t idx)
 {
 	int ret = 0;
-	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
+	auto *obj_worker = (struct obj_tx_worker *)worker->priv;
 	TX_BEGIN(obj_bench->pop)
 	{
 		if (obj_bench->obj_args->n_ops != obj_worker->tx_level) {
@@ -441,7 +441,7 @@ add_range_tx(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 {
 	int ret = 0;
 	size_t i = 0;
-	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
+	auto *obj_worker = (struct obj_tx_worker *)worker->priv;
 	TX_BEGIN(obj_bench->pop)
 	{
 		for (i = 0; i < obj_bench->obj_args->n_ops; i++) {
@@ -469,7 +469,7 @@ obj_op_sim(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 	   size_t idx)
 {
 	int ret = 0;
-	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
+	auto *obj_worker = (struct obj_tx_worker *)worker->priv;
 	if (obj_worker->max_level == obj_worker->tx_level) {
 		ret = obj_bench->fn_op[obj_bench->lib_op](obj_bench, worker,
 							  idx);
@@ -488,7 +488,7 @@ obj_op_tx(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 	  size_t idx)
 {
 	volatile int ret = 0;
-	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
+	auto *obj_worker = (struct obj_tx_worker *)worker->priv;
 	TX_BEGIN(obj_bench->pop)
 	{
 		if (obj_worker->max_level == obj_worker->tx_level) {
@@ -685,7 +685,7 @@ static size_t *
 rand_values(size_t min, size_t max, size_t n_ops)
 {
 	size_t size = max - min;
-	size_t *sizes = (size_t *)calloc(n_ops, sizeof(size_t));
+	auto *sizes = (size_t *)calloc(n_ops, sizeof(size_t));
 	if (sizes == nullptr) {
 		perror("calloc");
 		return nullptr;
@@ -710,10 +710,8 @@ rand_values(size_t min, size_t max, size_t n_ops)
 static int
 obj_tx_add_range_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct obj_tx_bench *obj_bench =
-		(struct obj_tx_bench *)pmembench_get_priv(bench);
-	struct obj_tx_worker *obj_worker =
-		(struct obj_tx_worker *)info->worker->priv;
+	auto *obj_bench = (struct obj_tx_bench *)pmembench_get_priv(bench);
+	auto *obj_worker = (struct obj_tx_worker *)info->worker->priv;
 	if (add_range_op[obj_bench->lib_op](obj_bench, info->worker,
 					    info->index) != 0)
 		return -1;
@@ -728,10 +726,8 @@ obj_tx_add_range_op(struct benchmark *bench, struct operation_info *info)
 static int
 obj_tx_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct obj_tx_bench *obj_bench =
-		(struct obj_tx_bench *)pmembench_get_priv(bench);
-	struct obj_tx_worker *obj_worker =
-		(struct obj_tx_worker *)info->worker->priv;
+	auto *obj_bench = (struct obj_tx_bench *)pmembench_get_priv(bench);
+	auto *obj_worker = (struct obj_tx_worker *)info->worker->priv;
 	int ret = nestings[obj_bench->nesting_mode](obj_bench, info->worker,
 						    info->index);
 	obj_worker->tx_level = 0;
@@ -746,9 +742,8 @@ static int
 obj_tx_init_worker(struct benchmark *bench, struct benchmark_args *args,
 		   struct worker_info *worker)
 {
-	struct obj_tx_bench *obj_bench =
-		(struct obj_tx_bench *)pmembench_get_priv(bench);
-	struct obj_tx_worker *obj_worker =
+	auto *obj_bench = (struct obj_tx_bench *)pmembench_get_priv(bench);
+	auto *obj_worker =
 		(struct obj_tx_worker *)calloc(1, sizeof(struct obj_tx_worker));
 	if (obj_worker == nullptr) {
 		perror("calloc");
@@ -785,9 +780,8 @@ obj_tx_init_worker_alloc_obj(struct benchmark *bench,
 	if (obj_tx_init_worker(bench, args, worker) != 0)
 		return -1;
 
-	struct obj_tx_bench *obj_bench =
-		(struct obj_tx_bench *)pmembench_get_priv(bench);
-	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
+	auto *obj_bench = (struct obj_tx_bench *)pmembench_get_priv(bench);
+	auto *obj_worker = (struct obj_tx_worker *)worker->priv;
 	for (i = 0; i < obj_bench->n_objs; i++) {
 		if (alloc_op[obj_bench->lib_mode](obj_bench, worker, i) != 0)
 			goto out;
@@ -811,9 +805,8 @@ static void
 obj_tx_exit_worker(struct benchmark *bench, struct benchmark_args *args,
 		   struct worker_info *worker)
 {
-	struct obj_tx_bench *obj_bench =
-		(struct obj_tx_bench *)pmembench_get_priv(bench);
-	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
+	auto *obj_bench = (struct obj_tx_bench *)pmembench_get_priv(bench);
+	auto *obj_worker = (struct obj_tx_worker *)worker->priv;
 	for (unsigned i = 0; i < obj_bench->n_objs; i++)
 		free_op[obj_bench->lib_op_free](obj_bench, worker, i);
 
@@ -831,15 +824,14 @@ obj_tx_exit_worker(struct benchmark *bench, struct benchmark_args *args,
 static int
 obj_tx_add_range_init(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct obj_tx_args *obj_args = (struct obj_tx_args *)args->opts;
+	auto *obj_args = (struct obj_tx_args *)args->opts;
 	obj_args->parse_mode = PARSE_OP_MODE_ADD_RANGE;
 	if (args->n_ops_per_thread > MAX_OPS)
 		args->n_ops_per_thread = MAX_OPS;
 	if (obj_tx_init(bench, args) != 0)
 		return -1;
 
-	struct obj_tx_bench *obj_bench =
-		(struct obj_tx_bench *)pmembench_get_priv(bench);
+	auto *obj_bench = (struct obj_tx_bench *)pmembench_get_priv(bench);
 
 	obj_bench->n_oid = diff_num;
 	if (obj_bench->op_mode < OP_MODE_ALL_OBJ) {
@@ -871,8 +863,7 @@ obj_tx_free_init(struct benchmark *bench, struct benchmark_args *args)
 	if (obj_tx_init(bench, args) != 0)
 		return -1;
 
-	struct obj_tx_bench *obj_bench =
-		(struct obj_tx_bench *)pmembench_get_priv(bench);
+	auto *obj_bench = (struct obj_tx_bench *)pmembench_get_priv(bench);
 	obj_bench->fn_op = free_op;
 
 	/*
@@ -898,8 +889,7 @@ obj_tx_alloc_init(struct benchmark *bench, struct benchmark_args *args)
 	if (obj_tx_init(bench, args) != 0)
 		return -1;
 
-	struct obj_tx_bench *obj_bench =
-		(struct obj_tx_bench *)pmembench_get_priv(bench);
+	auto *obj_bench = (struct obj_tx_bench *)pmembench_get_priv(bench);
 	obj_bench->fn_op = alloc_op;
 
 	/*
@@ -923,8 +913,7 @@ obj_tx_realloc_init(struct benchmark *bench, struct benchmark_args *args)
 	if (obj_tx_init(bench, args) != 0)
 		return -1;
 
-	struct obj_tx_bench *obj_bench =
-		(struct obj_tx_bench *)pmembench_get_priv(bench);
+	auto *obj_bench = (struct obj_tx_bench *)pmembench_get_priv(bench);
 	obj_bench->resizes =
 		rand_values(obj_bench->obj_args->min_rsize,
 			    obj_bench->obj_args->rsize, args->n_ops_per_thread);
@@ -1054,8 +1043,7 @@ free_random_types:
 int
 obj_tx_exit(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct obj_tx_bench *obj_bench =
-		(struct obj_tx_bench *)pmembench_get_priv(bench);
+	auto *obj_bench = (struct obj_tx_bench *)pmembench_get_priv(bench);
 	if (obj_bench->lib_mode != LIB_MODE_DRAM)
 		pmemobj_close(obj_bench->pop);
 
@@ -1072,8 +1060,7 @@ obj_tx_exit(struct benchmark *bench, struct benchmark_args *args)
 static int
 obj_tx_realloc_exit(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct obj_tx_bench *obj_bench =
-		(struct obj_tx_bench *)pmembench_get_priv(bench);
+	auto *obj_bench = (struct obj_tx_bench *)pmembench_get_priv(bench);
 	free(obj_bench->resizes);
 	return obj_tx_exit(bench, args);
 }

--- a/src/benchmarks/rpmem_persist.cpp
+++ b/src/benchmarks/rpmem_persist.cpp
@@ -210,8 +210,7 @@ do_warmup(struct rpmem_bench *mb)
 static int
 rpmem_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct rpmem_bench *mb =
-		(struct rpmem_bench *)pmembench_get_priv(bench);
+	auto *mb = (struct rpmem_bench *)pmembench_get_priv(bench);
 
 	assert(info->index < mb->n_offsets);
 
@@ -456,8 +455,7 @@ rpmem_init(struct benchmark *bench, struct benchmark_args *args)
 	assert(args != nullptr);
 	assert(args->opts != nullptr);
 
-	struct rpmem_bench *mb =
-		(struct rpmem_bench *)malloc(sizeof(struct rpmem_bench));
+	auto *mb = (struct rpmem_bench *)malloc(sizeof(struct rpmem_bench));
 	if (!mb) {
 		perror("malloc");
 		return -1;
@@ -510,8 +508,7 @@ err_parse_mode:
 static int
 rpmem_exit(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct rpmem_bench *mb =
-		(struct rpmem_bench *)pmembench_get_priv(bench);
+	auto *mb = (struct rpmem_bench *)pmembench_get_priv(bench);
 	rpmem_poolset_fini(mb);
 	free(mb->offsets);
 	free(mb);

--- a/src/benchmarks/vmem.cpp
+++ b/src/benchmarks/vmem.cpp
@@ -204,7 +204,7 @@ static int
 vmem_create_pools(struct vmem_bench *vb, struct benchmark_args *args)
 {
 	unsigned i;
-	struct vmem_args *va = (struct vmem_args *)args->opts;
+	auto *va = (struct vmem_args *)args->opts;
 	size_t dsize = args->dsize + va->rsize;
 	vb->pool_size =
 		dsize * args->n_ops_per_thread * args->n_threads / vb->npools;
@@ -287,7 +287,7 @@ vmem_do_warmup(struct vmem_bench *vb, struct benchmark_args *args)
 static int
 malloc_main_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct vmem_bench *vb = (struct vmem_bench *)pmembench_get_priv(bench);
+	auto *vb = (struct vmem_bench *)pmembench_get_priv(bench);
 	return malloc_op[vb->lib_mode](vb, info->worker->index, info->index);
 }
 
@@ -297,7 +297,7 @@ malloc_main_op(struct benchmark *bench, struct operation_info *info)
 static int
 free_main_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct vmem_bench *vb = (struct vmem_bench *)pmembench_get_priv(bench);
+	auto *vb = (struct vmem_bench *)pmembench_get_priv(bench);
 	return free_op[vb->lib_mode](vb, info->worker->index, info->index);
 }
 
@@ -307,7 +307,7 @@ free_main_op(struct benchmark *bench, struct operation_info *info)
 static int
 realloc_main_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct vmem_bench *vb = (struct vmem_bench *)pmembench_get_priv(bench);
+	auto *vb = (struct vmem_bench *)pmembench_get_priv(bench);
 	return realloc_op[vb->lib_mode](vb, info->worker->index, info->index);
 }
 
@@ -317,7 +317,7 @@ realloc_main_op(struct benchmark *bench, struct operation_info *info)
 static int
 vmem_mix_op(struct benchmark *bench, struct operation_info *info)
 {
-	struct vmem_bench *vb = (struct vmem_bench *)pmembench_get_priv(bench);
+	auto *vb = (struct vmem_bench *)pmembench_get_priv(bench);
 	unsigned idx = vb->mix_ops[info->index];
 	free_op[vb->lib_mode](vb, info->worker->index, idx);
 	return malloc_op[vb->lib_mode](vb, info->worker->index, idx);
@@ -392,8 +392,8 @@ static int
 vmem_init_worker(struct benchmark *bench, struct benchmark_args *args,
 		 struct worker_info *worker)
 {
-	struct vmem_args *va = (struct vmem_args *)args->opts;
-	struct vmem_bench *vb = (struct vmem_bench *)pmembench_get_priv(bench);
+	auto *va = (struct vmem_args *)args->opts;
+	auto *vb = (struct vmem_bench *)pmembench_get_priv(bench);
 	int ret = va->mix ? vmem_init_worker_alloc_mix(vb, args, worker)
 			  : vmem_init_worker_alloc(vb, args, worker);
 	return ret;
@@ -406,8 +406,8 @@ static int
 vmem_exit(struct benchmark *bench, struct benchmark_args *args)
 {
 	unsigned i;
-	struct vmem_bench *vb = (struct vmem_bench *)pmembench_get_priv(bench);
-	struct vmem_args *va = (struct vmem_args *)args->opts;
+	auto *vb = (struct vmem_bench *)pmembench_get_priv(bench);
+	auto *va = (struct vmem_args *)args->opts;
 	if (!va->stdlib_alloc) {
 		for (i = 0; i < vb->npools; i++) {
 			vmem_delete(vb->pools[i]);
@@ -432,7 +432,7 @@ vmem_exit(struct benchmark *bench, struct benchmark_args *args)
 static int
 vmem_exit_free(struct benchmark *bench, struct benchmark_args *args)
 {
-	struct vmem_bench *vb = (struct vmem_bench *)pmembench_get_priv(bench);
+	auto *vb = (struct vmem_bench *)pmembench_get_priv(bench);
 	for (unsigned i = 0; i < args->n_threads; i++) {
 		for (size_t j = 0; j < args->n_ops_per_thread; j++) {
 			free_op[vb->lib_mode](vb, i, j);
@@ -452,15 +452,14 @@ vmem_init(struct benchmark *bench, struct benchmark_args *args)
 	assert(bench != nullptr);
 	assert(args != nullptr);
 
-	struct vmem_bench *vb =
-		(struct vmem_bench *)calloc(1, sizeof(struct vmem_bench));
+	auto *vb = (struct vmem_bench *)calloc(1, sizeof(struct vmem_bench));
 	if (vb == nullptr) {
 		perror("malloc");
 		return -1;
 	}
 	pmembench_set_priv(bench, vb);
 	struct vmem_worker *vw;
-	struct vmem_args *va = (struct vmem_args *)args->opts;
+	auto *va = (struct vmem_args *)args->opts;
 	vb->alloc_sizes = nullptr;
 	vb->lib_mode = va->stdlib_alloc ? STDLIB_MODE : VMEM_MODE;
 
@@ -557,8 +556,8 @@ vmem_realloc_init(struct benchmark *bench, struct benchmark_args *args)
 	if (vmem_init(bench, args) != 0)
 		return -1;
 
-	struct vmem_bench *vb = (struct vmem_bench *)pmembench_get_priv(bench);
-	struct vmem_args *va = (struct vmem_args *)args->opts;
+	auto *vb = (struct vmem_bench *)pmembench_get_priv(bench);
+	auto *va = (struct vmem_args *)args->opts;
 	vb->rand_realloc = va->min_rsize != -1;
 
 	if (vb->rand_realloc && va->min_rsize > va->rsize) {
@@ -593,7 +592,7 @@ vmem_mix_init(struct benchmark *bench, struct benchmark_args *args)
 
 	size_t i;
 	unsigned idx, tmp;
-	struct vmem_bench *vb = (struct vmem_bench *)pmembench_get_priv(bench);
+	auto *vb = (struct vmem_bench *)pmembench_get_priv(bench);
 	if ((vb->mix_ops = (unsigned *)calloc(args->n_ops_per_thread,
 					      sizeof(unsigned))) == nullptr) {
 		perror("calloc");


### PR DESCRIPTION
Intention of this PR is improve a readability and maintenance of cpp code.
C+11 introduce auto specifier. 
When a variable is declared and initialized with a cast, the variable type is written two times: in the declaration type and in the cast expression. In this cases, the declaration type can be replaced with auto.
Variable type is present on the right side on initialization so IMHO there is no need to repeat it when auto specifier is available.
In any case any feedback will be appreciated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2859)
<!-- Reviewable:end -->
