### PR TITLE
test: enable rpmem_addr_ext

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -258,6 +258,7 @@ PMEMPOOL_TESTS = \
 
 RPMEM_TESTS = \
 	rpmem_addr\
+	rpmem_addr_ext\
 	rpmem_basic\
 	rpmem_fip\
 	rpmem_obc\
@@ -269,10 +270,6 @@ RPMEM_TESTS = \
 	rpmemd_log\
 	rpmemd_obc\
 	rpmemd_util
-
-# XXX: temporarily skip this test, as it fails with libfabric 1.6.0
-#	rpmem_addr_ext
-
 
 VMEM_TESTS = \
 	vmem_aligned_alloc\


### PR DESCRIPTION
Test was failing on one of the rc releases of libfabric 1.6.0.
In final release test pass without errors.

Ref: pmem/pmdk#2696

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2877)
<!-- Reviewable:end -->
