### PR TITLE
test: do not use 'rm -r' with log files

### DIFF
--- a/src/test/bttdevice/TEST0
+++ b/src/test/bttdevice/TEST0
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 echo "Create btt device - uuid defined by the user" >> $LOG
 expect_normal_exit $BTTCREATE -s 20M -b 1K -l 256 \

--- a/src/test/bttdevice/TEST1
+++ b/src/test/bttdevice/TEST1
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $BTTCREATE -v $POOL >> $LOG
 

--- a/src/test/libpmempool_backup/common.sh
+++ b/src/test/libpmempool_backup/common.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +43,7 @@ POOL_PART=$DIR/pool.part
 OUT=out${UNITTEST_NUM}.log
 OUT_TEMP=out${UNITTEST_NUM}_temp.log
 DIFF=diff${UNITTEST_NUM}.log
-rm -rf $LOG $DIFF $OUT_TEMP && touch $LOG $DIFF $OUT_TEMP
+rm -f $LOG $DIFF $OUT_TEMP && touch $LOG $DIFF $OUT_TEMP
 
 # params for blk, log and obj pools
 POOL_TYPES=( blk log obj )

--- a/src/test/libpmempool_sync/TEST0
+++ b/src/test/libpmempool_sync/TEST0
@@ -44,8 +44,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/pool0.set

--- a/src/test/libpmempool_sync/TEST1
+++ b/src/test/libpmempool_sync/TEST1
@@ -44,8 +44,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/pool0.set

--- a/src/test/libpmempool_sync/TEST2
+++ b/src/test/libpmempool_sync/TEST2
@@ -46,8 +46,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/poolset

--- a/src/test/libpmempool_transform/TEST0
+++ b/src/test/libpmempool_transform/TEST0
@@ -44,8 +44,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/libpmempool_transform/TEST1
+++ b/src/test/libpmempool_transform/TEST1
@@ -44,8 +44,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/libpmempool_transform/TEST2
+++ b/src/test/libpmempool_transform/TEST2
@@ -46,8 +46,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/magic/TEST0
+++ b/src/test/magic/TEST0
@@ -49,7 +49,7 @@ setup
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
 MAGIC=../../../utils/pmdk.magic
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 rm -rf $POOL
 expect_normal_exit $PMEMPOOL create blk 512 $POOL

--- a/src/test/obj_convert/TEST3
+++ b/src/test/obj_convert/TEST3
@@ -39,7 +39,7 @@
 . ../unittest/unittest.sh
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 require_command gdb
 require_test_type medium

--- a/src/test/obj_convert/TEST4
+++ b/src/test/obj_convert/TEST4
@@ -39,7 +39,7 @@
 . ../unittest/unittest.sh
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 require_command gdb
 require_test_type medium

--- a/src/test/pmempool_check/TEST0
+++ b/src/test/pmempool_check/TEST0
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 echo "PMEMLOG: consistent" >> $LOG
 rm -rf $POOL

--- a/src/test/pmempool_check/TEST1
+++ b/src/test/pmempool_check/TEST1
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 echo "PMEMLOG: pool_hdr" >> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOL

--- a/src/test/pmempool_check/TEST10
+++ b/src/test/pmempool_check/TEST10
@@ -50,7 +50,7 @@ POOL_R2_PART2=$DIR/pool.replica2.part2
 PARTS="$POOL_R1_PART1 $POOL_R1_PART2 $POOL_R2_PART1 $POOL_R2_PART2"
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 create_poolset $POOLSET \
 	20M:$POOL_R1_PART1 50M:$POOL_R1_PART2 \

--- a/src/test/pmempool_check/TEST11
+++ b/src/test/pmempool_check/TEST11
@@ -48,7 +48,7 @@ setup
 dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DEVICE_DAX_PATH
 

--- a/src/test/pmempool_check/TEST12
+++ b/src/test/pmempool_check/TEST12
@@ -48,7 +48,7 @@ setup
 dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:$DEVICE_DAX_PATH

--- a/src/test/pmempool_check/TEST13
+++ b/src/test/pmempool_check/TEST13
@@ -48,7 +48,7 @@ setup
 dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 HDR_MAJOR_OFFSET=8
 

--- a/src/test/pmempool_check/TEST14
+++ b/src/test/pmempool_check/TEST14
@@ -46,7 +46,7 @@ configure_valgrind force-disable $PMEMPOOL$EXESUFFIX
 setup
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:$DEVICE_DAX_PATH

--- a/src/test/pmempool_check/TEST15
+++ b/src/test/pmempool_check/TEST15
@@ -53,7 +53,7 @@ PART4=$DIR/pool.part4
 PARTS="$PART1 $PART2 $PART3 $PART4"
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 for args in "log" "blk 512" "obj" ; do
 	echo "Arguments: create $args" >> $LOG

--- a/src/test/pmempool_check/TEST16
+++ b/src/test/pmempool_check/TEST16
@@ -46,7 +46,7 @@ POOLSET=$DIR/pool.set
 POOL_P1=$DIR/pool.p1
 POOL_P2=$DIR/pool.p2
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 create_poolset $POOLSET 20M:$POOL_P1:z 20M:$POOL_P2:z
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOLSET

--- a/src/test/pmempool_check/TEST17
+++ b/src/test/pmempool_check/TEST17
@@ -47,7 +47,7 @@ POOLSET=$DIR/pool.set
 POOL_P1=$DIR/pool.p1
 POOL_P2=$DIR/pool.p2
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 create_poolset $POOLSET 20M:$POOL_P1:z 20M:$POOL_P2:z
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOLSET

--- a/src/test/pmempool_check/TEST18
+++ b/src/test/pmempool_check/TEST18
@@ -47,7 +47,7 @@ POOLSET=$DIR/pool.set
 POOL_P1=$DIR/pool.p1
 POOL_P2=$DIR/pool.p2
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 create_poolset $POOLSET 20M:$POOL_P1:z 50M:$POOL_P2:z
 

--- a/src/test/pmempool_check/TEST19
+++ b/src/test/pmempool_check/TEST19
@@ -46,7 +46,7 @@ POOLSET=$DIR/pool.set
 POOL_P1=$DIR/pool.p1
 POOL_P2=$DIR/pool.p2
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 create_poolset $POOLSET 20M:$POOL_P1:z 20M:$POOL_P2:z
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOLSET

--- a/src/test/pmempool_check/TEST2
+++ b/src/test/pmempool_check/TEST2
@@ -45,7 +45,7 @@ setup
 POOL=$DIR/file.pool
 POOL_BACKUP=$DIR/file.pool.backup
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create blk 512 $POOL
 check_file $POOL

--- a/src/test/pmempool_check/TEST20
+++ b/src/test/pmempool_check/TEST20
@@ -50,7 +50,7 @@ setup
 dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DEVICE_DAX_PATH
 

--- a/src/test/pmempool_check/TEST21
+++ b/src/test/pmempool_check/TEST21
@@ -50,7 +50,7 @@ setup
 dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:$DEVICE_DAX_PATH

--- a/src/test/pmempool_check/TEST22
+++ b/src/test/pmempool_check/TEST22
@@ -50,7 +50,7 @@ setup
 dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 HDR_MAJOR_OFFSET=8
 

--- a/src/test/pmempool_check/TEST23
+++ b/src/test/pmempool_check/TEST23
@@ -48,7 +48,7 @@ require_valgrind 3.11
 setup
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:$DEVICE_DAX_PATH

--- a/src/test/pmempool_check/TEST24
+++ b/src/test/pmempool_check/TEST24
@@ -52,7 +52,7 @@ setup
 dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}

--- a/src/test/pmempool_check/TEST25
+++ b/src/test/pmempool_check/TEST25
@@ -50,7 +50,7 @@ configure_valgrind force-disable $PMEMPOOL$EXESUFFIX
 setup
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}

--- a/src/test/pmempool_check/TEST26
+++ b/src/test/pmempool_check/TEST26
@@ -52,7 +52,7 @@ setup
 dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]} \

--- a/src/test/pmempool_check/TEST27
+++ b/src/test/pmempool_check/TEST27
@@ -50,7 +50,7 @@ configure_valgrind force-disable $PMEMPOOL$EXESUFFIX
 setup
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]} \

--- a/src/test/pmempool_check/TEST28
+++ b/src/test/pmempool_check/TEST28
@@ -45,7 +45,7 @@ require_fs_type any
 setup
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/poolset

--- a/src/test/pmempool_check/TEST29
+++ b/src/test/pmempool_check/TEST29
@@ -45,7 +45,7 @@ require_fs_type any
 setup
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/poolset

--- a/src/test/pmempool_check/TEST3
+++ b/src/test/pmempool_check/TEST3
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create -w blk 512 $POOL
 check_file $POOL

--- a/src/test/pmempool_check/TEST30
+++ b/src/test/pmempool_check/TEST30
@@ -45,7 +45,7 @@ require_fs_type any
 setup
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/poolset

--- a/src/test/pmempool_check/TEST31
+++ b/src/test/pmempool_check/TEST31
@@ -60,7 +60,7 @@ MOUNT_DIR="$DIR/mnt-pmem"
 ndctl_nfit_test_mount_pmem $FULLDEV $MOUNT_DIR
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET 10M:$DIR/testfile0:z 10M:$MOUNT_DIR/testfile1:z 10M:$DIR/testfile2:z \

--- a/src/test/pmempool_check/TEST32
+++ b/src/test/pmempool_check/TEST32
@@ -57,7 +57,7 @@ NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device $DEVICE)
 FULLDEV="/dev/$DEVICE"
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:$FULLDEV:x \

--- a/src/test/pmempool_check/TEST4
+++ b/src/test/pmempool_check/TEST4
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create -w blk 512 $POOL
 check_file $POOL

--- a/src/test/pmempool_check/TEST5
+++ b/src/test/pmempool_check/TEST5
@@ -47,7 +47,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 truncate -s2T $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX create -v -w blk 512M $POOL > /dev/null

--- a/src/test/pmempool_check/TEST6
+++ b/src/test/pmempool_check/TEST6
@@ -48,7 +48,7 @@ POOL_PART2=$DIR/pool.part2
 POOLS="$POOL_PART1 $POOL_PART2"
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 create_poolset $POOLSET 32M:$DIR/pool.part1:z 32M:$DIR/pool.part2
 check_file $POOLSET

--- a/src/test/pmempool_check/TEST7
+++ b/src/test/pmempool_check/TEST7
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 rm -f $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX create blk 512 $POOL

--- a/src/test/pmempool_check/TEST8
+++ b/src/test/pmempool_check/TEST8
@@ -50,7 +50,7 @@ POOL_P4=$DIR/pool.p4
 POOLS="$POOL_P1 $POOL_P2 $POOL_P3 $POOL_P4"
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 create_poolset $POOLSET\
 	32M:$POOL_P1:z\

--- a/src/test/pmempool_check/TEST9
+++ b/src/test/pmempool_check/TEST9
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $POOL
 

--- a/src/test/pmempool_create/TEST10
+++ b/src/test/pmempool_create/TEST10
@@ -57,7 +57,7 @@ NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device $DEVICE)
 FULLDEV="/dev/$DEVICE"
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:$FULLDEV:x

--- a/src/test/pmempool_create/TEST11
+++ b/src/test/pmempool_create/TEST11
@@ -65,7 +65,7 @@ fallocate -l 10M $DIR/testfile1
 fallocate -l 10M $DIR/testfile2
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET 10M:$DIR/testfile1:x 10M:$FILE:x 10M:$DIR/testfile2:x

--- a/src/test/pmempool_create/TEST12
+++ b/src/test/pmempool_create/TEST12
@@ -58,7 +58,7 @@ NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device $DEVICE)
 FULLDEV="/dev/$DEVICE"
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:$FULLDEV:x

--- a/src/test/pmempool_dump/TEST0
+++ b/src/test/pmempool_dump/TEST0
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOL
 expect_normal_exit $PMEMWRITE$EXESUFFIX $POOL TEST

--- a/src/test/pmempool_dump/TEST1
+++ b/src/test/pmempool_dump/TEST1
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOL
 expect_normal_exit $PMEMWRITE$EXESUFFIX $POOL TEST

--- a/src/test/pmempool_dump/TEST2
+++ b/src/test/pmempool_dump/TEST2
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOL
 expect_normal_exit $PMEMWRITE$EXESUFFIX $POOL TEST_test

--- a/src/test/pmempool_dump/TEST3
+++ b/src/test/pmempool_dump/TEST3
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create blk 512 $POOL
 expect_normal_exit $PMEMWRITE$EXESUFFIX $POOL 0:w:TEST0

--- a/src/test/pmempool_dump/TEST4
+++ b/src/test/pmempool_dump/TEST4
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOL
 expect_normal_exit $PMEMWRITE$EXESUFFIX $POOL TEST1TEST2TEST3TEST4

--- a/src/test/pmempool_dump/TEST5
+++ b/src/test/pmempool_dump/TEST5
@@ -47,7 +47,7 @@ POOLSET=$DIR/pool.set
 POOL_PART1=$DIR/pool.part1
 POOL_PART2=$DIR/pool.part2
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 rm -f $POOLSET $POOL_PART1 $POOL_PART2
 

--- a/src/test/pmempool_dump/TEST6
+++ b/src/test/pmempool_dump/TEST6
@@ -47,7 +47,7 @@ POOLSET=$DIR/pool.set
 POOL_PART1=$DIR/pool.part1
 POOL_PART2=$DIR/pool.part2
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 rm -f $POOLSET $POOL_PART1 $POOL_PART2
 

--- a/src/test/pmempool_help/TEST0
+++ b/src/test/pmempool_help/TEST0
@@ -43,7 +43,7 @@ require_fs_type pmem non-pmem
 setup
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX >> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX --version >> $LOG

--- a/src/test/pmempool_help/TEST1
+++ b/src/test/pmempool_help/TEST1
@@ -43,7 +43,7 @@ require_fs_type pmem non-pmem
 setup
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 for cmd in info dump create check
 do

--- a/src/test/pmempool_info/TEST0
+++ b/src/test/pmempool_info/TEST0
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create blk 512 $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL >> $LOG

--- a/src/test/pmempool_info/TEST1
+++ b/src/test/pmempool_info/TEST1
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL >> $LOG

--- a/src/test/pmempool_info/TEST10
+++ b/src/test/pmempool_info/TEST10
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 rm -rf $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX create --layout "pmempool$SUFFIX" obj\

--- a/src/test/pmempool_info/TEST11
+++ b/src/test/pmempool_info/TEST11
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 rm -rf $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX create --layout "pmempool$SUFFIX" obj $POOL

--- a/src/test/pmempool_info/TEST12
+++ b/src/test/pmempool_info/TEST12
@@ -42,7 +42,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 rm -rf $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX create --layout "pmempool$SUFFIX" obj $POOL

--- a/src/test/pmempool_info/TEST13
+++ b/src/test/pmempool_info/TEST13
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 rm -rf $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX create --layout "pmempool$SUFFIX" obj $POOL

--- a/src/test/pmempool_info/TEST14
+++ b/src/test/pmempool_info/TEST14
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 rm -rf $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX create --layout "pmempool$SUFFIX" obj $POOL

--- a/src/test/pmempool_info/TEST15
+++ b/src/test/pmempool_info/TEST15
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 rm -rf $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX create --layout "pmempool$SUFFIX" obj $POOL

--- a/src/test/pmempool_info/TEST16
+++ b/src/test/pmempool_info/TEST16
@@ -46,8 +46,8 @@ LOG=out${UNITTEST_NUM}.log
 LOG_REP0=rep${UNITTEST_NUM}.0.log
 LOG_REP1=rep${UNITTEST_NUM}.1.log
 
-rm -rf $LOG_REP0 $LOG_REP1
-rm -rf $LOG && touch $LOG
+rm -f $LOG_REP0 $LOG_REP1
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/pool.set
 POOL1=$DIR/pool.part1

--- a/src/test/pmempool_info/TEST17
+++ b/src/test/pmempool_info/TEST17
@@ -44,7 +44,7 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/pool.set
 POOL1=$DIR/pool.part1

--- a/src/test/pmempool_info/TEST18
+++ b/src/test/pmempool_info/TEST18
@@ -45,7 +45,7 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:$DEVICE_DAX_PATH

--- a/src/test/pmempool_info/TEST19
+++ b/src/test/pmempool_info/TEST19
@@ -47,7 +47,7 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}

--- a/src/test/pmempool_info/TEST2
+++ b/src/test/pmempool_info/TEST2
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create -w blk 512 $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL >> $LOG

--- a/src/test/pmempool_info/TEST20
+++ b/src/test/pmempool_info/TEST20
@@ -43,7 +43,7 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/pool.set
 POOL1=$DIR/pool.part1

--- a/src/test/pmempool_info/TEST21
+++ b/src/test/pmempool_info/TEST21
@@ -47,7 +47,7 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]} \

--- a/src/test/pmempool_info/TEST24
+++ b/src/test/pmempool_info/TEST24
@@ -57,7 +57,7 @@ NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device $DEVICE)
 FULLDEV="/dev/$DEVICE"
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:$FULLDEV:x

--- a/src/test/pmempool_info/TEST25
+++ b/src/test/pmempool_info/TEST25
@@ -60,7 +60,7 @@ MOUNT_DIR="$DIR/mnt-pmem"
 ndctl_nfit_test_mount_pmem $FULLDEV $MOUNT_DIR
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET 10M:$DIR/testfile0:z 10M:$MOUNT_DIR/testfile1:z 10M:$DIR/testfile2:z

--- a/src/test/pmempool_info/TEST3
+++ b/src/test/pmempool_info/TEST3
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create -w blk 512 $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX info -B $POOL >> $LOG

--- a/src/test/pmempool_info/TEST4
+++ b/src/test/pmempool_info/TEST4
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create -w blk 512 $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX info -s $POOL >> $LOG

--- a/src/test/pmempool_info/TEST5
+++ b/src/test/pmempool_info/TEST5
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX info -x $POOL >> $LOG

--- a/src/test/pmempool_info/TEST6
+++ b/src/test/pmempool_info/TEST6
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOL
 expect_normal_exit $PMEMWRITE$EXESUFFIX $POOL TEST

--- a/src/test/pmempool_info/TEST7
+++ b/src/test/pmempool_info/TEST7
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOL
 expect_normal_exit $PMEMWRITE$EXESUFFIX $POOL TEST

--- a/src/test/pmempool_info/TEST8
+++ b/src/test/pmempool_info/TEST8
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create blk 512 $POOL
 expect_normal_exit $PMEMWRITE$EXESUFFIX $POOL 1:e 2:w:TEST

--- a/src/test/pmempool_info/TEST9
+++ b/src/test/pmempool_info/TEST9
@@ -44,7 +44,7 @@ setup
 
 POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create -w blk 512 $POOL
 INFO_NFLOG=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL | $GREP 'Free blocks' | $GREP -o '[0-9]\+')

--- a/src/test/pmempool_rm/TEST0
+++ b/src/test/pmempool_rm/TEST0
@@ -41,7 +41,7 @@ require_test_type medium
 setup
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 # Create pmemlog, pmemblk and pmemobj pools
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $DIR/pool.log

--- a/src/test/pmempool_rm/TEST1
+++ b/src/test/pmempool_rm/TEST1
@@ -43,7 +43,7 @@ require_no_superuser
 setup
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 # Create pmemlog, pmemblk and pmemobj pools
 expect_normal_exit $PMEMPOOL$EXESUFFIX create -m400 log $DIR/pool.log

--- a/src/test/pmempool_rm/TEST2
+++ b/src/test/pmempool_rm/TEST2
@@ -41,7 +41,7 @@ require_test_type medium
 setup
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 # Create poolset with replica
 create_poolset $DIR/pool.set 32M:$DIR/pool.part1:x 32M:$DIR/pool.part2:x\

--- a/src/test/pmempool_rm/TEST7
+++ b/src/test/pmempool_rm/TEST7
@@ -42,7 +42,7 @@ require_fs_type any
 setup
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 # Create poolset with replica
 create_poolset $DIR/pool.set 32M:$DIR/pool.part1:z 32M:$DIR/pool.part2:z\

--- a/src/test/pmempool_sync/TEST0
+++ b/src/test/pmempool_sync/TEST0
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/pool0.set

--- a/src/test/pmempool_sync/TEST1
+++ b/src/test/pmempool_sync/TEST1
@@ -44,8 +44,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/pool0.set

--- a/src/test/pmempool_sync/TEST10
+++ b/src/test/pmempool_sync/TEST10
@@ -44,8 +44,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET1=$DIR/poolset1

--- a/src/test/pmempool_sync/TEST11
+++ b/src/test/pmempool_sync/TEST11
@@ -44,8 +44,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET1=$DIR/poolset1

--- a/src/test/pmempool_sync/TEST12
+++ b/src/test/pmempool_sync/TEST12
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT
 POOLSET=$DIR/pool0.set

--- a/src/test/pmempool_sync/TEST14
+++ b/src/test/pmempool_sync/TEST14
@@ -52,7 +52,7 @@ setup
 dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET \

--- a/src/test/pmempool_sync/TEST15
+++ b/src/test/pmempool_sync/TEST15
@@ -52,7 +52,7 @@ setup
 dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET \

--- a/src/test/pmempool_sync/TEST16
+++ b/src/test/pmempool_sync/TEST16
@@ -48,8 +48,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/pool0.set

--- a/src/test/pmempool_sync/TEST17
+++ b/src/test/pmempool_sync/TEST17
@@ -46,8 +46,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/pool0.set

--- a/src/test/pmempool_sync/TEST18
+++ b/src/test/pmempool_sync/TEST18
@@ -53,8 +53,8 @@ dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/poolset

--- a/src/test/pmempool_sync/TEST19
+++ b/src/test/pmempool_sync/TEST19
@@ -53,8 +53,8 @@ dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/poolset

--- a/src/test/pmempool_sync/TEST2
+++ b/src/test/pmempool_sync/TEST2
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/pool0.set

--- a/src/test/pmempool_sync/TEST20
+++ b/src/test/pmempool_sync/TEST20
@@ -53,8 +53,8 @@ dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/poolset

--- a/src/test/pmempool_sync/TEST21
+++ b/src/test/pmempool_sync/TEST21
@@ -53,8 +53,8 @@ dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/poolset

--- a/src/test/pmempool_sync/TEST22
+++ b/src/test/pmempool_sync/TEST22
@@ -48,8 +48,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/pool0.set

--- a/src/test/pmempool_sync/TEST23
+++ b/src/test/pmempool_sync/TEST23
@@ -46,8 +46,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET1=$DIR/poolset1

--- a/src/test/pmempool_sync/TEST24
+++ b/src/test/pmempool_sync/TEST24
@@ -46,8 +46,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET1=$DIR/poolset1

--- a/src/test/pmempool_sync/TEST25
+++ b/src/test/pmempool_sync/TEST25
@@ -50,8 +50,8 @@ dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET1=$DIR/poolset1

--- a/src/test/pmempool_sync/TEST26
+++ b/src/test/pmempool_sync/TEST26
@@ -47,8 +47,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/pool0.set

--- a/src/test/pmempool_sync/TEST27
+++ b/src/test/pmempool_sync/TEST27
@@ -60,7 +60,7 @@ MOUNT_DIR="$DIR/mnt-pmem"
 ndctl_nfit_test_mount_pmem $FULLDEV $MOUNT_DIR
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET 10M:$DIR/testfile0:z 10M:$MOUNT_DIR/testfile1:z 10M:$DIR/testfile2:z \

--- a/src/test/pmempool_sync/TEST28
+++ b/src/test/pmempool_sync/TEST28
@@ -57,7 +57,7 @@ NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device $DEVICE)
 FULLDEV="/dev/$DEVICE"
 
 LOG=out${UNITTEST_NUM}.log
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:$FULLDEV:x \

--- a/src/test/pmempool_sync/TEST3
+++ b/src/test/pmempool_sync/TEST3
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/pool0.set

--- a/src/test/pmempool_sync/TEST4
+++ b/src/test/pmempool_sync/TEST4
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/pool0.set

--- a/src/test/pmempool_sync/TEST5
+++ b/src/test/pmempool_sync/TEST5
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/pool0.set

--- a/src/test/pmempool_sync/TEST6
+++ b/src/test/pmempool_sync/TEST6
@@ -47,8 +47,8 @@ dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/pool1.set

--- a/src/test/pmempool_sync/TEST7
+++ b/src/test/pmempool_sync/TEST7
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET=$DIR/pool.set

--- a/src/test/pmempool_sync/TEST8
+++ b/src/test/pmempool_sync/TEST8
@@ -44,8 +44,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET1=$DIR/poolset1

--- a/src/test/pmempool_sync/TEST9
+++ b/src/test/pmempool_sync/TEST9
@@ -44,8 +44,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET1=$DIR/poolset1

--- a/src/test/pmempool_transform/TEST0
+++ b/src/test/pmempool_transform/TEST0
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST1
+++ b/src/test/pmempool_transform/TEST1
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST10
+++ b/src/test/pmempool_transform/TEST10
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST11
+++ b/src/test/pmempool_transform/TEST11
@@ -53,8 +53,8 @@ dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST12
+++ b/src/test/pmempool_transform/TEST12
@@ -54,8 +54,8 @@ dax_device_zero
 LOG=out${UNITTEST_NUM}.log
 ERR_LOG=err${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_1=$DIR/poolset.1

--- a/src/test/pmempool_transform/TEST13
+++ b/src/test/pmempool_transform/TEST13
@@ -46,8 +46,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST14
+++ b/src/test/pmempool_transform/TEST14
@@ -55,8 +55,8 @@ dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST15
+++ b/src/test/pmempool_transform/TEST15
@@ -54,8 +54,8 @@ dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST16
+++ b/src/test/pmempool_transform/TEST16
@@ -53,8 +53,8 @@ dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST17
+++ b/src/test/pmempool_transform/TEST17
@@ -47,8 +47,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST18
+++ b/src/test/pmempool_transform/TEST18
@@ -56,8 +56,8 @@ dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST19
+++ b/src/test/pmempool_transform/TEST19
@@ -46,8 +46,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_1=$DIR/poolset.1

--- a/src/test/pmempool_transform/TEST2
+++ b/src/test/pmempool_transform/TEST2
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST20
+++ b/src/test/pmempool_transform/TEST20
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST21
+++ b/src/test/pmempool_transform/TEST21
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST22
+++ b/src/test/pmempool_transform/TEST22
@@ -53,8 +53,8 @@ dax_device_zero
 LOG=out${UNITTEST_NUM}.log
 ERR_LOG=err${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 rm -rf $ERR_LOG && touch $ERR_LOG
 
 LAYOUT=OBJ_LAYOUT$SUFFIX

--- a/src/test/pmempool_transform/TEST23
+++ b/src/test/pmempool_transform/TEST23
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST24
+++ b/src/test/pmempool_transform/TEST24
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST3
+++ b/src/test/pmempool_transform/TEST3
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST4
+++ b/src/test/pmempool_transform/TEST4
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST5
+++ b/src/test/pmempool_transform/TEST5
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST6
+++ b/src/test/pmempool_transform/TEST6
@@ -45,8 +45,8 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST7
+++ b/src/test/pmempool_transform/TEST7
@@ -47,8 +47,8 @@ dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST8
+++ b/src/test/pmempool_transform/TEST8
@@ -48,8 +48,8 @@ dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform/TEST9
+++ b/src/test/pmempool_transform/TEST9
@@ -48,8 +48,8 @@ dax_device_zero
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 
 LAYOUT=OBJ_LAYOUT$SUFFIX
 POOLSET_IN=$DIR/poolset.in

--- a/src/test/pmempool_transform_remote/common.sh
+++ b/src/test/pmempool_transform_remote/common.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,8 +48,8 @@ require_node_log_files 1 pmempool$UNITTEST_NUM.log
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_part.log
-rm -rf $LOG && touch $LOG
-rm -rf $LOG_TEMP && touch $LOG_TEMP
+rm -f $LOG && touch $LOG
+rm -f $LOG_TEMP && touch $LOG_TEMP
 rm_files_from_node 0 ${NODE_TEST_DIR[0]}/$LOG
 rm_files_from_node 1 ${NODE_TEST_DIR[1]}/$LOG
 

--- a/src/test/pmemspoil/TEST0
+++ b/src/test/pmemspoil/TEST0
@@ -45,7 +45,7 @@ setup
 
 LOG=out${UNITTEST_NUM}.log
 
-rm -rf $LOG && touch $LOG
+rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/pool.set
 POOL1=$DIR/pool.part1

--- a/src/test/rpmemd_config/TEST1
+++ b/src/test/rpmemd_config/TEST1
@@ -46,7 +46,7 @@ RPMEMD=./rpmemd_config$EXESUFFIX
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_temp.log
-rm -rf $LOG $LOG_TEMP
+rm -f $LOG $LOG_TEMP
 
 CONFIG=in${UNITTEST_NUM}.conf
 

--- a/src/test/rpmemd_config/TEST3
+++ b/src/test/rpmemd_config/TEST3
@@ -46,7 +46,7 @@ RPMEMD=./rpmemd_config$EXESUFFIX
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_temp.log
-rm -rf $LOG $LOG_TEMP
+rm -f $LOG $LOG_TEMP
 
 CONFIG=in${UNITTEST_NUM}.conf
 

--- a/src/test/rpmemd_config/TEST4
+++ b/src/test/rpmemd_config/TEST4
@@ -46,7 +46,7 @@ RPMEMD=./rpmemd_config$EXESUFFIX
 
 LOG=out${UNITTEST_NUM}.log
 LOG_TEMP=out${UNITTEST_NUM}_temp.log
-rm -rf $LOG $LOG_TEMP
+rm -f $LOG $LOG_TEMP
 
 # use empty config to prevent loading config file from default location
 # which may have nondefault configuration


### PR DESCRIPTION
Replace string "rm -rf \$LOG" with "rm -f \$LOG".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2882)
<!-- Reviewable:end -->
