### PR TITLE
test: Workaround getconf(1) bug in FreeBSD

### DIFF
--- a/src/test/obj_pool/TEST17
+++ b/src/test/obj_pool/TEST17
@@ -43,8 +43,8 @@ require_test_type medium
 setup
 
 # non-existing file, poolsize == RANGE_OF_SIZE_T_AS_MB
-RANGE_OF_SIZE_T=$(getconf ULONG_MAX)
-RANGE_OF_SIZE_T_AS_MB=$(echo "$RANGE_OF_SIZE_T/1024/1024" | bc)
+# Use 2^64-1 as an arbitrarily huge number (fixed size for match file)
+RANGE_OF_SIZE_T_AS_MB=$(echo "2^64/1024/1024-1" | bc)
 expect_normal_exit ./obj_pool$EXESUFFIX c $DIR/testfile "test" \
     $RANGE_OF_SIZE_T_AS_MB 0640
 


### PR DESCRIPTION
Change obj_pool/TEST17 to use 2^64-1 rather than getconf ULONG_MAX.

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=164049

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2942)
<!-- Reviewable:end -->
