### PR TITLE
obj: use cl-aligned memcpy to write headers

### DIFF
--- a/src/common/util.h
+++ b/src/common/util.h
@@ -57,6 +57,8 @@ extern "C" {
 extern unsigned long long Pagesize;
 extern unsigned long long Mmap_align;
 
+#define CACHELINE_SIZE 64U
+
 #define PAGE_ALIGNED_DOWN_SIZE(size) ((size) & ~(Pagesize - 1))
 #define PAGE_ALIGNED_UP_SIZE(size)\
 	PAGE_ALIGNED_DOWN_SIZE((size) + (Pagesize - 1))

--- a/src/libpmemobj/heap_layout.h
+++ b/src/libpmemobj/heap_layout.h
@@ -145,6 +145,8 @@ struct allocation_header_legacy {
 	uint64_t type_num;
 };
 
+#define ALLOC_HDR_COMPACT_SIZE sizeof(struct allocation_header_compact)
+
 struct allocation_header_compact {
 	uint64_t size;
 	uint64_t extra;

--- a/src/libpmemobj/memblock.h
+++ b/src/libpmemobj/memblock.h
@@ -198,11 +198,6 @@ struct memory_block_ops {
 	/* writes a header of an allocation */
 	void (*write_header)(const struct memory_block *m,
 		uint64_t extra_field, uint16_t flags);
-
-	/* flushes allocation header */
-	void (*flush_header)(const struct memory_block *m);
-
-	/* invalidates allocation data and header */
 	void (*invalidate)(const struct memory_block *m);
 
 	/*

--- a/src/test/obj_action/pmemcheck2.log.match
+++ b/src/test/obj_action/pmemcheck2.log.match
@@ -5,33 +5,17 @@
 ==$(N)== Parent PID: $(N)
 ==$(N)== 
 ==$(N)== 
-==$(N)== Number of stores not made persistent: 7
+==$(N)== Number of stores not made persistent: 5
 ==$(N)== Stores not made persistent properly:
-==$(N)== [0]    at 0x$(X): ${memblock_header_compact_write|???} $(*)
-==$(N)==    by 0x$(X): ${block_write_header|???} $(*)
-==$(N)==    by 0x$(X): ${alloc_prep_block|???} $(*)
-==$(N)==    by 0x$(X): ${palloc_reservation_create|???} $(*)
-==$(N)==    by 0x$(X): ${palloc_reserve|???} $(*)
-==$(N)==    by 0x$(X): pmemobj_reserve $(*)
-==$(N)==    by 0x$(X): main (obj_action.c:$(N))
-==$(N)== 	Address: 0x$(X)	size: 8	state: DIRTY
-==$(N)== [1]    at 0x$(X): ${memblock_header_compact_write|???} $(*)
-==$(N)==    by 0x$(X): ${block_write_header|???} $(*)
-==$(N)==    by 0x$(X): ${alloc_prep_block|???} $(*)
-==$(N)==    by 0x$(X): ${palloc_reservation_create|???} $(*)
-==$(N)==    by 0x$(X): ${palloc_reserve|???} $(*)
-==$(N)==    by 0x$(X): pmemobj_reserve $(*)
-==$(N)==    by 0x$(X): main (obj_action.c:$(N))
-==$(N)== 	Address: 0x$(X)	size: 8	state: DIRTY
+==$(N)== [0]    at 0x$(X): main (obj_action.c:$(N))
+==$(N)== 	Address: 0x$(X)	size: 4	state: DIRTY
+==$(N)== [1]    at 0x$(X): main (obj_action.c:$(N))
+==$(N)== 	Address: 0x$(X)	size: 4	state: DIRTY
 ==$(N)== [2]    at 0x$(X): main (obj_action.c:$(N))
 ==$(N)== 	Address: 0x$(X)	size: 4	state: DIRTY
 ==$(N)== [3]    at 0x$(X): main (obj_action.c:$(N))
 ==$(N)== 	Address: 0x$(X)	size: 4	state: DIRTY
 ==$(N)== [4]    at 0x$(X): main (obj_action.c:$(N))
 ==$(N)== 	Address: 0x$(X)	size: 4	state: DIRTY
-==$(N)== [5]    at 0x$(X): main (obj_action.c:$(N))
-==$(N)== 	Address: 0x$(X)	size: 4	state: DIRTY
-==$(N)== [6]    at 0x$(X): main (obj_action.c:$(N))
-==$(N)== 	Address: 0x$(X)	size: 4	state: DIRTY
-==$(N)== Total memory not made persistent: 36
-==$(N)== ERROR SUMMARY: 7 errors
+==$(N)== Total memory not made persistent: 20
+==$(N)== ERROR SUMMARY: 5 errors

--- a/src/test/obj_persist_count/out0.log.match
+++ b/src/test/obj_persist_count/out0.log.match
@@ -2,18 +2,18 @@ obj_persist_count$(nW)TEST0: START: obj_persist_count
  $(nW)obj_persist_count$(nW) $(nW)testfile
 task           cl(all) drain(all) pmem_persist pmem_msync pmem_flush pmem_drain pmem_memcpy_cls pmem_memcpy_drain pmem_memset_cls pmem_memset_drain potential_cache_misses 
 pool_create    99467   19         0            19         0          0          0               0                 0               0                 99467                  
-root_alloc     514     8          0            8          0          0          0               0                 0               0                 514                    
-atomic_alloc   128     2          0            2          0          0          0               0                 0               0                 128                    
+root_alloc     515     8          0            8          0          0          0               0                 0               0                 515                    
+atomic_alloc   129     2          0            2          0          0          0               0                 0               0                 129                    
 atomic_free    64      1          0            1          0          0          0               0                 0               0                 64                     
 tx_begin_end   128     2          0            2          0          0          0               0                 0               0                 128                    
-tx_alloc       384     6          0            6          0          0          0               0                 0               0                 384                    
-tx_alloc_next  320     5          0            5          0          0          0               0                 0               0                 320                    
+tx_alloc       385     6          0            6          0          0          0               0                 0               0                 385                    
+tx_alloc_next  321     5          0            5          0          0          0               0                 0               0                 321                    
 tx_free        448     7          0            7          0          0          0               0                 0               0                 448                    
 tx_free_next   384     6          0            6          0          0          0               0                 0               0                 384                    
-tx_add         2181    18         0            18         0          0          0               0                 0               0                 2181                   
+tx_add         2182    18         0            18         0          0          0               0                 0               0                 2182                   
 tx_add_next    258     4          0            4          0          0          0               0                 0               0                 258                    
-pmalloc        384     6          0            6          0          0          0               0                 0               0                 384                    
+pmalloc        385     6          0            6          0          0          0               0                 0               0                 385                    
 pfree          320     5          0            5          0          0          0               0                 0               0                 320                    
-pmalloc_stack  128     2          0            2          0          0          0               0                 0               0                 128                    
+pmalloc_stack  129     2          0            2          0          0          0               0                 0               0                 129                    
 pfree_stack    64      1          0            1          0          0          0               0                 0               0                 64                     
 obj_persist_count$(nW)TEST0: DONE

--- a/src/test/obj_persist_count/out1.log.match
+++ b/src/test/obj_persist_count/out1.log.match
@@ -2,18 +2,18 @@ obj_persist_count$(nW)TEST1: START: obj_persist_count
  $(nW)obj_persist_count$(nW) $(nW)testfile
 task           cl(all) drain(all) pmem_persist pmem_msync pmem_flush pmem_drain pmem_memcpy_cls pmem_memcpy_drain pmem_memset_cls pmem_memset_drain potential_cache_misses 
 pool_create    49602   24         10           5          0          5          0               0                 49163           4                 443                    
-root_alloc     9       6          4            0          3          1          0               0                 2               1                 9                      
-atomic_alloc   2       2          1            0          1          1          0               0                 0               0                 2                      
+root_alloc     9       6          4            0          2          1          1               0                 2               1                 8                      
+atomic_alloc   2       2          1            0          0          1          1               0                 0               0                 1                      
 atomic_free    1       2          1            0          0          1          0               0                 0               0                 1                      
 tx_begin_end   2       3          2            0          0          1          0               0                 0               0                 2                      
-tx_alloc       7       5          4            0          2          1          0               0                 0               0                 7                      
-tx_alloc_next  6       4          3            0          2          1          0               0                 0               0                 6                      
+tx_alloc       7       5          4            0          1          1          1               0                 0               0                 6                      
+tx_alloc_next  6       4          3            0          1          1          1               0                 0               0                 5                      
 tx_free        7       7          6            0          1          1          0               0                 0               0                 7                      
 tx_free_next   6       6          5            0          1          1          0               0                 0               0                 6                      
-tx_add         537     15         11           0          4          1          1               1                 516             2                 23                     
+tx_add         537     15         11           0          3          1          2               1                 516             2                 22                     
 tx_add_next    4       3          1            0          1          0          1               1                 1               1                 4                      
-pmalloc        6       5          4            0          2          1          0               0                 0               0                 6                      
+pmalloc        6       5          4            0          1          1          1               0                 0               0                 5                      
 pfree          5       5          4            0          1          1          0               0                 0               0                 5                      
-pmalloc_stack  2       2          1            0          1          1          0               0                 0               0                 2                      
+pmalloc_stack  2       2          1            0          0          1          1               0                 0               0                 1                      
 pfree_stack    1       2          1            0          0          1          0               0                 0               0                 1                      
 obj_persist_count$(nW)TEST1: DONE


### PR DESCRIPTION
If an allocation is at least 64 bytes and cacheline aligned we can
utilize non-temporal writes to store the object's header, this allows
us to avoid a cache miss that would have otherwise happened.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2909)
<!-- Reviewable:end -->
