### PR TITLE
[RFC] test: shorter test setup v2

### DIFF
--- a/src/test/arch_flags/TEST0
+++ b/src/test/arch_flags/TEST0
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 #
@@ -35,9 +35,6 @@
 # src/test/arch_flags/TEST0 -- unit test for util_get_arch_flags function
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 require_fs_type none
@@ -56,5 +53,3 @@ expect_normal_exit ./arch_flags$EXESUFFIX\
 	0:0:0:0x0:0x1
 
 check
-
-pass

--- a/src/test/arch_flags/TEST0
+++ b/src/test/arch_flags/TEST0
@@ -35,11 +35,7 @@
 # src/test/arch_flags/TEST0 -- unit test for util_get_arch_flags function
 #
 
-require_test_type medium
-
-require_fs_type none
-
-setup
+setup -t medium -f none
 
 export ARCH_FLAGS_LOG_LEVEL=15
 export ARCH_FLAGS_LOG_FILE="log${UNITTEST_NUM}.log"
@@ -51,5 +47,3 @@ expect_normal_exit ./arch_flags$EXESUFFIX\
 	0:0:255:0x0:0x0\
 	0:0:0:0x1:0x0\
 	0:0:0:0x0:0x1
-
-check

--- a/src/test/blk_nblock/TEST0
+++ b/src/test/blk_nblock/TEST0
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2014-2018, Intel Corporation
 #
@@ -34,9 +34,6 @@
 #
 # src/test/blk_nblock/TEST0 -- unit test for pmemblk_nblock
 #
-
-# standard unit test setup
-. ../unittest/unittest.sh
 
 require_test_type medium
 
@@ -178,5 +175,3 @@ check_pools $DIR/testfile2.512\
 	$DIR/testfile7.4224
 
 check
-
-pass

--- a/src/test/blk_nblock/TEST0
+++ b/src/test/blk_nblock/TEST0
@@ -35,14 +35,11 @@
 # src/test/blk_nblock/TEST0 -- unit test for pmemblk_nblock
 #
 
-require_test_type medium
-
-require_fs_type any
 require_unlimited_vm
 
-# this test creates huge files
-configure_valgrind force-disable
-setup
+# Valgrind disabled because this test creates huge files
+
+setup -t medium -f any -v force-disable
 
 #
 # Create a gajillion files, each file size created
@@ -173,5 +170,3 @@ check_pools $DIR/testfile2.512\
 	$DIR/testfile7.4096\
 	$DIR/testfile7.4160\
 	$DIR/testfile7.4224
-
-check

--- a/src/test/blk_nblock/TEST1
+++ b/src/test/blk_nblock/TEST1
@@ -35,11 +35,7 @@
 # src/test/blk_nblock/TEST1 -- unit test for pmemblk_nblock
 #
 
-require_test_type medium
-
-require_fs_type any
-
-setup
+setup -t medium -f any
 
 #
 # Create many files with different block sizes - most of
@@ -106,5 +102,3 @@ check_pools $DIR/testfile1.2096896\
 	$DIR/testfile2.536870912\
 	$DIR/testfile2.1073741824\
 	$DIR/testfile2.2147483648\
-
-check

--- a/src/test/blk_nblock/TEST1
+++ b/src/test/blk_nblock/TEST1
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2014-2018, Intel Corporation
 #
@@ -34,9 +34,6 @@
 #
 # src/test/blk_nblock/TEST1 -- unit test for pmemblk_nblock
 #
-
-# standard unit test setup
-. ../unittest/unittest.sh
 
 require_test_type medium
 
@@ -111,5 +108,3 @@ check_pools $DIR/testfile1.2096896\
 	$DIR/testfile2.2147483648\
 
 check
-
-pass

--- a/src/test/blk_nblock/TEST2
+++ b/src/test/blk_nblock/TEST2
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2014-2018, Intel Corporation
 #
@@ -35,9 +35,6 @@
 # src/test/blk_nblock/TEST2 -- unit test for pmemblk_nblock
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 require_fs_type any
@@ -54,5 +51,3 @@ expect_normal_exit ./blk_nblock$EXESUFFIX\
 check_pools $DIR/testset1\
 	$DIR/testset2
 check
-
-pass

--- a/src/test/blk_nblock/TEST2
+++ b/src/test/blk_nblock/TEST2
@@ -35,11 +35,7 @@
 # src/test/blk_nblock/TEST2 -- unit test for pmemblk_nblock
 #
 
-require_test_type medium
-
-require_fs_type any
-
-setup
+setup -t medium -f any
 
 create_poolset $DIR/testset1 64M:$DIR/testfile11:x
 create_poolset $DIR/testset2 64M:$DIR/testfile21:x 64M:$DIR/testfile22:x
@@ -50,4 +46,3 @@ expect_normal_exit ./blk_nblock$EXESUFFIX\
 
 check_pools $DIR/testset1\
 	$DIR/testset2
-check

--- a/src/test/blk_non_zero/TEST0
+++ b/src/test/blk_non_zero/TEST0
@@ -37,12 +37,7 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-require_test_type medium
-
-# doesn't make sense to run in local directory
-require_fs_type pmem non-pmem
-
-setup
+setup -t medium -f "pmem non-pmem"
 
 # single arena and minimum pmemblk pool file case
 create_nonzeroed_file 17M 8K $DIR/testfile1
@@ -54,5 +49,3 @@ create_nonzeroed_file 17M 8K $DIR/testfile1
 #
 expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
 	r:0 r:1 r:34217 r:34218 z:0 z:1 r:0 e:3 r:4
-
-check

--- a/src/test/blk_non_zero/TEST0
+++ b/src/test/blk_non_zero/TEST0
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
@@ -37,9 +37,6 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 # doesn't make sense to run in local directory
@@ -59,5 +56,3 @@ expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
 	r:0 r:1 r:34217 r:34218 z:0 z:1 r:0 e:3 r:4
 
 check
-
-pass

--- a/src/test/blk_non_zero/TEST1
+++ b/src/test/blk_non_zero/TEST1
@@ -37,16 +37,10 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-# doesn't make sense to run in local directory
-require_fs_type pmem non-pmem
-require_test_type long
-
-setup
+setup -t long -f "pmem non-pmem"
 
 # single arena write case
 create_nonzeroed_file 1G 824K $DIR/testfile1
 
 expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
 	w:0 r:1 r:0 w:1 r:0 r:1 r:2
-
-check

--- a/src/test/blk_non_zero/TEST1
+++ b/src/test/blk_non_zero/TEST1
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
@@ -37,9 +37,6 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
 require_test_type long
@@ -53,5 +50,3 @@ expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
 	w:0 r:1 r:0 w:1 r:0 r:1 r:2
 
 check
-
-pass

--- a/src/test/blk_non_zero/TEST2
+++ b/src/test/blk_non_zero/TEST2
@@ -37,11 +37,7 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-# doesn't make sense to run in local directory
-require_fs_type pmem non-pmem
-require_test_type long
-
-setup
+setup -t long -f "pmem non-pmem"
 
 # write re-use test case
 create_nonzeroed_file 1G 824M $DIR/testfile1
@@ -51,5 +47,3 @@ expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
 
 expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 o\
 	w:0 r:4 r:3 r:2 r:1 r:0 w:0 r:0
-
-check

--- a/src/test/blk_non_zero/TEST2
+++ b/src/test/blk_non_zero/TEST2
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
@@ -37,9 +37,6 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
 require_test_type long
@@ -56,5 +53,3 @@ expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 o\
 	w:0 r:4 r:3 r:2 r:1 r:0 w:0 r:0
 
 check
-
-pass

--- a/src/test/blk_non_zero/TEST3
+++ b/src/test/blk_non_zero/TEST3
@@ -37,11 +37,7 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-# doesn't make sense to run in local directory
-require_fs_type pmem non-pmem
-require_test_type long
-
-setup
+setup -t long -f "pmem non-pmem"
 
 # mix writes with set_zero and set_error and check results
 create_nonzeroed_file 1G 824M $DIR/testfile1
@@ -53,5 +49,3 @@ expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
 	r:100 r:200 r:300 r:400\
 	e:100 w:200 e:300 w:400\
 	r:100 r:200 r:300 r:400
-
-check

--- a/src/test/blk_non_zero/TEST3
+++ b/src/test/blk_non_zero/TEST3
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
@@ -37,9 +37,6 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
 require_test_type long
@@ -58,5 +55,3 @@ expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
 	r:100 r:200 r:300 r:400
 
 check
-
-pass

--- a/src/test/blk_non_zero/TEST4
+++ b/src/test/blk_non_zero/TEST4
@@ -37,11 +37,7 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-# doesn't make sense to run in local directory
-require_fs_type pmem non-pmem
-require_test_type long
-
-setup
+setup -t long -f "pmem non-pmem"
 
 # mix writes with set_zero and set_error and check results
 create_nonzeroed_file 1G 824M $DIR/testfile1
@@ -53,5 +49,3 @@ expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
 		e:4 z:4 r:4\
 		w:5 e:5 z:5 r:5\
 		w:6 z:6 e:6 r:6
-
-check

--- a/src/test/blk_non_zero/TEST4
+++ b/src/test/blk_non_zero/TEST4
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
@@ -37,9 +37,6 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
 require_test_type long
@@ -58,5 +55,3 @@ expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
 		w:6 z:6 e:6 r:6
 
 check
-
-pass

--- a/src/test/blk_non_zero/TEST5
+++ b/src/test/blk_non_zero/TEST5
@@ -36,12 +36,7 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-require_test_type medium
-
-# doesn't make sense to run in local directory
-require_fs_type pmem non-pmem
-
-setup
+setup -t medium -f "pmem non-pmem"
 
 # single arena and minimum pmemblk pool file case
 MIN_POOL_SIZE=$((16*1024*1024 + 64*1024))
@@ -53,5 +48,3 @@ MIN_POOL_SIZE=$((16*1024*1024 + 64*1024))
 #
 expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c $MIN_POOL_SIZE\
 	r:0 r:1 r:32312 r:32313 z:0 z:1 r:0
-
-check

--- a/src/test/blk_non_zero/TEST5
+++ b/src/test/blk_non_zero/TEST5
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 #
@@ -36,9 +36,6 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 # doesn't make sense to run in local directory
@@ -58,5 +55,3 @@ expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c $MIN_POOL_SIZE\
 	r:0 r:1 r:32312 r:32313 z:0 z:1 r:0
 
 check
-
-pass

--- a/src/test/blk_non_zero/TEST6
+++ b/src/test/blk_non_zero/TEST6
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 #
@@ -36,9 +36,6 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 # doesn't make sense to run in local directory
@@ -53,5 +50,3 @@ expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c $FILE_SIZE\
 	w:0 r:1 r:0 w:1 r:0 r:1 r:2
 
 check
-
-pass

--- a/src/test/blk_non_zero/TEST6
+++ b/src/test/blk_non_zero/TEST6
@@ -36,17 +36,10 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-require_test_type medium
-
-# doesn't make sense to run in local directory
-require_fs_type pmem non-pmem
-
-setup
+setup -t medium -f "pmem non-pmem"
 
 # single arena write case
 FILE_SIZE=$((1024*1024*1024))
 
 expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c $FILE_SIZE\
 	w:0 r:1 r:0 w:1 r:0 r:1 r:2
-
-check

--- a/src/test/blk_non_zero/TEST7
+++ b/src/test/blk_non_zero/TEST7
@@ -36,12 +36,7 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-require_test_type medium
-
-# doesn't make sense to run in local directory
-require_fs_type pmem non-pmem
-
-setup
+setup -t medium -f "pmem non-pmem"
 
 # mix writes with set_zero and set_error and check results
 FILE_SIZE=$((1024*1024*1024))
@@ -53,5 +48,3 @@ expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c $FILE_SIZE\
 	r:100 r:200 r:300 r:400\
 	e:100 w:200 e:300 w:400\
 	r:100 r:200 r:300 r:400
-
-check

--- a/src/test/blk_non_zero/TEST7
+++ b/src/test/blk_non_zero/TEST7
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 #
@@ -36,9 +36,6 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 # doesn't make sense to run in local directory
@@ -58,5 +55,3 @@ expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c $FILE_SIZE\
 	r:100 r:200 r:300 r:400
 
 check
-
-pass

--- a/src/test/blk_non_zero/TEST8
+++ b/src/test/blk_non_zero/TEST8
@@ -36,12 +36,7 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-require_test_type medium
-
-# doesn't make sense to run in local directory
-require_fs_type pmem non-pmem
-
-setup
+setup -t medium -f "pmem non-pmem"
 
 # mix writes with set_zero and set_error and check results
 FILE_SIZE=$((1024*1024*1024))
@@ -53,5 +48,3 @@ expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c $FILE_SIZE\
 		e:4 z:4 r:4\
 		w:5 e:5 z:5 r:5\
 		w:6 z:6 e:6 r:6
-
-check

--- a/src/test/blk_non_zero/TEST8
+++ b/src/test/blk_non_zero/TEST8
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 #
@@ -36,9 +36,6 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 # doesn't make sense to run in local directory
@@ -58,5 +55,3 @@ expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c $FILE_SIZE\
 		w:6 z:6 e:6 r:6
 
 check
-
-pass

--- a/src/test/blk_non_zero/TEST9
+++ b/src/test/blk_non_zero/TEST9
@@ -37,11 +37,7 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-# long test, run only on pmem
-require_fs_type pmem
-require_test_type long
-configure_valgrind pmemcheck force-enable
-setup
+setup -t long -f pmem -v pmemcheck=force-enable
 
 # mix writes with set_zero and set_error and check results
 create_nonzeroed_file 128M 8K $DIR/testfile1
@@ -53,5 +49,3 @@ expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
 		e:4 z:4 r:4\
 		w:5 e:5 z:5 r:5\
 		w:6 z:6 e:6 r:6
-
-check

--- a/src/test/blk_non_zero/TEST9
+++ b/src/test/blk_non_zero/TEST9
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
@@ -37,9 +37,6 @@
 # pmemblk_read/write/set_zero/set_error
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 # long test, run only on pmem
 require_fs_type pmem
 require_test_type long
@@ -58,5 +55,3 @@ expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
 		w:6 z:6 e:6 r:6
 
 check
-
-pass

--- a/src/test/cto_valgrind/TEST1
+++ b/src/test/cto_valgrind/TEST1
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2014-2018, Intel Corporation
 #
@@ -39,9 +39,6 @@ export VALGRIND_OPTS="--suppressions=excluded-errors.supp\
 	--leak-check=full\
 	--show-reachable=yes"
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
@@ -52,5 +49,3 @@ configure_valgrind memcheck force-enable
 setup
 
 expect_abnormal_exit ./cto_valgrind$EXESUFFIX $DIR/testfile 1
-
-pass

--- a/src/test/cto_valgrind/TEST1
+++ b/src/test/cto_valgrind/TEST1
@@ -39,13 +39,8 @@ export VALGRIND_OPTS="--suppressions=excluded-errors.supp\
 	--leak-check=full\
 	--show-reachable=yes"
 
-require_test_type medium
-require_fs_type any
-require_build_type debug nondebug
-
 require_valgrind 3.7
-configure_valgrind memcheck force-enable
 
-setup
+setup -t medium -f any -b "debug nondebug" -v memcheck=force-enable -c
 
 expect_abnormal_exit ./cto_valgrind$EXESUFFIX $DIR/testfile 1

--- a/src/test/obj_basic_integration/TEST0
+++ b/src/test/obj_basic_integration/TEST0
@@ -32,16 +32,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+# memcheck is covered by TEST5
 
-require_test_type medium
-
-# covered by TEST5
-configure_valgrind memcheck force-disable
-
-setup
+setup -t medium -v memcheck=force-disable
 
 create_holey_file 16M $DIR/testfile1
 
 expect_normal_exit ./obj_basic_integration$EXESUFFIX $DIR/testfile1
-
-check

--- a/src/test/obj_basic_integration/TEST0
+++ b/src/test/obj_basic_integration/TEST0
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
@@ -33,9 +33,6 @@
 #
 
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 # covered by TEST5
@@ -48,5 +45,3 @@ create_holey_file 16M $DIR/testfile1
 expect_normal_exit ./obj_basic_integration$EXESUFFIX $DIR/testfile1
 
 check
-
-pass

--- a/src/test/obj_basic_integration/TEST1
+++ b/src/test/obj_basic_integration/TEST1
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
@@ -33,9 +33,6 @@
 #
 
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 configure_valgrind pmemcheck force-enable
@@ -47,5 +44,3 @@ expect_normal_exit\
 	./obj_basic_integration$EXESUFFIX $DIR/testfile1
 
 check
-
-pass

--- a/src/test/obj_basic_integration/TEST1
+++ b/src/test/obj_basic_integration/TEST1
@@ -32,15 +32,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-
-require_test_type medium
-
-configure_valgrind pmemcheck force-enable
-setup
+setup -t medium -v pmemcheck=force-enable
 
 create_holey_file 16M $DIR/testfile1
 
 expect_normal_exit\
 	./obj_basic_integration$EXESUFFIX $DIR/testfile1
-
-check

--- a/src/test/obj_basic_integration/TEST10
+++ b/src/test/obj_basic_integration/TEST10
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2016-2018, Intel Corporation
 #
@@ -31,10 +31,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 require_command $STRACE
 require_dax_devices 1
@@ -51,5 +47,3 @@ expect_normal_exit $STRACE -emsync -ostrace$UNITTEST_NUM.log \
 	./obj_basic_integration$EXESUFFIX $DEVICE_DAX_PATH
 
 check
-
-pass

--- a/src/test/obj_basic_integration/TEST10
+++ b/src/test/obj_basic_integration/TEST10
@@ -31,19 +31,15 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require_test_type medium
 require_command $STRACE
 require_dax_devices 1
 require_no_asan
 
-# covered by TEST5
-configure_valgrind memcheck force-disable
+# memcheck is covered by TEST5
 
-setup
+setup -t medium -v memcheck=force-disable
 
 dax_device_zero
 
 expect_normal_exit $STRACE -emsync -ostrace$UNITTEST_NUM.log \
 	./obj_basic_integration$EXESUFFIX $DEVICE_DAX_PATH
-
-check

--- a/src/test/obj_basic_integration/TEST11
+++ b/src/test/obj_basic_integration/TEST11
@@ -38,10 +38,9 @@
 # with 4K alignment.
 #
 
-require_test_type medium
 require_dax_device_alignments 4096 4096
 
-setup
+setup -t medium -c
 
 dax_device_zero
 

--- a/src/test/obj_basic_integration/TEST11
+++ b/src/test/obj_basic_integration/TEST11
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2017-2018, Intel Corporation
 #
@@ -38,9 +38,6 @@
 # with 4K alignment.
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 require_dax_device_alignments 4096 4096
 
@@ -51,5 +48,3 @@ dax_device_zero
 create_poolset $DIR/testset1 AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
 
 expect_normal_exit ./obj_basic_integration$EXESUFFIX $DIR/testset1
-
-pass

--- a/src/test/obj_basic_integration/TEST12
+++ b/src/test/obj_basic_integration/TEST12
@@ -39,10 +39,9 @@
 # if SINGLEHDR option is not specified.
 #
 
-require_test_type medium
 require_dax_device_alignments 2097152 2097152 # 2MiB
 
-setup
+setup -t medium -c
 
 dax_device_zero
 

--- a/src/test/obj_basic_integration/TEST12
+++ b/src/test/obj_basic_integration/TEST12
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2017-2018, Intel Corporation
 #
@@ -39,9 +39,6 @@
 # if SINGLEHDR option is not specified.
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 require_dax_device_alignments 2097152 2097152 # 2MiB
 
@@ -52,5 +49,3 @@ dax_device_zero
 create_poolset $DIR/testset1 AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
 
 expect_abnormal_exit ./obj_basic_integration$EXESUFFIX $DIR/testset1
-
-pass

--- a/src/test/obj_basic_integration/TEST13
+++ b/src/test/obj_basic_integration/TEST13
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2017-2018, Intel Corporation
 #
@@ -39,9 +39,6 @@
 # if SINGLEHDR option is not specified.
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 require_dax_device_alignments 2097152 2097152 # 2MiB
 
@@ -53,5 +50,3 @@ create_poolset $DIR/testset1 AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1
 	O SINGLEHDR
 
 expect_normal_exit ./obj_basic_integration$EXESUFFIX $DIR/testset1
-
-pass

--- a/src/test/obj_basic_integration/TEST13
+++ b/src/test/obj_basic_integration/TEST13
@@ -39,10 +39,9 @@
 # if SINGLEHDR option is not specified.
 #
 
-require_test_type medium
 require_dax_device_alignments 2097152 2097152 # 2MiB
 
-setup
+setup -t medium -c
 
 dax_device_zero
 

--- a/src/test/obj_basic_integration/TEST2
+++ b/src/test/obj_basic_integration/TEST2
@@ -31,15 +31,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-
-require_test_type medium
-
-setup
+setup -t medium
 
 create_poolset $DIR/testset1 8M:$DIR/testfile1:x 8M:$DIR/testfile2:x \
 	r 16M:$DIR/testfile3:x
 
 expect_normal_exit\
     ./obj_basic_integration$EXESUFFIX $DIR/testset1
-
-check

--- a/src/test/obj_basic_integration/TEST2
+++ b/src/test/obj_basic_integration/TEST2
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 #
@@ -32,9 +32,6 @@
 #
 
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 setup
@@ -46,5 +43,3 @@ expect_normal_exit\
     ./obj_basic_integration$EXESUFFIX $DIR/testset1
 
 check
-
-pass

--- a/src/test/obj_basic_integration/TEST3
+++ b/src/test/obj_basic_integration/TEST3
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 #
@@ -31,10 +31,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 setup
@@ -48,5 +44,3 @@ compare_replicas "-soOaAb -l -Z -H -C" \
 	$DIR/testfile1 $DIR/testfile2 > diff$UNITTEST_NUM.log
 
 check
-
-pass

--- a/src/test/obj_basic_integration/TEST3
+++ b/src/test/obj_basic_integration/TEST3
@@ -31,9 +31,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require_test_type medium
-
-setup
+setup -t medium
 
 create_poolset $DIR/testset1 16M:$DIR/testfile1:x r 16M:$DIR/testfile2:x
 
@@ -42,5 +40,3 @@ expect_normal_exit\
 
 compare_replicas "-soOaAb -l -Z -H -C" \
 	$DIR/testfile1 $DIR/testfile2 > diff$UNITTEST_NUM.log
-
-check

--- a/src/test/obj_basic_integration/TEST4
+++ b/src/test/obj_basic_integration/TEST4
@@ -31,9 +31,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require_test_type medium
-
-setup
+setup -t medium
 
 create_poolset $DIR/testset1 16M:$DIR/testfile1 \
 	r 18M:$DIR/testfile2 \
@@ -47,5 +45,3 @@ compare_replicas "-soOaAb -l -Z -H -C" \
 
 compare_replicas "-soOaAb -l -Z -H -C" \
 	$DIR/testfile1 $DIR/testfile3 >> diff$UNITTEST_NUM.log
-
-check

--- a/src/test/obj_basic_integration/TEST4
+++ b/src/test/obj_basic_integration/TEST4
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 #
@@ -31,10 +31,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 setup
@@ -53,5 +49,3 @@ compare_replicas "-soOaAb -l -Z -H -C" \
 	$DIR/testfile1 $DIR/testfile3 >> diff$UNITTEST_NUM.log
 
 check
-
-pass

--- a/src/test/obj_basic_integration/TEST5
+++ b/src/test/obj_basic_integration/TEST5
@@ -32,12 +32,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require_test_type medium
-
-configure_valgrind memcheck force-enable
 export PMEMOBJ_VG_CHECK_UNDEF=1
 
-setup
+setup -t medium -v memcheck=force-enable -c
 
 create_holey_file 16M $DIR/testfile1
 

--- a/src/test/obj_basic_integration/TEST5
+++ b/src/test/obj_basic_integration/TEST5
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
@@ -32,10 +32,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 configure_valgrind memcheck force-enable
@@ -47,5 +43,3 @@ create_holey_file 16M $DIR/testfile1
 
 expect_normal_exit\
     ./obj_basic_integration$EXESUFFIX $DIR/testfile1
-
-pass

--- a/src/test/obj_basic_integration/TEST6
+++ b/src/test/obj_basic_integration/TEST6
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 #
@@ -31,10 +31,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 configure_valgrind memcheck force-enable
@@ -47,5 +43,3 @@ create_poolset $DIR/testset1 8M:$DIR/testfile1:x 8M:$DIR/testfile2:x \
 
 expect_normal_exit\
     ./obj_basic_integration$EXESUFFIX $DIR/testset1
-
-pass

--- a/src/test/obj_basic_integration/TEST6
+++ b/src/test/obj_basic_integration/TEST6
@@ -31,12 +31,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require_test_type medium
-
-configure_valgrind memcheck force-enable
 export PMEMOBJ_VG_CHECK_UNDEF=1
 
-setup
+setup -t medium -v memcheck=force-enable -c
 
 create_poolset $DIR/testset1 8M:$DIR/testfile1:x 8M:$DIR/testfile2:x \
 	r 16M:$DIR/testfile3:x

--- a/src/test/obj_basic_integration/TEST7
+++ b/src/test/obj_basic_integration/TEST7
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2016-2018, Intel Corporation
 #
@@ -31,10 +31,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 require_dax_devices 1
 
@@ -46,5 +42,3 @@ setup
 dax_device_zero
 
 expect_normal_exit ./obj_basic_integration$EXESUFFIX $DEVICE_DAX_PATH
-
-pass

--- a/src/test/obj_basic_integration/TEST7
+++ b/src/test/obj_basic_integration/TEST7
@@ -31,13 +31,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require_test_type medium
 require_dax_devices 1
 
-# covered by TEST5
-configure_valgrind memcheck force-disable
+# memcheck is covered by TEST5
 
-setup
+setup -t medium -v memcheck=force-disable -c
 
 dax_device_zero
 

--- a/src/test/obj_basic_integration/TEST8
+++ b/src/test/obj_basic_integration/TEST8
@@ -31,10 +31,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require_test_type medium
 require_dax_devices 1
 
-setup
+setup -t medium -c
 
 dax_device_zero
 

--- a/src/test/obj_basic_integration/TEST8
+++ b/src/test/obj_basic_integration/TEST8
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2016-2018, Intel Corporation
 #
@@ -31,10 +31,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 require_dax_devices 1
 
@@ -45,5 +41,3 @@ dax_device_zero
 create_poolset $DIR/testset1 AUTO:$DEVICE_DAX_PATH
 
 expect_normal_exit ./obj_basic_integration$EXESUFFIX $DIR/testset1
-
-pass

--- a/src/test/obj_basic_integration/TEST9
+++ b/src/test/obj_basic_integration/TEST9
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2016-2018, Intel Corporation
 #
@@ -31,10 +31,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 require_dax_devices 2
 
@@ -48,5 +44,3 @@ create_poolset $DIR/testset1 \
 	AUTO:${DEVICE_DAX_PATH[1]}:x
 
 expect_normal_exit ./obj_basic_integration$EXESUFFIX $DIR/testset1
-
-pass

--- a/src/test/obj_basic_integration/TEST9
+++ b/src/test/obj_basic_integration/TEST9
@@ -31,10 +31,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require_test_type medium
 require_dax_devices 2
 
-setup
+setup -t medium -c
 
 dax_device_zero
 

--- a/src/test/obj_convert/TEST4
+++ b/src/test/obj_convert/TEST4
@@ -39,11 +39,8 @@ LOG=out${UNITTEST_NUM}.log
 rm -f $LOG && touch $LOG
 
 require_command gdb
-require_test_type medium
-require_build_type debug
-require_fs_type non-pmem
 
-setup
+setup -t medium -f non-pmem -b debug -c
 
 # set this to enable runtime creation of pools based on the old version of
 # the library.

--- a/src/test/obj_convert/TEST4
+++ b/src/test/obj_convert/TEST4
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2015-2018, Intel Corporation
 #
@@ -35,9 +35,6 @@
 # src/test/obj_convert/TEST4 -- unit test for pool conversion
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 LOG=out${UNITTEST_NUM}.log
 rm -f $LOG && touch $LOG
 
@@ -71,5 +68,3 @@ then
 
 	check
 fi
-
-pass

--- a/src/test/obj_sds/TEST2
+++ b/src/test/obj_sds/TEST2
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2017-2018, Intel Corporation
 #
@@ -35,9 +35,6 @@
 # src/test/obj_sds/TEST2 -- unittest for shutdown state
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 require_fs_type any
@@ -62,5 +59,3 @@ expect_abnormal_exit ./obj_sds 1 1 $POOLSET\
 
 expect_abnormal_exit ./obj_sds 0 0 $POOLSET\
 				   5 1 7 1 9 1 11 0 12 0
-
-pass

--- a/src/test/obj_sds/TEST2
+++ b/src/test/obj_sds/TEST2
@@ -35,13 +35,7 @@
 # src/test/obj_sds/TEST2 -- unittest for shutdown state
 #
 
-require_test_type medium
-
-require_fs_type any
-
-require_build_type debug
-
-setup
+setup -t medium -f any -b debug -c
 
 POOLSET=$DIR/pool.set
 # Create poolset file

--- a/src/test/obj_sds/TEST3
+++ b/src/test/obj_sds/TEST3
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2017-2018, Intel Corporation
 #
@@ -35,9 +35,6 @@
 # src/test/obj_sds/TEST3 -- unittest for shutdown state
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 require_fs_type any
@@ -62,5 +59,3 @@ expect_abnormal_exit ./obj_sds 1 1 $POOLSET\
 
 expect_abnormal_exit ./obj_sds 0 0 $POOLSET\
 				   5 0 7 0 9 0 11 0 12 1
-
-pass

--- a/src/test/obj_sds/TEST3
+++ b/src/test/obj_sds/TEST3
@@ -35,13 +35,7 @@
 # src/test/obj_sds/TEST3 -- unittest for shutdown state
 #
 
-require_test_type medium
-
-require_fs_type any
-
-require_build_type debug
-
-setup
+setup -t medium -f any -b debug -c
 
 POOLSET=$DIR/pool.set
 # Create poolset file

--- a/src/test/obj_sds/TEST4
+++ b/src/test/obj_sds/TEST4
@@ -35,13 +35,7 @@
 # src/test/obj_sds/TEST4 -- unittest for shutdown state
 #
 
-require_test_type medium
-
-require_fs_type any
-
-require_build_type debug
-
-setup
+setup -t medium -f any -b debug -c
 
 POOLSET=$DIR/pool.set
 # Create poolset file

--- a/src/test/obj_sds/TEST4
+++ b/src/test/obj_sds/TEST4
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2017-2018, Intel Corporation
 #
@@ -35,9 +35,6 @@
 # src/test/obj_sds/TEST4 -- unittest for shutdown state
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 require_fs_type any
@@ -62,5 +59,3 @@ expect_abnormal_exit ./obj_sds 1 1 $POOLSET\
 
 expect_abnormal_exit ./obj_sds 0 0 $POOLSET\
 				   5 0 7 0 23 0 11 0 12 0
-
-pass

--- a/src/test/obj_sds/TEST5
+++ b/src/test/obj_sds/TEST5
@@ -35,13 +35,7 @@
 # src/test/obj_sds/TEST5 -- unittest for shutdown state
 #
 
-require_test_type medium
-
-require_fs_type any
-
-require_build_type debug
-
-setup
+setup -t medium -f any -b debug -c
 
 POOLSET=$DIR/pool.set
 # Create poolset file

--- a/src/test/obj_sds/TEST5
+++ b/src/test/obj_sds/TEST5
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2017-2018, Intel Corporation
 #
@@ -35,9 +35,6 @@
 # src/test/obj_sds/TEST5 -- unittest for shutdown state
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 require_fs_type any
@@ -62,6 +59,3 @@ expect_abnormal_exit ./obj_sds 1 1 $POOLSET\
 
 expect_abnormal_exit ./obj_sds 0 0 $POOLSET\
 					 5 0 7 0 9 0 11 0 121 0
-
-
-pass

--- a/src/test/obj_sds/TEST6
+++ b/src/test/obj_sds/TEST6
@@ -35,13 +35,7 @@
 # src/test/obj_sds/TEST6 -- unittest for shutdown state
 #
 
-require_test_type medium
-
-require_fs_type any
-
-require_build_type debug
-
-setup
+setup -t medium -f any -b debug -c
 
 POOLSET=$DIR/pool.set
 

--- a/src/test/obj_sds/TEST6
+++ b/src/test/obj_sds/TEST6
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2017-2018, Intel Corporation
 #
@@ -35,9 +35,6 @@
 # src/test/obj_sds/TEST6 -- unittest for shutdown state
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 require_fs_type any
@@ -70,4 +67,3 @@ PMEMOBJ_LOG_LEVEL=4
 # the pool not closed and pool moved
 expect_abnormal_exit ./obj_sds 0 0 $POOLSET\
 				   43 0 11 0 23 0 11 0 12 0
-pass

--- a/src/test/obj_sync/TEST8
+++ b/src/test/obj_sync/TEST8
@@ -35,13 +35,8 @@
 # src/test/obj_sync/TEST8 -- unit test for PMEM-resident locks
 #
 
-require_test_type medium
-
-require_fs_type none
-require_build_type debug nondebug
 require_valgrind 3.10
-configure_valgrind drd force-enable
 
-setup
+setup -t medium -f none -b "debug nondebug" -v drd=force-enable -c
 
 expect_normal_exit ./obj_sync$EXESUFFIX t 10 5

--- a/src/test/obj_sync/TEST8
+++ b/src/test/obj_sync/TEST8
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2017-2018, Intel Corporation
 #
@@ -35,9 +35,6 @@
 # src/test/obj_sync/TEST8 -- unit test for PMEM-resident locks
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 require_fs_type none
@@ -48,5 +45,3 @@ configure_valgrind drd force-enable
 setup
 
 expect_normal_exit ./obj_sync$EXESUFFIX t 10 5
-
-pass

--- a/src/test/obj_sync/TEST9
+++ b/src/test/obj_sync/TEST9
@@ -35,13 +35,8 @@
 # src/test/obj_sync/TEST9 -- unit test for PMEM-resident locks
 #
 
-require_test_type medium
-
-require_fs_type none
-require_build_type debug nondebug
 require_valgrind 3.10
-configure_valgrind helgrind force-enable
 
-setup
+setup -t medium -f none -b "debug nondebug" -v helgrind=force-enable -c
 
 expect_normal_exit ./obj_sync$EXESUFFIX t 10 5

--- a/src/test/obj_sync/TEST9
+++ b/src/test/obj_sync/TEST9
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!../test.sh
 #
 # Copyright 2017-2018, Intel Corporation
 #
@@ -35,9 +35,6 @@
 # src/test/obj_sync/TEST9 -- unit test for PMEM-resident locks
 #
 
-# standard unit test setup
-. ../unittest/unittest.sh
-
 require_test_type medium
 
 require_fs_type none
@@ -48,5 +45,3 @@ configure_valgrind helgrind force-enable
 setup
 
 expect_normal_exit ./obj_sync$EXESUFFIX t 10 5
-
-pass

--- a/src/test/test.sh
+++ b/src/test/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2018, Intel Corporation
+# Copyright 2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,32 +30,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-# utils/check-shebang.sh -- interpreter directive check script
-#
-set -e
 
-err_count=0
+export SCRIPTNAME=$(basename $1)
 
-for file in $@ ; do
-        [ ! -f $file ] && continue
-	SHEBANG=`head -n1 $file | cut -d" " -f1`
-	[ "${SHEBANG:0:2}" != "#!" ] && continue
-	if [ "$SHEBANG" != "#!/usr/bin/env" -a $SHEBANG != "#!/bin/sh" -a $SHEBANG != "#!../test.sh" ]; then
-		INTERP=`echo $SHEBANG | rev | cut -d"/" -f1 | rev`
-		echo "$file:1: error: invalid interpreter directive:" >&2
-		echo "	(is: \"$SHEBANG\", should be: \"#!/usr/bin/env $INTERP\")" >&2
-		((err_count+=1))
-	fi
-done
+source ../unittest/unittest.sh
 
-if [ "$err_count" == "0" ]; then
-	echo "Interpreter directives are OK."
-else
-	echo "Found $err_count errors in interpreter directives!" >&2
-	err_count=1
-fi
+source $1
 
-exit $err_count
-
-
-
+pass

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -57,7 +57,9 @@ function fatal() {
 
 if [ -z "${UNITTEST_NAME}" ]; then
 	CURDIR=$(basename $(pwd))
-	SCRIPTNAME=$(basename $0)
+	if [ -z "$SCRIPTNAME" ]; then
+		SCRIPTNAME=$(basename $0)
+	fi
 
 	export UNITTEST_NAME=$CURDIR/$SCRIPTNAME
 	export UNITTEST_NUM=$(echo $SCRIPTNAME | sed "s/TEST//")


### PR DESCRIPTION
This is continuation of #2688.

The first part of this PR deals with inclusion of unittest.sh and "pass" function.
The second part replaces calls to "check" and the most common require_* functions by arguments to the "setup" function.

Conversion is time consuming, so I modified only some tests. If we decide to go with this version I'll convert all other tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2905)
<!-- Reviewable:end -->
