### PR TITLE
test: print physical block of given logical one

### DIFF
--- a/src/test/pmempool_check/TEST31
+++ b/src/test/pmempool_check/TEST31
@@ -70,7 +70,7 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 # inject bad block:
-FIRST_SECTOR=$($EXTENTS $MOUNT_DIR/testfile1 | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$($EXTENTS $MOUNT_DIR/testfile1 0)
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_bad_blocks

--- a/src/test/pmempool_create/TEST11
+++ b/src/test/pmempool_create/TEST11
@@ -71,8 +71,7 @@ POOLSET=$DIR/testset1
 create_poolset $POOLSET 10M:$DIR/testfile1:x 10M:$FILE:x 10M:$DIR/testfile2:x
 
 # inject bad block:
-FIRST_SECTOR=$($EXTENTS $FILE | awk '{if (NR==1) print $1}')
-SECTOR=$(($FIRST_SECTOR + 100))
+SECTOR=$($EXTENTS $FILE 100)
 ndctl_inject_error $NAMESPACE $SECTOR 1
 
 expect_abnormal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET &> $LOG

--- a/src/test/pmempool_info/TEST25
+++ b/src/test/pmempool_info/TEST25
@@ -69,7 +69,7 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 # inject bad block:
-FIRST_SECTOR=$($EXTENTS $MOUNT_DIR/testfile1 | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$($EXTENTS $MOUNT_DIR/testfile1 0)
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET >> $LOG

--- a/src/test/pmempool_sync/TEST27
+++ b/src/test/pmempool_sync/TEST27
@@ -70,7 +70,7 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 # inject bad block:
-FIRST_SECTOR=$($EXTENTS $MOUNT_DIR/testfile1 | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$($EXTENTS $MOUNT_DIR/testfile1 0)
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_bad_blocks

--- a/src/test/tools/extents/README
+++ b/src/test/tools/extents/README
@@ -5,7 +5,11 @@ This is src/test/tools/extents/README.
 This directory contains a tool for listing physical extents of a file.
 
 Usage:
-	$ extents file
+	$ extents file [logical-block-number]
 
-Output of this command is a simple list of pairs: offset and length expressed
-in sectors (offset from the beginning of the device).
+If no 'logical-block-number' is given, than the output of this command
+is a simple list of pairs: offset and length expressed in sectors
+(offset from the beginning of the device).
+
+If a 'logical-block-number' is given, than the output of this command
+is the physical block number of a given logical one.

--- a/src/test/util_badblock/TEST6
+++ b/src/test/util_badblock/TEST6
@@ -65,7 +65,7 @@ FILE="$MOUNT_DIR/file"
 fallocate -l 1M $FILE
 
 # inject bad block:
-FIRST_SECTOR=$($EXTENTS $FILE | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$($EXTENTS $FILE 0)
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_bad_blocks

--- a/src/test/util_badblock/TEST7
+++ b/src/test/util_badblock/TEST7
@@ -66,7 +66,7 @@ FILE="$MOUNT_DIR/file"
 fallocate -l 1M $FILE
 
 # inject bad block:
-FIRST_SECTOR=$($EXTENTS $FILE | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$($EXTENTS $FILE 0)
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_bad_blocks

--- a/src/test/util_badblock/TEST9
+++ b/src/test/util_badblock/TEST9
@@ -68,7 +68,7 @@ fallocate -l 10M $FILE
 expect_normal_exit ./util_badblock$EXESUFFIX $FILE r
 
 # inject bad block:
-FIRST_SECTOR=$($EXTENTS $FILE | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$($EXTENTS $FILE 0)
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_bad_blocks


### PR DESCRIPTION
The patch extends capabilities of the 'extents' tool.
If a logical block number is given, than the output of this command
is the physical block number of a given logical one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2929)
<!-- Reviewable:end -->
