### PR TITLE
test: print physical offset of given logical one

### DIFF
--- a/src/test/pmempool_check/TEST31
+++ b/src/test/pmempool_check/TEST31
@@ -70,7 +70,7 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 # inject bad block:
-FIRST_SECTOR=$(expect_normal_exit $EXTENTS $MOUNT_DIR/testfile1 | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $MOUNT_DIR/testfile1 -l 0)
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_bad_blocks

--- a/src/test/pmempool_check/TEST31
+++ b/src/test/pmempool_check/TEST31
@@ -70,7 +70,7 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 # inject bad block:
-FIRST_SECTOR=$($EXTENTS $MOUNT_DIR/testfile1 | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $MOUNT_DIR/testfile1 | awk '{if (NR==1) print $1}')
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_bad_blocks

--- a/src/test/pmempool_create/TEST11
+++ b/src/test/pmempool_create/TEST11
@@ -71,7 +71,7 @@ POOLSET=$DIR/testset1
 create_poolset $POOLSET 10M:$DIR/testfile1:x 10M:$FILE:x 10M:$DIR/testfile2:x
 
 # inject bad block:
-FIRST_SECTOR=$($EXTENTS $FILE | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $FILE | awk '{if (NR==1) print $1}')
 SECTOR=$(($FIRST_SECTOR + 100))
 ndctl_inject_error $NAMESPACE $SECTOR 1
 

--- a/src/test/pmempool_create/TEST11
+++ b/src/test/pmempool_create/TEST11
@@ -71,8 +71,7 @@ POOLSET=$DIR/testset1
 create_poolset $POOLSET 10M:$DIR/testfile1:x 10M:$FILE:x 10M:$DIR/testfile2:x
 
 # inject bad block:
-FIRST_SECTOR=$(expect_normal_exit $EXTENTS $FILE | awk '{if (NR==1) print $1}')
-SECTOR=$(($FIRST_SECTOR + 100))
+SECTOR=$(expect_normal_exit $EXTENTS $FILE -l 100)
 ndctl_inject_error $NAMESPACE $SECTOR 1
 
 expect_abnormal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET &> $LOG

--- a/src/test/pmempool_info/TEST25
+++ b/src/test/pmempool_info/TEST25
@@ -69,7 +69,7 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 # inject bad block:
-FIRST_SECTOR=$($EXTENTS $MOUNT_DIR/testfile1 | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $MOUNT_DIR/testfile1 | awk '{if (NR==1) print $1}')
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET >> $LOG

--- a/src/test/pmempool_info/TEST25
+++ b/src/test/pmempool_info/TEST25
@@ -69,7 +69,7 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 # inject bad block:
-FIRST_SECTOR=$(expect_normal_exit $EXTENTS $MOUNT_DIR/testfile1 | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $MOUNT_DIR/testfile1 -l 0)
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET >> $LOG

--- a/src/test/pmempool_sync/TEST27
+++ b/src/test/pmempool_sync/TEST27
@@ -70,7 +70,7 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 # inject bad block:
-FIRST_SECTOR=$(expect_normal_exit $EXTENTS $MOUNT_DIR/testfile1 | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $MOUNT_DIR/testfile1 -l 0)
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_bad_blocks

--- a/src/test/pmempool_sync/TEST27
+++ b/src/test/pmempool_sync/TEST27
@@ -70,7 +70,7 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 # inject bad block:
-FIRST_SECTOR=$($EXTENTS $MOUNT_DIR/testfile1 | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $MOUNT_DIR/testfile1 | awk '{if (NR==1) print $1}')
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_bad_blocks

--- a/src/test/tools/extents/README
+++ b/src/test/tools/extents/README
@@ -5,7 +5,11 @@ This is src/test/tools/extents/README.
 This directory contains a tool for listing physical extents of a file.
 
 Usage:
-	$ extents file
+	$ extents [-l <logical_offset>] <file>
 
-Output of this command is a simple list of pairs: offset and length expressed
-in sectors (offset from the beginning of the device).
+If no '<logical_offset>' is given, than the output of this command
+is a simple list of pairs: physical offset and length - both of them
+expressed in 512B sectors (offset from the beginning of the device).
+
+If a '<logical_offset>' is given, than the output of this command
+is the physical offset of the given logical one.

--- a/src/test/tools/extents/extents.c
+++ b/src/test/tools/extents/extents.c
@@ -36,26 +36,82 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
 
 #include "extent.h"
 
 #define B2SEC(n) ((n) >> 9)	/* convert bytes to sectors */
 
+enum modes {
+	MODE_PRINT_ALL_EXTENTS = 0,
+	MODE_PRINT_ONE_PHY_OF_LOG,
+};
+
+static const char *usage_str =
+	"usage: %s "
+	"[-h] "
+	"[-l <logical_offset>] "
+	"<file>\n";
+
 int
 main(int argc, char *argv[])
 {
+	long unsigned offset = 0;
+	unsigned extent = 0;
+	char *error;
 	int ret = -1;
+	int opt;
 
-	if (argc != 2) {
-		fprintf(stderr, "usage: %s file", argv[0]);
+	enum modes mode = MODE_PRINT_ALL_EXTENTS;
+
+	while ((opt = getopt(argc, argv, "hl:")) != -1) {
+		switch (opt) {
+		case 'h':
+			printf(usage_str, argv[0]);
+			return 0;
+
+		case 'l':
+			mode = MODE_PRINT_ONE_PHY_OF_LOG;
+			errno = 0;
+			offset = strtoul(optarg, &error, 10 /* base */);
+			if (errno || *error != '\0') {
+				if (errno)
+					perror("strtoul");
+				if (*error != '\0') {
+					fprintf(stderr,
+						"error: invalid character(s) in the given logical offset: %s\n",
+						error);
+				}
+				return -1;
+			}
+			break;
+
+		default:
+			fprintf(stderr, usage_str, argv[0]);
+			return -1;
+		}
+	}
+
+	if (optind + 1 < argc) {
+		fprintf(stderr, "error: unknown option: %s\n",
+			argv[optind + 1]);
+		fprintf(stderr, usage_str, argv[0]);
 		return -1;
 	}
+
+	if (optind >= argc) {
+		fprintf(stderr, usage_str, argv[0]);
+		return -1;
+	}
+
+	const char *file = argv[optind];
 
 	struct extents *exts = malloc(sizeof(struct extents));
 	if (exts == NULL)
 		return -1;
 
-	long count = os_extents_count(argv[1], exts);
+	long count = os_extents_count(file, exts);
 	if (count < 0)
 		goto exit_free;
 
@@ -68,21 +124,57 @@ main(int argc, char *argv[])
 	if (exts->extents == NULL)
 		goto exit_free;
 
-	ret = os_extents_get(argv[1], exts);
+	ret = os_extents_get(file, exts);
 	if (ret)
 		goto exit_free;
 
-	unsigned e;
-	for (e = 0; e < exts->extents_count; e++)
-		printf("%lu %lu\n",
+	switch (mode) {
+	case MODE_PRINT_ALL_EXTENTS:
+		for (unsigned e = 0; e < exts->extents_count; e++) {
 			/* extents are in bytes, convert them to sectors */
-			B2SEC(exts->extents[e].offset_physical),
-			B2SEC(exts->extents[e].length));
+			printf("%lu %lu\n",
+				B2SEC(exts->extents[e].offset_physical),
+				B2SEC(exts->extents[e].length));
+		}
+		break;
+
+	case MODE_PRINT_ONE_PHY_OF_LOG:
+		/* print the physical offset of the given logical one */
+		for (unsigned e = 0; e < exts->extents_count; e++) {
+			if (B2SEC(exts->extents[e].offset_logical) > offset)
+				break;
+			extent = e;
+		}
+
+		if (extent == exts->extents_count - 1) {
+			long unsigned max_log;
+
+			max_log = B2SEC(exts->extents[extent].offset_logical) +
+					B2SEC(exts->extents[extent].length);
+
+			if (offset > max_log) {
+				fprintf(stderr,
+					"error: maximum logical offset is %lu\n",
+					max_log);
+				ret = -1;
+				goto exit_free;
+			}
+		}
+
+		offset += B2SEC(exts->extents[extent].offset_physical) -
+				B2SEC(exts->extents[extent].offset_logical);
+
+		printf("%lu\n", offset);
+		break;
+
+	default:
+		fprintf(stderr, usage_str, argv[0]);
+		return -1;
+	}
 
 exit_free:
 	if (exts->extents)
 		free(exts->extents);
-
 	free(exts);
 
 	return ret;

--- a/src/test/util_badblock/TEST6
+++ b/src/test/util_badblock/TEST6
@@ -65,7 +65,7 @@ FILE="$MOUNT_DIR/file"
 fallocate -l 1M $FILE
 
 # inject bad block:
-FIRST_SECTOR=$(expect_normal_exit $EXTENTS $FILE | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $FILE -l 0)
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_bad_blocks

--- a/src/test/util_badblock/TEST6
+++ b/src/test/util_badblock/TEST6
@@ -65,7 +65,7 @@ FILE="$MOUNT_DIR/file"
 fallocate -l 1M $FILE
 
 # inject bad block:
-FIRST_SECTOR=$($EXTENTS $FILE | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $FILE | awk '{if (NR==1) print $1}')
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_bad_blocks

--- a/src/test/util_badblock/TEST7
+++ b/src/test/util_badblock/TEST7
@@ -66,7 +66,7 @@ FILE="$MOUNT_DIR/file"
 fallocate -l 1M $FILE
 
 # inject bad block:
-FIRST_SECTOR=$(expect_normal_exit $EXTENTS $FILE | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $FILE -l 0)
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_bad_blocks

--- a/src/test/util_badblock/TEST7
+++ b/src/test/util_badblock/TEST7
@@ -66,7 +66,7 @@ FILE="$MOUNT_DIR/file"
 fallocate -l 1M $FILE
 
 # inject bad block:
-FIRST_SECTOR=$($EXTENTS $FILE | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $FILE | awk '{if (NR==1) print $1}')
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_bad_blocks

--- a/src/test/util_badblock/TEST9
+++ b/src/test/util_badblock/TEST9
@@ -68,7 +68,7 @@ fallocate -l 10M $FILE
 expect_normal_exit ./util_badblock$EXESUFFIX $FILE r
 
 # inject bad block:
-FIRST_SECTOR=$($EXTENTS $FILE | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $FILE | awk '{if (NR==1) print $1}')
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_bad_blocks

--- a/src/test/util_badblock/TEST9
+++ b/src/test/util_badblock/TEST9
@@ -68,7 +68,7 @@ fallocate -l 10M $FILE
 expect_normal_exit ./util_badblock$EXESUFFIX $FILE r
 
 # inject bad block:
-FIRST_SECTOR=$(expect_normal_exit $EXTENTS $FILE | awk '{if (NR==1) print $1}')
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $FILE -l 0)
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_bad_blocks


### PR DESCRIPTION
The patch extends capabilities of the 'extents' tool.
If a logical offset is given, than the output of this command
is the physical offset of the given logical one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2936)
<!-- Reviewable:end -->
