### PR TITLE
common: add Wcast-function-type warning

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -72,6 +72,9 @@ endif
 ifeq ($(call check_flag, -Wswitch-default), y)
 DEFAULT_CFLAGS += -Wswitch-default
 endif
+ifeq ($(call check_flag, -Wcast-function-type), y)
+DEFAULT_CFLAGS += -Wcast-function-type
+endif
 endif
 
 ifeq ($(DEBUG),1)

--- a/src/jemalloc/jemalloc.mk
+++ b/src/jemalloc/jemalloc.mk
@@ -82,6 +82,7 @@ CFLAGS_FILTER += -Wdisabled-macro-expansion
 CFLAGS_FILTER += -Wlanguage-extension-token
 CFLAGS_FILTER += -Wfloat-equal
 CFLAGS_FILTER += -Wswitch-default
+CFLAGS_FILTER += -Wcast-function-type
 JEMALLOC_CFLAGS=$(filter-out $(CFLAGS_FILTER), $(CFLAGS))
 ifeq ($(shell uname -s),FreeBSD)
 JEMALLOC_CFLAGS += -I/usr/local/include

--- a/src/test/unittest/Makefile
+++ b/src/test/unittest/Makefile
@@ -75,6 +75,9 @@ endif
 ifeq ($(call check_flag, -Wswitch-default), y)
 CFLAGS += -Wswitch-default
 endif
+ifeq ($(call check_flag, -Wcast-function-type), y)
+CFLAGS += -Wcast-function-type
+endif
 endif
 
 ifeq ($(USE_LIBUNWIND),1)

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -69,6 +69,9 @@ endif
 ifeq ($(call check_flag, -Wswitch-default), y)
 CFLAGS += -Wswitch-default
 endif
+ifeq ($(call check_flag, -Wcast-function-type), y)
+CFLAGS += -Wcast-function-type
+endif
 endif
 
 ifeq ($(DEBUG),1)

--- a/utils/check_license/Makefile
+++ b/utils/check_license/Makefile
@@ -57,6 +57,9 @@ endif
 ifeq ($(call check_flag, -Wswitch-default), y)
 CFLAGS += -Wswitch-default
 endif
+ifeq ($(call check_flag, -Wcast-function-type), y)
+CFLAGS += -Wcast-function-type
+endif
 
 TARGET=check-license
 


### PR DESCRIPTION
Intention of this PR is to extend compilation warnings - add to compilation warning, when a function pointer is cast to an incompatible function pointer. For details please see : https://gcc.gnu.org/gcc-8/changes.html

I tested it locally: Ubuntu 18.04 LTS - gcc-8 (Ubuntu 8.1.0-1ubuntu1) 8.1.0- after merging changes from https://github.com/pmem/pmdk/pull/2933 compilation pass.

I kindly ask to review it - after https://github.com/pmem/pmdk/pull/2933 is merged  ( Ref: https://github.com/pmem/issues/issues/867#issuecomment-389590191 )
After merge I highly recommend to create "internally Jenkins jobs" with configuration described in comment above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2934)
<!-- Reviewable:end -->
