### PR TITLE
examples: queue comments and input validation update

### DIFF
--- a/src/examples/libpmemobj/queue/README
+++ b/src/examples/libpmemobj/queue/README
@@ -13,8 +13,7 @@ This file can be created using pmempool:
 $ pmempool create obj <file> --layout queue
 
 The queue supports 4 operations:
-	* new <capacity> - create a new queue with the given capacity. The
-	capacity must be a power of two.
+	* new <capacity> - create a new queue with the given capacity.
 	* enqueue <data> - inserts a new entry into the queue with the given
 	data string
 	* dequeue - removes the entry at the front of the queue

--- a/src/examples/libpmemobj/queue/queue.c
+++ b/src/examples/libpmemobj/queue/queue.c
@@ -242,9 +242,10 @@ main(int argc, char *argv[])
 			if (argc != 4)
 				fail("missing size of the queue");
 
+			char *end;
 			errno = 0;
-			capacity = strtoull(argv[3], NULL, 0);
-			if (errno == ERANGE)
+			capacity = strtoull(argv[3], &end, 0);
+			if (errno == ERANGE || *end != '\0')
 				fail("invalid size of the queue");
 
 			if (queue_new(pop, &rootp->queue, capacity) != 0)

--- a/src/examples/libpmemobj/queue/queue.c
+++ b/src/examples/libpmemobj/queue/queue.c
@@ -55,7 +55,7 @@ struct queue { /* array-based queue container */
 	size_t front; /* position of the first entry */
 	size_t back; /* position of the last entry */
 
-	size_t capacity; /* size of the entries array, must be power of two */
+	size_t capacity; /* size of the entries array */
 	TOID(struct entry) entries[];
 };
 


### PR DESCRIPTION
Intention of this PR is to extend input validation and remove misleading comments in queue example.

1. In case of queue and operation **new** it is possible to pass value, which valid conversion could be not performed and zero value is returned for example:

./queue /mnt/pmem/queue.pool new testvalue ( it will create new queue with capacity 0 )

2) I think comment regarding "capacity should be power of two" is obsolete and could be misleading ( in case of README ) - it is possible to create new queue with capacity for example equal 3.

 
In any case any feedback will be appreciated