### PR TITLE
obj: test for msync failures in non-pmem path

### DIFF
--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -996,6 +996,17 @@ obj_descr_check(PMEMobjpool *pop, const char *layout, size_t poolsize)
 }
 
 /*
+ * obj_msync_nofail -- (internal) pmem_msync wrapper that never fails from
+ * caller's perspective
+ */
+static void
+obj_msync_nofail(const void *addr, size_t size)
+{
+	if (pmem_msync(addr, size))
+		FATAL("!pmem_msync");
+}
+
+/*
  * obj_replica_init_local -- (internal) initialize runtime part
  *                               of the local replicas
  */
@@ -1030,8 +1041,8 @@ obj_replica_init_local(PMEMobjpool *rep, int is_pmem, size_t resvsize)
 		rep->memmove_local = pmem_memmove;
 		rep->memset_local = pmem_memset;
 	} else {
-		rep->persist_local = (persist_local_fn)pmem_msync;
-		rep->flush_local = (flush_local_fn)pmem_msync;
+		rep->persist_local = obj_msync_nofail;
+		rep->flush_local = obj_msync_nofail;
 		rep->drain_local = obj_drain_empty;
 		rep->memcpy_local = obj_nopmem_memcpy;
 		rep->memmove_local = obj_nopmem_memmove;

--- a/src/test/obj_list/obj_list_mocks.c
+++ b/src/test/obj_list/obj_list_mocks.c
@@ -34,6 +34,7 @@
  * obj_list_mocks.c -- mocks for redo/lane/heap/obj modules
  */
 
+#include <inttypes.h>
 #include "valgrind_internal.h"
 #include "obj_list.h"
 #include "set.h"
@@ -69,6 +70,30 @@ obj_flush(void *ctx, const void *addr, size_t len, unsigned flags)
 	pop->flush_local(addr, len);
 
 	return 0;
+}
+
+static uintptr_t Pool_addr;
+static size_t Pool_size;
+
+static void
+obj_msync_nofail(const void *addr, size_t size)
+{
+	uintptr_t addr_ptrt = (uintptr_t)addr;
+
+	/*
+	 * Verify msynced range is in the last mapped file range. Useful for
+	 * catching errors which normally would be caught only on Windows by
+	 * win_mmap.c.
+	 */
+	if (addr_ptrt < Pool_addr || addr_ptrt >= Pool_addr + Pool_size ||
+			addr_ptrt + size >= Pool_addr + Pool_size)
+		UT_FATAL("<0x%" PRIxPTR ",0x%" PRIxPTR "> "
+				"not in <0x%" PRIxPTR ",0x%" PRIxPTR "> range",
+				addr_ptrt, addr_ptrt + size, Pool_addr,
+				Pool_addr + Pool_size);
+
+	if (pmem_msync(addr, size))
+		UT_FATAL("!pmem_msync");
 }
 
 /*
@@ -122,6 +147,8 @@ FUNC_MOCK_RUN_DEFAULT
 		UT_OUT("!%s: pmem_map_file", fname);
 		return NULL;
 	}
+	Pool_addr = (uintptr_t)addr;
+	Pool_size = size;
 
 	Pop = (PMEMobjpool *)addr;
 	Pop->addr = Pop;
@@ -144,8 +171,8 @@ FUNC_MOCK_RUN_DEFAULT
 		Pop->flush_local = pmem_flush;
 		Pop->drain_local = pmem_drain;
 	} else {
-		Pop->persist_local = (persist_local_fn)pmem_msync;
-		Pop->flush_local = (persist_local_fn)pmem_msync;
+		Pop->persist_local = obj_msync_nofail;
+		Pop->flush_local = obj_msync_nofail;
 		Pop->drain_local = pmem_drain_nop;
 	}
 
@@ -218,6 +245,8 @@ FUNC_MOCK(pmemobj_close, void, PMEMobjpool *pop)
 		UT_ASSERTeq(pmem_unmap(Pop,
 			Pop->heap_size + Pop->heap_offset), 0);
 		Pop = NULL;
+		Pool_addr = 0;
+		Pool_size = 0;
 	}
 FUNC_MOCK_END
 
@@ -261,10 +290,12 @@ FUNC_MOCK(pmemobj_alloc, int, PMEMobjpool *pop, PMEMoid *oidp,
 	FUNC_MOCK_RUN_DEFAULT {
 		PMEMoid oid = {0, 0};
 		oid.pool_uuid_lo = 0;
-		pmalloc(NULL, &oid.off, size, 0, 0);
+		pmalloc(pop, &oid.off, size, 0, 0);
 		if (oidp) {
 			*oidp = oid;
-			pmemops_persist(&Pop->p_ops, oidp, sizeof(*oidp));
+			if (OBJ_PTR_FROM_POOL(pop, oidp))
+				pmemops_persist(&Pop->p_ops, oidp,
+						sizeof(*oidp));
 		}
 		return 0;
 	}

--- a/src/test/obj_list/obj_list_mocks_palloc.c
+++ b/src/test/obj_list/obj_list_mocks_palloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017, Intel Corporation
+ * Copyright 2015-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -53,7 +53,8 @@ FUNC_MOCK(pmalloc, int, PMEMobjpool *pop, uint64_t *ptr,
 		pmemops_persist(p_ops, alloc_size, sizeof(*alloc_size));
 
 		*ptr = *Heap_offset + sizeof(uint64_t);
-		pmemops_persist(p_ops, ptr, sizeof(*ptr));
+		if (OBJ_PTR_FROM_POOL(pop, ptr))
+			pmemops_persist(p_ops, ptr, sizeof(*ptr));
 
 		struct oob_item *item =
 			(struct oob_item *)((uintptr_t)Pop + *ptr);
@@ -85,7 +86,8 @@ FUNC_MOCK(pfree, void, PMEMobjpool *pop, uint64_t *ptr)
 			(struct oob_item *)((uintptr_t)Pop + *ptr - OOB_OFF);
 		UT_OUT("pfree(id = %d)", item->item.id);
 		*ptr = 0;
-		pmemops_persist(&Pop->p_ops, ptr, sizeof(*ptr));
+		if (OBJ_PTR_FROM_POOL(pop, ptr))
+			pmemops_persist(&Pop->p_ops, ptr, sizeof(*ptr));
 
 		return;
 	}
@@ -109,7 +111,8 @@ FUNC_MOCK(pmalloc_construct, int, PMEMobjpool *pop, uint64_t *off,
 		pmemops_persist(p_ops, alloc_size, sizeof(*alloc_size));
 
 		*off = *Heap_offset + sizeof(uint64_t) + OOB_OFF;
-		pmemops_persist(p_ops, off, sizeof(*off));
+		if (OBJ_PTR_FROM_POOL(pop, off))
+			pmemops_persist(p_ops, off, sizeof(*off));
 
 		*Heap_offset = *Heap_offset + sizeof(uint64_t) + size;
 		pmemops_persist(p_ops, Heap_offset, sizeof(*Heap_offset));

--- a/src/test/obj_memcheck/TEST0
+++ b/src/test/obj_memcheck/TEST0
@@ -42,6 +42,12 @@ require_test_type medium
 
 require_fs_type non-pmem
 
+# Valgrind merges errors which have the same last 4 stack frames. With non-debug
+# builds the depth of the stack trace depends on how much compiler optimized it.
+# So always use debug build to take a compiler out of the picture and get
+# deterministic stack traces.
+require_build_type debug
+
 require_valgrind 3.10
 configure_valgrind memcheck force-enable
 

--- a/src/test/obj_memcheck/memcheck0.log.match
+++ b/src/test/obj_memcheck/memcheck0.log.match
@@ -32,6 +32,7 @@ $(OPT)==$(N)==    $(S) 0x$(X): main $(*)
 ==$(N)== 
 ==$(N)== Unaddressable byte(s) found during client check request
 ==$(N)==    at 0x$(X): pmem_msync $(*)
+$(OPT)==$(N)==    by 0x$(X): ${obj_msync_nofail|???} $(*)
 $(OPT)==$(N)==    by 0x$(X): ${obj_norep_persist|???} $(*)
 $(OPT)==$(N)==    by 0x$(X): ${pmemops_xpersist|???} $(*)
 $(OPT)==$(N)==    by 0x$(X): ${pmemops_persist|???} $(*)
@@ -91,64 +92,10 @@ $(OPT)==$(N)==    $(S) 0x$(X): pmemobj_realloc $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): test_everything $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): main $(*)
 ==$(N)== 
-==$(N)== Unaddressable byte(s) found during client check request
-==$(N)==    at 0x$(X): pmem_msync $(*)
-$(OPT)==$(N)==    by 0x$(X): ${obj_norep_persist|???} $(*)
-$(OPT)==$(N)==    by 0x$(X): ${pmemops_xpersist|???} $(*)
-$(OPT)==$(N)==    by 0x$(X): ${pmemops_persist|???} $(*)
-$(OPT)==$(N)==    by 0x$(X): pmemobj_persist $(*)
-==$(N)==    by 0x$(X): test_everything (obj_memcheck.c:$(N))
-==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
-==$(N)==  Address 0x$(X) is $(N) bytes inside a block of size $(N) free'd
-$(OPT)==$(N)==    $(S) 0x$(X): ${palloc_heap_action_on_process|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): ${palloc_exec_actions|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): ${palloc_operation|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): ${pmalloc_operation|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): ${obj_free|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): pmemobj_free $(*)
-==$(N)==    by 0x$(X): test_everything (obj_memcheck.c:$(N))
-==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
-$(OPT)==$(N)==  Block was alloc'd at
-$(OPT)==$(N)==    $(S) 0x$(X): ${alloc_prep_block|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): ${palloc_reservation_create|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): ${palloc_operation|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): ${pmalloc_operation|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): ${obj_realloc_common|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): pmemobj_realloc $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): test_everything $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): main $(*)
-==$(N)== 
 ==$(N)== Invalid write of size 4
 ==$(N)==    at 0x$(X): test_everything (obj_memcheck.c:$(N))
 ==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
 ==$(N)==  Address 0x$(X) is $(N) bytes inside a block of size $(N) free'd
-$(OPT)==$(N)==    $(S) 0x$(X): ${palloc_heap_action_on_process|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): ${palloc_exec_actions|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): ${palloc_operation|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): ${pmalloc_operation|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): ${obj_free|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): pmemobj_free $(*)
-==$(N)==    by 0x$(X): test_everything (obj_memcheck.c:$(N))
-==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
-$(OPT)==$(N)==  Block was alloc'd at
-$(OPT)==$(N)==    $(S) 0x$(X): ${alloc_prep_block|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): ${palloc_reservation_create|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): ${palloc_operation|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): ${pmalloc_operation|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): ${obj_realloc_common|???} $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): pmemobj_realloc $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): test_everything $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): main $(*)
-==$(N)== 
-==$(N)== Unaddressable byte(s) found during client check request
-==$(N)==    at 0x$(X): pmem_msync $(*)
-$(OPT)==$(N)==    by 0x$(X): ${obj_norep_persist|???} $(*)
-$(OPT)==$(N)==    by 0x$(X): ${pmemops_xpersist|???} $(*)
-$(OPT)==$(N)==    by 0x$(X): ${pmemops_persist|???} $(*)
-$(OPT)==$(N)==    by 0x$(X): pmemobj_persist $(*)
-==$(N)==    by 0x$(X): test_everything (obj_memcheck.c:$(N))
-==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
-==$(N)==  Address 0x$(X) is 0 bytes inside a block of size $(N) free'd
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_heap_action_on_process|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_exec_actions|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_operation|???} $(*)
@@ -192,4 +139,4 @@ $(OPT)==$(N)==         suppressed: $(NC) bytes in $(N) blocks
 ==$(N)== 
 ==$(N)== For counts of detected and suppressed errors, rerun with: -v
 ==$(N)== Use --track-origins=yes to see where uninitialised values come from
-==$(N)== ERROR SUMMARY: 10 errors from 10 contexts (suppressed: $(N) from $(N))
+==$(N)== ERROR SUMMARY: 10 errors from 8 contexts (suppressed: $(N) from $(N))

--- a/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
+++ b/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
@@ -106,6 +106,13 @@ obj_drain(void *ctx)
 	pop->drain_local();
 }
 
+static void
+obj_msync_nofail(const void *addr, size_t size)
+{
+	if (pmem_msync(addr, size))
+		UT_FATAL("!pmem_msync");
+}
+
 /*
  * obj_memcpy -- pmemobj version of memcpy w/o replication
  */
@@ -297,8 +304,8 @@ test_mock_pool_allocs(void)
 	mock_pop->lanes_offset = sizeof(PMEMobjpool);
 	mock_pop->is_master_replica = 1;
 
-	mock_pop->persist_local = (persist_local_fn)pmem_msync;
-	mock_pop->flush_local = (flush_local_fn)pmem_msync;
+	mock_pop->persist_local = obj_msync_nofail;
+	mock_pop->flush_local = obj_msync_nofail;
 	mock_pop->drain_local = drain_empty;
 
 	mock_pop->p_ops.persist = obj_persist;

--- a/src/test/obj_redo_log/obj_redo_log.c
+++ b/src/test/obj_redo_log/obj_redo_log.c
@@ -114,6 +114,13 @@ redo_log_check_offset(void *ctx, uint64_t offset)
 	return OBJ_OFF_IS_VALID(pop, offset);
 }
 
+static void
+obj_msync_nofail(const void *addr, size_t size)
+{
+	if (pmem_msync(addr, size))
+		UT_FATAL("!pmem_msync");
+}
+
 static PMEMobjpool *
 pmemobj_open_mock(const char *fname, size_t redo_size)
 {
@@ -141,8 +148,8 @@ pmemobj_open_mock(const char *fname, size_t redo_size)
 		pop->flush_local = pmem_flush;
 		pop->drain_local = pmem_drain;
 	} else {
-		pop->persist_local = (persist_local_fn)pmem_msync;
-		pop->flush_local = (persist_local_fn)pmem_msync;
+		pop->persist_local = obj_msync_nofail;
+		pop->flush_local = obj_msync_nofail;
 		pop->drain_local = pmem_drain_nop;
 	}
 


### PR DESCRIPTION
Casting function to incompatible prototype is an undefined
behavior (see linked issue).

I had to remove "Unaddressable byte(s) found during client check
request" messages from obj_memcheck match file, because with
the new entry in the stack trace (obj_msync_nofail), Valgrind
merges the last 2 errors into the first one (it compares only
the first 4 entries in the stack trace when deciding to merge).

Ref: pmem/issues#867

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2933)
<!-- Reviewable:end -->
