### PR TITLE
pool: fix bash completion script

### DIFF
--- a/src/tools/pmempool/Makefile
+++ b/src/tools/pmempool/Makefile
@@ -81,7 +81,7 @@ MANPAGES = $(TOP)/doc/pmempool.1\
 	   $(TOP)/doc/pmempool-sync.1\
 	   $(TOP)/doc/pmempool-tranform.1
 
-BASH_COMP_FILES = pmempool.sh
+BASH_COMP_FILES = bash_completion/pmempool
 
 include ../Makefile.inc
 

--- a/src/tools/pmempool/bash_completion/pmempool
+++ b/src/tools/pmempool/bash_completion/pmempool
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #
@@ -31,7 +30,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #
-# pmempool.sh -- bash completion script for pmempool
+# pmempool -- bash completion script for pmempool
 #
 
 #

--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -816,7 +816,7 @@ cat << EOF > debian/pmempool.install
 usr/bin/pmempool
 $MAN1_DIR/pmempool.1.gz
 $MAN1_DIR/pmempool-*.1.gz
-etc/bash_completion.d/pmempool.sh
+etc/bash_completion.d/pmempool
 EOF
 
 cat << EOF > debian/pmempool.triggers

--- a/utils/pmdk.spec.in
+++ b/utils/pmdk.spec.in
@@ -729,7 +729,7 @@ and users of the applications based on PMDK libraries.
 %{_bindir}/pmempool
 %{_mandir}/man1/pmempool.1.gz
 %{_mandir}/man1/pmempool-*.1.gz
-%config(noreplace) %{_sysconfdir}/bash_completion.d/pmempool.sh
+%config(noreplace) %{_sysconfdir}/bash_completion.d/pmempool
 %license LICENSE
 %doc ChangeLog CONTRIBUTING.md README.md
 


### PR DESCRIPTION
Drop the interpreter from script and drop .sh extension.

Ref: pmem/issues#860

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2879)
<!-- Reviewable:end -->
