### PR TITLE
rpmem: fix performance with socket provider 

### DIFF
--- a/src/librpmem/rpmem_fip.c
+++ b/src/librpmem/rpmem_fip.c
@@ -81,7 +81,7 @@
 #define RPMEM_RAW_BUFF_SIZE 4096
 #define RPMEM_RAW_SIZE 8
 
-typedef int (*rpmem_fip_persist_fn)(struct rpmem_fip *fip, size_t offset,
+typedef ssize_t (*rpmem_fip_persist_fn)(struct rpmem_fip *fip, size_t offset,
 		size_t len, unsigned lane, unsigned flags);
 
 typedef int (*rpmem_fip_process_fn)(struct rpmem_fip *fip,
@@ -1124,13 +1124,17 @@ rpmem_fip_persist_send(struct rpmem_fip *fip, size_t offset,
  * for GPSPM - sockets provider implementation which doesn't use the
  * inline persist operation
  */
-static int
+static ssize_t
 rpmem_fip_persist_gpspm_sockets(struct rpmem_fip *fip, size_t offset,
 	size_t len, unsigned lane, unsigned flags)
 {
 	flags &= (unsigned)(~RPMEM_PERSIST_SEND);
+	len = min(len, SSIZE_MAX);
 
-	return rpmem_fip_persist_saw(fip, offset, len, lane, flags);
+	int ret = rpmem_fip_persist_saw(fip, offset, len, lane, flags);
+	if (ret)
+		return -abs(ret);
+	return (ssize_t)len;
 }
 
 /*
@@ -1138,40 +1142,62 @@ rpmem_fip_persist_gpspm_sockets(struct rpmem_fip *fip, size_t offset,
  * for APM - sockets provider implementation which doesn't use the
  * inline persist operation
  */
-static int
+static ssize_t
 rpmem_fip_persist_apm_sockets(struct rpmem_fip *fip, size_t offset,
 	size_t len, unsigned lane, unsigned flags)
 {
-	return rpmem_fip_persist_raw(fip, offset, len, lane);
+	len = min(len, SSIZE_MAX);
+
+	int ret = rpmem_fip_persist_raw(fip, offset, len, lane);
+	if (ret)
+		return -abs(ret);
+	return (ssize_t)len;
 }
 
 /*
  * rpmem_fip_persist_gpspm -- (internal) perform persist operation for GPSPM
  */
-static int
+static ssize_t
 rpmem_fip_persist_gpspm(struct rpmem_fip *fip, size_t offset,
 	size_t len, unsigned lane, unsigned flags)
 {
-	if ((flags & RPMEM_PERSIST_MASK) == RPMEM_PERSIST_SEND)
-		return rpmem_fip_persist_send(fip, offset, len, lane, flags);
+	int ret;
+	len = min(len, SSIZE_MAX);
 
-	return rpmem_fip_persist_saw(fip, offset, len, lane, flags);
+	if ((flags & RPMEM_PERSIST_MASK) == RPMEM_PERSIST_SEND) {
+		len = min(len, fip->buff_size);
+		ret = rpmem_fip_persist_send(fip, offset, len, lane, flags);
+	} else {
+		ret = rpmem_fip_persist_saw(fip, offset, len, lane, flags);
+	}
+
+	if (ret)
+		return -abs(ret);
+	return (ssize_t)len;
 }
 
 /*
  * rpmem_fip_persist_apm -- (internal) perform persist operation for APM
  */
-static int
+static ssize_t
 rpmem_fip_persist_apm(struct rpmem_fip *fip, size_t offset,
 	size_t len, unsigned lane, unsigned flags)
 {
+	int ret;
+	len = min(len, SSIZE_MAX);
+
 	if (unlikely(flags & RPMEM_DEEP_PERSIST))
-		return rpmem_fip_persist_saw(fip, offset, len, lane, flags);
+		ret = rpmem_fip_persist_saw(fip, offset, len, lane, flags);
+	else if ((flags & RPMEM_PERSIST_MASK) == RPMEM_PERSIST_SEND) {
+		len = min(len, fip->buff_size);
+		ret = rpmem_fip_persist_send(fip, offset, len, lane, flags);
+	} else {
+		ret = rpmem_fip_persist_raw(fip, offset, len, lane);
+	}
 
-	if ((flags & RPMEM_PERSIST_MASK) == RPMEM_PERSIST_SEND)
-		return rpmem_fip_persist_send(fip, offset, len, lane, flags);
-
-	return rpmem_fip_persist_raw(fip, offset, len, lane);
+	if (ret)
+		return -abs(ret);
+	return (ssize_t)len;
 }
 
 /*
@@ -1377,21 +1403,6 @@ close_monitor:
 }
 
 /*
- * rpmem_msg_size -- return maximum message size supported by hw and
- * persistency mechanism used for the operation
- */
-static inline size_t
-rpmem_msg_size(struct rpmem_fip *fip, size_t len, unsigned flags)
-{
-	size_t ret = min(len, fip->fi->ep_attr->max_msg_size);
-
-	if ((flags & RPMEM_PERSIST_MASK) == RPMEM_PERSIST_SEND)
-		ret = min(ret, fip->buff_size);
-
-	return ret;
-}
-
-/*
  * rpmem_fip_persist -- perform remote persist operation
  */
 int
@@ -1416,16 +1427,18 @@ rpmem_fip_persist(struct rpmem_fip *fip, size_t offset, size_t len,
 
 	int ret = 0;
 	while (len > 0) {
-		size_t tmp_len = rpmem_msg_size(fip, len, flags);
+		size_t tmplen = min(len, fip->fi->ep_attr->max_msg_size);
 
-		ret = fip->ops->persist(fip, offset, tmp_len, lane, flags);
-		if (ret) {
+		ssize_t r = fip->ops->persist(fip, offset, tmplen, lane, flags);
+		if (r < 0) {
 			RPMEM_LOG(ERR, "persist operation failed");
+			ret = (int)r;
 			goto err;
 		}
+		tmplen = (size_t)r;
 
-		offset += tmp_len;
-		len -= tmp_len;
+		offset += tmplen;
+		len -= tmplen;
 	}
 err:
 	if (unlikely(rpmem_fip_is_closing(fip)))

--- a/src/librpmem/rpmem_fip.c
+++ b/src/librpmem/rpmem_fip.c
@@ -1128,7 +1128,10 @@ static ssize_t
 rpmem_fip_persist_gpspm_sockets(struct rpmem_fip *fip, size_t offset,
 	size_t len, unsigned lane, unsigned flags)
 {
-	flags &= (unsigned)(~RPMEM_PERSIST_SEND);
+	unsigned mode = flags & RPMEM_PERSIST_MASK;
+	if (mode == RPMEM_PERSIST_SEND)
+		flags = (flags & (~RPMEM_PERSIST_MASK)) | RPMEM_PERSIST_WRITE;
+
 	len = min(len, SSIZE_MAX);
 
 	int ret = rpmem_fip_persist_saw(fip, offset, len, lane, flags);
@@ -1163,8 +1166,9 @@ rpmem_fip_persist_gpspm(struct rpmem_fip *fip, size_t offset,
 {
 	int ret;
 	len = min(len, SSIZE_MAX);
+	unsigned mode = flags & RPMEM_PERSIST_MASK;
 
-	if ((flags & RPMEM_PERSIST_MASK) == RPMEM_PERSIST_SEND) {
+	if (mode == RPMEM_PERSIST_SEND) {
 		len = min(len, fip->buff_size);
 		ret = rpmem_fip_persist_send(fip, offset, len, lane, flags);
 	} else {
@@ -1185,10 +1189,11 @@ rpmem_fip_persist_apm(struct rpmem_fip *fip, size_t offset,
 {
 	int ret;
 	len = min(len, SSIZE_MAX);
+	unsigned mode = flags & RPMEM_PERSIST_MASK;
 
-	if (unlikely(flags & RPMEM_DEEP_PERSIST))
+	if (unlikely(mode == RPMEM_DEEP_PERSIST))
 		ret = rpmem_fip_persist_saw(fip, offset, len, lane, flags);
-	else if ((flags & RPMEM_PERSIST_MASK) == RPMEM_PERSIST_SEND) {
+	else if (mode == RPMEM_PERSIST_SEND) {
 		len = min(len, fip->buff_size);
 		ret = rpmem_fip_persist_send(fip, offset, len, lane, flags);
 	} else {

--- a/src/rpmem_common/rpmem_proto.h
+++ b/src/rpmem_common/rpmem_proto.h
@@ -211,17 +211,17 @@ struct rpmem_msg_close_resp {
 	/* no more fields */
 } PACKED;
 
-#define RPMEM_PERSIST_WRITE	0	/* persist using RDMA WRITE */
-#define RPMEM_DEEP_PERSIST	1	/* deep persist operation */
-#define RPMEM_PERSIST_SEND	2	/* persist using RDMA SEND */
+#define RPMEM_PERSIST_WRITE	0U	/* persist using RDMA WRITE */
+#define RPMEM_DEEP_PERSIST	1U	/* deep persist operation */
+#define RPMEM_PERSIST_SEND	2U	/* persist using RDMA SEND */
 
-#define RPMEM_PERSIST_MAX	2	/* maximum valid value */
+#define RPMEM_PERSIST_MAX	2U	/* maximum valid value */
 
 /*
  * the two least significant bits
  * are reserved for mode of persist
  */
-#define RPMEM_PERSIST_MASK	0x3
+#define RPMEM_PERSIST_MASK	0x3U
 
 /*
  * rpmem_msg_persist -- remote persist message

--- a/src/tools/rpmemd/rpmemd_fip.c
+++ b/src/tools/rpmemd/rpmemd_fip.c
@@ -673,10 +673,11 @@ rpmemd_fip_process_recv(struct rpmemd_fip *fip, struct rpmemd_fip_lane *lanep)
 	ret = rpmemd_fip_check_pmsg(fip, pmsg);
 	if (unlikely(ret))
 		goto err;
+	unsigned mode = pmsg->flags & RPMEM_PERSIST_MASK;
 
-	if (pmsg->flags & RPMEM_DEEP_PERSIST) {
+	if (mode == RPMEM_DEEP_PERSIST) {
 		fip->deep_persist((void *)pmsg->addr, pmsg->size, fip->ctx);
-	} else if (pmsg->flags & RPMEM_PERSIST_SEND) {
+	} else if (mode == RPMEM_PERSIST_SEND) {
 		fip->memcpy_persist((void *)pmsg->addr, pmsg->data, pmsg->size);
 	} else {
 		fip->persist((void *)pmsg->addr, pmsg->size);


### PR DESCRIPTION
... after merge of #2853.

Commit 810dbcc0dd300f7aa132e3ae6a3d65e8744eb6a7 disabled new (safe but
slow) method of persistence for sockets provider, but left buffer size
calculations for this new method.
This meant that we chopped big persists into very small transfers,
even though we didn't have to.
And this slowed down tests enough to trigger Travis' hard limit on
single job execution time.

Second patch cleans up flags handling.