### PR TITLE
common: fix format specifier for string

### DIFF
--- a/src/common/mmap_posix.c
+++ b/src/common/mmap_posix.c
@@ -46,9 +46,9 @@
 char *Mmap_mapfile = OS_MAPFILE; /* Should be modified only for testing */
 
 #ifdef __FreeBSD__
-static const char *sscanf_os = "%p %p";
+static const char * const sscanf_os = "%p %p";
 #else
-static const char *sscanf_os = "%p-%p";
+static const char * const sscanf_os = "%p-%p";
 #endif
 
 /*

--- a/src/libpmempool/check_pool_hdr.c
+++ b/src/libpmempool/check_pool_hdr.c
@@ -306,7 +306,7 @@ pool_hdr_nondefault(PMEMpoolcheck *ppc, location *loc)
 	LOG(3, NULL);
 
 	if (loc->hdr.crtime > (uint64_t)ppc->pool->set_file->mtime) {
-		const char *error = "%spool_hdr.crtime is not valid";
+		const char * const error = "%spool_hdr.crtime is not valid";
 		if (CHECK_IS_NOT(ppc, REPAIR)) {
 			ppc->result = CHECK_RESULT_NOT_CONSISTENT;
 			return CHECK_ERR(ppc, error, loc->prefix);
@@ -326,7 +326,7 @@ pool_hdr_nondefault(PMEMpoolcheck *ppc, location *loc)
 			memcmp(&loc->valid_part_hdrp->arch_flags,
 				&loc->hdr.arch_flags,
 				sizeof(struct arch_flags)) != 0) {
-		const char *error = "%spool_hdr.arch_flags is not valid";
+		const char * const error = "%spool_hdr.arch_flags is not valid";
 		if (CHECK_IS_NOT(ppc, REPAIR)) {
 			ppc->result = CHECK_RESULT_NOT_CONSISTENT;
 			return CHECK_ERR(ppc, error, loc->prefix);

--- a/src/test/tools/ctrld/ctrld.c
+++ b/src/test/tools/ctrld/ctrld.c
@@ -390,8 +390,8 @@ has_port_inode(unsigned short port, struct inodes *inodes)
 		"%*d: "
 		"%*64[0-9A-Fa-f]:%X "
 		"%*64[0-9A-Fa-f]:%*X "
-		"%*X %*lX:%*lX %*X:%*lX "
-		"%*lX %*d %*d %lu %*s\n";
+		"%*X %*X:%*X %*X:%*X "
+		"%*X %*d %*d %lu %*s\n";
 
 	char buff[BUFF_SIZE];
 

--- a/src/test/tools/ctrld/ctrld.c
+++ b/src/test/tools/ctrld/ctrld.c
@@ -386,7 +386,7 @@ static int
 has_port_inode(unsigned short port, struct inodes *inodes)
 {
 	/* format of /proc/net/tcp entries */
-	const char *tcp_fmt =
+	const char * const tcp_fmt =
 		"%*d: "
 		"%*64[0-9A-Fa-f]:%X "
 		"%*64[0-9A-Fa-f]:%*X "

--- a/src/test/tools/pmemspoil/spoil.c
+++ b/src/test/tools/pmemspoil/spoil.c
@@ -290,7 +290,7 @@ static const struct pmemspoil pmemspoil_default = {
 /*
  * help_str -- string for help message
  */
-static const char *help_str =
+static const char * const  help_str =
 "Common options:\n"
 "  -v, --verbose        Increase verbose level\n"
 "  -?, --help           Display this help and exit\n"

--- a/src/test/tools/pmemspoil/spoil.c
+++ b/src/test/tools/pmemspoil/spoil.c
@@ -291,7 +291,7 @@ static const struct pmemspoil pmemspoil_default = {
  * help_str -- string for help message
  */
 static const char * const  help_str =
-"Common options:\n"
+"%s common options:\n"
 "  -v, --verbose        Increase verbose level\n"
 "  -?, --help           Display this help and exit\n"
 "  -r, --replica <num>  Replica index\n"
@@ -339,7 +339,7 @@ print_version(char *appname)
 }
 
 /*
- * pmempool_check_help -- print help message for check command
+ * pmemspoil_help -- print help message for spoil command
  */
 static void
 pmemspoil_help(char *appname)

--- a/src/tools/pmempool/check.c
+++ b/src/tools/pmempool/check.c
@@ -85,7 +85,7 @@ static const struct pmempool_check_context pmempool_check_default = {
 /*
  * help_str -- string for help message
  */
-static const char *help_str =
+static const char * const help_str =
 "Check consistency of a pool\n"
 "\n"
 "Common options:\n"

--- a/src/tools/pmempool/convert.c
+++ b/src/tools/pmempool/convert.c
@@ -50,7 +50,11 @@
 #include "convert.h"
 #include "util_pmem.h"
 
-static const char * const help_str = "";
+static const char * const help_str =
+"Upgrade pool files layout version.\n"
+"\n"
+"For complete documentation see %s-convert(1) manual page.\n"
+;
 
 /*
  * print_usage -- print application usage short description

--- a/src/tools/pmempool/convert.c
+++ b/src/tools/pmempool/convert.c
@@ -50,7 +50,7 @@
 #include "convert.h"
 #include "util_pmem.h"
 
-static const char *help_str = "";
+static const char * const help_str = "";
 
 /*
  * print_usage -- print application usage short description

--- a/src/tools/pmempool/create.c
+++ b/src/tools/pmempool/create.c
@@ -108,7 +108,7 @@ static const struct pmempool_create pmempool_create_default = {
 /*
  * help_str -- string for help message
  */
-static const char *help_str =
+static const char * const help_str =
 "Create pmem pool of specified size, type and name\n"
 "\n"
 "Common options:\n"

--- a/src/tools/pmempool/dump.c
+++ b/src/tools/pmempool/dump.c
@@ -95,7 +95,7 @@ static const struct option long_options[] = {
 /*
  * help_str -- string for help message
  */
-static const char *help_str =
+static const char * const help_str =
 "Dump user data from pool\n"
 "\n"
 "Available options:\n"

--- a/src/tools/pmempool/info.c
+++ b/src/tools/pmempool/info.c
@@ -259,7 +259,7 @@ static const struct option_requirement option_requirements[] = {
 /*
  * help_str -- string for help message
  */
-static const char *help_str =
+static const char * const help_str =
 "Show information about pmem pool from specified file.\n"
 "\n"
 "Common options:\n"

--- a/src/tools/pmempool/rm.c
+++ b/src/tools/pmempool/rm.c
@@ -75,7 +75,7 @@ static enum ask_type ask_mode;
 static int rpmem_avail;
 
 /* help message */
-static const char *help_str =
+static const char * const help_str =
 "Remove pool file or all files from poolset\n"
 "\n"
 "Available options:\n"

--- a/src/tools/pmempool/synchronize.c
+++ b/src/tools/pmempool/synchronize.c
@@ -68,7 +68,7 @@ static const struct pmempool_sync_context pmempool_sync_default = {
 /*
  * help_str -- string for help message
  */
-static const char *help_str =
+static const char * const help_str =
 "Check consistency of a pool\n"
 "\n"
 "Common options:\n"

--- a/src/tools/pmempool/transform.c
+++ b/src/tools/pmempool/transform.c
@@ -69,7 +69,7 @@ static const struct pmempool_transform_context pmempool_transform_default = {
 /*
  * help_str -- string for help message
  */
-static const char *help_str =
+static const char * const help_str =
 "Modify internal structure of a poolset\n"
 "\n"
 "Common options:\n"

--- a/src/tools/rpmemd/rpmemd_config.c
+++ b/src/tools/rpmemd/rpmemd_config.c
@@ -97,7 +97,7 @@ static const struct option options[] = {
 
 #define VALUE_INDENT	"                                        "
 
-static const char *help_str =
+static const char * const help_str =
 "\n"
 "Options:\n"
 "  -c, --config <path>           configuration file location\n"

--- a/utils/check_license/check-license.c
+++ b/utils/check_license/check-license.c
@@ -73,7 +73,7 @@
 /*
  * help_str -- string for the help message
  */
-static const char *help_str =
+static const char * const help_str =
 "Usage: %s <mode> <file_1> <file_2> [filename]\n"
 "\n"
 "Modes:\n"


### PR DESCRIPTION
Intention of this PR is to fix potential issues with string format specifier.
1.Format specifiers for help message's could be constant pointer to prevent point to any other data.
2.It is always safer to add %s specifier to print string
In any case any feedback will be appreciated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2894)
<!-- Reviewable:end -->
