### PR TITLE
obj: fix ctl get of alloc class alignment

### DIFF
--- a/src/libpmemobj/pmalloc.c
+++ b/src/libpmemobj/pmalloc.c
@@ -494,7 +494,7 @@ CTL_READ_HANDLER(desc)(PMEMobjpool *pop,
 	p->header_type = user_htype;
 	p->unit_size = c->unit_size;
 	p->class_id = c->id;
-	p->alignment = c->flags & CHUNK_FLAG_ALIGNED;
+	p->alignment = c->flags & CHUNK_FLAG_ALIGNED ? c->run.alignment : 0;
 
 	return 0;
 }

--- a/src/test/obj_ctl_alignment/obj_ctl_alignment.c
+++ b/src/test/obj_ctl_alignment/obj_ctl_alignment.c
@@ -77,6 +77,14 @@ test_aligned_allocs(size_t size, size_t alignment, enum pobj_header_type htype)
 	UT_ASSERTeq(ret, 0);
 	UT_ASSERTeq(oid.off % alignment, 0);
 	UT_ASSERTeq((uintptr_t)pmemobj_direct(oid) % alignment, 0);
+
+	char query[1024];
+	snprintf(query, 1024, "heap.alloc_class.%u.desc", ac.class_id);
+
+	struct pobj_alloc_class_desc read_ac;
+	ret = pmemobj_ctl_get(pop, query, &read_ac);
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERTeq(ac.alignment, read_ac.alignment);
 }
 
 int


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2921)
<!-- Reviewable:end -->
