### PR TITLE
common: don't clear sds drity flag on broken pool

### DIFF
--- a/src/common/set.c
+++ b/src/common/set.c
@@ -2299,7 +2299,7 @@ util_header_create(struct pool_set *set, unsigned repidx, unsigned partidx,
 					PART(rep, p)->path, PART(rep, 0)))
 				return -1;
 		}
-		shutdown_state_set_flag(&hdrp->sds, PART(rep, 0));
+		shutdown_state_set_dirty(&hdrp->sds, PART(rep, 0));
 	}
 
 	util_checksum(hdrp, sizeof(*hdrp), &hdrp->checksum,
@@ -2569,7 +2569,7 @@ util_header_check_remote(struct pool_set *set, unsigned partidx)
 			return -1;
 		}
 
-		shutdown_state_set_flag(&hdrp->sds, PART(rep, 0));
+		shutdown_state_set_dirty(&hdrp->sds, PART(rep, 0));
 	}
 
 
@@ -2877,7 +2877,7 @@ util_replica_close(struct pool_set *set, unsigned repidx)
 			/* XXX: DEEP DRAIN */
 			struct pool_hdr *hdr = part->addr;
 			RANGE_RW(hdr, sizeof(*hdr), part->is_dev_dax);
-			shutdown_state_clear_flag(&hdr->sds, part);
+			shutdown_state_clear_dirty(&hdr->sds, part);
 		}
 		for (unsigned p = 0; p < rep->nhdrs; p++)
 			util_unmap_hdr(&rep->part[p]);
@@ -3680,7 +3680,7 @@ util_replica_check(struct pool_set *set, const struct pool_attr *attr)
 				errno = EINVAL;
 				return -1;
 			}
-			shutdown_state_set_flag(&HDR(rep, 0)->sds,
+			shutdown_state_set_dirty(&HDR(rep, 0)->sds,
 				PART(rep, 0));
 		}
 	}

--- a/src/common/set.h
+++ b/src/common/set.h
@@ -115,6 +115,7 @@ struct pool_set_part {
 				/* the whole poolset */
 	uuid_t uuid;
 	int has_bad_blocks;	/* part file contains bad blocks */
+	int sds_dirty_modified;	/* sds dirty flag was set */
 };
 
 struct pool_set_directory {

--- a/src/common/shutdown_state.h
+++ b/src/common/shutdown_state.h
@@ -51,9 +51,9 @@ struct shutdown_state {
 int shutdown_state_init(struct shutdown_state *sds, struct pool_set_part *part);
 int shutdown_state_add_part(struct shutdown_state *sds, const char *path,
 	struct pool_set_part *part);
-void shutdown_state_set_flag(struct shutdown_state *sds,
+void shutdown_state_set_dirty(struct shutdown_state *sds,
 	struct pool_set_part *part);
-void shutdown_state_clear_flag(struct shutdown_state *sds,
+void shutdown_state_clear_dirty(struct shutdown_state *sds,
 	struct pool_set_part *part);
 
 int shutdown_state_check(struct shutdown_state *curr_sds,

--- a/src/test/pmempool_sync_remote/TEST20
+++ b/src/test/pmempool_sync_remote/TEST20
@@ -56,5 +56,6 @@ run_on_node 0 ../pmemspoil ${NODE_DIR[0]}remote.0.part.1 \
 				   "pool_hdr.shutdown_state.checksum_gen\(\)"
 
 expect_abnormal_exit run_on_node 1 "../pmempool sync ${NODE_DIR[1]}$POOLSET_LOCAL 2> /dev/null"
+expect_abnormal_exit run_on_node 1 "../pmempool sync ${NODE_DIR[1]}$POOLSET_LOCAL 2> /dev/null"
 
 pass


### PR DESCRIPTION
This path adds a runtime dirty flag tracker to not update a dirty flag
if the pool is corrupted. This is needed to distinguish between a dirty
flag set in current program runtime(which we can clear on close) and
dirty flag set in previous run which now shows that the pool is
corrupted (we can't clear it)

Ref: pmem/issues#865

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2920)
<!-- Reviewable:end -->
