### PR TITLE
obj: scalability improvements around run reuse

### DIFF
--- a/src/common/sys_util.h
+++ b/src/common/sys_util.h
@@ -87,6 +87,23 @@ util_mutex_lock(os_mutex_t *m)
 }
 
 /*
+ * util_mutex_trylock -- os_mutex_trylock variant that never fails from
+ * caller perspective (other than EBUSY). If util_mutex_trylock failed, this
+ * function aborts the program.
+ * Returns 0 if locked successfully, otherwise returns EBUSY.
+ */
+static inline int
+util_mutex_trylock(os_mutex_t *m)
+{
+	int tmp = os_mutex_trylock(m);
+	if (tmp && tmp != EBUSY) {
+		errno = tmp;
+		FATAL("!os_mutex_trylock");
+	}
+	return tmp;
+}
+
+/*
  * util_mutex_unlock -- os_mutex_unlock variant that never fails from
  * caller perspective. If os_mutex_unlock failed, this function aborts
  * the program.

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -56,7 +56,7 @@
 #define SIZEOF_RUN(runp, size_idx)\
 	(sizeof(*(runp)) + (((size_idx) - 1) * CHUNKSIZE))
 
-#define MAX_RUN_LOCKS 1024
+#define MAX_RUN_LOCKS MAX_CHUNK
 
 /*
  * This is the value by which the heap might grow once we hit an OOM.

--- a/src/libpmemobj/heap.h
+++ b/src/libpmemobj/heap.h
@@ -47,7 +47,6 @@
 #include "palloc.h"
 #include "os_thread.h"
 
-#define MAX_RUN_LOCKS 1024
 
 #define HEAP_OFF_TO_PTR(heap, off) ((void *)((char *)((heap)->base) + (off)))
 #define HEAP_PTR_TO_OFF(heap, ptr)\

--- a/src/libpmemobj/recycler.c
+++ b/src/libpmemobj/recycler.c
@@ -82,6 +82,9 @@ struct recycler {
 	 * blocks stored in the recycler.
 	 * The value is not meant to be accurate, but rather a rough measure on
 	 * how often should the memory block scores be recalculated.
+	 *
+	 * Per-chunk unaccounted units are shared for all zones, which might
+	 * lead to some unnecessary recalculations.
 	 */
 	size_t unaccounted_units[MAX_CHUNK];
 	size_t unaccounted_total;

--- a/src/test/obj_fragmentation2/obj_fragmentation2.c
+++ b/src/test/obj_fragmentation2/obj_fragmentation2.c
@@ -196,7 +196,7 @@ static workload *workloads[] = {
 };
 
 static float workloads_target[] = {
-	0.01f, 0.01f, 0.01f, 0.9f, 0.8f, 0.7f, 0.2f, 0.7f, 0.1f
+	0.01f, 0.01f, 0.01f, 0.9f, 0.8f, 0.7f, 0.2f, 0.8f, 0.73f
 };
 
 int

--- a/src/test/obj_fragmentation2/obj_fragmentation2.c
+++ b/src/test/obj_fragmentation2/obj_fragmentation2.c
@@ -196,7 +196,7 @@ static workload *workloads[] = {
 };
 
 static float workloads_target[] = {
-	0.01f, 0.01f, 0.01f, 0.9f, 0.8f, 0.7f, 0.2f, 0.8f, 0.73f
+	0.01f, 0.01f, 0.01f, 0.9f, 0.8f, 0.7f, 0.3f, 0.8f, 0.73f
 };
 
 int

--- a/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
+++ b/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
@@ -136,8 +136,13 @@ tx_worker(void *arg)
 	 * will automatically abort and all of the objects will be freed.
 	 */
 	TX_BEGIN(a->pop) {
-		for (;;) /* this is NOT an infinite loop */
+		for (int n = 0; ; ++n) { /* this is NOT an infinite loop */
 			pmemobj_tx_alloc(ALLOC_SIZE, a->idx);
+			if (Ops_per_thread != MAX_OPS_PER_THREAD &&
+			    n == Ops_per_thread) {
+				pmemobj_tx_abort(0);
+			}
+		}
 	} TX_END
 
 	return NULL;


### PR DESCRIPTION
In my synthetic benchmarks I've observed 2x improvement in the runtime state performance when throwing lots of threads at the allocator (100++).

I'd like to ask for a diligent review of `heap_run_process_bitmap_value`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2884)
<!-- Reviewable:end -->
