### PR TITLE
test: change obj_pmalloc_mt/drd to long

### DIFF
--- a/src/test/obj_pmalloc_mt/TEST3
+++ b/src/test/obj_pmalloc_mt/TEST3
@@ -41,7 +41,7 @@
 
 require_valgrind 3.10
 require_fs_type pmem non-pmem
-require_test_type medium
+require_test_type long
 configure_valgrind drd force-enable
 setup
 


### PR DESCRIPTION
DRD is very finnicky about the test duration, the smallest of
change can considerably lengthen the test run. Its functionality
is mostly mirrored in helgrind which will still be ran at every
build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2919)
<!-- Reviewable:end -->
