### PR TITLE
common: use macro parentheses

### DIFF
--- a/src/benchmarks/benchmark.hpp
+++ b/src/benchmarks/benchmark.hpp
@@ -343,9 +343,9 @@ struct benchmark_info *pmembench_get_info(struct benchmark *bench);
 int pmembench_register(struct benchmark_info *bench_info);
 
 #define REGISTER_BENCHMARK(bench)                                              \
-	if (pmembench_register(&bench)) {                                      \
+	if (pmembench_register(&(bench))) {                                    \
 		fprintf(stderr, "Unable to register benchmark '%s'\n",         \
-			bench.name);                                           \
+			(bench).name);                                         \
 	}
 
 #endif /* _BENCHMARK_H */

--- a/src/benchmarks/config_reader_win.cpp
+++ b/src/benchmarks/config_reader_win.cpp
@@ -57,7 +57,7 @@
 #define KV_LIST_EMPTY(x) (_tcslen(x) == 0)
 #define KV_FIRST(x)
 #define KV_LIST_NEXT(x)                                                        \
-	((x) += (_tcslen(x) + 1), x += (_tcslen(x) + 1),                       \
+	((x) += (_tcslen(x) + 1), (x) += (_tcslen(x) + 1),                     \
 	 (x) = kv_list_skip_comment(x))
 
 #define KV_LIST_KEY(x) (x)

--- a/src/common/queue.h
+++ b/src/common/queue.h
@@ -150,7 +150,7 @@ struct {								\
 } while (/*CONSTCOND*/0)
 
 #define	LIST_REMOVE(elm, field) do {					\
-	ANALYZER_ASSERT(elm != NULL);					\
+	ANALYZER_ASSERT((elm) != NULL);					\
 	if ((elm)->field.le_next != NULL)				\
 		(elm)->field.le_next->field.le_prev = 			\
 		    (elm)->field.le_prev;				\
@@ -450,7 +450,7 @@ struct {								\
 } while (/*CONSTCOND*/0)
 
 #define	TAILQ_REMOVE(head, elm, field) do {				\
-	ANALYZER_ASSERT(elm != NULL);					\
+	ANALYZER_ASSERT((elm) != NULL);					\
 	if (((elm)->field.tqe_next) != NULL)				\
 		(elm)->field.tqe_next->field.tqe_prev = 		\
 		    (elm)->field.tqe_prev;				\
@@ -501,7 +501,7 @@ struct name {								\
 }
 
 #define	CIRCLEQ_HEAD_INITIALIZER(head)					\
-	{ (void *)&head, (void *)&head }
+	{ (void *)&(head), (void *)&(head) }
 
 #define	CIRCLEQ_ENTRY(type)						\
 struct {								\
@@ -592,11 +592,11 @@ struct {								\
 #define CIRCLEQ_LOOP_NEXT(head, elm, field)				\
 	(((elm)->field.cqe_next == (void *)(head))			\
 	    ? ((head)->cqh_first)					\
-	    : (elm->field.cqe_next))
+	    : ((elm)->field.cqe_next))
 #define CIRCLEQ_LOOP_PREV(head, elm, field)				\
 	(((elm)->field.cqe_prev == (void *)(head))			\
 	    ? ((head)->cqh_last)					\
-	    : (elm->field.cqe_prev))
+	    : ((elm)->field.cqe_prev))
 
 /*
  * Sorted queue functions.

--- a/src/common/shutdown_state.c
+++ b/src/common/shutdown_state.c
@@ -44,7 +44,7 @@
 #include "os_deep.h"
 
 #define FLUSH_SDS(sds, part) \
-	if (part != NULL) os_part_deep_common(part, sds, sizeof(*sds), 1)
+	if ((part) != NULL) os_part_deep_common(part, sds, sizeof(*(sds)), 1)
 
 /*
  * shutdown_state_checksum -- (internal) counts SDS checksum and flush it

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -65,7 +65,7 @@ extern unsigned long long Mmap_align;
 #define ALIGN_UP(size, align) (((size) + (align) - 1) & ~((align) - 1))
 #define ALIGN_DOWN(size, align) ((size) & ~((align) - 1))
 
-#define ADDR_SUM(vp, lp) ((void *)((char *)(vp) + lp))
+#define ADDR_SUM(vp, lp) ((void *)((char *)(vp) + (lp)))
 
 #define util_alignof(t) offsetof(struct {char _util_c; t _util_m; }, _util_m)
 #define FORMAT_PRINTF(a, b) __attribute__((__format__(__printf__, (a), (b))))

--- a/src/common/valgrind/drd.h
+++ b/src/common/valgrind/drd.h
@@ -355,7 +355,7 @@
  * be reported.
  */
 #define ANNOTATE_BENIGN_RACE(addr, descr) \
-   ANNOTATE_BENIGN_RACE_SIZED(addr, sizeof(*addr), descr)
+   ANNOTATE_BENIGN_RACE_SIZED(addr, sizeof(*(addr)), descr)
 
 /* Same as ANNOTATE_BENIGN_RACE(addr, descr), but applies to
    the memory range [addr, addr + size). */

--- a/src/common/vec.h
+++ b/src/common/vec.h
@@ -82,7 +82,7 @@ struct name {\
 
 #define VEC_ERASE_BY_PTR(vec, element) do {\
 	ptrdiff_t elpos = (uintptr_t)(element) - (uintptr_t)((vec)->buffer);\
-	elpos /= sizeof(*element);\
+	elpos /= sizeof(*(element));\
 	VEC_ERASE_BY_POS(vec, elpos);\
 } while (0)
 
@@ -101,15 +101,15 @@ struct name {\
 
 #define VEC_FOREACH(el, vec)\
 for (size_t _vec_i = 0;\
-	_vec_i < (vec)->size && ((el = (vec)->buffer[_vec_i]), 1);\
+	_vec_i < (vec)->size && (((el) = (vec)->buffer[_vec_i]), 1);\
 	++_vec_i)
 
 #define VEC_FOREACH_BY_POS(elpos, vec)\
-for (elpos = 0; elpos < (vec)->size; ++elpos)
+for ((elpos) = 0; (elpos) < (vec)->size; ++(elpos))
 
 #define VEC_FOREACH_BY_PTR(el, vec)\
 for (size_t _vec_i = 0;\
-	_vec_i < (vec)->size && ((el = &(vec)->buffer[_vec_i]), 1);\
+	_vec_i < (vec)->size && (((el) = &(vec)->buffer[_vec_i]), 1);\
 	++_vec_i)
 
 #define VEC_SIZE(vec)\

--- a/src/examples/libpmemcto/libart/art.c
+++ b/src/examples/libpmemcto/libart/art.c
@@ -62,9 +62,9 @@
 /*
  * Macros to manipulate pointer tags
  */
-#define IS_LEAF(x) (((uintptr_t)x & 1))
-#define SET_LEAF(x) ((void *)((uintptr_t)x | 1))
-#define LEAF_RAW(x) ((void *)((uintptr_t)x & ~1))
+#define IS_LEAF(x) (((uintptr_t)(x) & 1))
+#define SET_LEAF(x) ((void *)((uintptr_t)(x) | 1))
+#define LEAF_RAW(x) ((void *)((uintptr_t)(x) & ~1))
 
 /*
  * Allocates a node of the given type,

--- a/src/examples/libpmemcto/libart/arttree.c
+++ b/src/examples/libpmemcto/libart/arttree.c
@@ -1135,9 +1135,9 @@ dump_art_leaf_callback(void *data,
 /*
  * Macros to manipulate pointer tags
  */
-#define IS_LEAF(x) (((uintptr_t)x & 1))
-#define SET_LEAF(x) ((void *)((uintptr_t)x | 1))
-#define LEAF_RAW(x) ((void *)((uintptr_t)x & ~1))
+#define IS_LEAF(x) (((uintptr_t)(x) & 1))
+#define SET_LEAF(x) ((void *)((uintptr_t)(x) | 1))
+#define LEAF_RAW(x) ((void *)((uintptr_t)(x) & ~1))
 
 unsigned char hexvals[] = {
 	0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,

--- a/src/examples/libpmemobj++/pman/pman.cpp
+++ b/src/examples/libpmemobj++/pman/pman.cpp
@@ -58,7 +58,7 @@
 #define GAME_DELAY 40000
 #define SLEEP(t)                                                               \
 	do {                                                                   \
-		struct timespec req = {0, t * 1000};                           \
+		struct timespec req = {0, (t)*1000};                           \
 		while (nanosleep(&req, &req) == -1 && errno == EINTR)          \
 			;                                                      \
 	} while (0)

--- a/src/examples/libpmemobj/libart/art.h
+++ b/src/examples/libpmemobj/libart/art.h
@@ -183,13 +183,13 @@ typedef struct _cb_data {
 /*
  * Macros to manipulate art_node tags
  */
-#define IS_LEAF(x) ((x->art_node_type == art_leaf_t))
-#define SET_LEAF(x) ((x->art_node_tag = art_leaf_t))
+#define IS_LEAF(x) (((x)->art_node_type == art_leaf_t))
+#define SET_LEAF(x) (((x)->art_node_tag = art_leaf_t))
 
 #define COPY_BLOB(_obj, _blob, _len) \
     D_RW(_obj)->len = _len; \
     TX_MEMCPY(D_RW(_obj)->s, _blob, _len); \
-    D_RW(_obj)->s[_len - 1] = '\0';
+    D_RW(_obj)->s[(_len) - 1] = '\0';
 
 
 typedef int(*art_callback)(void *data,

--- a/src/examples/libpmemobj/pmemobjfs/pmemobjfs.c
+++ b/src/examples/libpmemobj/pmemobjfs/pmemobjfs.c
@@ -113,24 +113,24 @@ struct {\
 } while (0)
 
 #define PDLL_FOREACH(entry, head, field)\
-for (entry = ((head)).first; !TOID_IS_NULL(entry);\
-		entry = D_RO(entry)->field.next)
+for ((entry) = ((head)).first; !TOID_IS_NULL(entry);\
+		(entry) = D_RO(entry)->field.next)
 
 #define PDLL_FOREACH_SAFE(entry, next, head, field)\
-for (entry = ((head)).first; !TOID_IS_NULL(entry) &&\
-		(next = D_RO(entry)->field.next, 1);\
-		entry = next)
+for ((entry) = ((head)).first; !TOID_IS_NULL(entry) &&\
+		((next) = D_RO(entry)->field.next, 1);\
+		(entry) = (next))
 
 #define PDLL_INSERT_HEAD(head, entry, field) do {\
-	pmemobj_tx_add_range_direct(&head.first, sizeof(head.first));\
+	pmemobj_tx_add_range_direct(&(head).first, sizeof((head).first));\
 	TX_ADD_FIELD(entry, field);\
-	D_RW(entry)->field.next = head.first;\
+	D_RW(entry)->field.next = (head).first;\
 	D_RW(entry)->field.prev =\
 		(typeof(D_RW(entry)->field.prev))OID_NULL;\
-	head.first = entry;\
-	if (TOID_IS_NULL(head.last)) {\
-		pmemobj_tx_add_range_direct(&head.last, sizeof(head.last));\
-		head.last = entry;\
+	(head).first = entry;\
+	if (TOID_IS_NULL((head).last)) {\
+		pmemobj_tx_add_range_direct(&(head).last, sizeof((head).last));\
+		(head).last = entry;\
 	}\
 	typeof(entry) next = D_RO(entry)->field.next;\
 	if (!TOID_IS_NULL(next)) {\
@@ -141,25 +141,27 @@ for (entry = ((head)).first; !TOID_IS_NULL(entry) &&\
 } while (0)
 
 #define PDLL_REMOVE(head, entry, field) do {\
-	if (TOID_EQUALS(head.first, entry) &&\
-		TOID_EQUALS(head.last, entry)) {\
-		pmemobj_tx_add_range_direct(&head.first, sizeof(head.first));\
-		pmemobj_tx_add_range_direct(&head.last, sizeof(head.last));\
-		head.first = (typeof(D_RW(entry)->field.prev))OID_NULL;\
-		head.last = (typeof(D_RW(entry)->field.prev))OID_NULL;\
-	} else if (TOID_EQUALS(head.first, entry)) {\
+	if (TOID_EQUALS((head).first, entry) &&\
+		TOID_EQUALS((head).last, entry)) {\
+		pmemobj_tx_add_range_direct(&(head).first,\
+				sizeof((head).first));\
+		pmemobj_tx_add_range_direct(&(head).last, sizeof((head).last));\
+		(head).first = (typeof(D_RW(entry)->field.prev))OID_NULL;\
+		(head).last = (typeof(D_RW(entry)->field.prev))OID_NULL;\
+	} else if (TOID_EQUALS((head).first, entry)) {\
 		typeof(entry) next = D_RW(entry)->field.next;\
 		pmemobj_tx_add_range_direct(&D_RW(next)->field.prev,\
 				sizeof(D_RW(next)->field.prev));\
-		pmemobj_tx_add_range_direct(&head.first, sizeof(head.first));\
-		head.first = D_RO(entry)->field.next;\
+		pmemobj_tx_add_range_direct(&(head).first,\
+				sizeof((head).first));\
+		(head).first = D_RO(entry)->field.next;\
 		D_RW(next)->field.prev.oid = OID_NULL;\
-	} else if (TOID_EQUALS(head.last, entry)) {\
+	} else if (TOID_EQUALS((head).last, entry)) {\
 		typeof(entry) prev = D_RW(entry)->field.prev;\
 		pmemobj_tx_add_range_direct(&D_RW(prev)->field.next,\
 				sizeof(D_RW(prev)->field.next));\
-		pmemobj_tx_add_range_direct(&head.last, sizeof(head.last));\
-		head.last = D_RO(entry)->field.prev;\
+		pmemobj_tx_add_range_direct(&(head).last, sizeof((head).last));\
+		(head).last = D_RO(entry)->field.prev;\
 		D_RW(prev)->field.next.oid = OID_NULL;\
 	} else {\
 		typeof(entry) prev = D_RW(entry)->field.prev;\

--- a/src/examples/libpmemobj/tree_map/btree_map.c
+++ b/src/examples/libpmemobj/tree_map/btree_map.c
@@ -495,10 +495,10 @@ btree_map_remove_from_node(TOID(struct btree_map) map,
 }
 
 #define NODE_CONTAINS_ITEM(_n, _i, _k)\
-(_i != D_RO(_n)->n && D_RO(_n)->items[_i].key == _k)
+((_i) != D_RO(_n)->n && D_RO(_n)->items[_i].key == (_k))
 
 #define NODE_CHILD_CAN_CONTAIN_ITEM(_n, _i, _k)\
-(_i == D_RO(_n)->n || D_RO(_n)->items[_i].key > _k) &&\
+((_i) == D_RO(_n)->n || D_RO(_n)->items[_i].key > (_k)) &&\
 !TOID_IS_NULL(D_RO(_n)->slots[_i])
 
 /*

--- a/src/examples/libvmem/libart/art.c
+++ b/src/examples/libvmem/libart/art.c
@@ -62,9 +62,9 @@
 /*
  * Macros to manipulate pointer tags
  */
-#define IS_LEAF(x) (((uintptr_t)x & 1))
-#define SET_LEAF(x) ((void *)((uintptr_t)x | 1))
-#define LEAF_RAW(x) ((void *)((uintptr_t)x & ~1))
+#define IS_LEAF(x) (((uintptr_t)(x) & 1))
+#define SET_LEAF(x) ((void *)((uintptr_t)(x) | 1))
+#define LEAF_RAW(x) ((void *)((uintptr_t)(x) & ~1))
 
 /*
  * Allocates a node of the given type,

--- a/src/examples/libvmem/libart/arttree.c
+++ b/src/examples/libvmem/libart/arttree.c
@@ -1124,9 +1124,9 @@ dump_art_leaf_callback(void *data,
 /*
  * Macros to manipulate pointer tags
  */
-#define IS_LEAF(x) (((uintptr_t)x & 1))
-#define SET_LEAF(x) ((void *)((uintptr_t)x | 1))
-#define LEAF_RAW(x) ((void *)((uintptr_t)x & ~1))
+#define IS_LEAF(x) (((uintptr_t)(x) & 1))
+#define SET_LEAF(x) ((void *)((uintptr_t)(x) | 1))
+#define LEAF_RAW(x) ((void *)((uintptr_t)(x) & ~1))
 
 unsigned char hexvals[] = {
 	0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,

--- a/src/include/libpmemobj/tx.h
+++ b/src/include/libpmemobj/tx.h
@@ -126,7 +126,7 @@ pmemobj_tx_add_range((o).oid, 0, sizeof(*(o)._type))
 	TX_ADD_DIRECT(&(D_RO(o)->field))
 
 #define TX_ADD_DIRECT(p)\
-pmemobj_tx_add_range_direct(p, sizeof(*p))
+pmemobj_tx_add_range_direct(p, sizeof(*(p)))
 
 #define TX_ADD_FIELD_DIRECT(p, field)\
 pmemobj_tx_add_range_direct(&(p)->field, sizeof((p)->field))
@@ -138,7 +138,7 @@ pmemobj_tx_xadd_range((o).oid, 0, sizeof(*(o)._type), flags)
 	TX_XADD_DIRECT(&(D_RO(o)->field), flags)
 
 #define TX_XADD_DIRECT(p, flags)\
-pmemobj_tx_xadd_range_direct(p, sizeof(*p), flags)
+pmemobj_tx_xadd_range_direct(p, sizeof(*(p)), flags)
 
 #define TX_XADD_FIELD_DIRECT(p, field, flags)\
 pmemobj_tx_xadd_range_direct(&(p)->field, sizeof((p)->field), flags)
@@ -179,11 +179,11 @@ pmemobj_tx_free((o).oid)
 
 #define TX_SET(o, field, value) (\
 	TX_ADD_FIELD(o, field),\
-	D_RW(o)->field = value)
+	D_RW(o)->field = (value))
 
 #define TX_SET_DIRECT(p, field, value) (\
 	TX_ADD_FIELD_DIRECT(p, field),\
-	(p)->field = value)
+	(p)->field = (value))
 
 static inline void *
 TX_MEMCPY(void *dest, const void *src, size_t num)

--- a/src/jemalloc/include/jemalloc/internal/jemalloc_internal_macros.h
+++ b/src/jemalloc/include/jemalloc/internal/jemalloc_internal_macros.h
@@ -35,10 +35,10 @@
 #  define UNUSED
 #endif
 
-#define	ZU(z)	((size_t)z)
-#define	ZI(z)	((ssize_t)z)
-#define	QU(q)	((uint64_t)q)
-#define	QI(q)	((int64_t)q)
+#define	ZU(z)	((size_t)(z))
+#define	ZI(z)	((ssize_t)(z))
+#define	QU(q)	((uint64_t)(q))
+#define	QI(q)	((int64_t)(q))
 
 #define	KZU(z)	ZU(z##ULL)
 #define	KZI(z)	ZI(z##LL)

--- a/src/jemalloc/src/arena.c
+++ b/src/jemalloc/src/arena.c
@@ -13,7 +13,7 @@ const uint32_t	small_bin2size_tab[NBINS] = {
 	size,
 #define	B2S_bin_no(size)
 #define	SC(index, lg_grp, lg_delta, ndelta, bin, lg_delta_lookup) \
-	B2S_bin_##bin((ZU(1)<<lg_grp) + (ZU(ndelta)<<lg_delta))
+	B2S_bin_##bin((ZU(1)<<(lg_grp)) + (ZU(ndelta)<<(lg_delta)))
 	SIZE_CLASSES
 #undef B2S_bin_yes
 #undef B2S_bin_no
@@ -2625,7 +2625,7 @@ bin_info_init(void)
 	bitmap_info_init(&bin_info->bitmap_info, bin_info->nregs);
 #define	BIN_INFO_INIT_bin_no(index, size)
 #define	SC(index, lg_grp, lg_delta, ndelta, bin, lg_delta_lookup)	\
-	BIN_INFO_INIT_bin_##bin(index, (ZU(1)<<lg_grp) + (ZU(ndelta)<<lg_delta))
+	BIN_INFO_INIT_bin_##bin(index, (ZU(1)<<(lg_grp)) + (ZU(ndelta)<<(lg_delta)))
 	SIZE_CLASSES
 #undef BIN_INFO_INIT_bin_yes
 #undef BIN_INFO_INIT_bin_no

--- a/src/jemalloc/src/jemalloc.c
+++ b/src/jemalloc/src/jemalloc.c
@@ -660,15 +660,15 @@ malloc_conf_init(void)
 					    "Invalid conf value",	\
 					    k, klen, v, vlen);		\
 				} else if (clip) {			\
-					if (min != 0 && um < min)	\
+					if ((min) != 0 && um < (min))	\
 						o = min;		\
-					else if (um > max)		\
+					else if (um > (max))		\
 						o = max;		\
 					else				\
 						o = um;			\
 				} else {				\
-					if ((min != 0 && um < min) ||	\
-					    um > max) {			\
+					if (((min) != 0 && um < (min)) ||	\
+					    um > (max)) {			\
 						malloc_conf_error(	\
 						    "Out-of-range "	\
 						    "conf value",	\
@@ -690,8 +690,8 @@ malloc_conf_init(void)
 					malloc_conf_error(		\
 					    "Invalid conf value",	\
 					    k, klen, v, vlen);		\
-				} else if (l < (ssize_t)min || l >	\
-				    (ssize_t)max) {			\
+				} else if (l < (ssize_t)(min) || l >	\
+				    (ssize_t)(max)) {			\
 					malloc_conf_error(		\
 					    "Out-of-range conf value",	\
 					    k, klen, v, vlen);		\

--- a/src/jemalloc/src/stats.c
+++ b/src/jemalloc/src/stats.c
@@ -9,7 +9,7 @@
 #define	CTL_P_GET_ARRAY(n, v, t, c) do {				\
 	size_t mib[8];							\
 	size_t miblen = sizeof(mib) / sizeof(size_t);			\
-	size_t sz = sizeof(t) * c;					\
+	size_t sz = sizeof(t) * (c);					\
 	xmallctlnametomib(n, mib, &miblen);				\
 	mib[1] = p;							\
 	xmallctlbymib(mib, miblen, v, &sz, NULL, 0);			\

--- a/src/jemalloc/src/util.c
+++ b/src/jemalloc/src/util.c
@@ -320,16 +320,16 @@ malloc_vsnprintf(char *str, size_t size, const char *format, va_list ap)
 } while (0)
 #define	APPEND_S(s, slen) do {						\
 	if (i < size) {							\
-		size_t cpylen = (slen <= size - i) ? slen : size - i;	\
+		size_t cpylen = ((slen) <= size - i) ? (slen) : size - i;	\
 		memcpy(&str[i], s, cpylen);				\
 	}								\
-	i += slen;							\
+	i += (slen);							\
 } while (0)
 #define	APPEND_PADDED_S(s, slen, width, left_justify) do {		\
 	/* Left padding. */						\
-	size_t pad_len = (width == -1) ? 0 : ((slen < (size_t)width) ?	\
-	    (size_t)width - slen : 0);					\
-	if (left_justify == false && pad_len != 0) {			\
+	size_t pad_len = ((width) == -1) ? 0 : (((slen) < (size_t)(width)) ?	\
+	    (size_t)(width) - (slen) : 0);					\
+	if ((left_justify) == false && pad_len != 0) {			\
 		size_t j;						\
 		for (j = 0; j < pad_len; j++)				\
 			APPEND_C(' ');					\
@@ -337,7 +337,7 @@ malloc_vsnprintf(char *str, size_t size, const char *format, va_list ap)
 	/* Value. */							\
 	APPEND_S(s, slen);						\
 	/* Right padding. */						\
-	if (left_justify && pad_len != 0) {				\
+	if ((left_justify) && pad_len != 0) {				\
 		size_t j;						\
 		for (j = 0; j < pad_len; j++)				\
 			APPEND_C(' ');					\

--- a/src/jemalloc/test/unit/mallctl.c
+++ b/src/jemalloc/test/unit/mallctl.c
@@ -382,7 +382,7 @@ TEST_BEGIN(test_arenas_constants)
 #define	TEST_ARENAS_CONSTANT(t, name, expected) do {			\
 	t name;								\
 	size_t sz = sizeof(t);						\
-	assert_d_eq(mallctl("pool.0.arenas."#name, &name, &sz, NULL, 0), 0,	\
+	assert_d_eq(mallctl("pool.0.arenas."#name, &(name), &sz, NULL, 0), 0,	\
 	    "Unexpected mallctl() failure");				\
 	assert_zu_eq(name, expected, "Incorrect "#name" size");		\
 } while (0)
@@ -402,7 +402,7 @@ TEST_BEGIN(test_arenas_bin_constants)
 #define	TEST_ARENAS_BIN_CONSTANT(t, name, expected) do {		\
 	t name;								\
 	size_t sz = sizeof(t);						\
-	assert_d_eq(mallctl("pool.0.arenas.bin.0."#name, &name, &sz, NULL, 0),	\
+	assert_d_eq(mallctl("pool.0.arenas.bin.0."#name, &(name), &sz, NULL, 0),	\
 	    0, "Unexpected mallctl() failure");				\
 	assert_zu_eq(name, expected, "Incorrect "#name" size");		\
 } while (0)
@@ -420,7 +420,7 @@ TEST_BEGIN(test_arenas_lrun_constants)
 #define	TEST_ARENAS_LRUN_CONSTANT(t, name, expected) do {		\
 	t name;								\
 	size_t sz = sizeof(t);						\
-	assert_d_eq(mallctl("pool.0.arenas.lrun.0."#name, &name, &sz, NULL,	\
+	assert_d_eq(mallctl("pool.0.arenas.lrun.0."#name, &(name), &sz, NULL,	\
 	    0), 0, "Unexpected mallctl() failure");			\
 	assert_zu_eq(name, expected, "Incorrect "#name" size");		\
 } while (0)
@@ -494,7 +494,7 @@ TEST_BEGIN(test_stats_arenas)
 #define	TEST_STATS_ARENAS(t, name) do {					\
 	t name;								\
 	size_t sz = sizeof(t);						\
-	assert_d_eq(mallctl("pool.0.stats.arenas.0."#name, &name, &sz, NULL,	\
+	assert_d_eq(mallctl("pool.0.stats.arenas.0."#name, &(name), &sz, NULL,	\
 	    0), 0, "Unexpected mallctl() failure");			\
 } while (0)
 

--- a/src/libpmemobj/alloc_class.c
+++ b/src/libpmemobj/alloc_class.c
@@ -118,7 +118,7 @@ static struct {
  * Calculates the size in bytes of a single run instance
  */
 #define RUN_SIZE_BYTES(size_idx)\
-(RUNSIZE + ((size_idx - 1) * CHUNKSIZE))
+(RUNSIZE + (((size_idx) - 1) * CHUNKSIZE))
 
 /*
  * Target number of allocations per run instance.

--- a/src/libpmemobj/bucket.h
+++ b/src/libpmemobj/bucket.h
@@ -45,7 +45,7 @@
 #include "os_thread.h"
 
 #define CALC_SIZE_IDX(_unit_size, _size)\
-(_size == 0 ? 0 : (uint32_t)(((_size - 1) / _unit_size) + 1))
+((_size) == 0 ? 0 : (uint32_t)((((_size) - 1) / (_unit_size)) + 1))
 
 struct bucket {
 	os_mutex_t lock;

--- a/src/libpmemobj/heap.h
+++ b/src/libpmemobj/heap.h
@@ -51,7 +51,7 @@
 
 #define HEAP_OFF_TO_PTR(heap, off) ((void *)((char *)((heap)->base) + (off)))
 #define HEAP_PTR_TO_OFF(heap, ptr)\
-	((uintptr_t)(ptr) - (uintptr_t)(heap->base))
+	((uintptr_t)(ptr) - (uintptr_t)((heap)->base))
 
 #define BIT_IS_CLR(a, i)	(!((a) & (1ULL << (i))))
 

--- a/src/libpmemobj/stats.h
+++ b/src/libpmemobj/stats.h
@@ -54,18 +54,18 @@ struct stats {
 };
 
 #define STATS_INC(stats, type, name, value) do {\
-	if (stats->enabled)\
-		util_fetch_and_add64((&stats->type->name), (value));\
+	if ((stats)->enabled)\
+		util_fetch_and_add64((&(stats)->type->name), (value));\
 } while (0)
 
 #define STATS_SUB(stats, type, name, value) do {\
-	if (stats->enabled)\
-		util_fetch_and_sub64((&stats->type->name), (value));\
+	if ((stats)->enabled)\
+		util_fetch_and_sub64((&(stats)->type->name), (value));\
 } while (0)
 
 #define STATS_SET(stats, type, name, value) do {\
-	if (stats->enabled)\
-		util_atomic_store_explicit64((&stats->type->name), (value),\
+	if ((stats)->enabled)\
+		util_atomic_store_explicit64((&(stats)->type->name), (value),\
 		memory_order_release);\
 } while (0)
 

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -214,14 +214,14 @@ obj_tx_abort_null(int errnum)
 
 /* ASSERT_IN_TX -- checks whether there's open transaction */
 #define ASSERT_IN_TX(tx) do {\
-	if (tx->stage == TX_STAGE_NONE)\
+	if ((tx)->stage == TX_STAGE_NONE)\
 		FATAL("%s called outside of transaction", __func__);\
 } while (0)
 
 /* ASSERT_TX_STAGE_WORK -- checks whether current transaction stage is WORK */
 #define ASSERT_TX_STAGE_WORK(tx) do {\
-	if (tx->stage != TX_STAGE_WORK)\
-		FATAL("%s called in invalid stage %d", __func__, tx->stage);\
+	if ((tx)->stage != TX_STAGE_WORK)\
+		FATAL("%s called in invalid stage %d", __func__, (tx)->stage);\
 } while (0)
 
 /*

--- a/src/test/ex_linkedlist/ex_linkedlist.c
+++ b/src/test/ex_linkedlist/ex_linkedlist.c
@@ -44,7 +44,7 @@
 
 #define ELEMENT_NO	10
 #define PRINT_RES(res, struct_name) do {\
-	if (res == 0) {\
+	if ((res) == 0) {\
 		UT_OUT("Outcome for " #struct_name " is correct!");\
 	} else {\
 		UT_ERR("Outcome for " #struct_name\

--- a/src/test/obj_fragmentation2/obj_fragmentation2.c
+++ b/src/test/obj_fragmentation2/obj_fragmentation2.c
@@ -49,7 +49,7 @@
 #define GIGABYTE (1UL << 30)
 
 #define RRAND(seed, max, min)\
-((min) == (max) ? (min) : (os_rand_r(&seed) % ((max) - (min)) + (min)))
+((min) == (max) ? (min) : (os_rand_r(&(seed)) % ((max) - (min)) + (min)))
 
 uint64_t *objects;
 size_t nobjects;

--- a/src/test/obj_lane/obj_lane.c
+++ b/src/test/obj_lane/obj_lane.c
@@ -60,7 +60,7 @@
 #define MINOR_VERSION 0
 
 static void *base_ptr;
-#define RPTR(p) (uintptr_t)((char *)p - (char *)base_ptr)
+#define RPTR(p) (uintptr_t)((char *)(p) - (char *)base_ptr)
 
 struct mock_pop {
 	PMEMobjpool p;

--- a/src/test/obj_pmalloc_rand_mt/obj_pmalloc_rand_mt.c
+++ b/src/test/obj_pmalloc_rand_mt/obj_pmalloc_rand_mt.c
@@ -37,7 +37,7 @@
 
 #include "unittest.h"
 
-#define RRAND(seed, max, min) (os_rand_r(&seed) % ((max) - (min)) + (min))
+#define RRAND(seed, max, min) (os_rand_r(&(seed)) % ((max) - (min)) + (min))
 
 static ssize_t object_size;
 static int nobjects;

--- a/src/test/rpmem_basic/rpmem_basic.c
+++ b/src/test/rpmem_basic/rpmem_basic.c
@@ -255,12 +255,12 @@ cmp_pool_attr(const struct rpmem_pool_attr *attr1,
  * check_return_and_errno - validate return value and errno
  */
 #define check_return_and_errno(ret, error_must_occur, exp_errno) \
-	if (exp_errno != 0) { \
+	if ((exp_errno) != 0) { \
 		if (error_must_occur) { \
 			UT_ASSERTne(ret, 0); \
 			UT_ASSERTeq(errno, exp_errno); \
 		} else { \
-			if (ret != 0) { \
+			if ((ret) != 0) { \
 				UT_ASSERTeq(errno, exp_errno); \
 			} \
 		} \

--- a/src/test/tools/cmpmap/cmpmap.c
+++ b/src/test/tools/cmpmap/cmpmap.c
@@ -49,7 +49,7 @@
 
 #define CMPMAP_ZERO (1<<0)
 
-#define ADDR_SUM(vp, lp) ((void *)((char *)(vp) + lp))
+#define ADDR_SUM(vp, lp) ((void *)((char *)(vp) + (lp)))
 
 /* arguments */
 static char *File1 = NULL;	/* file1 name */

--- a/src/test/unittest/unittest.h
+++ b/src/test/unittest/unittest.h
@@ -673,7 +673,7 @@ _name(const struct test_case *tc, int argc, char *argv[])
 #define TEST_CASE(_name)\
 {\
 	.name = #_name,\
-	.func = _name,\
+	.func = (_name),\
 }
 
 #define STR(x) #x

--- a/src/test/util_cpuid/util_cpuid.c
+++ b/src/test/util_cpuid/util_cpuid.c
@@ -47,9 +47,11 @@
  * functions are defined here in terms of asm statements for now.
  */
 #define _mm_clflushopt(addr)\
-	asm volatile(".byte 0x66; clflush %0" : "+m" (*(volatile char *)addr));
+	asm volatile(".byte 0x66; clflush %0" :\
+	"+m" (*(volatile char *)(addr)));
 #define _mm_clwb(addr)\
-	asm volatile(".byte 0x66; xsaveopt %0" : "+m" (*(volatile char *)addr));
+	asm volatile(".byte 0x66; xsaveopt %0" :\
+	"+m" (*(volatile char *)(addr)));
 #endif
 
 static char Buf[32];

--- a/src/test/util_sds/util_sds.c
+++ b/src/test/util_sds/util_sds.c
@@ -49,7 +49,7 @@ static size_t uscs_size;
 static size_t usc_it;
 
 #define FAIL(X, Y) \
-	if (X == Y) {\
+	if ((X) == (Y)) {\
 		common_fini();\
 		DONE(NULL);\
 		exit(0);\

--- a/src/test/vmem_realloc_inplace/vmem_realloc_inplace.c
+++ b/src/test/vmem_realloc_inplace/vmem_realloc_inplace.c
@@ -38,7 +38,7 @@
 
 #include "unittest.h"
 
-#define POOL_SIZE 16 * 1024 * 1024
+#define POOL_SIZE (16 * 1024 * 1024)
 
 int
 main(int argc, char *argv[])

--- a/src/tools/pmempool/common.h
+++ b/src/tools/pmempool/common.h
@@ -100,7 +100,7 @@
 ((void *)((uintptr_t)(entry) - sizeof(struct allocation_header)))
 
 #define OBJH_FROM_PTR(ptr)\
-((void *)((uintptr_t)ptr - sizeof(struct legacy_object_header)))
+((void *)((uintptr_t)(ptr) - sizeof(struct legacy_object_header)))
 
 #define DEFAULT_HDR_SIZE	4096UL /* 4 KB */
 #define DEFAULT_DESC_SIZE	4096UL /* 4 KB */
@@ -111,7 +111,7 @@
 	sizeof(struct legacy_object_header)))
 
 #define OBJH_TO_PTR(objh)\
-((void *)((uintptr_t)objh + sizeof(struct legacy_object_header)))
+((void *)((uintptr_t)(objh) + sizeof(struct legacy_object_header)))
 
 /* invalid answer for ask_* functions */
 #define INV_ANS	'\0'

--- a/src/tools/pmempool/convert_obj_v1_v2.c
+++ b/src/tools/pmempool/convert_obj_v1_v2.c
@@ -287,7 +287,7 @@ struct heap_layout {
 					+ ZONE_MAX_SIZE * (zone_id)))
 
 #define CALC_SIZE_IDX(_unit_size, _size)\
-((uint32_t)(((_size - 1) / _unit_size) + 1))
+((uint32_t)((((_size) - 1) / (_unit_size)) + 1))
 
 static void *
 pmemobj_direct(PMEMoid oid)

--- a/src/tools/pmempool/info_obj.c
+++ b/src/tools/pmempool/info_obj.c
@@ -54,7 +54,7 @@
 
 #define OFF_TO_PTR(pop, off) ((void *)((uintptr_t)(pop) + (off)))
 
-#define PTR_TO_OFF(pop, ptr) ((uintptr_t)ptr - (uintptr_t)pop)
+#define PTR_TO_OFF(pop, ptr) ((uintptr_t)(ptr) - (uintptr_t)(pop))
 
 typedef void (*pvector_callback_fn)(struct pmem_info *pip, int v, int vnum,
 		const struct memory_block *m, uint64_t i);

--- a/src/windows/jemalloc_gen/include/jemalloc/internal/jemalloc_internal.h
+++ b/src/windows/jemalloc_gen/include/jemalloc/internal/jemalloc_internal.h
@@ -277,11 +277,11 @@ static const bool config_ivsalloc =
 
 /* Return the offset between a and the nearest aligned address at or below a. */
 #define	ALIGNMENT_ADDR2OFFSET(a, alignment)				\
-	((size_t)((uintptr_t)(a) & (alignment - 1)))
+	((size_t)((uintptr_t)(a) & ((alignment) - 1)))
 
 /* Return the smallest alignment multiple that is >= s. */
 #define	ALIGNMENT_CEILING(s, alignment)					\
-	(((s) + (alignment - 1)) & (-(alignment)))
+	(((s) + ((alignment) - 1)) & (-(alignment)))
 
 /* Declare a variable length array */
 #if __STDC_VERSION__ < 199901L

--- a/src/windows/jemalloc_gen/include/jemalloc/jemalloc.h
+++ b/src/windows/jemalloc_gen/include/jemalloc/jemalloc.h
@@ -107,7 +107,7 @@ extern "C" {
 #    define MALLOCX_ALIGN(a)	(ffs(a)-1)
 #  else
 #    define MALLOCX_ALIGN(a)						\
-	 ((a < (size_t)INT_MAX) ? ffs(a)-1 : ffs(a>>32)+31)
+	 (((a) < (size_t)INT_MAX) ? ffs(a)-1 : ffs((a)>>32)+31)
 #  endif
 #  define MALLOCX_ZERO	((int)0x40)
 /* Bias arena index bits so that 0 encodes "MALLOCX_ARENA() unspecified". */

--- a/src/windows/jemalloc_gen/include/jemalloc/jemalloc_macros.h
+++ b/src/windows/jemalloc_gen/include/jemalloc/jemalloc_macros.h
@@ -15,7 +15,7 @@
 #    define MALLOCX_ALIGN(a)	(ffs(a)-1)
 #  else
 #    define MALLOCX_ALIGN(a)						\
-	 ((a < (size_t)INT_MAX) ? ffs(a)-1 : ffs(a>>32)+31)
+	 (((a) < (size_t)INT_MAX) ? ffs(a)-1 : ffs((a)>>32)+31)
 #  endif
 #  define MALLOCX_ZERO	((int)0x40)
 /* Bias arena index bits so that 0 encodes "MALLOCX_ARENA() unspecified". */


### PR DESCRIPTION
Intention of this PR is to provide parenthesize parameter names in macro definitions.
Missing parenthesize the parameter names in a macro can result in unintended program behavior.
In any case any feedback will be appreciated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2874)
<!-- Reviewable:end -->
