### PR TITLE
Added pmemobj_root_offset function

### DIFF
--- a/doc/libpmemobj/pmemobj_root.3.md
+++ b/doc/libpmemobj/pmemobj_root.3.md
@@ -47,6 +47,7 @@ date: pmemobj API version 2.3
 
 **pmemobj_root**(), **pmemobj_root_construct**()
 **POBJ_ROOT**(), **pmemobj_root_size**() -- root object management
+**POBJ_ROOT**(), **pmemobj_root_offset**() -- root object management
 
 
 # SYNOPSIS #
@@ -59,6 +60,7 @@ PMEMoid pmemobj_root_construct(PMEMobjpool *pop, size_t size,
 	pmemobj_constr constructor, void *arg);
 POBJ_ROOT(PMEMobjpool *pop, TYPE)
 size_t pmemobj_root_size(PMEMobjpool *pop);
+size_t pmemobj_root_offset(PMEMobjpool *pop);
 ```
 
 
@@ -94,6 +96,10 @@ except it returns a typed *OID* value.
 The **pmemobj_root_size**() function returns the current size of the root object
 associated with the persistent memory pool *pop*.
 
+The **pmemobj_root_offset**() function returns the address of the start of
+the pool memory after the pool header.
+
+
 
 # RETURN VALUE #
 
@@ -118,6 +124,9 @@ The **pmemobj_root_size**() function returns the current size of the root object
 associated with the persistent memory pool *pop*. The returned size is the
 largest value requested by any of the earlier **pmemobj_root**() calls. If the
 root object has not been allocated yet, **pmemobj_root_size**() returns 0.
+
+The **pmemobj_root_offset**() function returns the address of the data after
+the pool header.
 
 
 # SEE ALSO #

--- a/src/include/libpmemobj/pool_base.h
+++ b/src/include/libpmemobj/pool_base.h
@@ -118,6 +118,12 @@ PMEMoid pmemobj_root_construct(PMEMobjpool *pop, size_t size,
  */
 size_t pmemobj_root_size(PMEMobjpool *pop);
 
+/*
+ * Returns the offset to the root after the header 
+ */
+size_t pmemobj_root_offset(PMEMobjpool *pop);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/libpmemobj/pool_base.h
+++ b/src/include/libpmemobj/pool_base.h
@@ -119,7 +119,7 @@ PMEMoid pmemobj_root_construct(PMEMobjpool *pop, size_t size,
 size_t pmemobj_root_size(PMEMobjpool *pop);
 
 /*
- * Returns the offset to the root after the header 
+ * Returns the offset to the root after the header
  */
 size_t pmemobj_root_offset(PMEMobjpool *pop);
 

--- a/src/libpmemobj/libpmemobj.def
+++ b/src/libpmemobj/libpmemobj.def
@@ -88,6 +88,7 @@ EXPORTS
 	pmemobj_root
 	pmemobj_root_construct
 	pmemobj_root_size
+  pmemobj_root_offset
 	pmemobj_first
 	pmemobj_next
 	pmemobj_list_insert

--- a/src/libpmemobj/libpmemobj.map
+++ b/src/libpmemobj/libpmemobj.map
@@ -78,6 +78,7 @@ LIBPMEMOBJ_1.0 {
 		pmemobj_root;
 		pmemobj_root_construct;
 		pmemobj_root_size;
+ 		pmemobj_root_offset;  
 		pmemobj_first;
 		pmemobj_next;
 		pmemobj_list_insert;

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -2797,6 +2797,15 @@ pmemobj_root_size(PMEMobjpool *pop)
 }
 
 /*
+ * pmemobj_root_offset -- returns offset from pool header to root object
+ */
+size_t
+pmemobj_root_offset(PMEMobjpool *pop)
+{
+  return pop->root_offset;
+}
+
+/*
  * pmemobj_root_construct -- returns root object
  */
 PMEMoid
@@ -3132,3 +3141,4 @@ _pobj_debug_notice(const char *api_name, const char *file, int line)
 	}
 #endif /* DEBUG */
 }
+


### PR DESCRIPTION
Allows the user to get hold of the memory for an object pool.  This is useful for registering the pool memory with other subsystems such as RDMA where registration is slow and needs to be performed a priori.
