### PR TITLE
test: obj_verify.c FreeBSD compatibility

### DIFF
--- a/src/test/tools/obj_verify/obj_verify.c
+++ b/src/test/tools/obj_verify/obj_verify.c
@@ -36,6 +36,7 @@
 
 #include <stddef.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 
 #include "libpmemobj.h"
 #include "set.h"


### PR DESCRIPTION
Add <sys/stat.h> for pmemobj_create.