### PR TITLE
pool: sync single blocks not the whole part

### DIFF
--- a/doc/pmempool/pmempool-sync.1.md
+++ b/doc/pmempool/pmempool-sync.1.md
@@ -75,6 +75,28 @@ be opened are recreated.=e=)
 
 ##### Available options: #####
 
+`-b, --bad-blocks`
+
+: Fix bad blocks - requires creating or reading special recovery files.
+When bad blocks are detected, special recovery files have to be created
+in order to fix them safely. A separate recovery file is created per each part
+containing bad blocks. The recovery files are created in the same directory
+where the poolset file is located using the following name pattern:
+\<poolset-file-name\>_r\<replica-number\>_p\<part-number\>_badblocks.txt
+These recovery files are automatically removed if the sync operation finishes
+successfully.
+If the last sync operation was interrupted and not finished correctly
+(eg. the application crashed) and the bad blocks fixing procedure was
+in progress, the bad block recovery files may be left over. In such case
+bad blocks might have been cleared and zeroed, but the correct data from these
+blocks was not recovered (not copied from a healthy replica), so the recovery
+files MUST NOT be deleted manually, because it would cause a data loss.
+Pmempool-sync should be run again with the '-b' option set. It will finish
+the previously interrupted sync operation and copy correct data to zeroed
+bad blocks using the left-over bad block recovery files (the bad blocks
+will be read from the saved recovery files). Pmempool will delete the recovery
+files automatically at the end of the sync operation.
+
 `-d, --dry-run`
 
 : Enable dry run mode. In this mode no changes are applied, only check for

--- a/src/common/badblock.h
+++ b/src/common/badblock.h
@@ -45,4 +45,8 @@ void badblocks_delete(struct badblocks *bbs);
 int badblocks_check_poolset(struct pool_set *set, int create);
 int badblocks_clear_poolset(struct pool_set *set, int create);
 
+char *badblocks_recovery_file_alloc(const char *file,
+					unsigned rep, unsigned part);
+int badblocks_recovery_file_exists(struct pool_set *set);
+
 #endif /* PMDK_BADBLOCK_POOLSET_H */

--- a/src/common/badblock_linux.c
+++ b/src/common/badblock_linux.c
@@ -100,6 +100,13 @@ os_badblocks_get(const char *file, struct badblocks *bbs)
 	if (extents == 0) {
 		/* dax device has no extents */
 		bb_found = (int)bbs->bb_cnt;
+
+		for (unsigned b = 0; b < bbs->bb_cnt; b++) {
+			LOG(4, "bad block found: offset: %llu, length: %u",
+				bbs->bbv[b].offset,
+				bbs->bbv[b].length);
+		}
+
 		goto exit_free_all;
 	}
 

--- a/src/common/os.h
+++ b/src/common/os.h
@@ -109,6 +109,7 @@ typedef off_t os_off_t;
 #endif
 int os_open(const char *pathname, int flags, ...);
 int os_fsync(int fd);
+int os_fsync_dir(const char *dir_name);
 int os_stat(const char *pathname, os_stat_t *buf);
 int os_unlink(const char *pathname);
 int os_access(const char *pathname, int mode);

--- a/src/common/os.h
+++ b/src/common/os.h
@@ -108,6 +108,7 @@ typedef off_t os_off_t;
 /* XXX: os_off_t defined in platform.h */
 #endif
 int os_open(const char *pathname, int flags, ...);
+int os_fsync(int fd);
 int os_stat(const char *pathname, os_stat_t *buf);
 int os_unlink(const char *pathname);
 int os_access(const char *pathname, int mode);

--- a/src/common/os_posix.c
+++ b/src/common/os_posix.c
@@ -79,6 +79,15 @@ os_open(const char *pathname, int flags, ...)
 }
 
 /*
+ * os_fsync -- fsync abstraction layer
+ */
+int
+os_fsync(int fd)
+{
+	return fsync(fd);
+}
+
+/*
  * os_stat -- stat abstraction layer
  */
 int

--- a/src/common/os_posix.c
+++ b/src/common/os_posix.c
@@ -88,6 +88,23 @@ os_fsync(int fd)
 }
 
 /*
+ * os_fsync_dir -- fsync the directory
+ */
+int
+os_fsync_dir(const char *dir_name)
+{
+	int fd = os_open(dir_name, O_RDONLY | O_DIRECTORY);
+	if (fd < 0)
+		return -1;
+
+	int ret = os_fsync(fd);
+
+	os_close(fd);
+
+	return ret;
+}
+
+/*
  * os_stat -- stat abstraction layer
  */
 int

--- a/src/common/os_windows.c
+++ b/src/common/os_windows.c
@@ -84,6 +84,27 @@ os_open(const char *pathname, int flags, ...)
 }
 
 /*
+ * os_fsync -- fsync abstraction layer
+ */
+int
+os_fsync(int fd)
+{
+	HANDLE handle = (HANDLE) _get_osfhandle(fd);
+
+	if (handle == INVALID_HANDLE_VALUE) {
+		errno = EBADF;
+		return -1;
+	}
+
+	if (!FlushFileBuffers(handle)) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	return 0;
+}
+
+/*
  * os_stat -- stat abstraction layer
  */
 int

--- a/src/common/os_windows.c
+++ b/src/common/os_windows.c
@@ -105,6 +105,17 @@ os_fsync(int fd)
 }
 
 /*
+ * os_fsync_dir -- fsync the directory
+ */
+int
+os_fsync_dir(const char *dir_name)
+{
+	/* XXX not used and not implemented */
+	ASSERT(0);
+	return -1;
+}
+
+/*
  * os_stat -- stat abstraction layer
  */
 int

--- a/src/common/set.c
+++ b/src/common/set.c
@@ -1552,9 +1552,9 @@ util_poolset_parse(struct pool_set **setp, const char *path, int fd)
 		goto err;
 	}
 
-	set->path = strdup(path);
+	set->path = Strdup(path);
 	if (set->path == NULL)  {
-		ERR("!strdup");
+		ERR("!Strdup");
 		goto err;
 	}
 
@@ -3725,7 +3725,7 @@ util_replica_check(struct pool_set *set, const struct pool_attr *attr)
 /*
  * util_pool_open_nocheck -- open a memory pool (set or a single file)
  *
- * This function opens opens a pool set without checking the header values.
+ * This function opens a pool set without checking the header values.
  */
 int
 util_pool_open_nocheck(struct pool_set *set, unsigned flags)
@@ -3746,6 +3746,14 @@ util_pool_open_nocheck(struct pool_set *set, unsigned flags)
 	ASSERTne(set, NULL);
 	ASSERT(set->nreplicas > 0);
 
+	/* check if any bad block recovery file exists */
+	if (badblocks_recovery_file_exists(set)) {
+		LOG(1,
+			"error: a bad block recovery file exists, run 'pmempool sync --bad-blocks' utility to try to recover the pool");
+		errno = EINVAL;
+		return -1;
+	}
+
 	int bbs = badblocks_check_poolset(set, 0 /* not create */);
 	if (bbs < 0) {
 		LOG(1, "WARNING: failed to check pool set for bad blocks");
@@ -3757,7 +3765,7 @@ util_pool_open_nocheck(struct pool_set *set, unsigned flags)
 				"WARNING: pool set contains bad blocks, ignoring");
 		} else {
 			ERR(
-				"pool set contains bad blocks and cannot be opened, run 'pmempool' utility to try to recover the pool");
+				"pool set contains bad blocks and cannot be opened, run 'pmempool sync --bad-blocks' utility to try to recover the pool");
 			errno = EIO;
 			return -1;
 		}
@@ -3847,6 +3855,14 @@ util_pool_open(struct pool_set **setp, const char *path, size_t minpartsize,
 
 	ASSERT(set->nreplicas > 0);
 
+	/* check if any bad block recovery file exists */
+	if (badblocks_recovery_file_exists(set)) {
+		LOG(1,
+			"error: a bad block recovery file exists, run 'pmempool sync --bad-blocks' utility to try to recover the pool");
+		errno = EINVAL;
+		return -1;
+	}
+
 	int bbs = badblocks_check_poolset(set, 0 /* not create */);
 	if (bbs < 0) {
 		LOG(1,
@@ -3861,7 +3877,7 @@ util_pool_open(struct pool_set **setp, const char *path, size_t minpartsize,
 				path);
 		} else {
 			ERR(
-				"pool set contains bad blocks and cannot be opened, run 'pmempool' utility to try to recover the pool -- '%s'",
+				"pool set contains bad blocks and cannot be opened, run 'pmempool sync --bad-blocks' utility to try to recover the pool -- '%s'",
 				path);
 			errno = EIO;
 			return -1;

--- a/src/common/set.c
+++ b/src/common/set.c
@@ -540,6 +540,7 @@ util_poolset_free(struct pool_set *set)
 		VEC_DELETE(&rep->directory);
 		Free(set->replica[r]);
 	}
+	Free(set->path);
 	Free(set);
 }
 
@@ -1548,6 +1549,12 @@ util_poolset_parse(struct pool_set **setp, const char *path, int fd)
 	set = Zalloc(sizeof(struct pool_set));
 	if (set == NULL) {
 		ERR("!Malloc for pool set");
+		goto err;
+	}
+
+	set->path = strdup(path);
+	if (set->path == NULL)  {
+		ERR("!strdup");
 		goto err;
 	}
 

--- a/src/common/set.h
+++ b/src/common/set.h
@@ -148,6 +148,7 @@ struct pool_replica {
 };
 
 struct pool_set {
+	char *path;		/* path of the poolset file */
 	unsigned nreplicas;
 	uuid_t uuid;
 	int rdonly;

--- a/src/include/libpmempool.h
+++ b/src/include/libpmempool.h
@@ -77,14 +77,6 @@ extern "C" {
 #include <limits.h>
 
 
-/* COMMON FLAGS */
-
-/*
- * do not apply changes, only check if operation is viable
- */
-#define PMEMPOOL_DRY_RUN (1U << 1)
-
-
 /* PMEMPOOL CHECK */
 
 /*
@@ -106,7 +98,7 @@ enum pmempool_pool_type {
 /*
  * emulate repairs
  */
-#define PMEMPOOL_CHECK_DRY_RUN PMEMPOOL_DRY_RUN
+#define PMEMPOOL_CHECK_DRY_RUN		(1U << 1)
 /*
  * perform hazardous repairs
  */
@@ -160,6 +152,27 @@ enum pmempool_check_result pmempool_check_end(PMEMpoolcheck *ppc);
 #define PMEMPOOL_RM_FORCE		(1U << 0) /* ignore any errors */
 #define PMEMPOOL_RM_POOLSET_LOCAL	(1U << 1) /* remove local poolsets */
 #define PMEMPOOL_RM_POOLSET_REMOTE	(1U << 2) /* remove remote poolsets */
+
+
+/*
+ * LIBPMEMPOOL SYNC
+ */
+
+/*
+ * do not apply changes, only check if operation is viable
+ */
+#define PMEMPOOL_SYNC_DRY_RUN		(1U << 1)
+
+
+/*
+ * LIBPMEMPOOL TRANSFORM
+ */
+
+/*
+ * do not apply changes, only check if operation is viable
+ */
+#define PMEMPOOL_TRANSFORM_DRY_RUN	(1U << 1)
+
 
 /*
  * PMEMPOOL_MAJOR_VERSION and PMEMPOOL_MINOR_VERSION provide the current version

--- a/src/include/libpmempool.h
+++ b/src/include/libpmempool.h
@@ -159,6 +159,10 @@ enum pmempool_check_result pmempool_check_end(PMEMpoolcheck *ppc);
  */
 
 /*
+ * fix bad blocks - it requires creating or reading special recovery files
+ */
+#define PMEMPOOL_SYNC_FIX_BAD_BLOCKS	(1U << 0)
+/*
  * do not apply changes, only check if operation is viable
  */
 #define PMEMPOOL_SYNC_DRY_RUN		(1U << 1)

--- a/src/include/libpmempool.h
+++ b/src/include/libpmempool.h
@@ -82,7 +82,7 @@ extern "C" {
 /*
  * do not apply changes, only check if operation is viable
  */
-#define PMEMPOOL_DRY_RUN (1 << 1)
+#define PMEMPOOL_DRY_RUN (1U << 1)
 
 
 /* PMEMPOOL CHECK */
@@ -102,7 +102,7 @@ enum pmempool_pool_type {
 /*
  * perform repairs
  */
-#define PMEMPOOL_CHECK_REPAIR		(1 << 0)
+#define PMEMPOOL_CHECK_REPAIR		(1U << 0)
 /*
  * emulate repairs
  */
@@ -110,19 +110,19 @@ enum pmempool_pool_type {
 /*
  * perform hazardous repairs
  */
-#define PMEMPOOL_CHECK_ADVANCED		(1 << 2)
+#define PMEMPOOL_CHECK_ADVANCED		(1U << 2)
 /*
  * do not ask before repairs
  */
-#define PMEMPOOL_CHECK_ALWAYS_YES	(1 << 3)
+#define PMEMPOOL_CHECK_ALWAYS_YES	(1U << 3)
 /*
  * generate info statuses
  */
-#define PMEMPOOL_CHECK_VERBOSE		(1 << 4)
+#define PMEMPOOL_CHECK_VERBOSE		(1U << 4)
 /*
  * generate string format statuses
  */
-#define PMEMPOOL_CHECK_FORMAT_STR	(1 << 5)
+#define PMEMPOOL_CHECK_FORMAT_STR	(1U << 5)
 
 /*
  * types of check statuses
@@ -157,9 +157,9 @@ enum pmempool_check_result pmempool_check_end(PMEMpoolcheck *ppc);
 
 /* PMEMPOOL RM */
 
-#define PMEMPOOL_RM_FORCE		(1 << 0) /* ignore any errors */
-#define PMEMPOOL_RM_POOLSET_LOCAL	(1 << 1) /* remove local poolsets */
-#define PMEMPOOL_RM_POOLSET_REMOTE	(1 << 2) /* remove remote poolsets */
+#define PMEMPOOL_RM_FORCE		(1U << 0) /* ignore any errors */
+#define PMEMPOOL_RM_POOLSET_LOCAL	(1U << 1) /* remove local poolsets */
+#define PMEMPOOL_RM_POOLSET_REMOTE	(1U << 2) /* remove remote poolsets */
 
 /*
  * PMEMPOOL_MAJOR_VERSION and PMEMPOOL_MINOR_VERSION provide the current version
@@ -200,7 +200,7 @@ struct pmempool_check_argsU {
 	const char *path;
 	const char *backup_path;
 	enum pmempool_pool_type pool_type;
-	int flags;
+	unsigned flags;
 };
 
 #ifndef _WIN32
@@ -210,7 +210,7 @@ struct pmempool_check_argsW {
 	const wchar_t *path;
 	const wchar_t *backup_path;
 	enum pmempool_pool_type pool_type;
-	int flags;
+	unsigned flags;
 };
 #endif
 
@@ -270,10 +270,10 @@ int pmempool_transformW(const wchar_t *poolset_file_src,
 
 /* PMEMPOOL RM */
 #ifndef _WIN32
-int pmempool_rm(const char *path, int flags);
+int pmempool_rm(const char *path, unsigned flags);
 #else
-int pmempool_rmU(const char *path, int flags);
-int pmempool_rmW(const wchar_t *path, int flags);
+int pmempool_rmU(const char *path, unsigned flags);
+int pmempool_rmW(const wchar_t *path, unsigned flags);
 #endif
 
 #ifndef _WIN32

--- a/src/libpmempool/replica.c
+++ b/src/libpmempool/replica.c
@@ -64,7 +64,7 @@
 static int
 check_flags_sync(unsigned flags)
 {
-	flags &= ~(unsigned)PMEMPOOL_DRY_RUN;
+	flags &= ~PMEMPOOL_SYNC_DRY_RUN;
 	return flags > 0;
 }
 
@@ -75,7 +75,7 @@ check_flags_sync(unsigned flags)
 static int
 check_flags_transform(unsigned flags)
 {
-	flags &= ~(unsigned)PMEMPOOL_DRY_RUN;
+	flags &= ~PMEMPOOL_TRANSFORM_DRY_RUN;
 	return flags > 0;
 }
 

--- a/src/libpmempool/replica.c
+++ b/src/libpmempool/replica.c
@@ -57,6 +57,7 @@
 #include "uuid.h"
 #include "shutdown_state.h"
 #include "os_dimm.h"
+#include "badblock.h"
 
 /*
  * check_flags_sync -- (internal) check if flags are supported for sync
@@ -64,7 +65,7 @@
 static int
 check_flags_sync(unsigned flags)
 {
-	flags &= ~PMEMPOOL_SYNC_DRY_RUN;
+	flags &= ~(PMEMPOOL_SYNC_DRY_RUN | PMEMPOOL_SYNC_FIX_BAD_BLOCKS);
 	return flags > 0;
 }
 
@@ -80,6 +81,26 @@ check_flags_transform(unsigned flags)
 }
 
 /*
+ * replica_align_badblock_offset_length -- align offset and length
+ *                                          of the bad block for the given part
+ */
+void
+replica_align_badblock_offset_length(size_t *offset, size_t *length,
+			struct pool_set *set_in, unsigned repn, unsigned partn)
+{
+	LOG(3, "offset %zu, length %zu, pool_set %p, replica %u, part %u",
+		*offset, *length, set_in, repn, partn);
+
+	size_t alignment = set_in->replica[repn]->part[partn].alignment;
+
+	size_t off = ALIGN_DOWN(*offset, alignment);
+	size_t len = ALIGN_UP(*length + (*offset - off), alignment);
+
+	*offset = off;
+	*length = len;
+}
+
+/*
  * replica_get_part_data_len -- get data length for given part
  */
 size_t
@@ -90,6 +111,16 @@ replica_get_part_data_len(struct pool_set *set_in, unsigned repn,
 	size_t hdrsize = (set_in->options & OPTION_SINGLEHDR) ? 0 : alignment;
 	return ALIGN_DOWN(set_in->replica[repn]->part[partn].filesize,
 		alignment) - ((partn == 0) ? POOL_HDR_SIZE : hdrsize);
+}
+
+/*
+ * replica_get_part_offset -- get part's offset from the beginning of replica
+ */
+uint64_t
+replica_get_part_offset(struct pool_set *set, unsigned repn, unsigned partn)
+{
+	return (uint64_t)set->replica[repn]->part[partn].addr -
+		(uint64_t)set->replica[repn]->part[0].addr;
 }
 
 /*
@@ -152,17 +183,65 @@ static struct replica_health_status *
 create_replica_health_status(struct pool_set *set, unsigned repn)
 {
 	LOG(3, "set %p, repn %u", set, repn);
+
 	unsigned nparts = set->replica[repn]->nparts;
 	struct replica_health_status *replica_hs;
+
 	replica_hs = Zalloc(sizeof(struct replica_health_status)
-			+ nparts * sizeof(unsigned));
+				+ nparts * sizeof(struct part_health_status));
 	if (replica_hs == NULL) {
 		ERR("!Zalloc for replica health status");
 		return NULL;
 	}
+
 	replica_hs->nparts = nparts;
 	replica_hs->nhdrs = set->replica[repn]->nhdrs;
+
 	return replica_hs;
+}
+
+/*
+ * replica_part_remove_recovery_file -- remove bad blocks' recovery file
+ */
+static int
+replica_part_remove_recovery_file(struct part_health_status *phs)
+{
+	LOG(3, "phs %p", phs);
+
+	if (phs->recovery_file_name == NULL || phs->recovery_file_exists == 0)
+		return 0;
+
+	if (os_unlink(phs->recovery_file_name) < 0) {
+		ERR("!removing the bad block recovery file failed -- '%s'",
+			phs->recovery_file_name);
+		return -1;
+	}
+
+	LOG(3, "bad block recovery file removed -- '%s'",
+		phs->recovery_file_name);
+
+	phs->recovery_file_exists = 0;
+
+	return 0;
+}
+
+/*
+ * replica_remove_all_recovery_files -- remove all recovery files
+ */
+int
+replica_remove_all_recovery_files(struct poolset_health_status *set_hs)
+{
+	LOG(3, "set_hs %p", set_hs);
+
+	int ret = 0;
+
+	for (unsigned r = 0; r < set_hs->nreplicas; ++r) {
+		struct replica_health_status *rhs = set_hs->replica[r];
+		for (unsigned p = 0; p < rhs->nparts; ++p)
+			ret |= replica_part_remove_recovery_file(&rhs->part[p]);
+	}
+
+	return ret;
 }
 
 /*
@@ -173,9 +252,16 @@ void
 replica_free_poolset_health_status(struct poolset_health_status *set_hs)
 {
 	LOG(3, "set_hs %p", set_hs);
-	for (unsigned i = 0; i < set_hs->nreplicas; ++i) {
-		Free(set_hs->replica[i]);
+
+	for (unsigned r = 0; r < set_hs->nreplicas; ++r) {
+		struct replica_health_status *rep_hs = set_hs->replica[r];
+
+		for (unsigned p = 0; p < rep_hs->nparts; ++p)
+			Free(rep_hs->part[p].recovery_file_name);
+
+		Free(set_hs->replica[r]);
 	}
+
 	Free(set_hs);
 }
 
@@ -253,6 +339,24 @@ replica_is_replica_consistent(unsigned repn,
 }
 
 /*
+ * replica_has_bad_blocks -- (internal) check if replica has bad blocks
+ */
+static int
+replica_has_bad_blocks(unsigned repn, struct poolset_health_status *set_hs)
+{
+	return REP_HEALTH(set_hs, repn)->flags & HAS_BAD_BLOCKS;
+}
+
+/*
+ * replica_part_has_bad_blocks -- check if replica's part has bad blocks
+ */
+int
+replica_part_has_bad_blocks(struct part_health_status *phs)
+{
+	return phs->flags & HAS_BAD_BLOCKS;
+}
+
+/*
  * replica_is_replica_healthy -- check if replica is unbroken and consistent
  */
 int
@@ -260,7 +364,8 @@ replica_is_replica_healthy(unsigned repn,
 		struct poolset_health_status *set_hs)
 {
 	return !replica_is_replica_broken(repn, set_hs) &&
-			replica_is_replica_consistent(repn, set_hs);
+			replica_is_replica_consistent(repn, set_hs) &&
+			!replica_has_bad_blocks(repn, set_hs);
 }
 
 /*
@@ -421,7 +526,7 @@ check_and_open_poolset_part_files(struct pool_set *set,
 			if (os_access(path, R_OK|W_OK) != 0) {
 				LOG(1, "part file %s is not accessible", path);
 				errno = 0;
-				rep_hs->part[p] |= IS_BROKEN;
+				rep_hs->part[p].flags |= IS_BROKEN;
 				if (is_dry_run(flags))
 					continue;
 			}
@@ -434,7 +539,7 @@ check_and_open_poolset_part_files(struct pool_set *set,
 				}
 				LOG(1, "opening part %s failed", path);
 				errno = 0;
-				rep_hs->part[p] |= IS_BROKEN;
+				rep_hs->part[p].flags |= IS_BROKEN;
 			}
 		}
 	}
@@ -465,7 +570,7 @@ map_all_unbroken_headers(struct pool_set *set,
 			LOG(4, "mapping header for part %u, replica %u", p, r);
 			if (util_map_hdr(&rep->part[p], MAP_SHARED, 0) != 0) {
 				LOG(1, "header mapping failed - part #%d", p);
-				rep_hs->part[p] |= IS_BROKEN;
+				rep_hs->part[p].flags |= IS_BROKEN;
 			}
 		}
 	}
@@ -528,15 +633,15 @@ check_checksums_and_signatures(struct pool_set *set,
 			if (!util_checksum(hdr, sizeof(*hdr), &hdr->checksum, 0,
 					POOL_HDR_CSUM_END_OFF(hdr))) {
 				ERR("invalid checksum of pool header");
-				rep_hs->part[p] |= IS_BROKEN;
+				rep_hs->part[p].flags |= IS_BROKEN;
 			} else if (util_is_zeroed(hdr, sizeof(*hdr))) {
-					rep_hs->part[p] |= IS_BROKEN;
+					rep_hs->part[p].flags |= IS_BROKEN;
 			}
 
 			enum pool_type type = pool_hdr_get_type(hdr);
 			if (type == POOL_TYPE_UNKNOWN) {
 				ERR("invalid signature");
-				rep_hs->part[p] |= IS_BROKEN;
+				rep_hs->part[p].flags |= IS_BROKEN;
 			}
 		}
 	}
@@ -544,10 +649,374 @@ check_checksums_and_signatures(struct pool_set *set,
 }
 
 /*
- * check_badblocks -- (internal) check if replica contains bad blocks
+ * replica_badblocks_recovery_file_save -- save bad blocks in the bad blocks
+ *                                         recovery file before clearing them
  */
 static int
-check_badblocks(struct pool_set *set, struct poolset_health_status *set_hs)
+replica_badblocks_recovery_file_save(struct part_health_status *part_hs)
+{
+	LOG(3, "part_health_status %p", part_hs);
+
+	ASSERTeq(part_hs->recovery_file_exists, 1);
+	ASSERTne(part_hs->recovery_file_name, NULL);
+
+	struct badblocks *bbs = &part_hs->bbs;
+	char *path = part_hs->recovery_file_name;
+	int ret = -1;
+
+	int fd = os_open(path, O_WRONLY | O_TRUNC);
+	if (fd < 0) {
+		ERR("!opening bad block recovery file failed -- '%s'", path);
+		return -1;
+	}
+
+	FILE *recovery_file_name = os_fdopen(fd, "w");
+	if (recovery_file_name == NULL) {
+		ERR(
+			"!opening a file stream for bad block recovery file failed -- '%s'",
+			path);
+		os_close(fd);
+		return -1;
+	}
+
+	/* save bad blocks */
+	for (unsigned i = 0; i < bbs->bb_cnt; i++) {
+		ASSERT(bbs->bbv[i].length != 0);
+		fprintf(recovery_file_name, "%llu %u\n",
+			bbs->bbv[i].offset, bbs->bbv[i].length);
+	}
+
+	if (fflush(recovery_file_name) == EOF) {
+		ERR("!flushing bad block recovery file failed -- '%s'", path);
+		goto exit_error;
+	}
+
+	if (os_fsync(fd) < 0) {
+		ERR("!syncing bad block recovery file failed -- '%s'", path);
+		goto exit_error;
+	}
+
+	/* save the finish flag */
+	fprintf(recovery_file_name, "0 0\n");
+
+	if (fflush(recovery_file_name) == EOF) {
+		ERR("!flushing bad block recovery file failed -- '%s'", path);
+		goto exit_error;
+	}
+
+	if (os_fsync(fd) < 0) {
+		ERR("!syncing bad block recovery file failed -- '%s'", path);
+		goto exit_error;
+	}
+
+	LOG(3, "bad blocks saved in the recovery file -- '%s'", path);
+	ret = 0;
+
+exit_error:
+	os_fclose(recovery_file_name);
+
+	return ret;
+}
+
+/*
+ * replica_part_badblocks_recovery_file_read -- read bad blocks
+ *                                             from the bad block recovery file
+ *                                             for the current part
+ */
+static int
+replica_part_badblocks_recovery_file_read(struct part_health_status *part_hs)
+{
+	LOG(3, "part_health_status %p", part_hs);
+
+	ASSERT(part_hs->recovery_file_exists);
+	ASSERTne(part_hs->recovery_file_name, NULL);
+
+	VEC(bbsvec, struct bad_block) bbv = VEC_INITIALIZER;
+	char *path = part_hs->recovery_file_name;
+	struct bad_block bb;
+	int ret = -1;
+
+	FILE *recovery_file = os_fopen(path, "r");
+	if (!recovery_file) {
+		ERR("!opening the recovery file for reading failed -- '%s'",
+			path);
+		return -1;
+	}
+
+	unsigned long long min_offset = 0; /* minimum possible offset */
+
+	do {
+		if (fscanf(recovery_file, "%llu %u\n",
+				&bb.offset, &bb.length) < 2) {
+			LOG(1, "incomplete bad block recovery file -- '%s'",
+				path);
+			ret = 1;
+			goto error_exit;
+		}
+
+		if (bb.offset == 0 && bb.length == 0) {
+			/* finish_flag */
+			break;
+		}
+
+		/* check if bad blocks build an increasing sequence */
+		if (bb.offset < min_offset) {
+			ERR(
+				"wrong format of bad block recovery file (bad blocks are not sorted by the offset in ascending order) -- '%s'",
+				path);
+			errno = EINVAL;
+			ret = -1;
+			goto error_exit;
+		}
+
+		/* update the minimum possible offset */
+		min_offset = bb.offset + bb.length;
+
+		/* add the new bad block to the vector */
+		if (VEC_PUSH_BACK(&bbv, bb))
+			goto error_exit;
+	} while (1);
+
+	part_hs->bbs.bbv = VEC_ARR(&bbv);
+	part_hs->bbs.bb_cnt = (unsigned)VEC_SIZE(&bbv);
+
+	os_fclose(recovery_file);
+
+	LOG(1, "bad blocks read from the recovery file -- '%s'", path);
+
+	return 0;
+
+error_exit:
+	VEC_DELETE(&bbv);
+	os_fclose(recovery_file);
+	return ret;
+}
+
+/* status returned by the replica_badblocks_recovery_files_check() function */
+enum badblocks_recovery_files_status {
+	RECOVERY_FILES_ERROR = -1,
+	RECOVERY_FILES_DO_NOT_EXIST = 0,
+	RECOVERY_FILES_EXIST_ALL = 1,
+	RECOVERY_FILES_NOT_ALL_EXIST = 2
+};
+
+/*
+ * replica_badblocks_recovery_files_check -- (internal) check if bad blocks
+ *                                           recovery files exist
+ */
+static enum badblocks_recovery_files_status
+replica_badblocks_recovery_files_check(struct pool_set *set,
+					struct poolset_health_status *set_hs)
+{
+	LOG(3, "set %p, set_hs %p", set, set_hs);
+
+	int recovery_file_exists = 0;
+	int recovery_file_does_not_exist = 0;
+
+	for (unsigned r = 0; r < set->nreplicas; ++r) {
+		struct pool_replica *rep = set->replica[r];
+		struct replica_health_status *rep_hs = set_hs->replica[r];
+
+		/* XXX: not supported yet */
+		if (rep->remote) {
+			LOG(1,
+				"WARNING: skipping the remote replica #%u (checking and fixing bad blocks in remote replicas is not supported yet",
+				r);
+			continue;
+		}
+
+		for (unsigned p = 0; p < rep->nparts; ++p) {
+			const char *path = PART(rep, p)->path;
+			struct part_health_status *part_hs = &rep_hs->part[p];
+
+			int exists = util_file_exists(path);
+			if (exists < 0)
+				return -1;
+
+			if (!exists) {
+				/* part file does not exist - skip it */
+				continue;
+			}
+
+			part_hs->recovery_file_name =
+					badblocks_recovery_file_alloc(set->path,
+									r, p);
+			if (part_hs->recovery_file_name == NULL) {
+				LOG(1,
+					"allocating name of bad block recovery file failed");
+				return RECOVERY_FILES_ERROR;
+			}
+
+			exists = util_file_exists(part_hs->recovery_file_name);
+			if (exists < 0)
+				return -1;
+
+			part_hs->recovery_file_exists = exists;
+
+			if (part_hs->recovery_file_exists) {
+				LOG(3, "bad block recovery file exists: %s",
+					part_hs->recovery_file_name);
+
+				recovery_file_exists = 1;
+
+			} else {
+				LOG(3,
+					"bad block recovery file does not exist: %s",
+					part_hs->recovery_file_name);
+
+				recovery_file_does_not_exist = 1;
+			}
+		}
+	}
+
+	if (recovery_file_exists) {
+		if (recovery_file_does_not_exist)
+			return RECOVERY_FILES_NOT_ALL_EXIST;
+		else
+			return RECOVERY_FILES_EXIST_ALL;
+	}
+
+	return RECOVERY_FILES_DO_NOT_EXIST;
+}
+
+/*
+ * replica_badblocks_recovery_files_read -- (internal) read bad blocks from all
+ *                                     bad block recovery files for all parts
+ */
+static int
+replica_badblocks_recovery_files_read(struct pool_set *set,
+					struct poolset_health_status *set_hs)
+{
+	LOG(3, "set %p, set_hs %p", set, set_hs);
+
+	int ret;
+
+	for (unsigned r = 0; r < set->nreplicas; ++r) {
+		struct pool_replica *rep = set->replica[r];
+		struct replica_health_status *rep_hs = set_hs->replica[r];
+
+		/* XXX: not supported yet */
+		if (rep->remote)
+			continue;
+
+		for (unsigned p = 0; p < rep->nparts; ++p) {
+			const char *path = PART(rep, p)->path;
+			struct part_health_status *part_hs = &rep_hs->part[p];
+
+			int exists = util_file_exists(path);
+			if (exists < 0)
+				return -1;
+
+			if (!exists) {
+				/* the part does not exist */
+				continue;
+			}
+
+			LOG(1,
+				"reading bad blocks from the recovery file -- '%s'",
+				part_hs->recovery_file_name);
+
+			ret = replica_part_badblocks_recovery_file_read(
+								part_hs);
+			if (ret < 0) {
+				LOG(1,
+					"reading bad blocks from the recovery file failed -- '%s'",
+					part_hs->recovery_file_name);
+				return -1;
+			}
+
+			if (ret > 0) {
+				LOG(1,
+					"incomplete bad block recovery file detected -- '%s'",
+					part_hs->recovery_file_name);
+				return 1;
+			}
+
+			if (part_hs->bbs.bb_cnt) {
+				LOG(3, "part %u contains %u bad blocks -- '%s'",
+					p, part_hs->bbs.bb_cnt, path);
+			}
+		}
+	}
+
+	return 0;
+}
+
+/*
+ * replica_badblocks_recovery_files_create_empty -- (internal) create one empty
+ *                                                  bad block recovery file
+ *                                                  for each part file
+ */
+static int
+replica_badblocks_recovery_files_create_empty(struct pool_set *set,
+					struct poolset_health_status *set_hs)
+{
+	LOG(3, "set %p, set_hs %p", set, set_hs);
+
+	struct part_health_status *part_hs;
+	const char *path;
+	int fd;
+
+	for (unsigned r = 0; r < set->nreplicas; ++r) {
+		struct pool_replica *rep = set->replica[r];
+		struct replica_health_status *rep_hs = set_hs->replica[r];
+
+		/* XXX: not supported yet */
+		if (rep->remote)
+			continue;
+
+		for (unsigned p = 0; p < rep->nparts; ++p) {
+			part_hs = &rep_hs->part[p];
+			path = PART(rep, p)->path;
+
+			if (!part_hs->recovery_file_name)
+				continue;
+
+			fd = os_open(part_hs->recovery_file_name,
+					O_RDWR | O_CREAT | O_EXCL,
+					0600);
+			if (fd < 0) {
+				ERR(
+					"!creating an empty bad block recovery file failed -- '%s' (part file '%s')",
+					part_hs->recovery_file_name, path);
+				return -1;
+			}
+
+			os_close(fd);
+
+			char *file_name = Strdup(part_hs->recovery_file_name);
+			if (file_name == NULL) {
+				ERR("!Strdup");
+				return -1;
+			}
+
+			char *dir_name = dirname(file_name);
+
+			/* fsync the file's directory */
+			if (os_fsync_dir(dir_name) < 0) {
+				ERR(
+					"!syncing the directory of the bad block recovery file failed -- '%s' (part file '%s')",
+					dir_name, path);
+				Free(file_name);
+				return -1;
+			}
+
+			Free(file_name);
+
+			part_hs->recovery_file_exists = 1;
+		}
+	}
+
+	return 0;
+}
+
+/*
+ * replica_badblocks_recovery_files_save -- (internal) save bad blocks
+ *                                     in the bad block recovery files
+ */
+static int
+replica_badblocks_recovery_files_save(struct pool_set *set,
+					struct poolset_health_status *set_hs)
 {
 	LOG(3, "set %p, set_hs %p", set, set_hs);
 
@@ -560,26 +1029,17 @@ check_badblocks(struct pool_set *set, struct poolset_health_status *set_hs)
 			continue;
 
 		for (unsigned p = 0; p < rep->nparts; ++p) {
-			const char *path = PART(rep, p)->path;
+			struct part_health_status *part_hs = &rep_hs->part[p];
 
-			int exists = util_file_exists(path);
-			if (exists < 0)
-				return -1;
-			if (!exists)
+			if (!part_hs->recovery_file_name)
 				continue;
 
-			int ret = os_badblocks_check_file(path);
+			int ret = replica_badblocks_recovery_file_save(part_hs);
 			if (ret < 0) {
-				ERR(
-					"checking replica for bad blocks failed -- '%s'",
-					path);
+				LOG(1,
+					"opening bad block recovery file failed -- '%s'",
+					part_hs->recovery_file_name);
 				return -1;
-			}
-
-			if (ret > 0) {
-				/* bad blocks were found */
-				rep_hs->part[p] |= IS_BROKEN;
-				rep_hs->flags |= IS_BROKEN;
 			}
 		}
 	}
@@ -587,6 +1047,287 @@ check_badblocks(struct pool_set *set, struct poolset_health_status *set_hs)
 	return 0;
 }
 
+/*
+ * replica_badblocks_get -- (internal) get all bad blocks and save them
+ *                          in part_hs->bbs structures.
+ *                          Returns 1 if any bad block was found, 0 otherwise.
+ */
+static int
+replica_badblocks_get(struct pool_set *set,
+			struct poolset_health_status *set_hs)
+{
+	LOG(3, "set %p, set_hs %p", set, set_hs);
+
+	int bad_blocks_found = 0;
+
+	for (unsigned r = 0; r < set->nreplicas; ++r) {
+		struct pool_replica *rep = set->replica[r];
+		struct replica_health_status *rep_hs = set_hs->replica[r];
+
+		/* XXX: not supported yet */
+		if (rep->remote)
+			continue;
+
+		for (unsigned p = 0; p < rep->nparts; ++p) {
+			const char *path = PART(rep, p)->path;
+			struct part_health_status *part_hs = &rep_hs->part[p];
+
+			int exists = util_file_exists(path);
+			if (exists < 0)
+				return -1;
+
+			if (!exists)
+				continue;
+
+			int ret = os_badblocks_get(path, &part_hs->bbs);
+			if (ret < 0) {
+				ERR(
+					"checking the pool part for bad blocks failed -- '%s'",
+					path);
+				return -1;
+			}
+
+			if (part_hs->bbs.bb_cnt) {
+				LOG(3, "part %u contains %u bad blocks -- '%s'",
+					p, part_hs->bbs.bb_cnt, path);
+
+				bad_blocks_found = 1;
+			}
+		}
+	}
+
+	return bad_blocks_found;
+}
+
+/*
+ * replica_badblocks_clear -- (internal) clear all bad blocks
+ */
+static int
+replica_badblocks_clear(struct pool_set *set,
+			struct poolset_health_status *set_hs)
+{
+	LOG(3, "set %p, set_hs %p", set, set_hs);
+
+	int ret;
+
+	for (unsigned r = 0; r < set->nreplicas; ++r) {
+		struct pool_replica *rep = set->replica[r];
+		struct replica_health_status *rep_hs = set_hs->replica[r];
+
+		/* XXX: not supported yet */
+		if (rep->remote)
+			continue;
+
+		for (unsigned p = 0; p < rep->nparts; ++p) {
+			const char *path = PART(rep, p)->path;
+			struct part_health_status *part_hs = &rep_hs->part[p];
+
+			int exists = util_file_exists(path);
+			if (exists < 0)
+				return -1;
+
+			if (!exists) {
+				/* the part does not exist */
+				continue;
+			}
+
+			if (part_hs->bbs.bb_cnt == 0) {
+				/* no bad blocks found */
+				continue;
+			}
+
+			/* bad blocks were found */
+			part_hs->flags |= HAS_BAD_BLOCKS;
+			rep_hs->flags |= HAS_BAD_BLOCKS;
+
+			ret = os_badblocks_clear(path, &part_hs->bbs);
+			if (ret < 0) {
+				LOG(1,
+					"clearing bad blocks in replica failed -- '%s'",
+					path);
+				return -1;
+			}
+		}
+	}
+
+	return 0;
+}
+
+/*
+ * replica_badblocks_check_or_clear -- (internal) check if replica contains
+ *                                     bad blocks when in dry run
+ *                                     or clear them otherwise
+ */
+static int
+replica_badblocks_check_or_clear(struct pool_set *set,
+				struct poolset_health_status *set_hs,
+				int dry_run, int called_from_sync,
+				int use_recovery_files)
+{
+	LOG(3,
+		"set %p, set_hs %p, dry_run %i, called_from_sync %i, use_recovery_files %i",
+		set, set_hs, dry_run, called_from_sync, use_recovery_files);
+
+#define ERR_MSG_BB \
+	"       please read the manual first and use this option\n"\
+	"       ONLY IF you are sure that you know what you are doing"
+
+	enum badblocks_recovery_files_status status;
+	int ret;
+
+	/* check all bad block recovery files */
+	status = replica_badblocks_recovery_files_check(set, set_hs);
+
+	/* phase #1 - error handling */
+	switch (status) {
+	case RECOVERY_FILES_ERROR:
+		LOG(1, "checking bad block recovery files failed");
+		return -1;
+
+	case RECOVERY_FILES_EXIST_ALL:
+	case RECOVERY_FILES_NOT_ALL_EXIST:
+		if (!called_from_sync) {
+			ERR(
+				"error: a bad block recovery file exists, run 'pmempool sync --bad-blocks' to fix bad blocks first");
+			return -1;
+		}
+
+		if (!use_recovery_files) {
+			ERR(
+				"error: a bad block recovery file exists, but the '--bad-blocks' option is not set\n"
+				ERR_MSG_BB);
+			return -1;
+		}
+		break;
+
+	default:
+		break;
+	};
+
+	/* phase #2 - reading recovery files */
+	switch (status) {
+	case RECOVERY_FILES_EXIST_ALL:
+		/* read all bad block recovery files */
+		ret = replica_badblocks_recovery_files_read(set, set_hs);
+		if (ret < 0) {
+			LOG(1, "checking bad block recovery files failed");
+			return -1;
+		}
+
+		if (ret > 0) {
+			/* incomplete bad block recovery file was detected */
+
+			LOG(1,
+				"warning: incomplete bad block recovery file detected\n"
+				"         - all recovery files will be removed");
+
+			/* changing status to RECOVERY_FILES_NOT_ALL_EXIST */
+			status = RECOVERY_FILES_NOT_ALL_EXIST;
+		}
+		break;
+
+	case RECOVERY_FILES_NOT_ALL_EXIST:
+		LOG(1,
+			"warning: one of bad block recovery files does not exist\n"
+			"         - all recovery files will be removed");
+		break;
+
+	default:
+		break;
+	};
+
+	if (status == RECOVERY_FILES_NOT_ALL_EXIST) {
+		/*
+		 * At least one of bad block recovery files does not exist,
+		 * or an incomplete bad block recovery file was detected,
+		 * so all recovery files have to be removed.
+		 */
+
+		if (!dry_run) {
+			LOG(1, "removing all bad block recovery files...");
+			ret = replica_remove_all_recovery_files(set_hs);
+			if (ret < 0) {
+				LOG(1,
+					"removing bad block recovery files failed");
+				return -1;
+			}
+		} else {
+			LOG(1, "all bad block recovery files would be removed");
+		}
+
+		/* changing status to RECOVERY_FILES_DO_NOT_EXIST */
+		status = RECOVERY_FILES_DO_NOT_EXIST;
+	}
+
+	if (status == RECOVERY_FILES_DO_NOT_EXIST) {
+		/*
+		 * There are no bad block recovery files,
+		 * so let's check bad blocks.
+		 */
+
+		int bad_blocks_found = replica_badblocks_get(set, set_hs);
+		if (bad_blocks_found < 0) {
+			LOG(1, "checking bad blocks failed");
+			return -1;
+		}
+
+		if (!bad_blocks_found) {
+			LOG(4, "no bad blocks found");
+			return 0;
+		}
+
+		/* bad blocks were found */
+
+		if (!called_from_sync) {
+			ERR(
+				"error: bad blocks found, run 'pmempool sync --bad-blocks' to fix bad blocks first");
+			return -1;
+		}
+
+		if (!use_recovery_files) {
+			ERR(
+				"error: bad blocks found, but the '--bad-blocks' option is not set\n"
+				ERR_MSG_BB);
+			return -1;
+		}
+
+		if (dry_run) {
+			/* dry-run - do nothing */
+			LOG(1, "warning: bad blocks were found");
+			return 0;
+		}
+
+		/* create one empty recovery file for each part file */
+		ret = replica_badblocks_recovery_files_create_empty(set,
+								set_hs);
+		if (ret < 0) {
+			LOG(1,
+				"creating empty bad block recovery files failed");
+			return -1;
+		}
+
+		/* save bad blocks in recovery files */
+		ret = replica_badblocks_recovery_files_save(set, set_hs);
+		if (ret < 0) {
+			LOG(1, "saving bad block recovery files failed");
+			return -1;
+		}
+	}
+
+	if (dry_run) {
+		/* dry-run - do nothing */
+		LOG(1, "bad blocks would be cleared");
+		return 0;
+	}
+
+	ret = replica_badblocks_clear(set, set_hs);
+	if (ret < 0) {
+		ERR("clearing bad blocks failed");
+		return -1;
+	}
+
+	return 0;
+}
 
 /*
  * check_shutdown_state -- (internal) check if replica has
@@ -768,7 +1509,7 @@ check_replica_options(struct pool_set *set, unsigned repn,
 			LOG(1,
 				"improper options are set in part %u's header in replica %u",
 				p, repn);
-			rep_hs->part[p] |= IS_BROKEN;
+			rep_hs->part[p].flags |= IS_BROKEN;
 		}
 	}
 	return 0;
@@ -1065,9 +1806,12 @@ check_replica_sizes(struct pool_set *set, struct poolset_health_status *set_hs)
  */
 int
 replica_check_poolset_health(struct pool_set *set,
-		struct poolset_health_status **set_hsp, unsigned flags)
+		struct poolset_health_status **set_hsp,
+		int called_from_sync, unsigned flags)
 {
-	LOG(3, "set %p, set_hsp %p, flags %u", set, set_hsp, flags);
+	LOG(3, "set %p, set_hsp %p, called_from_sync %i, flags %u",
+		set, set_hsp, called_from_sync, flags);
+
 	if (replica_create_poolset_health_status(set, set_hsp)) {
 		LOG(1, "creating poolset health status failed");
 		return -1;
@@ -1078,6 +1822,14 @@ replica_check_poolset_health(struct pool_set *set,
 	/* check if part files exist and are accessible */
 	if (check_and_open_poolset_part_files(set, set_hs, flags)) {
 		LOG(1, "poolset part files check failed");
+		goto err;
+	}
+
+	/* check for bad blocks when in dry run or clear them otherwise */
+	if (replica_badblocks_check_or_clear(set, set_hs, is_dry_run(flags),
+			called_from_sync,
+			called_from_sync && use_recovery_files(flags))) {
+		LOG(1, "replica bad_blocks check failed");
 		goto err;
 	}
 
@@ -1093,11 +1845,6 @@ replica_check_poolset_health(struct pool_set *set,
 	/* check if option flags are consistent */
 	if (check_options(set, set_hs)) {
 		LOG(1, "flags check failed");
-		goto err;
-	}
-
-	if (check_badblocks(set, set_hs)) {
-		LOG(1, "replica bad_blocks check failed");
 		goto err;
 	}
 

--- a/src/libpmempool/replica.h
+++ b/src/libpmempool/replica.h
@@ -133,7 +133,14 @@ uint64_t replica_get_part_data_offset(struct pool_set *set_in, unsigned repn,
 static inline bool
 is_dry_run(unsigned flags)
 {
-	return flags & PMEMPOOL_DRY_RUN;
+	/*
+	 * PMEMPOOL_SYNC_DRY_RUN and PMEMPOOL_TRANSFORM_DRY_RUN
+	 * have to have the same value in order to use this common function.
+	 */
+	ASSERT_COMPILE_ERROR_ON(PMEMPOOL_SYNC_DRY_RUN !=
+				PMEMPOOL_TRANSFORM_DRY_RUN);
+
+	return flags & PMEMPOOL_SYNC_DRY_RUN;
 }
 
 int replica_remove_part(struct pool_set *set, unsigned repn, unsigned partn);

--- a/src/libpmempool/replica.h
+++ b/src/libpmempool/replica.h
@@ -35,6 +35,7 @@
  */
 #include "libpmempool.h"
 #include "pool.h"
+#include "os_badblock.h"
 
 #define UNDEF_REPLICA UINT_MAX
 #define UNDEF_PART UINT_MAX
@@ -43,24 +44,39 @@
  * A part marked as broken does not exist or is damaged so that
  * it cannot be opened and has to be recreated.
  */
-#define IS_BROKEN (1 << 0)
+#define IS_BROKEN		(1U << 0)
 
 /*
  * A replica marked as inconsistent exists but has inconsistent metadata
  * (e.g. inconsistent parts or replicas linkage)
  */
-#define IS_INCONSISTENT (1 << 1)
+#define IS_INCONSISTENT		(1U << 1)
+
+/*
+ * A part or replica marked in this way has bad blocks inside.
+ */
+#define HAS_BAD_BLOCKS		(1U << 2)
 
 /*
  * A flag which can be passed to sync_replica() to indicate that the function is
  * called by pmempool_transform
  */
-#define IS_TRANSFORMED (1 << 10)
+#define IS_TRANSFORMED		(1U << 10)
 
 /*
  * Number of lanes utilized when working with remote replicas
  */
 #define REMOTE_NLANES	1
+
+/*
+ * Helping structures for storing part's health status
+ */
+struct part_health_status {
+	unsigned flags;
+	struct badblocks bbs;		/* structure with bad blocks */
+	char *recovery_file_name;	/* name of bad block recovery file */
+	int recovery_file_exists;	/* bad block recovery file exists */
+};
 
 /*
  * Helping structures for storing replica and poolset's health status
@@ -73,7 +89,7 @@ struct replica_health_status {
 	/* effective size of a pool, valid only for healthy replica */
 	size_t pool_size;
 	/* flags for each part */
-	unsigned part[];
+	struct part_health_status part[];
 };
 
 struct poolset_health_status {
@@ -119,8 +135,14 @@ REP_HEALTH(struct poolset_health_status *set, unsigned r)
 static inline unsigned
 PART_HEALTH(struct replica_health_status *rep, unsigned p)
 {
-	return rep->part[PART_HEALTHidx(rep, p)];
+	return rep->part[PART_HEALTHidx(rep, p)].flags;
 }
+
+uint64_t replica_get_part_offset(struct pool_set *set,
+		unsigned repn, unsigned partn);
+
+void replica_align_badblock_offset_length(size_t *offset, size_t *length,
+		struct pool_set *set_in, unsigned repn, unsigned partn);
 
 size_t replica_get_part_data_len(struct pool_set *set_in, unsigned repn,
 		unsigned partn);
@@ -143,15 +165,27 @@ is_dry_run(unsigned flags)
 	return flags & PMEMPOOL_SYNC_DRY_RUN;
 }
 
+/*
+ * use_recovery_files -- (internal) read or create recovery file for bad blocks
+ *                                  (depending on if they exist or not)
+ */
+static inline bool
+use_recovery_files(unsigned flags)
+{
+	return flags & PMEMPOOL_SYNC_FIX_BAD_BLOCKS;
+}
+
+int replica_remove_all_recovery_files(struct poolset_health_status *set_hs);
 int replica_remove_part(struct pool_set *set, unsigned repn, unsigned partn);
 int replica_create_poolset_health_status(struct pool_set *set,
 		struct poolset_health_status **set_hsp);
 void replica_free_poolset_health_status(struct poolset_health_status *set_s);
 int replica_check_poolset_health(struct pool_set *set,
 		struct poolset_health_status **set_hs,
-		unsigned flags);
+		int called_from_sync, unsigned flags);
 int replica_is_part_broken(unsigned repn, unsigned partn,
 		struct poolset_health_status *set_hs);
+int replica_part_has_bad_blocks(struct part_health_status *phs);
 unsigned replica_find_unbroken_part(unsigned repn,
 		struct poolset_health_status *set_hs);
 int replica_is_replica_broken(unsigned repn,

--- a/src/libpmempool/rm.c
+++ b/src/libpmempool/rm.c
@@ -58,7 +58,7 @@
 #define CHECK_FLAG(f, i) ((f) & PMEMPOOL_RM_##i)
 
 struct cb_args {
-	int flags;
+	unsigned flags;
 	int error;
 };
 
@@ -66,7 +66,7 @@ struct cb_args {
  * rm_local -- (internal) remove single local file
  */
 static int
-rm_local(const char *path, int flags, int is_part_file)
+rm_local(const char *path, unsigned flags, int is_part_file)
 {
 	int ret = util_unlink_flock(path);
 	if (!ret) {
@@ -105,7 +105,7 @@ rm_local(const char *path, int flags, int is_part_file)
  * rm_remote -- (internal) remove remote replica
  */
 static int
-rm_remote(const char *node, const char *path, int flags)
+rm_remote(const char *node, const char *path, unsigned flags)
 {
 	if (!Rpmem_remove) {
 		ERR_F(flags, "cannot remove remote replica"
@@ -160,7 +160,7 @@ rm_cb(struct part_file *pf, void *arg)
 static inline
 #endif
 int
-pmempool_rmU(const char *path, int flags)
+pmempool_rmU(const char *path, unsigned flags)
 {
 	LOG(3, "path %s flags %x", path, flags);
 	int ret;
@@ -255,7 +255,7 @@ pmempool_rmU(const char *path, int flags)
  * pmempool_rm -- remove pool files or poolsets
  */
 int
-pmempool_rm(const char *path, int flags)
+pmempool_rm(const char *path, unsigned flags)
 {
 	return pmempool_rmU(path, flags);
 }
@@ -264,7 +264,7 @@ pmempool_rm(const char *path, int flags)
  * pmempool_rmW -- remove pool files or poolsets in widechar
  */
 int
-pmempool_rmW(const wchar_t *path, int flags)
+pmempool_rmW(const wchar_t *path, unsigned flags)
 {
 	char *upath = util_toUTF8(path);
 	if (upath == NULL) {

--- a/src/libpmempool/transform.c
+++ b/src/libpmempool/transform.c
@@ -929,7 +929,8 @@ replica_transform(struct pool_set *set_in, struct pool_set *set_out,
 
 	/* check if the source poolset is healthy */
 	struct poolset_health_status *set_in_hs = NULL;
-	if (replica_check_poolset_health(set_in, &set_in_hs, flags)) {
+	if (replica_check_poolset_health(set_in, &set_in_hs,
+					0 /* called from transform */, flags)) {
 		ERR("source poolset health check failed");
 		return -1;
 	}

--- a/src/test/common_badblock.sh
+++ b/src/test/common_badblock.sh
@@ -40,31 +40,30 @@
 
 LOG=out${UNITTEST_NUM}.log
 
-#
-# ndctl_inject_error -- inject error (bad blocks) to the namespace
-#
-# Input arguments:
-# 1) namespace
-# 2) the first bad block
-# 3) number of bad blocks
-#
-function ndctl_inject_error() {
-	local NAMESPACE=$1
-	local BLOCK=$2
-	local COUNT=$3
-	ndctl inject-error --block=$BLOCK --count=$COUNT $NAMESPACE &>> $PREP_LOG_FILE
-}
+COMMAND_NDCTL_NFIT_TEST_INIT="\
+	sudo ndctl disable-region all &>>$PREP_LOG_FILE && \
+	sudo modprobe -r nfit_test &>>$PREP_LOG_FILE && \
+	sudo modprobe nfit_test &>>$PREP_LOG_FILE && \
+	sudo ndctl disable-region all &>>$PREP_LOG_FILE && \
+	sudo ndctl zero-labels all &>>$PREP_LOG_FILE && \
+	sudo ndctl enable-region all &>>$PREP_LOG_FILE"
+
+COMMAND_NDCTL_NFIT_TEST_FINI="\
+	sudo ndctl disable-region all &>>$PREP_LOG_FILE && \
+	sudo modprobe -r nfit_test &>>$PREP_LOG_FILE"
 
 #
 # ndctl_nfit_test_init -- reset all regions and reload the nfit_test module
 #
 function ndctl_nfit_test_init() {
-	ndctl disable-region all &>> $PREP_LOG_FILE
-	modprobe -r nfit_test
-	modprobe nfit_test
-	ndctl disable-region all &>> $PREP_LOG_FILE
-	ndctl zero-labels all &>> $PREP_LOG_FILE
-	ndctl enable-region all &>> $PREP_LOG_FILE
+	eval $COMMAND_NDCTL_NFIT_TEST_INIT
+}
+
+#
+# ndctl_nfit_test_init_node -- reset all regions and reload the nfit_test module on a remote node
+#
+function ndctl_nfit_test_init_node() {
+	expect_normal_exit run_on_node $1 "$COMMAND_NDCTL_NFIT_TEST_INIT"
 }
 
 #
@@ -74,8 +73,49 @@ function ndctl_nfit_test_init() {
 function ndctl_nfit_test_fini() {
 	MOUNT_DIR=$1
 	[ $MOUNT_DIR ] && umount $MOUNT_DIR &>> $PREP_LOG_FILE
-	ndctl disable-region all &>> $PREP_LOG_FILE
-	modprobe -r nfit_test
+	eval $COMMAND_NDCTL_NFIT_TEST_FINI
+}
+
+#
+# ndctl_nfit_test_fini_node -- disable all regions, remove the nfit_test module
+#                              and (optionally) umount the pmem block device on a remote node
+#
+function ndctl_nfit_test_fini_node() {
+	MOUNT_DIR=$2
+	[ $MOUNT_DIR ] && expect_normal_exit run_on_node $1 sudo umount $MOUNT_DIR &>> $PREP_LOG_FILE
+	expect_normal_exit run_on_node $1 "$COMMAND_NDCTL_NFIT_TEST_FINI"
+}
+
+#
+# ndctl_nfit_test_mount_pmem -- mount a pmem block device
+#
+# Input argument:
+# 1) path of a pmem block device
+# 2) mount directory
+#
+function ndctl_nfit_test_mount_pmem() {
+	FULLDEV=$1
+	MOUNT_DIR=$2
+	mkfs.ext4 $FULLDEV &>>$PREP_LOG_FILE
+	mkdir -p $MOUNT_DIR &>>$PREP_LOG_FILE
+	mount $FULLDEV $MOUNT_DIR &>>$PREP_LOG_FILE
+}
+
+#
+# ndctl_nfit_test_mount_pmem_node -- mount a pmem block device on a remote node
+#
+# Input argument:
+# 1) number of a node
+# 2) path of a pmem block device
+# 3) mount directory
+#
+function ndctl_nfit_test_mount_pmem_node() {
+	FULLDEV=$2
+	MOUNT_DIR=$3
+	expect_normal_exit run_on_node $1 "\
+		sudo mkfs.ext4 $FULLDEV &>>$PREP_LOG_FILE && \
+		sudo mkdir -p $MOUNT_DIR &>>$PREP_LOG_FILE && \
+		sudo mount $FULLDEV $MOUNT_DIR &>>$PREP_LOG_FILE"
 }
 
 #
@@ -99,6 +139,26 @@ function ndctl_nfit_test_get_device() {
 }
 
 #
+# ndctl_nfit_test_get_device_node -- create a namespace and get name of the pmem device
+#                                    of the nfit_test module on a remote node
+#
+# Input argument:
+# 1) mode of the namespace (devdax or fsdax)
+#
+function ndctl_nfit_test_get_device_node() {
+	MODE=$2
+	DEVTYPE=""
+	[ "$MODE" == "devdax" ] && DEVTYPE="chardev"
+	[ "$MODE" == "fsdax"  ] && DEVTYPE="blockdev"
+	[ "$DEVTYPE" == "" ] && echo "ERROR: wrong namespace mode: $MODE" >&2 && exit 1
+
+	BUS="nfit_test.0"
+	REGION=$(expect_normal_exit run_on_node $1 sudo ndctl list -b $BUS -t pmem -Ri | sed "/dev/!d;s/[\", ]//g;s/dev://g" | tail -1)
+	DEVICE=$(expect_normal_exit run_on_node $1 sudo ndctl create-namespace -b $BUS -r $REGION -f -m $MODE -a 4096 | sed "/$DEVTYPE/!d;s/[\", ]//g;s/$DEVTYPE://g")
+	echo $DEVICE
+}
+
+#
 # ndctl_nfit_test_get_dax_device -- create a namespace and get name of the dax device
 #                                   of the nfit_test module
 #
@@ -117,6 +177,15 @@ function ndctl_nfit_test_get_block_device() {
 }
 
 #
+# ndctl_nfit_test_get_block_device_node -- create a namespace and get name of the pmem block device
+#                                          of the nfit_test module on a remote node
+#
+function ndctl_nfit_test_get_block_device_node() {
+	DEVICE=$(ndctl_nfit_test_get_device_node $1 fsdax)
+	echo $DEVICE
+}
+
+#
 # ndctl_nfit_test_get_namespace_of_device -- get namespace of the pmem device
 #
 # Input argument:
@@ -129,19 +198,31 @@ function ndctl_nfit_test_get_namespace_of_device() {
 }
 
 #
-# ndctl_nfit_test_mount_pmem -- mount a pmem block device
+# ndctl_nfit_test_get_namespace_of_device_node -- get namespace of the pmem device on a remote node
 #
 # Input argument:
-# 1) path of a pmem block device
-# 2) mount directory
+# 1) a node number
+# 2) a name of pmem device
 #
-function ndctl_nfit_test_mount_pmem() {
-	FULLDEV=$1
-	MOUNT_DIR=$2
+function ndctl_nfit_test_get_namespace_of_device_node() {
+	DEVICE=$2
+	NAMESPACE=$(expect_normal_exit run_on_node $1 sudo ndctl list | grep -e "$DEVICE" -e namespace | grep -B1 -e "$DEVICE" | head -n1 | cut -d'"' -f4)
+	echo $NAMESPACE
+}
 
-	mkfs.ext4 $FULLDEV &>> $PREP_LOG_FILE
-	mkdir -p $MOUNT_DIR
-	mount $FULLDEV $MOUNT_DIR
+#
+# ndctl_inject_error -- inject error (bad blocks) to the namespace
+#
+# Input arguments:
+# 1) namespace
+# 2) the first bad block
+# 3) number of bad blocks
+#
+function ndctl_inject_error() {
+	local NAMESPACE=$1
+	local BLOCK=$2
+	local COUNT=$3
+	ndctl inject-error --block=$BLOCK --count=$COUNT $NAMESPACE &>> $PREP_LOG_FILE
 }
 
 #
@@ -168,4 +249,12 @@ function expect_bad_blocks {
 		msg ""
 		fatal "Error: ndctl failed to inject or retain bad blocks"
 	fi
+}
+
+#
+# expect_bad_blocks -- verify if there are required bad blocks
+#                      and fail if they are not there
+#
+function expect_bad_blocks_node {
+	expect_normal_exit run_on_node $1 sudo ndctl list -M | grep -e "badblock_count" -e "offset" -e "length" >> $LOG || fatal "Error: ndctl failed to inject or retain bad blocks"
 }

--- a/src/test/common_badblock.sh
+++ b/src/test/common_badblock.sh
@@ -70,6 +70,9 @@ function ndctl_nfit_test_init_node() {
 # ndctl_nfit_test_fini -- disable all regions, remove the nfit_test module
 #                         and (optionally) umount the pmem block device
 #
+# Input argument:
+# 1) pmem mount directory to be umounted
+#
 function ndctl_nfit_test_fini() {
 	MOUNT_DIR=$1
 	[ $MOUNT_DIR ] && sudo umount $MOUNT_DIR &>> $PREP_LOG_FILE
@@ -80,6 +83,10 @@ function ndctl_nfit_test_fini() {
 # ndctl_nfit_test_fini_node -- disable all regions, remove the nfit_test module
 #                              and (optionally) umount the pmem block device on a remote node
 #
+# Input arguments:
+# 1) node number
+# 2) pmem mount directory to be umounted
+#
 function ndctl_nfit_test_fini_node() {
 	MOUNT_DIR=$2
 	[ $MOUNT_DIR ] && expect_normal_exit run_on_node $1 sudo umount $MOUNT_DIR &>> $PREP_LOG_FILE
@@ -89,7 +96,7 @@ function ndctl_nfit_test_fini_node() {
 #
 # ndctl_nfit_test_mount_pmem -- mount a pmem block device
 #
-# Input argument:
+# Input arguments:
 # 1) path of a pmem block device
 # 2) mount directory
 #
@@ -106,7 +113,7 @@ function ndctl_nfit_test_mount_pmem() {
 #
 # ndctl_nfit_test_mount_pmem_node -- mount a pmem block device on a remote node
 #
-# Input argument:
+# Input arguments:
 # 1) number of a node
 # 2) path of a pmem block device
 # 3) mount directory
@@ -219,7 +226,7 @@ function ndctl_nfit_test_grant_access() {
 #
 # XXX needed by libndctl (it should be removed when these extra access rights are not needed)
 #
-# Input argument:
+# Input arguments:
 # 1) node number
 # 2) name of pmem device
 #
@@ -254,9 +261,9 @@ function ndctl_nfit_test_get_namespace_of_device() {
 #
 # ndctl_nfit_test_get_namespace_of_device_node -- get namespace of the pmem device on a remote node
 #
-# Input argument:
-# 1) a node number
-# 2) a name of pmem device
+# Input arguments:
+# 1) node number
+# 2) name of pmem device
 #
 function ndctl_nfit_test_get_namespace_of_device_node() {
 	DEVICE=$2

--- a/src/test/libpmempool_rm/libpmempool_rm.c
+++ b/src/test/libpmempool_rm/libpmempool_rm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Intel Corporation
+ * Copyright 2017-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -53,7 +53,7 @@ main(int argc, char *argv[])
 	if (argc < 2)
 		FATAL_USAGE(argv[0]);
 
-	int flags = 0;
+	unsigned flags = 0;
 
 	char *optstr = "flro";
 	int do_open = 0;

--- a/src/test/libpmempool_rm_win/libpmempool_rm_win.c
+++ b/src/test/libpmempool_rm_win/libpmempool_rm_win.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Intel Corporation
+ * Copyright 2017-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -53,7 +53,7 @@ wmain(int argc, wchar_t *argv[])
 	if (argc < 2)
 		FATAL_USAGE(ut_toUTF8(argv[0]));
 
-	int flags = 0;
+	unsigned flags = 0;
 	int do_open = 0;
 	int i = 1;
 	for (; i < argc - 1; i++) {

--- a/src/test/libpmempool_sync/TEST2
+++ b/src/test/libpmempool_sync/TEST2
@@ -67,7 +67,7 @@ cat $LOG >> $LOG_TEMP
 rm -f $DIR/part10
 
 # Try to synchronize replicas
-FLAG=1 #invalid flag
+FLAG=32 #invalid flag
 expect_normal_exit ./libpmempool_sync$EXESUFFIX $POOLSET $FLAG
 cat $LOG >> $LOG_TEMP
 

--- a/src/test/libpmempool_sync/TEST2.PS1
+++ b/src/test/libpmempool_sync/TEST2.PS1
@@ -68,7 +68,7 @@ cat -Encoding Ascii $LOG | out-file -append -encoding ascii -literalpath $LOG_TE
 rm $DIR\part10 -Force -ea si
 
 # Try to synchronize replicas
-$FLAGS = "1" # invalid flag
+$FLAGS = "32" # invalid flag
 expect_normal_exit $Env:EXE_DIR\libpmempool_sync$Env:EXESUFFIX `
 	$POOLSET $FLAGS
 cat -Encoding Ascii $LOG | out-file -append -encoding ascii -literalpath $LOG_TEMP

--- a/src/test/libpmempool_sync/out2.log.match
+++ b/src/test/libpmempool_sync/out2.log.match
@@ -1,5 +1,5 @@
 libpmempool_sync$(nW)TEST2: START: libpmempool_sync$(nW)
- $(nW)libpmempool_sync$(nW) $(nW)poolset 1
+ $(nW)libpmempool_sync$(nW) $(nW)poolset 32
 result: -1, errno: 22
 libpmempool_sync$(nW)TEST2: DONE
 libpmempool_sync$(nW)TEST2: START: libpmempool_sync$(nW)

--- a/src/test/libpmempool_sync_win/TEST2.PS1
+++ b/src/test/libpmempool_sync_win/TEST2.PS1
@@ -67,7 +67,7 @@ cat -Encoding Ascii $LOG | out-file -append -encoding ascii -literalpath $LOG_TE
 rm $DIR\part10 -Force -ea si
 
 # Try to synchronize replicas
-$FLAGS = "1" # invalid flag
+$FLAGS = "32" # invalid flag
 expect_normal_exit $Env:EXE_DIR\libpmempool_sync_win$Env:EXESUFFIX `
 	$POOLSET $FLAGS
 cat -Encoding Ascii $LOG | out-file -append -encoding ascii -literalpath $LOG_TEMP

--- a/src/test/libpmempool_sync_win/out2.log.match
+++ b/src/test/libpmempool_sync_win/out2.log.match
@@ -1,5 +1,5 @@
 libpmempool_sync_win$(nW)TEST2: START: libpmempool_sync_win$(nW)
- $(nW)libpmempool_sync_win$(nW) $(nW)poolset 1
+ $(nW)libpmempool_sync_win$(nW) $(nW)poolset 32
 result: -1, errno: 22
 libpmempool_sync_win$(nW)TEST2: DONE
 libpmempool_sync_win$(nW)TEST2: START: libpmempool_sync_win$(nW)

--- a/src/test/obj_pool/TEST32
+++ b/src/test/obj_pool/TEST32
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_pool/TEST32 -- unit test for pmemobj_open
+#                             with a bad block recovery file
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+
+setup
+
+#
+# TEST32 existing file, file size >= min required size,
+#        layout matches the value from pool header
+#
+expect_normal_exit ./obj_pool$EXESUFFIX c $DIR/testfile "test" 20 0640
+
+# create a bad block recovery file
+echo "0 0" > $DIR/testfile_r0_p0_badblocks.txt
+
+# pmemobj_open() should fail, because the bad block recovery file exists
+expect_normal_exit ./obj_pool$EXESUFFIX o $DIR/testfile "test"
+
+check
+
+pass

--- a/src/test/obj_pool/TEST33
+++ b/src/test/obj_pool/TEST33
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_pool/TEST33 -- unit test for pmemobj_open
+#                             with a poolset and bad block recovery files
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+
+setup
+
+POOLSET=$DIR/testset1
+create_poolset $POOLSET 10M:$DIR/testfile0:z 10M:$DIR/testfile1:z 10M:$DIR/testfile2:z \
+			R 30M:$DIR/testfile3:z
+
+#
+# TEST33 existing file, file size >= min required size,
+#        layout matches the value from pool header
+#
+expect_normal_exit ./obj_pool$EXESUFFIX c $DIR/testset1 "test" 20 0640
+
+# create recovery files - no bad blocks
+echo "0 0" > $DIR/testset1_r0_p0_badblocks.txt
+echo "0 0" > $DIR/testset1_r0_p1_badblocks.txt
+echo "0 0" > $DIR/testset1_r0_p2_badblocks.txt
+echo "0 0" > $DIR/testset1_r1_p0_badblocks.txt
+
+# pmemobj_open() should fail, because the bad block recovery files exist
+expect_normal_exit ./obj_pool$EXESUFFIX o $DIR/testset1 "test"
+
+check
+
+pass

--- a/src/test/obj_pool/out32.log.match
+++ b/src/test/obj_pool/out32.log.match
@@ -1,0 +1,4 @@
+obj_pool$(nW)TEST32: START: obj_pool$(nW)
+ $(nW)obj_pool$(nW) o $(nW)testfile test$(nW)
+$(nW)testfile: pmemobj_open: Invalid argument
+obj_pool$(nW)TEST32: DONE

--- a/src/test/obj_pool/out33.log.match
+++ b/src/test/obj_pool/out33.log.match
@@ -1,0 +1,4 @@
+obj_pool$(nW)/TEST33: START: obj_pool$(nW)
+ $(nW)/obj_pool$(nW) o $(nW)/testset1 test$(nW)
+$(nW)/testset1: pmemobj_open: Invalid argument
+obj_pool$(nW)/TEST33: DONE

--- a/src/test/pmempool_check/TEST31
+++ b/src/test/pmempool_check/TEST31
@@ -42,7 +42,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl

--- a/src/test/pmempool_check/TEST31
+++ b/src/test/pmempool_check/TEST31
@@ -42,6 +42,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX

--- a/src/test/pmempool_check/TEST32
+++ b/src/test/pmempool_check/TEST32
@@ -42,7 +42,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl

--- a/src/test/pmempool_check/TEST32
+++ b/src/test/pmempool_check/TEST32
@@ -42,6 +42,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX

--- a/src/test/pmempool_check/out31.log.match
+++ b/src/test/pmempool_check/out31.log.match
@@ -28,7 +28,7 @@ size                     : 31457280
 POOL Header:
 Signature                : PMEMOBJ
 Major                    : $(nW)
-Mandatory features       : 0x0
+Mandatory features       : $(*)
 Not mandatory features   : 0x0
 Forced RO                : 0x0
 Pool set UUID            : $(nW)
@@ -88,7 +88,7 @@ size                     : 31457280
 POOL Header:
 Signature                : PMEMOBJ
 Major                    : $(nW)
-Mandatory features       : 0x0
+Mandatory features       : $(*)
 Not mandatory features   : 0x0
 Forced RO                : 0x0
 Pool set UUID            : $(nW)

--- a/src/test/pmempool_check/out32.log.match
+++ b/src/test/pmempool_check/out32.log.match
@@ -21,7 +21,7 @@ size                     : 10485760
 POOL Header:
 Signature                : PMEMOBJ
 Major                    : $(nW)
-Mandatory features       : 0x0
+Mandatory features       : $(*)
 Not mandatory features   : 0x0
 Forced RO                : 0x0
 Pool set UUID            : $(nW)
@@ -74,7 +74,7 @@ size                     : 10485760
 POOL Header:
 Signature                : PMEMOBJ
 Major                    : $(nW)
-Mandatory features       : 0x0
+Mandatory features       : $(*)
 Not mandatory features   : 0x0
 Forced RO                : 0x0
 Pool set UUID            : $(nW)

--- a/src/test/pmempool_create/TEST10
+++ b/src/test/pmempool_create/TEST10
@@ -42,7 +42,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl

--- a/src/test/pmempool_create/TEST10
+++ b/src/test/pmempool_create/TEST10
@@ -42,6 +42,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX

--- a/src/test/pmempool_create/TEST11
+++ b/src/test/pmempool_create/TEST11
@@ -42,7 +42,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl

--- a/src/test/pmempool_create/TEST11
+++ b/src/test/pmempool_create/TEST11
@@ -42,6 +42,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX

--- a/src/test/pmempool_create/TEST12
+++ b/src/test/pmempool_create/TEST12
@@ -43,7 +43,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl

--- a/src/test/pmempool_create/TEST12
+++ b/src/test/pmempool_create/TEST12
@@ -43,6 +43,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX

--- a/src/test/pmempool_info/TEST24
+++ b/src/test/pmempool_info/TEST24
@@ -42,7 +42,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl

--- a/src/test/pmempool_info/TEST24
+++ b/src/test/pmempool_info/TEST24
@@ -42,6 +42,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX

--- a/src/test/pmempool_info/TEST25
+++ b/src/test/pmempool_info/TEST25
@@ -42,7 +42,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl

--- a/src/test/pmempool_info/TEST25
+++ b/src/test/pmempool_info/TEST25
@@ -42,6 +42,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX

--- a/src/test/pmempool_info/out24.log.match
+++ b/src/test/pmempool_info/out24.log.match
@@ -16,7 +16,7 @@ bad blocks:
 POOL Header:
 Signature                : PMEMOBJ
 Major                    : $(nW)
-Mandatory features       : 0x0
+Mandatory features       : $(*)
 Not mandatory features   : 0x0
 Forced RO                : 0x0
 Pool set UUID            : $(nW)

--- a/src/test/pmempool_info/out25.log.match
+++ b/src/test/pmempool_info/out25.log.match
@@ -23,7 +23,7 @@ size                     : 10485760
 POOL Header:
 Signature                : PMEMOBJ
 Major                    : $(nW)
-Mandatory features       : 0x0
+Mandatory features       : $(*)
 Not mandatory features   : 0x0
 Forced RO                : 0x0
 Pool set UUID            : $(nW)

--- a/src/test/pmempool_sync/TEST27
+++ b/src/test/pmempool_sync/TEST27
@@ -43,7 +43,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl

--- a/src/test/pmempool_sync/TEST27
+++ b/src/test/pmempool_sync/TEST27
@@ -43,6 +43,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX

--- a/src/test/pmempool_sync/TEST27
+++ b/src/test/pmempool_sync/TEST27
@@ -33,6 +33,7 @@
 #
 # pmempool_sync/TEST27 -- test for sync command with badblocks
 #                         - bad blocks in the regular file
+#                           blocks: offset: 0 length: 512
 #
 
 # standard unit test setup
@@ -70,19 +71,24 @@ create_poolset $POOLSET 10M:$DIR/testfile0:z 10M:$MOUNT_DIR/testfile1:z 10M:$DIR
 expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG
+
 # inject bad block:
 FIRST_SECTOR=$(expect_normal_exit $EXTENTS $MOUNT_DIR/testfile1 -l 0)
-ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
+ndctl_inject_error $NAMESPACE $FIRST_SECTOR 512
 
 expect_bad_blocks
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET &>> $LOG
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> /dev/null
 
 expect_bad_blocks
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX sync -v $POOLSET &>> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &>> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET &>> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET &>> $LOG
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
 
 ndctl_nfit_test_fini $MOUNT_DIR
 

--- a/src/test/pmempool_sync/TEST28
+++ b/src/test/pmempool_sync/TEST28
@@ -43,7 +43,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl

--- a/src/test/pmempool_sync/TEST28
+++ b/src/test/pmempool_sync/TEST28
@@ -43,6 +43,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX

--- a/src/test/pmempool_sync/TEST28
+++ b/src/test/pmempool_sync/TEST28
@@ -33,6 +33,7 @@
 #
 # pmempool_sync/TEST28 -- test for sync command with badblocks
 #                         - bad blocks in the dax device
+#                           blocks: offset: 0 length: 512
 #
 
 # standard unit test setup
@@ -67,16 +68,19 @@ create_poolset $POOLSET AUTO:$FULLDEV:x \
 expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
-# inject bad block: OFF=11 LEN=12
-ndctl_inject_error $NAMESPACE 11 12
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG
+
+# inject bad block: OFF=0 LEN=512
+ndctl_inject_error $NAMESPACE 0 512
 
 expect_bad_blocks
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET &>> $LOG
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> /dev/null
 
 expect_bad_blocks
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX sync -v $POOLSET &>> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &>> $LOG
 
 print_bad_blocks
 
@@ -87,6 +91,8 @@ print_bad_blocks
 expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET &>> $LOG
 
 print_bad_blocks
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
 
 ndctl_nfit_test_fini $MOUNT_DIR
 

--- a/src/test/pmempool_sync/TEST29
+++ b/src/test/pmempool_sync/TEST29
@@ -62,8 +62,9 @@ expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG
 # inject errors
 dd if=/dev/urandom of=$DIR/testfile1 bs=512 count=100 seek=0 conv=notrunc status=none
 
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> /dev/null
 expect_abnormal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET &>> $LOG
-expect_normal_exit $PMEMPOOL$EXESUFFIX sync -v $POOLSET &>> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &>> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET &>> $LOG
 
 expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG

--- a/src/test/pmempool_sync/TEST30
+++ b/src/test/pmempool_sync/TEST30
@@ -43,7 +43,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl

--- a/src/test/pmempool_sync/TEST30
+++ b/src/test/pmempool_sync/TEST30
@@ -43,6 +43,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX

--- a/src/test/pmempool_sync/TEST30
+++ b/src/test/pmempool_sync/TEST30
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync/TEST30 -- test for sync command with badblocks
+#                         - bad blocks in the regular file
+#                           blocks: offset: 1000 length: 512
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+
+require_superuser
+require_kernel_module nfit_test
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+require_command ndctl
+
+setup
+
+. ../common_badblock.sh
+
+ndctl_nfit_test_init
+
+DEVICE=$(ndctl_nfit_test_get_block_device)
+NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device $DEVICE)
+FULLDEV="/dev/$DEVICE"
+MOUNT_DIR="$DIR/mnt-pmem"
+
+ndctl_nfit_test_mount_pmem $FULLDEV $MOUNT_DIR
+
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET=$DIR/testset1
+create_poolset $POOLSET 10M:$DIR/testfile0:z 10M:$MOUNT_DIR/testfile1:z 10M:$DIR/testfile2:z \
+			R 30M:$DIR/testfile3:z
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG
+
+# inject bad block:
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $MOUNT_DIR/testfile1 -l 1000)
+ndctl_inject_error $NAMESPACE $FIRST_SECTOR 512
+
+expect_bad_blocks
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET &>> $LOG
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> /dev/null
+
+expect_bad_blocks
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &>> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET &>> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET &>> $LOG
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+ndctl_nfit_test_fini $MOUNT_DIR
+
+check
+
+pass

--- a/src/test/pmempool_sync/TEST31
+++ b/src/test/pmempool_sync/TEST31
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync/TEST31 -- test for sync command with badblocks
+#                         - bad blocks in the dax device
+#                           blocks: offset: 1000 length: 512
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+
+require_superuser
+require_kernel_module nfit_test
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+require_command ndctl
+
+setup
+
+. ../common_badblock.sh
+
+ndctl_nfit_test_init
+
+DEVICE=$(ndctl_nfit_test_get_dax_device)
+NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device $DEVICE)
+FULLDEV="/dev/$DEVICE"
+
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET=$DIR/testset1
+create_poolset $POOLSET AUTO:$FULLDEV:x \
+			R 10M:$DIR/testfile1:z
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG
+
+# inject bad block: OFF=1000 LEN=512
+ndctl_inject_error $NAMESPACE 1000 512
+
+expect_bad_blocks
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET &>> $LOG
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> /dev/null
+
+expect_bad_blocks
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &>> $LOG
+
+print_bad_blocks
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET &>> $LOG
+
+print_bad_blocks
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET &>> $LOG
+
+print_bad_blocks
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+ndctl_nfit_test_fini $MOUNT_DIR
+
+check
+
+pass

--- a/src/test/pmempool_sync/TEST31
+++ b/src/test/pmempool_sync/TEST31
@@ -43,7 +43,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl

--- a/src/test/pmempool_sync/TEST31
+++ b/src/test/pmempool_sync/TEST31
@@ -43,6 +43,7 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX

--- a/src/test/pmempool_sync/TEST32
+++ b/src/test/pmempool_sync/TEST32
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync/TEST32 -- test for sync command
+#                         with bad blocks recovery files
+#                         and one bad block:
+#                         - offset: 0 length: 2000
+#                         in the 1st part
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+
+setup
+
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET=$DIR/testset1
+create_poolset $POOLSET 10M:$DIR/testfile0:z 10M:$DIR/testfile1:z 10M:$DIR/testfile2:z \
+			R 30M:$DIR/testfile3:z
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG
+
+# create recovery files - no bad blocks
+echo "0 0" > $DIR/testset1_r0_p1_badblocks.txt
+echo "0 0" > $DIR/testset1_r0_p2_badblocks.txt
+echo "0 0" > $DIR/testset1_r1_p0_badblocks.txt
+
+# create recovery file - one bad block: offset: 0 length: 2000 in the 1st part
+echo "0 $((2000 * 512))" > $DIR/testset1_r0_p0_badblocks.txt
+echo "0 0" >> $DIR/testset1_r0_p0_badblocks.txt
+
+# inject errors: zero blocks: offset: 0 length: 2000
+dd if=/dev/zero of=$DIR/testfile0 bs=512 seek=0 count=2000 conv=notrunc status=none
+
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &>> $LOG
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+check
+
+pass

--- a/src/test/pmempool_sync/TEST33
+++ b/src/test/pmempool_sync/TEST33
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync/TEST33 -- test for sync command
+#                         with bad blocks recovery files
+#                         and one bad block:
+#                         - offset: 0 length: 2000
+#                         in the 2nd part
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+
+setup
+
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET=$DIR/testset1
+create_poolset $POOLSET 10M:$DIR/testfile0:z 10M:$DIR/testfile1:z 10M:$DIR/testfile2:z \
+			R 30M:$DIR/testfile3:z
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG
+
+# create recovery files - no bad blocks
+echo "0 0" > $DIR/testset1_r0_p0_badblocks.txt
+echo "0 0" > $DIR/testset1_r0_p2_badblocks.txt
+echo "0 0" > $DIR/testset1_r1_p0_badblocks.txt
+
+# create recovery file - one bad block: offset: 0 length: 2000 in the 2nd part
+echo "0 $((2000 * 512))" > $DIR/testset1_r0_p1_badblocks.txt
+echo "0 0" >> $DIR/testset1_r0_p1_badblocks.txt
+
+# inject errors: zero blocks: offset: 0 length: 2000
+dd if=/dev/zero of=$DIR/testfile1 bs=512 seek=0 count=2000 conv=notrunc status=none
+
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &>> $LOG
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+check
+
+pass

--- a/src/test/pmempool_sync/TEST34
+++ b/src/test/pmempool_sync/TEST34
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync/TEST34 -- test for sync command
+#                         with bad blocks recovery files
+#                         and one bad block:
+#                         - offset: 8000 length: 2000
+#                         in the 1st part
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+
+setup
+
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET=$DIR/testset1
+create_poolset $POOLSET 10M:$DIR/testfile0:z 10M:$DIR/testfile1:z 10M:$DIR/testfile2:z \
+			R 30M:$DIR/testfile3:z
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG
+
+# inject errors: zero blocks: offset: 8000 length: 2000 in the 1st part
+dd if=/dev/zero of=$DIR/testfile0 bs=512 seek=8000 count=2000 conv=notrunc status=none
+
+# fail because of bad blocks
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+# create recovery file - one bad block: offset: 8000 length: 2000
+echo "4096000 1024000" > $DIR/testset1_r0_p0_badblocks.txt
+echo "0 0" >> $DIR/testset1_r0_p0_badblocks.txt
+
+# create recovery files - no bad blocks
+echo "0 0" > $DIR/testset1_r0_p1_badblocks.txt
+echo "0 0" > $DIR/testset1_r0_p2_badblocks.txt
+echo "0 0" > $DIR/testset1_r1_p0_badblocks.txt
+
+# fail because of recovery files
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+# repair
+expect_normal_exit $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &>> $LOG
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+check
+
+pass

--- a/src/test/pmempool_sync/TEST35
+++ b/src/test/pmempool_sync/TEST35
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync/TEST35 -- test for sync command
+#                         with bad blocks recovery files
+#                         and one bad block:
+#                         - offset: 8000 length: 2000
+#                         in the 2nd part
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+
+setup
+
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET=$DIR/testset1
+create_poolset $POOLSET 10M:$DIR/testfile0:z 10M:$DIR/testfile1:z 10M:$DIR/testfile2:z \
+			R 30M:$DIR/testfile3:z
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG
+
+# inject errors: zero blocks: offset: 8000 length: 2000 in the 2nd part
+dd if=/dev/zero of=$DIR/testfile1 bs=512 seek=8000 count=2000 conv=notrunc status=none
+
+# fail because of bad blocks
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+# create recovery file - one bad block: offset: 8000 length: 2000
+echo "4096000 1024000" > $DIR/testset1_r0_p1_badblocks.txt
+echo "0 0" >> $DIR/testset1_r0_p1_badblocks.txt
+
+# create recovery files - no bad blocks
+echo "0 0" > $DIR/testset1_r0_p0_badblocks.txt
+echo "0 0" > $DIR/testset1_r0_p2_badblocks.txt
+echo "0 0" > $DIR/testset1_r1_p0_badblocks.txt
+
+# fail because of recovery files
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+# repair
+expect_normal_exit $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &>> $LOG
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+check
+
+pass

--- a/src/test/pmempool_sync/TEST36
+++ b/src/test/pmempool_sync/TEST36
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync/TEST36 -- test for sync command
+#                         with bad blocks recovery files,
+#                         one bad block:
+#                         - offset: 8000 length: 2000
+#                         in the 1st part
+#                         and missing one recovery file
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+
+setup
+
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET=$DIR/testset1
+create_poolset $POOLSET 10M:$DIR/testfile0:z 10M:$DIR/testfile1:z 10M:$DIR/testfile2:z \
+			R 30M:$DIR/testfile3:z
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG
+
+# inject errors: zero blocks: offset: 8000 length: 2000
+dd if=/dev/zero of=$DIR/testfile0 bs=512 seek=8000 count=2000 conv=notrunc status=none
+
+# fail because of bad blocks
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+# create recovery files - no bad blocks
+echo "0 0" > $DIR/testset1_r0_p1_badblocks.txt
+echo "0 0" > $DIR/testset1_r0_p2_badblocks.txt
+
+# one recovery file is missing
+rm -f $DIR/testset1_r1_p0_badblocks.txt
+
+# create recovery file - one bad block: offset: 8000 length: 2000
+echo "$((8000 * 512)) $((2000 * 512))" > $DIR/testset1_r0_p0_badblocks.txt
+echo "0 0" >> $DIR/testset1_r0_p0_badblocks.txt
+
+# fail because of recovery files
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+# repair
+expect_normal_exit $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &>> $LOG
+
+# sync was uneable to fix bad blocks, because one recovery file was missing
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+check
+
+pass

--- a/src/test/pmempool_sync/TEST37
+++ b/src/test/pmempool_sync/TEST37
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync/TEST37 -- test for sync command
+#                         with bad blocks recovery files,
+#                         one bad block:
+#                         - offset: 1000 length: 1000
+#                         in the 2nd part
+#                         and missing one recovery file
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+
+setup
+
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET=$DIR/testset1
+create_poolset $POOLSET 10M:$DIR/testfile0:z 10M:$DIR/testfile1:z 10M:$DIR/testfile2:z \
+			R 30M:$DIR/testfile3:z
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG
+
+# inject errors: zero blocks: offset: 1000 length: 1000
+dd if=/dev/zero of=$DIR/testfile1 bs=512 seek=1000 count=1000 conv=notrunc status=none
+
+# fail because of bad blocks
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+# create recovery files - no bad blocks
+echo "0 0" > $DIR/testset1_r0_p0_badblocks.txt
+echo "0 0" > $DIR/testset1_r0_p2_badblocks.txt
+
+# one recovery file is missing
+rm -f $DIR/testset1_r1_p0_badblocks.txt
+
+# create recovery file - one bad block: offset: 1000 length: 1000
+echo "$((1000 * 512)) $((1000 * 512))" > $DIR/testset1_r0_p1_badblocks.txt
+echo "0 0" >> $DIR/testset1_r0_p1_badblocks.txt
+
+# fail because of recovery files
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+# repair
+expect_normal_exit $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &>> $LOG
+
+# sync was uneable to fix bad blocks, because one recovery file was missing
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+check
+
+pass

--- a/src/test/pmempool_sync/TEST38
+++ b/src/test/pmempool_sync/TEST38
@@ -53,7 +53,7 @@ require_fs_type any
 require_build_type debug
 require_command gdb
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl

--- a/src/test/pmempool_sync/TEST38
+++ b/src/test/pmempool_sync/TEST38
@@ -53,6 +53,7 @@ require_fs_type any
 require_build_type debug
 require_command gdb
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX

--- a/src/test/pmempool_sync/TEST38
+++ b/src/test/pmempool_sync/TEST38
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync/TEST38 -- test for sync command with badblocks
+#                         - bad blocks in the regular file
+#                           blocks: offset: 8000 length: 512
+#                           in the 1st part
+#                         - run sync and break it after clearing bad blocks
+#                           and before recovering data using gdb
+#                         - run sync again and it should recover data
+#                           using bad block recovery files
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+
+# must be non-static debug release of the binary because the test relies on the
+# gdb ability to interrupt the program at a static method inside
+# the libpmempool library
+require_build_type debug
+require_command gdb
+
+require_superuser
+require_kernel_module nfit_test
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+require_command ndctl
+
+setup
+
+. ../common_badblock.sh
+
+ndctl_nfit_test_init
+
+DEVICE=$(ndctl_nfit_test_get_block_device)
+NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device $DEVICE)
+FULLDEV="/dev/$DEVICE"
+MOUNT_DIR="$DIR/mnt-pmem"
+
+ndctl_nfit_test_mount_pmem $FULLDEV $MOUNT_DIR
+
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET=$DIR/testset1
+create_poolset $POOLSET 10M:$MOUNT_DIR/testfile0:z 10M:$DIR/testfile1:z 10M:$DIR/testfile2:z \
+			R 30M:$DIR/testfile3:z
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG
+
+# inject bad block:
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $MOUNT_DIR/testfile0 -l 8000)
+ndctl_inject_error $NAMESPACE $FIRST_SECTOR 512
+
+expect_bad_blocks
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET &>> $LOG
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> /dev/null
+
+expect_bad_blocks
+
+# run sync and break it after clearing bad blocks and before recovering data using gdb
+expect_normal_exit gdb --batch \
+	--command=trip_on_recreate_broken_parts.gdb \
+	--args $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &> /dev/null
+
+# obj_verify should fail, because the recovery files exist
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+# run sync again and it should recover data using bad block recovery files
+expect_normal_exit $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &>> $LOG
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET &>> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET &>> $LOG
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+ndctl_nfit_test_fini $MOUNT_DIR
+
+check
+
+pass

--- a/src/test/pmempool_sync/TEST39
+++ b/src/test/pmempool_sync/TEST39
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync/TEST39 -- test for sync command with badblocks
+#                         - bad blocks in the regular file
+#                           blocks: offset: 1000 length: 512
+#                           in the 2nd part
+#                         - run sync and break it after clearing bad blocks
+#                           and before recovering data using gdb
+#                         - run sync again and it should recover data
+#                           using bad block recovery files
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+
+# must be non-static debug release of the binary because the test relies on the
+# gdb ability to interrupt the program at a static method inside
+# the libpmempool library
+require_build_type debug
+require_command gdb
+
+require_superuser
+require_kernel_module nfit_test
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+require_command ndctl
+
+setup
+
+. ../common_badblock.sh
+
+ndctl_nfit_test_init
+
+DEVICE=$(ndctl_nfit_test_get_block_device)
+NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device $DEVICE)
+FULLDEV="/dev/$DEVICE"
+MOUNT_DIR="$DIR/mnt-pmem"
+
+ndctl_nfit_test_mount_pmem $FULLDEV $MOUNT_DIR
+
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET=$DIR/testset1
+create_poolset $POOLSET 10M:$DIR/testfile0:z 10M:$MOUNT_DIR/testfile1:z 10M:$DIR/testfile2:z \
+			R 30M:$DIR/testfile3:z
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG
+
+# inject bad block:
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $MOUNT_DIR/testfile1 -l 1000)
+ndctl_inject_error $NAMESPACE $FIRST_SECTOR 512
+
+expect_bad_blocks
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET &>> $LOG
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> /dev/null
+
+expect_bad_blocks
+
+# run sync and break it after clearing bad blocks and before recovering data using gdb
+expect_normal_exit gdb --batch \
+	--command=trip_on_recreate_broken_parts.gdb \
+	--args $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &> /dev/null
+
+# obj_verify should fail, because the recovery files exist
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+# run sync again and it should recover data using bad block recovery files
+expect_normal_exit $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &>> $LOG
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET &>> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET &>> $LOG
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+ndctl_nfit_test_fini $MOUNT_DIR
+
+check
+
+pass

--- a/src/test/pmempool_sync/TEST39
+++ b/src/test/pmempool_sync/TEST39
@@ -53,7 +53,7 @@ require_fs_type any
 require_build_type debug
 require_command gdb
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl

--- a/src/test/pmempool_sync/TEST39
+++ b/src/test/pmempool_sync/TEST39
@@ -53,6 +53,7 @@ require_fs_type any
 require_build_type debug
 require_command gdb
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX

--- a/src/test/pmempool_sync/TEST40
+++ b/src/test/pmempool_sync/TEST40
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync/TEST40 -- test for sync command with badblocks
+#                         - bad blocks in the regular file
+#                           blocks: offset: 1000 length: 512
+#                           in the 1st part
+#                         - run sync and break it after clearing bad blocks
+#                           and before recovering data using gdb
+#                         - run sync and break it during saving
+#                           bad block recovery files
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+
+# must be non-static debug release of the binary because the test relies on the
+# gdb ability to interrupt the program at a static method inside
+# the libpmempool library
+require_build_type debug
+require_command gdb
+
+require_superuser
+require_kernel_module nfit_test
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+require_command ndctl
+
+setup
+
+. ../common_badblock.sh
+
+ndctl_nfit_test_init
+
+DEVICE=$(ndctl_nfit_test_get_block_device)
+NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device $DEVICE)
+FULLDEV="/dev/$DEVICE"
+MOUNT_DIR="$DIR/mnt-pmem"
+
+ndctl_nfit_test_mount_pmem $FULLDEV $MOUNT_DIR
+
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET=$DIR/testset1
+create_poolset $POOLSET 10M:$MOUNT_DIR/testfile0:z 10M:$DIR/testfile1:z 10M:$DIR/testfile2:z \
+			R 30M:$DIR/testfile3:z
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG
+
+# inject bad block:
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $MOUNT_DIR/testfile0 -l 1000)
+ndctl_inject_error $NAMESPACE $FIRST_SECTOR 512
+
+expect_bad_blocks
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET &>> $LOG
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> /dev/null
+
+expect_bad_blocks
+
+# run sync and break it during saving bad block recovery files
+expect_normal_exit gdb --batch \
+	--command=trip_on_os_fsync.gdb \
+	--args $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &> /dev/null
+
+# obj_verify should fail, because the recovery files exist
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+# run sync again and it should recover data using bad block recovery files
+expect_normal_exit $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &>> $LOG
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET &>> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET &>> $LOG
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+ndctl_nfit_test_fini $MOUNT_DIR
+
+check
+
+pass

--- a/src/test/pmempool_sync/TEST40
+++ b/src/test/pmempool_sync/TEST40
@@ -53,7 +53,7 @@ require_fs_type any
 require_build_type debug
 require_command gdb
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl

--- a/src/test/pmempool_sync/TEST40
+++ b/src/test/pmempool_sync/TEST40
@@ -53,6 +53,7 @@ require_fs_type any
 require_build_type debug
 require_command gdb
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX

--- a/src/test/pmempool_sync/TEST41
+++ b/src/test/pmempool_sync/TEST41
@@ -53,7 +53,7 @@ require_fs_type any
 require_build_type debug
 require_command gdb
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl

--- a/src/test/pmempool_sync/TEST41
+++ b/src/test/pmempool_sync/TEST41
@@ -53,6 +53,7 @@ require_fs_type any
 require_build_type debug
 require_command gdb
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX

--- a/src/test/pmempool_sync/TEST41
+++ b/src/test/pmempool_sync/TEST41
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync/TEST41 -- test for sync command with badblocks
+#                         - bad blocks in the regular file
+#                           blocks: offset: 1000 length: 512
+#                           in the 2nd part
+#                         - run sync and break it after clearing bad blocks
+#                           and before recovering data using gdb
+#                         - run sync and break it during saving
+#                           bad block recovery files
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+
+# must be non-static debug release of the binary because the test relies on the
+# gdb ability to interrupt the program at a static method inside
+# the libpmempool library
+require_build_type debug
+require_command gdb
+
+require_superuser
+require_kernel_module nfit_test
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+require_command ndctl
+
+setup
+
+. ../common_badblock.sh
+
+ndctl_nfit_test_init
+
+DEVICE=$(ndctl_nfit_test_get_block_device)
+NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device $DEVICE)
+FULLDEV="/dev/$DEVICE"
+MOUNT_DIR="$DIR/mnt-pmem"
+
+ndctl_nfit_test_mount_pmem $FULLDEV $MOUNT_DIR
+
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET=$DIR/testset1
+create_poolset $POOLSET 10M:$DIR/testfile0:z 10M:$MOUNT_DIR/testfile1:z 10M:$DIR/testfile2:z \
+			R 30M:$DIR/testfile3:z
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG
+
+# inject bad block:
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $MOUNT_DIR/testfile1 -l 1000)
+ndctl_inject_error $NAMESPACE $FIRST_SECTOR 512
+
+expect_bad_blocks
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET &>> $LOG
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> /dev/null
+
+expect_bad_blocks
+
+# run sync and break it during saving bad block recovery files
+expect_normal_exit gdb --batch \
+	--command=trip_on_os_fsync.gdb \
+	--args $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &> /dev/null
+
+# obj_verify should fail, because the recovery files exist
+expect_abnormal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+# run sync again and it should recover data using bad block recovery files
+expect_normal_exit $PMEMPOOL$EXESUFFIX sync -b -v $POOLSET &>> $LOG
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET &>> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX info -k $POOLSET &>> $LOG
+
+expect_normal_exit $OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG
+
+ndctl_nfit_test_fini $MOUNT_DIR
+
+check
+
+pass

--- a/src/test/pmempool_sync/out27.log.match
+++ b/src/test/pmempool_sync/out27.log.match
@@ -28,7 +28,7 @@ size                     : 31457280
 POOL Header:
 Signature                : PMEMOBJ
 Major                    : $(nW)
-Mandatory features       : 0x0
+Mandatory features       : $(*)
 Not mandatory features   : 0x0
 Forced RO                : 0x0
 Pool set UUID            : $(nW)
@@ -94,7 +94,7 @@ size                     : 31457280
 POOL Header:
 Signature                : PMEMOBJ
 Major                    : $(nW)
-Mandatory features       : 0x0
+Mandatory features       : $(*)
 Not mandatory features   : 0x0
 Forced RO                : 0x0
 Pool set UUID            : $(nW)

--- a/src/test/pmempool_sync/out27.log.match
+++ b/src/test/pmempool_sync/out27.log.match
@@ -1,3 +1,6 @@
+create($(nW)/testset1): allocating records in the pool ...
+create($(nW)/testset1): allocated $(N) records (of size $(N))
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))
     "badblock_count":$(N),
         "offset":$(N),
         "length":$(N),
@@ -14,7 +17,7 @@ type                     : regular file
 size                     : 10485760
 bad blocks:
 	offset		length
-	0		2
+	0		$(N)
 part 2:
 path                     : $(nW)/testfile2
 type                     : regular file
@@ -119,3 +122,4 @@ Heap offset              : $(nW)
 Heap size                : $(nW)
 Checksum                 : $(*)
 Root offset              : $(nW)
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))

--- a/src/test/pmempool_sync/out28.log.match
+++ b/src/test/pmempool_sync/out28.log.match
@@ -1,5 +1,8 @@
+create($(nW)/testset1): allocating records in the pool ...
+create($(nW)/testset1): allocated $(N) records (of size $(N))
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))
     "badblock_count":$(N),
-        "offset":$(N),
+        "offset":0,
         "length":$(N),
 Poolset structure:
 Number of replicas       : 2
@@ -11,7 +14,7 @@ size                     : $(N)
 alignment                : 4096
 bad blocks:
 	offset		length
-	11		$(N)
+	0		$(N)
 Replica 1 - local, 1 part(s):
 part 0:
 path                     : $(nW)/testfile1
@@ -47,7 +50,7 @@ Heap size                : $(nW)
 Checksum                 : $(*)
 Root offset              : $(nW)
     "badblock_count":$(N),
-        "offset":$(N),
+        "offset":0,
         "length":$(N),
 $(nW)/testset1: synchronized
 No bad blocks found
@@ -104,3 +107,4 @@ Heap size                : $(nW)
 Checksum                 : $(*)
 Root offset              : $(nW)
 No bad blocks found
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))

--- a/src/test/pmempool_sync/out28.log.match
+++ b/src/test/pmempool_sync/out28.log.match
@@ -21,7 +21,7 @@ size                     : 10485760
 POOL Header:
 Signature                : PMEMOBJ
 Major                    : $(nW)
-Mandatory features       : 0x0
+Mandatory features       : $(*)
 Not mandatory features   : 0x0
 Forced RO                : 0x0
 Pool set UUID            : $(nW)
@@ -78,7 +78,7 @@ size                     : 10485760
 POOL Header:
 Signature                : PMEMOBJ
 Major                    : $(nW)
-Mandatory features       : 0x0
+Mandatory features       : $(*)
 Not mandatory features   : 0x0
 Forced RO                : 0x0
 Pool set UUID            : $(nW)

--- a/src/test/pmempool_sync/out30.log.match
+++ b/src/test/pmempool_sync/out30.log.match
@@ -1,0 +1,125 @@
+create($(nW)/testset1): allocating records in the pool ...
+create($(nW)/testset1): allocated $(N) records (of size $(N))
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))
+    "badblock_count":$(N),
+        "offset":$(N),
+        "length":$(N),
+Poolset structure:
+Number of replicas       : 2
+Replica 0 (master) - local, 3 part(s):
+part 0:
+path                     : $(nW)/testfile0
+type                     : regular file
+size                     : 10485760
+part 1:
+path                     : $(nW)/mnt-pmem/testfile1
+type                     : regular file
+size                     : 10485760
+bad blocks:
+	offset		length
+	1000		$(N)
+part 2:
+path                     : $(nW)/testfile2
+type                     : regular file
+size                     : 10485760
+Replica 1 - local, 1 part(s):
+part 0:
+path                     : $(nW)/testfile3
+type                     : regular file
+size                     : 31457280
+
+POOL Header:
+Signature                : PMEMOBJ
+Major                    : $(nW)
+Mandatory features       : $(*)
+Not mandatory features   : $(*)
+Forced RO                : 0x0
+Pool set UUID            : $(nW)
+UUID                     : $(nW)
+Previous part UUID       : $(nW)
+Next part UUID           : $(nW)
+Previous replica UUID    : $(nW)
+Next replica UUID        : $(nW)
+Creation Time            : $(*)
+Alignment Descriptor     : $(nW)
+Class                    : $(nW)
+Data                     : $(*)
+Machine                  : $(*)
+Last shutdown            : clean
+Checksum                 : $(*)
+
+PMEM OBJ Header:
+Layout                   : pmempool$(*)
+Lanes offset             : $(nW)
+Number of lanes          : $(nW)
+Heap offset              : $(nW)
+Heap size                : $(nW)
+Checksum                 : $(*)
+Root offset              : $(nW)
+    "badblock_count":$(N),
+        "offset":$(N),
+        "length":$(N),
+$(nW)/testset1: synchronized
+replica 0: checking shutdown state
+replica 0: shutdown state correct
+replica 1: checking shutdown state
+replica 1: shutdown state correct
+replica 0 part 0: checking pool header
+replica 0 part 0: pool header correct
+replica 0 part 1: checking pool header
+replica 0 part 1: pool header correct
+replica 0 part 2: checking pool header
+replica 0 part 2: pool header correct
+replica 1 part 0: checking pool header
+replica 1 part 0: pool header correct
+$(nW)/testset1: consistent
+Poolset structure:
+Number of replicas       : 2
+Replica 0 (master) - local, 3 part(s):
+part 0:
+path                     : $(nW)/testfile0
+type                     : regular file
+size                     : 10485760
+part 1:
+path                     : $(nW)/mnt-pmem/testfile1
+type                     : regular file
+size                     : 10485760
+part 2:
+path                     : $(nW)/testfile2
+type                     : regular file
+size                     : 10485760
+Replica 1 - local, 1 part(s):
+part 0:
+path                     : $(nW)/testfile3
+type                     : regular file
+size                     : 31457280
+
+POOL Header:
+Signature                : PMEMOBJ
+Major                    : $(nW)
+Mandatory features       : $(*)
+Not mandatory features   : $(*)
+Forced RO                : 0x0
+Pool set UUID            : $(nW)
+UUID                     : $(nW)
+Previous part UUID       : $(nW)
+Next part UUID           : $(nW)
+Previous replica UUID    : $(nW)
+Next replica UUID        : $(nW)
+Creation Time            : $(*)
+Alignment Descriptor     : $(nW)
+Class                    : $(nW)
+Data                     : $(*)
+Machine                  : $(*)
+Last shutdown            : clean
+Checksum                 : $(*)
+
+PMEM OBJ Header:
+Layout                   : pmempool$(*)
+Lanes offset             : $(nW)
+Number of lanes          : $(nW)
+Heap offset              : $(nW)
+Heap size                : $(nW)
+Checksum                 : $(*)
+Root offset              : $(nW)
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))

--- a/src/test/pmempool_sync/out31.log.match
+++ b/src/test/pmempool_sync/out31.log.match
@@ -1,0 +1,110 @@
+create($(nW)/testset1): allocating records in the pool ...
+create($(nW)/testset1): allocated $(N) records (of size $(N))
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))
+    "badblock_count":$(N),
+        "offset":$(N),
+        "length":$(N),
+Poolset structure:
+Number of replicas       : 2
+Replica 0 (master) - local, 1 part(s):
+part 0:
+path                     : /dev/dax$(N).0
+type                     : device dax
+size                     : $(N)
+alignment                : 4096
+bad blocks:
+	offset		length
+	1000		$(N)
+Replica 1 - local, 1 part(s):
+part 0:
+path                     : $(nW)/testfile1
+type                     : regular file
+size                     : 10485760
+
+POOL Header:
+Signature                : PMEMOBJ
+Major                    : $(nW)
+Mandatory features       : $(*)
+Not mandatory features   : $(*)
+Forced RO                : 0x0
+Pool set UUID            : $(nW)
+UUID                     : $(nW)
+Previous part UUID       : $(nW)
+Next part UUID           : $(nW)
+Previous replica UUID    : $(nW)
+Next replica UUID        : $(nW)
+Creation Time            : $(*)
+Alignment Descriptor     : $(nW)
+Class                    : $(nW)
+Data                     : $(*)
+Machine                  : $(*)
+Last shutdown            : clean
+Checksum                 : $(*)
+
+PMEM OBJ Header:
+Layout                   : pmempool$(*)
+Lanes offset             : $(nW)
+Number of lanes          : $(nW)
+Heap offset              : $(nW)
+Heap size                : $(nW)
+Checksum                 : $(*)
+Root offset              : $(nW)
+    "badblock_count":$(N),
+        "offset":$(N),
+        "length":$(N),
+$(nW)/testset1: synchronized
+No bad blocks found
+replica 0: checking shutdown state
+replica 0: shutdown state correct
+replica 1: checking shutdown state
+replica 1: shutdown state correct
+replica 0 part 0: checking pool header
+replica 0 part 0: pool header correct
+replica 1 part 0: checking pool header
+replica 1 part 0: pool header correct
+$(nW)/testset1: consistent
+No bad blocks found
+Poolset structure:
+Number of replicas       : 2
+Replica 0 (master) - local, 1 part(s):
+part 0:
+path                     : /dev/dax$(N).0
+type                     : device dax
+size                     : $(N)
+alignment                : 4096
+Replica 1 - local, 1 part(s):
+part 0:
+path                     : $(nW)/testfile1
+type                     : regular file
+size                     : 10485760
+
+POOL Header:
+Signature                : PMEMOBJ
+Major                    : $(nW)
+Mandatory features       : $(*)
+Not mandatory features   : $(*)
+Forced RO                : 0x0
+Pool set UUID            : $(nW)
+UUID                     : $(nW)
+Previous part UUID       : $(nW)
+Next part UUID           : $(nW)
+Previous replica UUID    : $(nW)
+Next replica UUID        : $(nW)
+Creation Time            : $(*)
+Alignment Descriptor     : $(nW)
+Class                    : $(nW)
+Data                     : $(*)
+Machine                  : $(*)
+Last shutdown            : clean
+Checksum                 : $(*)
+
+PMEM OBJ Header:
+Layout                   : pmempool$(*)
+Lanes offset             : $(nW)
+Number of lanes          : $(nW)
+Heap offset              : $(nW)
+Heap size                : $(nW)
+Checksum                 : $(*)
+Root offset              : $(nW)
+No bad blocks found
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))

--- a/src/test/pmempool_sync/out32.log.match
+++ b/src/test/pmempool_sync/out32.log.match
@@ -1,0 +1,6 @@
+create($(nW)/testset1): allocating records in the pool ...
+create($(nW)/testset1): allocated $(N) records (of size $(N))
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))
+pmemobj_open: $(nW)/testset1: Invalid argument
+$(nW)/testset1: synchronized
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))

--- a/src/test/pmempool_sync/out33.log.match
+++ b/src/test/pmempool_sync/out33.log.match
@@ -1,0 +1,6 @@
+create($(nW)/testset1): allocating records in the pool ...
+create($(nW)/testset1): allocated $(N) records (of size $(N))
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))
+pmemobj_open: $(nW)/testset1: Invalid argument
+$(nW)/testset1: synchronized
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))

--- a/src/test/pmempool_sync/out34.log.match
+++ b/src/test/pmempool_sync/out34.log.match
@@ -1,0 +1,11 @@
+create($(nW)/testset1): allocating records in the pool ...
+create($(nW)/testset1): allocated $(N) records (of size $(N))
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))
+verify($(nW)/testset1): incorrect record: OBJ_VERIFY$(N) (#$(N))
+verify($(nW)/testset1): incorrect number of records (is: $(N), should be: $(N))
+verify($(nW)/testset1): pool file contains error
+verify($(nW)/testset1): incorrect record: OBJ_VERIFY$(N) (#$(N))
+verify($(nW)/testset1): incorrect number of records (is: $(N), should be: $(N))
+verify($(nW)/testset1): pool file contains error
+$(nW)/testset1: synchronized
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))

--- a/src/test/pmempool_sync/out35.log.match
+++ b/src/test/pmempool_sync/out35.log.match
@@ -1,0 +1,11 @@
+create($(nW)/testset1): allocating records in the pool ...
+create($(nW)/testset1): allocated $(N) records (of size $(N))
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))
+verify($(nW)/testset1): incorrect record: OBJ_VERIFY$(N) (#$(N))
+verify($(nW)/testset1): incorrect number of records (is: $(N), should be: $(N))
+verify($(nW)/testset1): pool file contains error
+verify($(nW)/testset1): incorrect record: OBJ_VERIFY$(N) (#$(N))
+verify($(nW)/testset1): incorrect number of records (is: $(N), should be: $(N))
+verify($(nW)/testset1): pool file contains error
+$(nW)/testset1: synchronized
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))

--- a/src/test/pmempool_sync/out36.log.match
+++ b/src/test/pmempool_sync/out36.log.match
@@ -1,0 +1,13 @@
+create($(nW)/testset1): allocating records in the pool ...
+create($(nW)/testset1): allocated $(N) records (of size $(N))
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))
+verify($(nW)/testset1): incorrect record: OBJ_VERIFY$(N) (#$(N))
+verify($(nW)/testset1): incorrect number of records (is: $(N), should be: $(N))
+verify($(nW)/testset1): pool file contains error
+verify($(nW)/testset1): incorrect record: OBJ_VERIFY$(N) (#$(N))
+verify($(nW)/testset1): incorrect number of records (is: $(N), should be: $(N))
+verify($(nW)/testset1): pool file contains error
+$(nW)/testset1: synchronized
+verify($(nW)/testset1): incorrect record: OBJ_VERIFY$(N) (#$(N))
+verify($(nW)/testset1): incorrect number of records (is: $(N), should be: $(N))
+verify($(nW)/testset1): pool file contains error

--- a/src/test/pmempool_sync/out37.log.match
+++ b/src/test/pmempool_sync/out37.log.match
@@ -1,0 +1,13 @@
+create($(nW)/testset1): allocating records in the pool ...
+create($(nW)/testset1): allocated $(N) records (of size $(N))
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))
+verify($(nW)/testset1): incorrect record: OBJ_VERIFY$(N) (#$(N))
+verify($(nW)/testset1): incorrect number of records (is: $(N), should be: $(N))
+verify($(nW)/testset1): pool file contains error
+verify($(nW)/testset1): incorrect record: OBJ_VERIFY$(N) (#$(N))
+verify($(nW)/testset1): incorrect number of records (is: $(N), should be: $(N))
+verify($(nW)/testset1): pool file contains error
+$(nW)/testset1: synchronized
+verify($(nW)/testset1): incorrect record: OBJ_VERIFY$(N) (#$(N))
+verify($(nW)/testset1): incorrect number of records (is: $(N), should be: $(N))
+verify($(nW)/testset1): pool file contains error

--- a/src/test/pmempool_sync/out38.log.match
+++ b/src/test/pmempool_sync/out38.log.match
@@ -1,0 +1,128 @@
+create($(nW)/testset1): allocating records in the pool ...
+create($(nW)/testset1): allocated $(N) records (of size $(N))
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))
+    "badblock_count":$(N),
+        "offset":$(N),
+        "length":$(N),
+Poolset structure:
+Number of replicas       : 2
+Replica 0 (master) - local, 3 part(s):
+part 0:
+path                     : $(nW)/mnt-pmem/testfile0
+type                     : regular file
+size                     : 10485760
+bad blocks:
+	offset		length
+	8000		$(N)
+part 1:
+path                     : $(nW)/testfile1
+type                     : regular file
+size                     : 10485760
+part 2:
+path                     : $(nW)/testfile2
+type                     : regular file
+size                     : 10485760
+Replica 1 - local, 1 part(s):
+part 0:
+path                     : $(nW)/testfile3
+type                     : regular file
+size                     : 31457280
+
+POOL Header:
+Signature                : PMEMOBJ
+Major                    : $(nW)
+Mandatory features       : $(*)
+Not mandatory features   : $(*)
+Forced RO                : 0x0
+Pool set UUID            : $(nW)
+UUID                     : $(nW)
+Previous part UUID       : $(nW)
+Next part UUID           : $(nW)
+Previous replica UUID    : $(nW)
+Next replica UUID        : $(nW)
+Creation Time            : $(*)
+Alignment Descriptor     : $(nW)
+Class                    : $(nW)
+Data                     : $(*)
+Machine                  : $(*)
+Last shutdown            : clean
+Checksum                 : $(*)
+
+PMEM OBJ Header:
+Layout                   : pmempool$(*)
+Lanes offset             : $(nW)
+Number of lanes          : $(nW)
+Heap offset              : $(nW)
+Heap size                : $(nW)
+Checksum                 : $(*)
+Root offset              : $(nW)
+    "badblock_count":$(N),
+        "offset":$(N),
+        "length":$(N),
+verify($(nW)/testset1): incorrect record: OBJ_VERIFY$(N) (#$(N))
+verify($(nW)/testset1): incorrect number of records (is: $(N), should be: $(N))
+verify($(nW)/testset1): pool file contains error
+$(nW)/testset1: synchronized
+replica 0: checking shutdown state
+replica 0: shutdown state correct
+replica 1: checking shutdown state
+replica 1: shutdown state correct
+replica 0 part 0: checking pool header
+replica 0 part 0: pool header correct
+replica 0 part 1: checking pool header
+replica 0 part 1: pool header correct
+replica 0 part 2: checking pool header
+replica 0 part 2: pool header correct
+replica 1 part 0: checking pool header
+replica 1 part 0: pool header correct
+$(nW)/testset1: consistent
+Poolset structure:
+Number of replicas       : 2
+Replica 0 (master) - local, 3 part(s):
+part 0:
+path                     : $(nW)/mnt-pmem/testfile0
+type                     : regular file
+size                     : 10485760
+part 1:
+path                     : $(nW)/testfile1
+type                     : regular file
+size                     : 10485760
+part 2:
+path                     : $(nW)/testfile2
+type                     : regular file
+size                     : 10485760
+Replica 1 - local, 1 part(s):
+part 0:
+path                     : $(nW)/testfile3
+type                     : regular file
+size                     : 31457280
+
+POOL Header:
+Signature                : PMEMOBJ
+Major                    : $(nW)
+Mandatory features       : $(*)
+Not mandatory features   : $(*)
+Forced RO                : 0x0
+Pool set UUID            : $(nW)
+UUID                     : $(nW)
+Previous part UUID       : $(nW)
+Next part UUID           : $(nW)
+Previous replica UUID    : $(nW)
+Next replica UUID        : $(nW)
+Creation Time            : $(*)
+Alignment Descriptor     : $(nW)
+Class                    : $(nW)
+Data                     : $(*)
+Machine                  : $(*)
+Last shutdown            : clean
+Checksum                 : $(*)
+
+PMEM OBJ Header:
+Layout                   : pmempool$(*)
+Lanes offset             : $(nW)
+Number of lanes          : $(nW)
+Heap offset              : $(nW)
+Heap size                : $(nW)
+Checksum                 : $(*)
+Root offset              : $(nW)
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))

--- a/src/test/pmempool_sync/out39.log.match
+++ b/src/test/pmempool_sync/out39.log.match
@@ -1,0 +1,128 @@
+create($(nW)/testset1): allocating records in the pool ...
+create($(nW)/testset1): allocated $(N) records (of size $(N))
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))
+    "badblock_count":$(N),
+        "offset":$(N),
+        "length":$(N),
+Poolset structure:
+Number of replicas       : 2
+Replica 0 (master) - local, 3 part(s):
+part 0:
+path                     : $(nW)/testfile0
+type                     : regular file
+size                     : 10485760
+part 1:
+path                     : $(nW)/mnt-pmem/testfile1
+type                     : regular file
+size                     : 10485760
+bad blocks:
+	offset		length
+	1000		$(N)
+part 2:
+path                     : $(nW)/testfile2
+type                     : regular file
+size                     : 10485760
+Replica 1 - local, 1 part(s):
+part 0:
+path                     : $(nW)/testfile3
+type                     : regular file
+size                     : 31457280
+
+POOL Header:
+Signature                : PMEMOBJ
+Major                    : $(nW)
+Mandatory features       : $(*)
+Not mandatory features   : $(*)
+Forced RO                : 0x0
+Pool set UUID            : $(nW)
+UUID                     : $(nW)
+Previous part UUID       : $(nW)
+Next part UUID           : $(nW)
+Previous replica UUID    : $(nW)
+Next replica UUID        : $(nW)
+Creation Time            : $(*)
+Alignment Descriptor     : $(nW)
+Class                    : $(nW)
+Data                     : $(*)
+Machine                  : $(*)
+Last shutdown            : clean
+Checksum                 : $(*)
+
+PMEM OBJ Header:
+Layout                   : pmempool$(*)
+Lanes offset             : $(nW)
+Number of lanes          : $(nW)
+Heap offset              : $(nW)
+Heap size                : $(nW)
+Checksum                 : $(*)
+Root offset              : $(nW)
+    "badblock_count":$(N),
+        "offset":$(N),
+        "length":$(N),
+verify($(nW)/testset1): incorrect record: OBJ_VERIFY$(N) (#$(N))
+verify($(nW)/testset1): incorrect number of records (is: $(N), should be: $(N))
+verify($(nW)/testset1): pool file contains error
+$(nW)/testset1: synchronized
+replica 0: checking shutdown state
+replica 0: shutdown state correct
+replica 1: checking shutdown state
+replica 1: shutdown state correct
+replica 0 part 0: checking pool header
+replica 0 part 0: pool header correct
+replica 0 part 1: checking pool header
+replica 0 part 1: pool header correct
+replica 0 part 2: checking pool header
+replica 0 part 2: pool header correct
+replica 1 part 0: checking pool header
+replica 1 part 0: pool header correct
+$(nW)/testset1: consistent
+Poolset structure:
+Number of replicas       : 2
+Replica 0 (master) - local, 3 part(s):
+part 0:
+path                     : $(nW)/testfile0
+type                     : regular file
+size                     : 10485760
+part 1:
+path                     : $(nW)/mnt-pmem/testfile1
+type                     : regular file
+size                     : 10485760
+part 2:
+path                     : $(nW)/testfile2
+type                     : regular file
+size                     : 10485760
+Replica 1 - local, 1 part(s):
+part 0:
+path                     : $(nW)/testfile3
+type                     : regular file
+size                     : 31457280
+
+POOL Header:
+Signature                : PMEMOBJ
+Major                    : $(nW)
+Mandatory features       : $(*)
+Not mandatory features   : $(*)
+Forced RO                : 0x0
+Pool set UUID            : $(nW)
+UUID                     : $(nW)
+Previous part UUID       : $(nW)
+Next part UUID           : $(nW)
+Previous replica UUID    : $(nW)
+Next replica UUID        : $(nW)
+Creation Time            : $(*)
+Alignment Descriptor     : $(nW)
+Class                    : $(nW)
+Data                     : $(*)
+Machine                  : $(*)
+Last shutdown            : clean
+Checksum                 : $(*)
+
+PMEM OBJ Header:
+Layout                   : pmempool$(*)
+Lanes offset             : $(nW)
+Number of lanes          : $(nW)
+Heap offset              : $(nW)
+Heap size                : $(nW)
+Checksum                 : $(*)
+Root offset              : $(nW)
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))

--- a/src/test/pmempool_sync/out40.log.match
+++ b/src/test/pmempool_sync/out40.log.match
@@ -1,0 +1,126 @@
+create($(nW)/testset1): allocating records in the pool ...
+create($(nW)/testset1): allocated $(N) records (of size $(N))
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))
+    "badblock_count":$(N),
+        "offset":$(N),
+        "length":$(N),
+Poolset structure:
+Number of replicas       : 2
+Replica 0 (master) - local, 3 part(s):
+part 0:
+path                     : $(nW)/mnt-pmem/testfile0
+type                     : regular file
+size                     : 10485760
+bad blocks:
+	offset		length
+	1000		$(N)
+part 1:
+path                     : $(nW)/testfile1
+type                     : regular file
+size                     : 10485760
+part 2:
+path                     : $(nW)/testfile2
+type                     : regular file
+size                     : 10485760
+Replica 1 - local, 1 part(s):
+part 0:
+path                     : $(nW)/testfile3
+type                     : regular file
+size                     : 31457280
+
+POOL Header:
+Signature                : PMEMOBJ
+Major                    : $(nW)
+Mandatory features       : $(*)
+Not mandatory features   : $(*)
+Forced RO                : 0x0
+Pool set UUID            : $(nW)
+UUID                     : $(nW)
+Previous part UUID       : $(nW)
+Next part UUID           : $(nW)
+Previous replica UUID    : $(nW)
+Next replica UUID        : $(nW)
+Creation Time            : $(*)
+Alignment Descriptor     : $(nW)
+Class                    : $(nW)
+Data                     : $(*)
+Machine                  : $(*)
+Last shutdown            : clean
+Checksum                 : $(*)
+
+PMEM OBJ Header:
+Layout                   : pmempool$(*)
+Lanes offset             : $(nW)
+Number of lanes          : $(nW)
+Heap offset              : $(nW)
+Heap size                : $(nW)
+Checksum                 : $(*)
+Root offset              : $(nW)
+    "badblock_count":$(N),
+        "offset":$(N),
+        "length":$(N),
+pmemobj_open: $(nW)/testset1: Input/output error
+$(nW)/testset1: synchronized
+replica 0: checking shutdown state
+replica 0: shutdown state correct
+replica 1: checking shutdown state
+replica 1: shutdown state correct
+replica 0 part 0: checking pool header
+replica 0 part 0: pool header correct
+replica 0 part 1: checking pool header
+replica 0 part 1: pool header correct
+replica 0 part 2: checking pool header
+replica 0 part 2: pool header correct
+replica 1 part 0: checking pool header
+replica 1 part 0: pool header correct
+$(nW)/testset1: consistent
+Poolset structure:
+Number of replicas       : 2
+Replica 0 (master) - local, 3 part(s):
+part 0:
+path                     : $(nW)/mnt-pmem/testfile0
+type                     : regular file
+size                     : 10485760
+part 1:
+path                     : $(nW)/testfile1
+type                     : regular file
+size                     : 10485760
+part 2:
+path                     : $(nW)/testfile2
+type                     : regular file
+size                     : 10485760
+Replica 1 - local, 1 part(s):
+part 0:
+path                     : $(nW)/testfile3
+type                     : regular file
+size                     : 31457280
+
+POOL Header:
+Signature                : PMEMOBJ
+Major                    : $(nW)
+Mandatory features       : $(*)
+Not mandatory features   : $(*)
+Forced RO                : 0x0
+Pool set UUID            : $(nW)
+UUID                     : $(nW)
+Previous part UUID       : $(nW)
+Next part UUID           : $(nW)
+Previous replica UUID    : $(nW)
+Next replica UUID        : $(nW)
+Creation Time            : $(*)
+Alignment Descriptor     : $(nW)
+Class                    : $(nW)
+Data                     : $(*)
+Machine                  : $(*)
+Last shutdown            : clean
+Checksum                 : $(*)
+
+PMEM OBJ Header:
+Layout                   : pmempool$(*)
+Lanes offset             : $(nW)
+Number of lanes          : $(nW)
+Heap offset              : $(nW)
+Heap size                : $(nW)
+Checksum                 : $(*)
+Root offset              : $(nW)
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))

--- a/src/test/pmempool_sync/out41.log.match
+++ b/src/test/pmempool_sync/out41.log.match
@@ -1,0 +1,126 @@
+create($(nW)/testset1): allocating records in the pool ...
+create($(nW)/testset1): allocated $(N) records (of size $(N))
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))
+    "badblock_count":$(N),
+        "offset":$(N),
+        "length":$(N),
+Poolset structure:
+Number of replicas       : 2
+Replica 0 (master) - local, 3 part(s):
+part 0:
+path                     : $(nW)/testfile0
+type                     : regular file
+size                     : 10485760
+part 1:
+path                     : $(nW)/mnt-pmem/testfile1
+type                     : regular file
+size                     : 10485760
+bad blocks:
+	offset		length
+	1000		$(N)
+part 2:
+path                     : $(nW)/testfile2
+type                     : regular file
+size                     : 10485760
+Replica 1 - local, 1 part(s):
+part 0:
+path                     : $(nW)/testfile3
+type                     : regular file
+size                     : 31457280
+
+POOL Header:
+Signature                : PMEMOBJ
+Major                    : $(nW)
+Mandatory features       : $(*)
+Not mandatory features   : $(*)
+Forced RO                : 0x0
+Pool set UUID            : $(nW)
+UUID                     : $(nW)
+Previous part UUID       : $(nW)
+Next part UUID           : $(nW)
+Previous replica UUID    : $(nW)
+Next replica UUID        : $(nW)
+Creation Time            : $(*)
+Alignment Descriptor     : $(nW)
+Class                    : $(nW)
+Data                     : $(*)
+Machine                  : $(*)
+Last shutdown            : clean
+Checksum                 : $(*)
+
+PMEM OBJ Header:
+Layout                   : pmempool$(*)
+Lanes offset             : $(nW)
+Number of lanes          : $(nW)
+Heap offset              : $(nW)
+Heap size                : $(nW)
+Checksum                 : $(*)
+Root offset              : $(nW)
+    "badblock_count":$(N),
+        "offset":$(N),
+        "length":$(N),
+pmemobj_open: $(nW)/testset1: Input/output error
+$(nW)/testset1: synchronized
+replica 0: checking shutdown state
+replica 0: shutdown state correct
+replica 1: checking shutdown state
+replica 1: shutdown state correct
+replica 0 part 0: checking pool header
+replica 0 part 0: pool header correct
+replica 0 part 1: checking pool header
+replica 0 part 1: pool header correct
+replica 0 part 2: checking pool header
+replica 0 part 2: pool header correct
+replica 1 part 0: checking pool header
+replica 1 part 0: pool header correct
+$(nW)/testset1: consistent
+Poolset structure:
+Number of replicas       : 2
+Replica 0 (master) - local, 3 part(s):
+part 0:
+path                     : $(nW)/testfile0
+type                     : regular file
+size                     : 10485760
+part 1:
+path                     : $(nW)/mnt-pmem/testfile1
+type                     : regular file
+size                     : 10485760
+part 2:
+path                     : $(nW)/testfile2
+type                     : regular file
+size                     : 10485760
+Replica 1 - local, 1 part(s):
+part 0:
+path                     : $(nW)/testfile3
+type                     : regular file
+size                     : 31457280
+
+POOL Header:
+Signature                : PMEMOBJ
+Major                    : $(nW)
+Mandatory features       : $(*)
+Not mandatory features   : $(*)
+Forced RO                : 0x0
+Pool set UUID            : $(nW)
+UUID                     : $(nW)
+Previous part UUID       : $(nW)
+Next part UUID           : $(nW)
+Previous replica UUID    : $(nW)
+Next replica UUID        : $(nW)
+Creation Time            : $(*)
+Alignment Descriptor     : $(nW)
+Class                    : $(nW)
+Data                     : $(*)
+Machine                  : $(*)
+Last shutdown            : clean
+Checksum                 : $(*)
+
+PMEM OBJ Header:
+Layout                   : pmempool$(*)
+Lanes offset             : $(nW)
+Number of lanes          : $(nW)
+Heap offset              : $(nW)
+Heap size                : $(nW)
+Checksum                 : $(*)
+Root offset              : $(nW)
+verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))

--- a/src/test/pmempool_sync/trip_on_os_fsync.gdb
+++ b/src/test/pmempool_sync/trip_on_os_fsync.gdb
@@ -1,0 +1,9 @@
+set width 0
+set height 0
+set verbose off
+set confirm off
+set breakpoint pending on
+
+b os_fsync
+run
+quit

--- a/src/test/pmempool_sync/trip_on_recreate_broken_parts.gdb
+++ b/src/test/pmempool_sync/trip_on_recreate_broken_parts.gdb
@@ -1,0 +1,9 @@
+set width 0
+set height 0
+set verbose off
+set confirm off
+set breakpoint pending on
+
+b recreate_broken_parts
+run
+quit

--- a/src/test/pmempool_sync_remote/TEST22
+++ b/src/test/pmempool_sync_remote/TEST22
@@ -45,6 +45,7 @@ require_fs_type any
 require_build_type debug nondebug
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
+require_nfit_tests_enabled
 require_nodes 2
 require_sudo_allowed_node 0
 require_kernel_module_node 0 nfit_test

--- a/src/test/pmempool_sync_remote/TEST22
+++ b/src/test/pmempool_sync_remote/TEST22
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync_remote/TEST22 -- pmempool sync with remote replication
+#                                and bad blocks in the regular file:
+#                                - the pool consists of 1 part
+#                                - bad blocks: 0-511
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+
+require_nodes 2
+require_sudo_allowed_node 0
+require_kernel_module_node 0 nfit_test
+require_command_node 0 ndctl
+
+setup
+
+require_node_libfabric 0 $RPMEM_PROVIDER
+require_node_libfabric 1 $RPMEM_PROVIDER
+
+init_rpmem_on_node 0 1
+
+require_node_log_files 0 pmemobj$UNITTEST_NUM.log
+require_node_log_files 0 pmempool$UNITTEST_NUM.log
+
+. ../common_badblock.sh
+
+ndctl_nfit_test_init_node 0
+
+DEVICE=$(ndctl_nfit_test_get_block_device_node 0)
+NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device_node 0 $DEVICE)
+FULLDEV="/dev/$DEVICE"
+MOUNT_DIR="$DIR/mnt-pmem"
+LAYOUT="layout"
+
+ndctl_nfit_test_mount_pmem_node 0 $FULLDEV $MOUNT_DIR
+
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET_LOCAL="local_pool.set"
+POOLSET_REMOTE="remote_pool.set"
+
+create_poolset $DIR/$POOLSET_LOCAL \
+	8M:${MOUNT_DIR}/pool.local:z \
+	M \
+	${NODE_ADDR[1]}:$POOLSET_REMOTE
+
+create_poolset $DIR/$POOLSET_REMOTE \
+	8M:${NODE_DIR[1]}/pool.remote:z
+
+copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
+copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE
+
+expect_normal_exit run_on_node 0 ../pmempool rm -sf ${NODE_DIR[0]}$POOLSET_LOCAL
+expect_normal_exit run_on_node 0 ../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT c v &>> $LOG
+
+# inject bad block:
+FILE=${MOUNT_DIR}/pool.local
+FIRST_SECTOR=$(expect_normal_exit run_on_node 0 ../extents $FILE -l 0)
+
+expect_normal_exit run_on_node 0 sudo ndctl inject-error --block=$FIRST_SECTOR --count=512 $NAMESPACE &>> $PREP_LOG_FILE
+
+expect_bad_blocks_node 0
+
+expect_abnormal_exit run_on_node 0 ../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG
+expect_abnormal_exit run_on_node 0 ../pmempool sync -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG
+expect_normal_exit run_on_node 0 ../pmempool sync -b -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG
+expect_normal_exit run_on_node 0 ../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG
+
+ndctl_nfit_test_fini_node 0 $MOUNT_DIR
+
+pass

--- a/src/test/pmempool_sync_remote/TEST23
+++ b/src/test/pmempool_sync_remote/TEST23
@@ -45,6 +45,7 @@ require_fs_type any
 require_build_type debug nondebug
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
+require_nfit_tests_enabled
 require_nodes 2
 require_sudo_allowed_node 0
 require_kernel_module_node 0 nfit_test

--- a/src/test/pmempool_sync_remote/TEST23
+++ b/src/test/pmempool_sync_remote/TEST23
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync_remote/TEST23 -- pmempool sync with remote replication
+#                                and bad blocks in the regular file:
+#                                - the pool consists of 1 part
+#                                - bad blocks: 1000-1511
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+
+require_nodes 2
+require_sudo_allowed_node 0
+require_kernel_module_node 0 nfit_test
+require_command_node 0 ndctl
+
+setup
+
+require_node_libfabric 0 $RPMEM_PROVIDER
+require_node_libfabric 1 $RPMEM_PROVIDER
+
+init_rpmem_on_node 0 1
+
+require_node_log_files 0 pmemobj$UNITTEST_NUM.log
+require_node_log_files 0 pmempool$UNITTEST_NUM.log
+
+. ../common_badblock.sh
+
+ndctl_nfit_test_init_node 0
+
+DEVICE=$(ndctl_nfit_test_get_block_device_node 0)
+NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device_node 0 $DEVICE)
+FULLDEV="/dev/$DEVICE"
+MOUNT_DIR="$DIR/mnt-pmem"
+LAYOUT="layout"
+
+ndctl_nfit_test_mount_pmem_node 0 $FULLDEV $MOUNT_DIR
+
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET_LOCAL="local_pool.set"
+POOLSET_REMOTE="remote_pool.set"
+
+create_poolset $DIR/$POOLSET_LOCAL \
+	8M:${MOUNT_DIR}/pool.local:z \
+	M \
+	${NODE_ADDR[1]}:$POOLSET_REMOTE
+
+create_poolset $DIR/$POOLSET_REMOTE \
+	8M:${NODE_DIR[1]}/pool.remote:z
+
+copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
+copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE
+
+expect_normal_exit run_on_node 0 ../pmempool rm -sf ${NODE_DIR[0]}$POOLSET_LOCAL
+expect_normal_exit run_on_node 0 ../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT c v &>> $LOG
+
+# inject bad block:
+FILE=${MOUNT_DIR}/pool.local
+FIRST_SECTOR=$(expect_normal_exit run_on_node 0 ../extents $FILE -l 1000)
+
+expect_normal_exit run_on_node 0 sudo ndctl inject-error --block=$FIRST_SECTOR --count=512 $NAMESPACE &>> $PREP_LOG_FILE
+
+expect_bad_blocks_node 0
+
+expect_abnormal_exit run_on_node 0 ../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG
+expect_abnormal_exit run_on_node 0 ../pmempool sync -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG
+expect_normal_exit run_on_node 0 ../pmempool sync -b -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG
+expect_normal_exit run_on_node 0 ../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG
+
+ndctl_nfit_test_fini_node 0 $MOUNT_DIR
+
+pass

--- a/src/test/pmempool_sync_remote/TEST24
+++ b/src/test/pmempool_sync_remote/TEST24
@@ -45,6 +45,7 @@ require_fs_type any
 require_build_type debug nondebug
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
+require_nfit_tests_enabled
 require_nodes 2
 require_sudo_allowed_node 0
 require_kernel_module_node 0 nfit_test

--- a/src/test/pmempool_sync_remote/TEST24
+++ b/src/test/pmempool_sync_remote/TEST24
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync_remote/TEST24 -- pmempool sync with remote replication
+#                                and bad blocks in the regular file:
+#                                - the pool consists of 3 parts
+#                                - bad blocks in the 2nd part: 0-511
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+
+require_nodes 2
+require_sudo_allowed_node 0
+require_kernel_module_node 0 nfit_test
+require_command_node 0 ndctl
+
+setup
+
+require_node_libfabric 0 $RPMEM_PROVIDER
+require_node_libfabric 1 $RPMEM_PROVIDER
+
+init_rpmem_on_node 0 1
+
+require_node_log_files 0 pmemobj$UNITTEST_NUM.log
+require_node_log_files 0 pmempool$UNITTEST_NUM.log
+
+. ../common_badblock.sh
+
+ndctl_nfit_test_init_node 0
+
+DEVICE=$(ndctl_nfit_test_get_block_device_node 0)
+NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device_node 0 $DEVICE)
+FULLDEV="/dev/$DEVICE"
+MOUNT_DIR="$DIR/mnt-pmem"
+LAYOUT="layout"
+
+ndctl_nfit_test_mount_pmem_node 0 $FULLDEV $MOUNT_DIR
+
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET_LOCAL="local_pool.set"
+POOLSET_REMOTE="remote_pool.set"
+
+create_poolset $DIR/$POOLSET_LOCAL \
+	8M:${NODE_DIR[0]}/pool.local.part.0:z \
+	8M:${MOUNT_DIR}/pool.local.part.1:z \
+	8M:${NODE_DIR[0]}/pool.local.part.2:z \
+	M \
+	${NODE_ADDR[1]}:$POOLSET_REMOTE
+
+create_poolset $DIR/$POOLSET_REMOTE \
+	24M:${NODE_DIR[1]}/pool.remote:z
+
+copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
+copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE
+
+expect_normal_exit run_on_node 0 ../pmempool rm -sf ${NODE_DIR[0]}$POOLSET_LOCAL
+expect_normal_exit run_on_node 0 ../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT c v &>> $LOG
+
+# inject bad block:
+FILE=${MOUNT_DIR}/pool.local.part.1
+FIRST_SECTOR=$(expect_normal_exit run_on_node 0 ../extents $FILE -l 0)
+
+expect_normal_exit run_on_node 0 sudo ndctl inject-error --block=$FIRST_SECTOR --count=512 $NAMESPACE &>> $PREP_LOG_FILE
+
+expect_bad_blocks_node 0
+
+expect_abnormal_exit run_on_node 0 ../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG
+expect_abnormal_exit run_on_node 0 ../pmempool sync -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG
+expect_normal_exit run_on_node 0 ../pmempool sync -b -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG
+expect_normal_exit run_on_node 0 ../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG
+
+ndctl_nfit_test_fini_node 0 $MOUNT_DIR
+
+pass

--- a/src/test/pmempool_sync_remote/TEST25
+++ b/src/test/pmempool_sync_remote/TEST25
@@ -45,6 +45,7 @@ require_fs_type any
 require_build_type debug nondebug
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
+require_nfit_tests_enabled
 require_nodes 2
 require_sudo_allowed_node 0
 require_kernel_module_node 0 nfit_test

--- a/src/test/pmempool_sync_remote/TEST25
+++ b/src/test/pmempool_sync_remote/TEST25
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync_remote/TEST25 -- pmempool sync with remote replication
+#                                and bad blocks in the regular file:
+#                                - the pool consists of 3 parts
+#                                - bad blocks in the 2nd part: 1000-1511
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+
+require_nodes 2
+require_sudo_allowed_node 0
+require_kernel_module_node 0 nfit_test
+require_command_node 0 ndctl
+
+setup
+
+require_node_libfabric 0 $RPMEM_PROVIDER
+require_node_libfabric 1 $RPMEM_PROVIDER
+
+init_rpmem_on_node 0 1
+
+require_node_log_files 0 pmemobj$UNITTEST_NUM.log
+require_node_log_files 0 pmempool$UNITTEST_NUM.log
+
+. ../common_badblock.sh
+
+ndctl_nfit_test_init_node 0
+
+DEVICE=$(ndctl_nfit_test_get_block_device_node 0)
+NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device_node 0 $DEVICE)
+FULLDEV="/dev/$DEVICE"
+MOUNT_DIR="$DIR/mnt-pmem"
+LAYOUT="layout"
+
+ndctl_nfit_test_mount_pmem_node 0 $FULLDEV $MOUNT_DIR
+
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET_LOCAL="local_pool.set"
+POOLSET_REMOTE="remote_pool.set"
+
+create_poolset $DIR/$POOLSET_LOCAL \
+	8M:${NODE_DIR[0]}/pool.local.part.0:z \
+	8M:${MOUNT_DIR}/pool.local.part.1:z \
+	8M:${NODE_DIR[0]}/pool.local.part.2:z \
+	M \
+	${NODE_ADDR[1]}:$POOLSET_REMOTE
+
+create_poolset $DIR/$POOLSET_REMOTE \
+	24M:${NODE_DIR[1]}/pool.remote:z
+
+copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
+copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE
+
+expect_normal_exit run_on_node 0 ../pmempool rm -sf ${NODE_DIR[0]}$POOLSET_LOCAL
+expect_normal_exit run_on_node 0 ../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT c v &>> $LOG
+
+# inject bad block:
+FILE=${MOUNT_DIR}/pool.local.part.1
+FIRST_SECTOR=$(expect_normal_exit run_on_node 0 ../extents $FILE -l 1000)
+
+expect_normal_exit run_on_node 0 sudo ndctl inject-error --block=$FIRST_SECTOR --count=512 $NAMESPACE &>> $PREP_LOG_FILE
+
+expect_bad_blocks_node 0
+
+expect_abnormal_exit run_on_node 0 ../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG
+expect_abnormal_exit run_on_node 0 ../pmempool sync -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG
+expect_normal_exit run_on_node 0 ../pmempool sync -b -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG
+expect_normal_exit run_on_node 0 ../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG
+
+ndctl_nfit_test_fini_node 0 $MOUNT_DIR
+
+pass

--- a/src/test/pmempool_sync_remote/TEST26
+++ b/src/test/pmempool_sync_remote/TEST26
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync_remote/TEST26 -- pmempool sync with remote replication
+#                                and bad block recovery files:
+#                                - the pool consists of 1 part
+#                                - bad block: offset: 0 length: 8*512
+#                                (it is similar to TEST22)
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+
+require_nodes 2
+
+setup
+
+require_node_libfabric 0 $RPMEM_PROVIDER
+require_node_libfabric 1 $RPMEM_PROVIDER
+
+init_rpmem_on_node 0 1
+
+require_node_log_files 0 pmemobj$UNITTEST_NUM.log
+require_node_log_files 0 pmempool$UNITTEST_NUM.log
+
+LAYOUT="layout"
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET_LOCAL="local_pool.set"
+POOLSET_REMOTE="remote_pool.set"
+RECOVERY_FILE=$DIR/${POOLSET_LOCAL}_r0_p0_badblocks.txt
+
+create_poolset $DIR/$POOLSET_LOCAL \
+	10M:${NODE_DIR[0]}/pool.local:z \
+	M \
+	${NODE_ADDR[1]}:$POOLSET_REMOTE
+
+create_poolset $DIR/$POOLSET_REMOTE \
+	10M:${NODE_DIR[1]}/pool.remote:z
+
+# create the recovery file
+echo "0 $((8 * 512))" > $RECOVERY_FILE
+echo "0 0"  >> $RECOVERY_FILE
+
+copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
+copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE
+
+expect_normal_exit run_on_node 0 ../pmempool rm -sf ${NODE_DIR[0]}$POOLSET_LOCAL
+expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT c v &>> $LOG"
+
+# inject bad block:
+expect_normal_exit run_on_node 0 "dd if=/dev/zero of=${NODE_DIR[0]}/pool.local bs=512 seek=0 count=8 conv=notrunc status=none"
+
+# copy the recovery file
+copy_files_to_node 0 ${NODE_DIR[0]} $RECOVERY_FILE
+
+expect_abnormal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG"
+expect_abnormal_exit run_on_node 0 "../pmempool sync -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+expect_normal_exit run_on_node 0 "../pmempool sync -b -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG"
+
+pass

--- a/src/test/pmempool_sync_remote/TEST27
+++ b/src/test/pmempool_sync_remote/TEST27
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync_remote/TEST27 -- pmempool sync with remote replication
+#                                and bad block recovery files:
+#                                - the pool consists of 1 part
+#                                - bad block: offset: 8000*512 length: 8*512
+#                                (it is similar to TEST23)
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+
+require_nodes 2
+
+setup
+
+require_node_libfabric 0 $RPMEM_PROVIDER
+require_node_libfabric 1 $RPMEM_PROVIDER
+
+init_rpmem_on_node 0 1
+
+require_node_log_files 0 pmemobj$UNITTEST_NUM.log
+require_node_log_files 0 pmempool$UNITTEST_NUM.log
+
+LAYOUT="layout"
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET_LOCAL="local_pool.set"
+POOLSET_REMOTE="remote_pool.set"
+RECOVERY_FILE=$DIR/${POOLSET_LOCAL}_r0_p0_badblocks.txt
+
+create_poolset $DIR/$POOLSET_LOCAL \
+	10M:${NODE_DIR[0]}/pool.local:z \
+	M \
+	${NODE_ADDR[1]}:$POOLSET_REMOTE
+
+create_poolset $DIR/$POOLSET_REMOTE \
+	10M:${NODE_DIR[1]}/pool.remote:z
+
+# create the recovery file
+echo "$((8000 * 512)) $((8 * 512))" > $RECOVERY_FILE
+echo "0 0"  >> $RECOVERY_FILE
+
+copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
+copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE
+
+expect_normal_exit run_on_node 0 ../pmempool rm -sf ${NODE_DIR[0]}$POOLSET_LOCAL
+expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT c v &>> $LOG"
+
+# inject bad block:
+expect_normal_exit run_on_node 0 "dd if=/dev/zero of=${NODE_DIR[0]}/pool.local bs=512 seek=8000 count=8 conv=notrunc status=none"
+
+# copy the recovery file
+copy_files_to_node 0 ${NODE_DIR[0]} $RECOVERY_FILE
+
+expect_abnormal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG"
+expect_abnormal_exit run_on_node 0 "../pmempool sync -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+expect_normal_exit run_on_node 0 "../pmempool sync -b -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG"
+
+pass

--- a/src/test/pmempool_sync_remote/TEST28
+++ b/src/test/pmempool_sync_remote/TEST28
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync_remote/TEST28 -- pmempool sync with remote replication
+#                                and bad block recovery files:
+#                                - the pool consists of 3 parts
+#                                - bad block in the 2nd part: offset: 0 length: 8*512
+#                                (it is similar to TEST24)
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+
+require_nodes 2
+
+setup
+
+require_node_libfabric 0 $RPMEM_PROVIDER
+require_node_libfabric 1 $RPMEM_PROVIDER
+
+init_rpmem_on_node 0 1
+
+require_node_log_files 0 pmemobj$UNITTEST_NUM.log
+require_node_log_files 0 pmempool$UNITTEST_NUM.log
+
+LAYOUT="layout"
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET_LOCAL="local_pool.set"
+POOLSET_REMOTE="remote_pool.set"
+RECOVERY_FILE_P0=$DIR/${POOLSET_LOCAL}_r0_p0_badblocks.txt
+RECOVERY_FILE_P1=$DIR/${POOLSET_LOCAL}_r0_p1_badblocks.txt
+RECOVERY_FILE_P2=$DIR/${POOLSET_LOCAL}_r0_p2_badblocks.txt
+
+create_poolset $DIR/$POOLSET_LOCAL \
+	10M:${NODE_DIR[0]}/pool.local.part.0:z \
+	10M:${NODE_DIR[0]}/pool.local.part.1:z \
+	10M:${NODE_DIR[0]}/pool.local.part.2:z \
+	M \
+	${NODE_ADDR[1]}:$POOLSET_REMOTE
+
+create_poolset $DIR/$POOLSET_REMOTE \
+	30M:${NODE_DIR[1]}/pool.remote:z
+
+# create the recovery file with bad block
+echo "0 $((8 * 512))" > $RECOVERY_FILE_P1
+echo "0 0"  >> $RECOVERY_FILE_P1
+
+# create the empty recovery files
+echo "0 0" > $RECOVERY_FILE_P0
+echo "0 0" > $RECOVERY_FILE_P2
+
+copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
+copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE
+
+expect_normal_exit run_on_node 0 ../pmempool rm -sf ${NODE_DIR[0]}$POOLSET_LOCAL
+expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT c v &>> $LOG"
+
+# inject bad block:
+expect_normal_exit run_on_node 0 "dd if=/dev/zero of=${NODE_DIR[0]}/pool.local.part.1 bs=512 seek=0 count=8 conv=notrunc status=none"
+
+# copy the recovery files
+copy_files_to_node 0 ${NODE_DIR[0]} $RECOVERY_FILE_P0 $RECOVERY_FILE_P1 $RECOVERY_FILE_P2
+
+expect_abnormal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG"
+expect_abnormal_exit run_on_node 0 "../pmempool sync -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+expect_normal_exit run_on_node 0 "../pmempool sync -b -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG"
+
+pass

--- a/src/test/pmempool_sync_remote/TEST29
+++ b/src/test/pmempool_sync_remote/TEST29
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync_remote/TEST29 -- pmempool sync with remote replication
+#                                and bad block recovery files:
+#                                - the pool consists of 3 parts
+#                                - bad block in the 2nd part: offset: 8000*512 length: 8*512
+#                                (it is similar to TEST25)
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+
+require_nodes 2
+
+setup
+
+require_node_libfabric 0 $RPMEM_PROVIDER
+require_node_libfabric 1 $RPMEM_PROVIDER
+
+init_rpmem_on_node 0 1
+
+require_node_log_files 0 pmemobj$UNITTEST_NUM.log
+require_node_log_files 0 pmempool$UNITTEST_NUM.log
+
+LAYOUT="layout"
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET_LOCAL="local_pool.set"
+POOLSET_REMOTE="remote_pool.set"
+RECOVERY_FILE_P0=$DIR/${POOLSET_LOCAL}_r0_p0_badblocks.txt
+RECOVERY_FILE_P1=$DIR/${POOLSET_LOCAL}_r0_p1_badblocks.txt
+RECOVERY_FILE_P2=$DIR/${POOLSET_LOCAL}_r0_p2_badblocks.txt
+
+create_poolset $DIR/$POOLSET_LOCAL \
+	10M:${NODE_DIR[0]}/pool.local.part.0:z \
+	10M:${NODE_DIR[0]}/pool.local.part.1:z \
+	10M:${NODE_DIR[0]}/pool.local.part.2:z \
+	M \
+	${NODE_ADDR[1]}:$POOLSET_REMOTE
+
+create_poolset $DIR/$POOLSET_REMOTE \
+	30M:${NODE_DIR[1]}/pool.remote:z
+
+# create the recovery file with bad block
+echo "$((8000 * 512)) $((8 * 512))" > $RECOVERY_FILE_P1
+echo "0 0"  >> $RECOVERY_FILE_P1
+
+# create the empty recovery files
+echo "0 0" > $RECOVERY_FILE_P0
+echo "0 0" > $RECOVERY_FILE_P2
+
+copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
+copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE
+
+expect_normal_exit run_on_node 0 ../pmempool rm -sf ${NODE_DIR[0]}$POOLSET_LOCAL
+expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT c v &>> $LOG"
+
+# inject bad block:
+expect_normal_exit run_on_node 0 "dd if=/dev/zero of=${NODE_DIR[0]}/pool.local.part.1 bs=512 seek=8000 count=8 conv=notrunc status=none"
+
+# copy the recovery files
+copy_files_to_node 0 ${NODE_DIR[0]} $RECOVERY_FILE_P0 $RECOVERY_FILE_P1 $RECOVERY_FILE_P2
+
+expect_abnormal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG"
+expect_abnormal_exit run_on_node 0 "../pmempool sync -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+expect_normal_exit run_on_node 0 "../pmempool sync -b -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG"
+
+pass

--- a/src/test/pmempool_sync_remote/TEST30
+++ b/src/test/pmempool_sync_remote/TEST30
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync_remote/TEST30 -- pmempool sync with remote replication
+#                                and bad block recovery files:
+#                                - the pool consists of 3 parts
+#                                - bad block in all parts: offset: 0 length: 8*512
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+
+require_nodes 2
+
+setup
+
+require_node_libfabric 0 $RPMEM_PROVIDER
+require_node_libfabric 1 $RPMEM_PROVIDER
+
+init_rpmem_on_node 0 1
+
+require_node_log_files 0 pmemobj$UNITTEST_NUM.log
+require_node_log_files 0 pmempool$UNITTEST_NUM.log
+
+LAYOUT="layout"
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET_LOCAL="local_pool.set"
+POOLSET_REMOTE="remote_pool.set"
+RECOVERY_FILE_P0=$DIR/${POOLSET_LOCAL}_r0_p0_badblocks.txt
+RECOVERY_FILE_P1=$DIR/${POOLSET_LOCAL}_r0_p1_badblocks.txt
+RECOVERY_FILE_P2=$DIR/${POOLSET_LOCAL}_r0_p2_badblocks.txt
+
+create_poolset $DIR/$POOLSET_LOCAL \
+	10M:${NODE_DIR[0]}/pool.local.part.0:z \
+	10M:${NODE_DIR[0]}/pool.local.part.1:z \
+	10M:${NODE_DIR[0]}/pool.local.part.2:z \
+	M \
+	${NODE_ADDR[1]}:$POOLSET_REMOTE
+
+create_poolset $DIR/$POOLSET_REMOTE \
+	30M:${NODE_DIR[1]}/pool.remote:z
+
+# create the recovery files with bad block
+echo "0 $((8 * 512))" > $RECOVERY_FILE_P0
+echo "0 $((8 * 512))" > $RECOVERY_FILE_P1
+echo "0 $((8 * 512))" > $RECOVERY_FILE_P2
+echo "0 0"  >> $RECOVERY_FILE_P0
+echo "0 0"  >> $RECOVERY_FILE_P1
+echo "0 0"  >> $RECOVERY_FILE_P2
+
+copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
+copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE
+
+expect_normal_exit run_on_node 0 ../pmempool rm -sf ${NODE_DIR[0]}$POOLSET_LOCAL
+expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT c v &>> $LOG"
+
+# inject bad blocks
+expect_normal_exit run_on_node 0 "dd if=/dev/zero of=${NODE_DIR[0]}/pool.local.part.0 bs=512 seek=0 count=8 conv=notrunc status=none"
+expect_normal_exit run_on_node 0 "dd if=/dev/zero of=${NODE_DIR[0]}/pool.local.part.1 bs=512 seek=0 count=8 conv=notrunc status=none"
+expect_normal_exit run_on_node 0 "dd if=/dev/zero of=${NODE_DIR[0]}/pool.local.part.2 bs=512 seek=0 count=8 conv=notrunc status=none"
+
+# copy the recovery files
+copy_files_to_node 0 ${NODE_DIR[0]} $RECOVERY_FILE_P0 $RECOVERY_FILE_P1 $RECOVERY_FILE_P2
+
+expect_abnormal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG"
+expect_abnormal_exit run_on_node 0 "../pmempool sync -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+expect_normal_exit run_on_node 0 "../pmempool sync -b -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG"
+
+pass

--- a/src/test/pmempool_sync_remote/TEST31
+++ b/src/test/pmempool_sync_remote/TEST31
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync_remote/TEST31 -- pmempool sync with remote replication
+#                                and bad block recovery files:
+#                                - the pool consists of 3 parts
+#                                - bad block in all parts: offset: 8000*512 length: 8*512
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+
+require_nodes 2
+
+setup
+
+require_node_libfabric 0 $RPMEM_PROVIDER
+require_node_libfabric 1 $RPMEM_PROVIDER
+
+init_rpmem_on_node 0 1
+
+require_node_log_files 0 pmemobj$UNITTEST_NUM.log
+require_node_log_files 0 pmempool$UNITTEST_NUM.log
+
+LAYOUT="layout"
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET_LOCAL="local_pool.set"
+POOLSET_REMOTE="remote_pool.set"
+RECOVERY_FILE_P0=$DIR/${POOLSET_LOCAL}_r0_p0_badblocks.txt
+RECOVERY_FILE_P1=$DIR/${POOLSET_LOCAL}_r0_p1_badblocks.txt
+RECOVERY_FILE_P2=$DIR/${POOLSET_LOCAL}_r0_p2_badblocks.txt
+
+create_poolset $DIR/$POOLSET_LOCAL \
+	10M:${NODE_DIR[0]}/pool.local.part.0:z \
+	10M:${NODE_DIR[0]}/pool.local.part.1:z \
+	10M:${NODE_DIR[0]}/pool.local.part.2:z \
+	M \
+	${NODE_ADDR[1]}:$POOLSET_REMOTE
+
+create_poolset $DIR/$POOLSET_REMOTE \
+	30M:${NODE_DIR[1]}/pool.remote:z
+
+# create the recovery files with bad block
+echo "$((8000 * 512)) $((8 * 512))" > $RECOVERY_FILE_P0
+echo "$((8000 * 512)) $((8 * 512))" > $RECOVERY_FILE_P1
+echo "$((8000 * 512)) $((8 * 512))" > $RECOVERY_FILE_P2
+echo "0 0"  >> $RECOVERY_FILE_P0
+echo "0 0"  >> $RECOVERY_FILE_P1
+echo "0 0"  >> $RECOVERY_FILE_P2
+
+copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
+copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE
+
+expect_normal_exit run_on_node 0 ../pmempool rm -sf ${NODE_DIR[0]}$POOLSET_LOCAL
+expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT c v &>> $LOG"
+
+# inject bad blocks
+expect_normal_exit run_on_node 0 "dd if=/dev/zero of=${NODE_DIR[0]}/pool.local.part.0 bs=512 seek=8000 count=8 conv=notrunc status=none"
+expect_normal_exit run_on_node 0 "dd if=/dev/zero of=${NODE_DIR[0]}/pool.local.part.1 bs=512 seek=8000 count=8 conv=notrunc status=none"
+expect_normal_exit run_on_node 0 "dd if=/dev/zero of=${NODE_DIR[0]}/pool.local.part.2 bs=512 seek=8000 count=8 conv=notrunc status=none"
+
+# copy the recovery files
+copy_files_to_node 0 ${NODE_DIR[0]} $RECOVERY_FILE_P0 $RECOVERY_FILE_P1 $RECOVERY_FILE_P2
+
+expect_abnormal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG"
+expect_abnormal_exit run_on_node 0 "../pmempool sync -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+expect_normal_exit run_on_node 0 "../pmempool sync -b -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG"
+
+pass

--- a/src/test/pmempool_sync_remote/TEST32
+++ b/src/test/pmempool_sync_remote/TEST32
@@ -45,6 +45,7 @@ require_fs_type any
 require_build_type debug nondebug
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
+require_nfit_tests_enabled
 require_nodes 2
 require_sudo_allowed_node 0
 require_kernel_module_node 0 nfit_test

--- a/src/test/pmempool_sync_remote/TEST32
+++ b/src/test/pmempool_sync_remote/TEST32
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync_remote/TEST32 -- pmempool sync with remote replication
+#                                and bad blocks in the regular file:
+#                                - the pool consists of 2 parts
+#                                - offset of bad block in all 2 parts: 0
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+
+require_nodes 2
+require_sudo_allowed_node 0
+require_kernel_module_node 0 nfit_test
+require_command_node 0 ndctl
+
+setup
+
+require_node_libfabric 0 $RPMEM_PROVIDER
+require_node_libfabric 1 $RPMEM_PROVIDER
+
+init_rpmem_on_node 0 1
+
+export PMEMPOOL_LOG_LEVEL=10
+export PMEMOBJ_LOG_LEVEL=10
+export_vars_node 0 PMEMPOOL_LOG_LEVEL
+export_vars_node 0 PMEMOBJ_LOG_LEVEL
+
+require_node_log_files 0 pmemobj$UNITTEST_NUM.log
+require_node_log_files 0 pmempool$UNITTEST_NUM.log
+
+. ../common_badblock.sh
+
+ndctl_nfit_test_init_node 0
+
+DEVICE=$(ndctl_nfit_test_get_block_device_node 0)
+NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device_node 0 $DEVICE)
+FULLDEV="/dev/$DEVICE"
+MOUNT_DIR="$DIR/mnt-pmem"
+LAYOUT="layout"
+
+ndctl_nfit_test_mount_pmem_node 0 $FULLDEV $MOUNT_DIR
+
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET_LOCAL="local_pool.set"
+POOLSET_REMOTE="remote_pool.set"
+
+create_poolset $DIR/$POOLSET_LOCAL \
+	8M:${MOUNT_DIR}/pool.local.part.0:z \
+	8M:${MOUNT_DIR}/pool.local.part.1:z \
+	M \
+	${NODE_ADDR[1]}:$POOLSET_REMOTE
+
+create_poolset $DIR/$POOLSET_REMOTE \
+	24M:${NODE_DIR[1]}/pool.remote:z
+
+copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
+copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE
+
+expect_normal_exit run_on_node 0 ../pmempool rm -sf ${NODE_DIR[0]}$POOLSET_LOCAL
+expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT c v &>> $LOG"
+
+# inject bad block in the part #0
+FILE=${MOUNT_DIR}/pool.local.part.0
+FIRST_SECTOR=$(expect_normal_exit run_on_node 0 ../extents $FILE -l 0)
+expect_normal_exit run_on_node 0 "sudo ndctl inject-error --block=$FIRST_SECTOR --count=1 $NAMESPACE &>> $PREP_LOG_FILE"
+
+# inject bad block in the part #1
+FILE=${MOUNT_DIR}/pool.local.part.1
+FIRST_SECTOR=$(expect_normal_exit run_on_node 0 ../extents $FILE -l 0)
+expect_normal_exit run_on_node 0 "sudo ndctl inject-error --block=$FIRST_SECTOR --count=1 $NAMESPACE &>> $PREP_LOG_FILE"
+
+expect_normal_exit run_on_node 0 "sudo ndctl start-scrub &>> $PREP_LOG_FILE"
+expect_normal_exit run_on_node 0 "sudo ndctl wait-scrub &>> $PREP_LOG_FILE"
+
+expect_bad_blocks_node 0
+
+expect_abnormal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG"
+expect_abnormal_exit run_on_node 0 "../pmempool sync -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+expect_normal_exit run_on_node 0 "../pmempool sync -b -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+expect_normal_exit run_on_node 0 "../pmempool sync -b -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG"
+
+ndctl_nfit_test_fini_node 0 $MOUNT_DIR
+
+pass

--- a/src/test/pmempool_sync_remote/TEST33
+++ b/src/test/pmempool_sync_remote/TEST33
@@ -45,6 +45,7 @@ require_fs_type any
 require_build_type debug nondebug
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
+require_nfit_tests_enabled
 require_nodes 2
 require_sudo_allowed_node 0
 require_kernel_module_node 0 nfit_test

--- a/src/test/pmempool_sync_remote/TEST33
+++ b/src/test/pmempool_sync_remote/TEST33
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_sync_remote/TEST33 -- pmempool sync with remote replication
+#                                and bad blocks in the regular file:
+#                                - the pool consists of 2 parts
+#                                - offset of bad block in all 2 parts: 1000
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+require_build_type debug nondebug
+require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
+
+require_nodes 2
+require_sudo_allowed_node 0
+require_kernel_module_node 0 nfit_test
+require_command_node 0 ndctl
+
+setup
+
+require_node_libfabric 0 $RPMEM_PROVIDER
+require_node_libfabric 1 $RPMEM_PROVIDER
+
+init_rpmem_on_node 0 1
+
+export PMEMPOOL_LOG_LEVEL=10
+export PMEMOBJ_LOG_LEVEL=10
+export_vars_node 0 PMEMPOOL_LOG_LEVEL
+export_vars_node 0 PMEMOBJ_LOG_LEVEL
+
+require_node_log_files 0 pmemobj$UNITTEST_NUM.log
+require_node_log_files 0 pmempool$UNITTEST_NUM.log
+
+. ../common_badblock.sh
+
+ndctl_nfit_test_init_node 0
+
+DEVICE=$(ndctl_nfit_test_get_block_device_node 0)
+NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device_node 0 $DEVICE)
+FULLDEV="/dev/$DEVICE"
+MOUNT_DIR="$DIR/mnt-pmem"
+LAYOUT="layout"
+
+ndctl_nfit_test_mount_pmem_node 0 $FULLDEV $MOUNT_DIR
+
+LOG=out${UNITTEST_NUM}.log
+rm -f $LOG && touch $LOG
+
+POOLSET_LOCAL="local_pool.set"
+POOLSET_REMOTE="remote_pool.set"
+
+create_poolset $DIR/$POOLSET_LOCAL \
+	8M:${MOUNT_DIR}/pool.local.part.0:z \
+	8M:${MOUNT_DIR}/pool.local.part.1:z \
+	M \
+	${NODE_ADDR[1]}:$POOLSET_REMOTE
+
+create_poolset $DIR/$POOLSET_REMOTE \
+	24M:${NODE_DIR[1]}/pool.remote:z
+
+copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
+copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE
+
+expect_normal_exit run_on_node 0 ../pmempool rm -sf ${NODE_DIR[0]}$POOLSET_LOCAL
+expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT c v &>> $LOG"
+
+# inject bad block in the part #0
+FILE=${MOUNT_DIR}/pool.local.part.0
+FIRST_SECTOR=$(expect_normal_exit run_on_node 0 ../extents $FILE -l 1000)
+expect_normal_exit run_on_node 0 "sudo ndctl inject-error --block=$FIRST_SECTOR --count=1 $NAMESPACE &>> $PREP_LOG_FILE"
+
+# inject bad block in the part #1
+FILE=${MOUNT_DIR}/pool.local.part.1
+FIRST_SECTOR=$(expect_normal_exit run_on_node 0 ../extents $FILE -l 1000)
+expect_normal_exit run_on_node 0 "sudo ndctl inject-error --block=$FIRST_SECTOR --count=1 $NAMESPACE &>> $PREP_LOG_FILE"
+
+expect_normal_exit run_on_node 0 "sudo ndctl start-scrub &>> $PREP_LOG_FILE"
+expect_normal_exit run_on_node 0 "sudo ndctl wait-scrub &>> $PREP_LOG_FILE"
+
+expect_bad_blocks_node 0
+
+expect_abnormal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG"
+expect_abnormal_exit run_on_node 0 "../pmempool sync -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+expect_normal_exit run_on_node 0 "../pmempool sync -b -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG"
+
+ndctl_nfit_test_fini_node 0 $MOUNT_DIR
+
+pass

--- a/src/test/testconfig.sh.example
+++ b/src/test/testconfig.sh.example
@@ -119,6 +119,15 @@ TM=1
 #PMDK_LIB_PATH_DEBUG=/usr/lib/x86_64-linux-gnu/pmdk_dbg
 
 #
+# The 'nfit' tests test the code handling bad blocks.
+# They use the 'sudo' command many times and insert the 'nfit_test' kernel
+# module, so they can be considered as POTENTIALLY DANGEROUS
+# and have to be explicitly enabled.
+# Enable them ONLY IF you are sure you know what you are doing.
+#
+#ENABLE_NFIT_TESTS=y
+
+#
 # 2) *** REMOTE CONFIGURATION ***
 #
 # The second part of the file tells the script unittest/unittest.sh

--- a/src/test/tools/Makefile
+++ b/src/test/tools/Makefile
@@ -55,7 +55,9 @@ DIRS = \
 
 REMOTE_TOOLS = \
 	ctrld\
+	extents\
 	fip\
+	obj_verify\
 	pmemobjcli\
 	pmemspoil\
 	pmemdetect

--- a/src/test/tools/extents/Makefile
+++ b/src/test/tools/extents/Makefile
@@ -31,6 +31,8 @@
 # Makefile -- Makefile for extents tool
 #
 
+SCP_TO_REMOTE_NODES = y
+
 TOP = ../../../..
 
 TARGET = extents

--- a/src/test/tools/obj_verify/Makefile
+++ b/src/test/tools/obj_verify/Makefile
@@ -34,6 +34,8 @@
 # src/test/tools/obj_verify -- build obj_verify tool
 #
 
+SCP_TO_REMOTE_NODES = y
+
 TOP = ../../../..
 
 TARGET = obj_verify

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -116,6 +116,8 @@ FILES_COMMON_DIR="\
 $DIR_SRC/test/*.supp \
 $DIR_SRC/tools/rpmemd/rpmemd \
 $DIR_SRC/tools/pmempool/pmempool \
+$DIR_SRC/test/tools/extents/extents \
+$DIR_SRC/test/tools/obj_verify/obj_verify \
 $DIR_SRC/test/tools/ctrld/ctrld \
 $DIR_SRC/test/tools/fip/fip"
 

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -3381,3 +3381,13 @@ function require_free_space() {
 		exit 0
 	fi
 }
+
+#
+# require_nfit_tests_enabled - check if tests using the nfit_test kernel module are not enabled
+#
+function require_nfit_tests_enabled() {
+	if [ "$ENABLE_NFIT_TESTS" != "y" ]; then
+		msg "$UNITTEST_NAME: SKIP: tests using the nfit_test kernel module are not enabled in testconfig.sh"
+		exit 0
+	fi
+}

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -987,6 +987,8 @@ function require_unlimited_vm() {
 #
 # require_linked_with_ndctl -- require an executable linked with libndctl
 #
+# usage: require_linked_with_ndctl <executable-file>
+#
 function require_linked_with_ndctl() {
 	[ "$1" == "" -o ! -x "$1" ] && \
 		fatal "$UNITTEST_NAME: ERROR: require_linked_with_ndctl() requires one argument - an executable file"
@@ -1009,6 +1011,8 @@ function require_sudo_allowed() {
 
 #
 # require_sudo_allowed_node -- require sudo command on a remote node
+#
+# usage: require_sudo_allowed_node <node-number>
 #
 function require_sudo_allowed_node() {
 	if ! run_on_node $1 "timeout --signal=SIGKILL --kill-after=3s 3s sudo date" >/dev/null 2>&1
@@ -1481,6 +1485,8 @@ function require_command() {
 #
 # require_command_node -- only allow script to continue if specified command exists on a remote node
 #
+# usage: require_command_node <node-number>
+#
 function require_command_node() {
 	if ! run_on_node $1 "which $1 &>/dev/null"; then
 		msg "$UNITTEST_NAME: SKIP: node $1: '$2' command required"
@@ -1491,8 +1497,7 @@ function require_command_node() {
 #
 # require_kernel_module -- only allow script to continue if specified kernel module exists
 #
-# Syntax:
-# require_kernel_module <module_name> [path_to_modinfo]
+# usage: require_kernel_module <module_name> [path_to_modinfo]
 #
 function require_kernel_module() {
 	MODULE=$1
@@ -1527,8 +1532,7 @@ function require_kernel_module() {
 #
 # require_kernel_module_node -- only allow script to continue if specified kernel module exists on a remote node
 #
-# Syntax:
-# require_kernel_module_node <node> <module_name> [path_to_modinfo]
+# usage: require_kernel_module_node <node> <module_name> [path_to_modinfo]
 #
 function require_kernel_module_node() {
 	NODE_N=$1

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -997,21 +997,21 @@ function require_linked_with_ndctl() {
 }
 
 #
-# require_superuser -- require user with superuser rights
+# require_sudo_allowed -- require sudo command is allowed
 #
-function require_superuser() {
-	# user_id can be used later to check if we have superuser rights
-	user_id=$(id -u)
-	[ "$user_id" == "0" ] && return
-	msg "$UNITTEST_NAME: SKIP required: run with superuser rights"
-	exit 0
+function require_sudo_allowed() {
+	if ! timeout --signal=SIGKILL --kill-after=3s 3s sudo date >/dev/null 2>&1
+	then
+		msg "$UNITTEST_NAME: SKIP required: sudo allowed"
+		exit 0
+	fi
 }
 
 #
 # require_sudo_allowed_node -- require sudo command on a remote node
 #
 function require_sudo_allowed_node() {
-	if ! run_on_node $1 "timeout --signal=SIGKILL --kill-after=3s 3s sudo date" 1>/dev/null
+	if ! run_on_node $1 "timeout --signal=SIGKILL --kill-after=3s 3s sudo date" >/dev/null 2>&1
 	then
 		msg "$UNITTEST_NAME: SKIP required: sudo allowed on node $1"
 		exit 0
@@ -1495,8 +1495,6 @@ function require_command_node() {
 # require_kernel_module <module_name> [path_to_modinfo]
 #
 function require_kernel_module() {
-	[ "$user_id" == "" ] && require_superuser
-
 	MODULE=$1
 	MODINFO=$2
 

--- a/src/test/util_badblock/TEST2
+++ b/src/test/util_badblock/TEST2
@@ -43,6 +43,7 @@
 require_test_type medium
 require_fs_type any
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX

--- a/src/test/util_badblock/TEST2
+++ b/src/test/util_badblock/TEST2
@@ -55,6 +55,10 @@ setup
 ndctl_nfit_test_init
 
 DEVICE=$(ndctl_nfit_test_get_dax_device)
+
+# XXX needed by libndctl (it should be removed when it is not needed)
+ndctl_nfit_test_grant_access $DEVICE
+
 FULLDEV="/dev/$DEVICE"
 
 expect_normal_exit ./util_badblock$EXESUFFIX $FULLDEV l

--- a/src/test/util_badblock/TEST2
+++ b/src/test/util_badblock/TEST2
@@ -43,7 +43,7 @@
 require_test_type medium
 require_fs_type any
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX
 require_command ndctl

--- a/src/test/util_badblock/TEST3
+++ b/src/test/util_badblock/TEST3
@@ -43,6 +43,7 @@
 require_test_type medium
 require_fs_type any
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX

--- a/src/test/util_badblock/TEST3
+++ b/src/test/util_badblock/TEST3
@@ -43,7 +43,7 @@
 require_test_type medium
 require_fs_type any
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX
 require_command ndctl

--- a/src/test/util_badblock/TEST4
+++ b/src/test/util_badblock/TEST4
@@ -44,6 +44,7 @@
 require_test_type medium
 require_fs_type any
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX

--- a/src/test/util_badblock/TEST4
+++ b/src/test/util_badblock/TEST4
@@ -44,7 +44,7 @@
 require_test_type medium
 require_fs_type any
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX
 require_command ndctl

--- a/src/test/util_badblock/TEST5
+++ b/src/test/util_badblock/TEST5
@@ -43,6 +43,7 @@
 require_test_type medium
 require_fs_type any
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX

--- a/src/test/util_badblock/TEST5
+++ b/src/test/util_badblock/TEST5
@@ -43,7 +43,7 @@
 require_test_type medium
 require_fs_type any
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX
 require_command ndctl

--- a/src/test/util_badblock/TEST6
+++ b/src/test/util_badblock/TEST6
@@ -43,6 +43,7 @@
 require_test_type medium
 require_fs_type any
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX

--- a/src/test/util_badblock/TEST6
+++ b/src/test/util_badblock/TEST6
@@ -43,7 +43,7 @@
 require_test_type medium
 require_fs_type any
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX
 require_command ndctl

--- a/src/test/util_badblock/TEST7
+++ b/src/test/util_badblock/TEST7
@@ -44,6 +44,7 @@
 require_test_type medium
 require_fs_type any
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX

--- a/src/test/util_badblock/TEST7
+++ b/src/test/util_badblock/TEST7
@@ -44,7 +44,7 @@
 require_test_type medium
 require_fs_type any
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX
 require_command ndctl

--- a/src/test/util_badblock/TEST8
+++ b/src/test/util_badblock/TEST8
@@ -43,6 +43,7 @@
 require_test_type medium
 require_fs_type any
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX

--- a/src/test/util_badblock/TEST8
+++ b/src/test/util_badblock/TEST8
@@ -43,7 +43,7 @@
 require_test_type medium
 require_fs_type any
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX
 require_command ndctl

--- a/src/test/util_badblock/TEST9
+++ b/src/test/util_badblock/TEST9
@@ -43,6 +43,7 @@
 require_test_type medium
 require_fs_type any
 
+require_nfit_tests_enabled
 require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX

--- a/src/test/util_badblock/TEST9
+++ b/src/test/util_badblock/TEST9
@@ -43,7 +43,7 @@
 require_test_type medium
 require_fs_type any
 
-require_superuser
+require_sudo_allowed
 require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX
 require_command ndctl

--- a/src/tools/pmempool/synchronize.c
+++ b/src/tools/pmempool/synchronize.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -131,7 +131,7 @@ pmempool_sync_parse_args(struct pmempool_sync_context *ctx, char *appname,
 			long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'd':
-			ctx->flags = PMEMPOOL_DRY_RUN;
+			ctx->flags = PMEMPOOL_SYNC_DRY_RUN;
 			break;
 		case 'h':
 			pmempool_sync_help(appname);

--- a/src/tools/pmempool/synchronize.c
+++ b/src/tools/pmempool/synchronize.c
@@ -72,8 +72,8 @@ static const char * const help_str =
 "Check consistency of a pool\n"
 "\n"
 "Common options:\n"
-"  -d, --dry-run        do not apply changes, only check for viability of"
-" synchronization\n"
+"  -b, --bad-blocks     fix bad blocks - it requires creating or reading special recovery files\n"
+"  -d, --dry-run        do not apply changes, only check for viability of synchronization\n"
 "  -v, --verbose        increase verbosity level\n"
 "  -h, --help           display this help and exit\n"
 "\n"
@@ -84,6 +84,7 @@ static const char * const help_str =
  * long_options -- command line options
  */
 static const struct option long_options[] = {
+	{"bad-blocks",	no_argument,		NULL,	'b'},
 	{"dry-run",	no_argument,		NULL,	'd'},
 	{"help",	no_argument,		NULL,	'h'},
 	{"verbose",	no_argument,		NULL,	'v'},
@@ -127,11 +128,14 @@ pmempool_sync_parse_args(struct pmempool_sync_context *ctx, char *appname,
 		int argc, char *argv[])
 {
 	int opt;
-	while ((opt = getopt_long(argc, argv, "dhv",
+	while ((opt = getopt_long(argc, argv, "bdhv",
 			long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'd':
 			ctx->flags = PMEMPOOL_SYNC_DRY_RUN;
+			break;
+		case 'b':
+			ctx->flags = PMEMPOOL_SYNC_FIX_BAD_BLOCKS;
 			break;
 		case 'h':
 			pmempool_sync_help(appname);

--- a/src/tools/pmempool/transform.c
+++ b/src/tools/pmempool/transform.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -133,7 +133,7 @@ pmempool_transform_parse_args(struct pmempool_transform_context *ctx,
 			long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'd':
-			ctx->flags = PMEMPOOL_DRY_RUN;
+			ctx->flags = PMEMPOOL_TRANSFORM_DRY_RUN;
 			break;
 		case 'h':
 			pmempool_transform_help(appname);


### PR DESCRIPTION
Make 'pmempool-sync' sync single blocks (not the whole part) in case of bad blocks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2957)
<!-- Reviewable:end -->
