### PR TITLE
common: reduce build system overhead

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -111,7 +111,7 @@ endif
 
 # On FreeBSD libvmmalloc defines pthread_create, which conflicts with asan
 tsanitize := $(SANITIZE)
-ifeq ($(shell uname -s),FreeBSD)
+ifeq ($(OS_KERNEL_NAME),FreeBSD)
 ifeq ($(JEMALLOC_PMDKDIR),libvmmalloc)
 hasaddrcomma := address,
 tsanitize := $(subst address,,$(subst $(hasaddrcomma),,$(SANITIZE)))

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -139,10 +139,7 @@ ifneq ($(NORPATH),1)
 LDFLAGS += -Wl,-rpath=$(libdir)$(LIB_SUBDIR)
 endif
 
-# XXX: required by clock_gettime(), if glibc version < 2.17
-# The os_clock_gettime() function is now in OS abstraction layer,
-# linked to all the librariess, unit tests and benchmarks.
-ifeq ($(call check_librt), n)
+ifeq ($(LIBRT_NEEDED), y)
 LIBS += -lrt
 endif
 

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -158,7 +158,6 @@ ifneq ($(TESTBUILD), 1)
 $(error "$(TESTCMD)" failed)
 endif
 
-ARCH := $(call get_arch)
 ifneq ($(ARCH), x86_64)
 ifneq ($(ARCH), aarch64)
 $(error unsupported architecture: $(ARCH))

--- a/src/benchmarks/Makefile
+++ b/src/benchmarks/Makefile
@@ -112,7 +112,7 @@ LIBS += ../debug/libpmemcommon.a
 endif
 LIBS += -lpmemobj -lpmemlog -lpmemblk -lpmempool -lpmem -lvmem -pthread -lm \
 	$(LIBDL) $(LIBUUID) $(LIBNDCTL)
-ifeq ($(call check_librt), n)
+ifeq ($(LIBRT_NEEDED), y)
 LIBS += -lrt
 endif
 

--- a/src/common.inc
+++ b/src/common.inc
@@ -64,7 +64,12 @@ GCOV_CFLAGS=-fprofile-arcs -ftest-coverage --coverage
 GCOV_LDFLAGS=-fprofile-arcs -ftest-coverage
 GCOV_LIBS=-lgcov
 
-osdep = $(1)_$(shell uname -s | tr "[:upper:]" "[:lower:]")$(2)
+ifeq ($(OS_KERNEL_NAME),)
+export OS_KERNEL_NAME := $(shell uname -s)
+endif
+
+osdep = $(1)_$(shell echo $(OS_KERNEL_NAME) | tr "[:upper:]" "[:lower:]")$(2)
+
 get_arch = $(shell $(CC) -dumpmachine | awk -F'[/-]' '{print $$1}')
 
 ifeq ($(PKG_CONFIG_CHECKED),)
@@ -258,7 +263,7 @@ NDCTL_MIN_VERSION := 60.1
 
 sparse-c = $(shell for c in *.c; do sparse -Wsparse-all -Wno-declaration-after-statement $(CFLAGS) $(INCS) $$c || true; done)
 
-ifeq ($(shell uname -s),FreeBSD)
+ifeq ($(OS_KERNEL_NAME),FreeBSD)
 
 GLIBC_CXXFLAGS=-D_GLIBCXX_USE_C99
 UNIX98_CFLAGS=

--- a/src/common.inc
+++ b/src/common.inc
@@ -246,10 +246,12 @@ LIBFABRIC_MIN_VERSION := 1.4.2
 
 # Keep in sync with requirements in src/test/unittest/unittest.sh and
 # utils/docker/images/install-libfabric.sh.
+ifeq ($(BUILD_RPMEM),)
 export BUILD_RPMEM := $(call check_package, libfabric --atleast-version=$(LIBFABRIC_MIN_VERSION))
 ifneq ($(BUILD_RPMEM),y)
 export BUILD_RPMEM_INFO := libfabric (version >= $(LIBFABRIC_MIN_VERSION)) is missing -- \
 see src/librpmem/README for details.
+endif
 endif
 
 NDCTL_MIN_VERSION := 60.1

--- a/src/common.inc
+++ b/src/common.inc
@@ -67,9 +67,12 @@ GCOV_LIBS=-lgcov
 osdep = $(1)_$(shell uname -s | tr "[:upper:]" "[:lower:]")$(2)
 get_arch = $(shell $(CC) -dumpmachine | awk -F'[/-]' '{print $$1}')
 
+ifeq ($(PKG_CONFIG_CHECKED),)
 ifeq ($(shell command -v $(PKG_CONFIG) && echo y || echo n), n)
 $(error $(PKG_CONFIG) not found)
 endif
+endif
+export PKG_CONFIG_CHECKED := y
 
 check_package = $(shell $(PKG_CONFIG) $(1) && echo y || echo n)
 

--- a/src/common.inc
+++ b/src/common.inc
@@ -310,4 +310,14 @@ OS_DIMM=none
 LIBNDCTL=
 endif
 
+ifeq ($(USE_LIBUNWIND),)
+export USE_LIBUNWIND := $(call check_package, libunwind)
+ifeq ($(USE_LIBUNWIND),y)
+export LIBUNWIND_LIBS := $(shell $(PKG_CONFIG) --libs libunwind)
+endif
+else
+export USE_LIBUNWIND
+export LIBUNWIND_LIBS
+endif
+
 endif

--- a/src/common.inc
+++ b/src/common.inc
@@ -103,7 +103,16 @@ check_Wconversion = $(shell echo "long random(void); char test(void); char test(
 	$(CC) -c $(CFLAGS) -Wconversion -x c -o /dev/null - 2>/dev/null && echo y || echo n)
 
 check_librt = $(shell echo "int main() { struct timespec t; return clock_gettime(CLOCK_MONOTONIC, &t); }" |\
-	$(CC) $(CFLAGS) -x c -include time.h -o /dev/null - 2>/dev/null && echo y || echo n)
+	$(CC) $(CFLAGS) -x c -include time.h -o /dev/null - 2>/dev/null && echo n || echo y)
+
+# XXX: required by clock_gettime(), if glibc version < 2.17
+# The os_clock_gettime() function is now in OS abstraction layer,
+# linked to all the librariess, unit tests and benchmarks.
+ifeq ($(LIBRT_NEEDED),)
+export LIBRT_NEEDED := $(call check_librt)
+else
+export LIBRT_NEEDED
+endif
 
 install_recursive = $(shell cd $(1) && find . -type f -exec install -m $(2) -D {} $(3)/{} \;)
 

--- a/src/common.inc
+++ b/src/common.inc
@@ -54,10 +54,12 @@ COVERAGE = 0
 PKG_CONFIG ?= pkg-config
 HEADERS = $(wildcard *.h) $(wildcard *.hpp)
 
+ifeq ($(CLANG_FORMAT),)
 ifeq ($(shell command -v clang-format-3.8 > /dev/null && echo y || echo n), y)
-CLANG_FORMAT ?= clang-format-3.8
+export CLANG_FORMAT ?= clang-format-3.8
 else
-CLANG_FORMAT ?= clang-format
+export CLANG_FORMAT ?= clang-format
+endif
 endif
 
 GCOV_CFLAGS=-fprofile-arcs -ftest-coverage --coverage

--- a/src/common.inc
+++ b/src/common.inc
@@ -71,6 +71,9 @@ endif
 osdep = $(1)_$(shell echo $(OS_KERNEL_NAME) | tr "[:upper:]" "[:lower:]")$(2)
 
 get_arch = $(shell $(CC) -dumpmachine | awk -F'[/-]' '{print $$1}')
+ifeq ($(ARCH),)
+export ARCH := $(call get_arch)
+endif
 
 ifeq ($(PKG_CONFIG_CHECKED),)
 ifeq ($(shell command -v $(PKG_CONFIG) && echo y || echo n), n)

--- a/src/examples/libpmemcto/libart/Makefile
+++ b/src/examples/libpmemcto/libart/Makefile
@@ -48,8 +48,6 @@
 
 include ../../../common.inc
 
-ARCH := $(call get_arch)
-
 ifeq ($(ARCH), x86_64)
 # libart uses x86 intrinsics
 PROGS = arttree

--- a/src/examples/libpmemobj/libart/Makefile
+++ b/src/examples/libpmemobj/libart/Makefile
@@ -49,8 +49,6 @@
 
 include ../../../common.inc
 
-ARCH := $(call get_arch)
-
 ifeq ($(ARCH), x86_64)
 # libart uses x86 intrinsics
 PROGS = arttree examine_arttree

--- a/src/examples/libvmem/libart/Makefile
+++ b/src/examples/libvmem/libart/Makefile
@@ -48,8 +48,6 @@
 
 include ../../../common.inc
 
-ARCH := $(call get_arch)
-
 ifeq ($(ARCH), x86_64)
 # libart uses x86 intrinsics
 PROGS = arttree

--- a/src/libpmem/Makefile
+++ b/src/libpmem/Makefile
@@ -59,6 +59,8 @@ SOURCE =\
 
 include $(ARCH)/sources.inc
 
+SOURCE += $(LIBPMEM_ARCH_SOURCE)
+
 include ../Makefile.inc
 
 include $(ARCH)/flags.inc

--- a/src/libpmem/Makefile
+++ b/src/libpmem/Makefile
@@ -34,8 +34,6 @@
 
 include ../common.inc
 
-ARCH := $(call get_arch)
-
 LIBRARY_NAME = pmem
 LIBRARY_SO_VERSION = 1
 LIBRARY_VERSION = 0.0

--- a/src/libpmem/aarch64/sources.inc
+++ b/src/libpmem/aarch64/sources.inc
@@ -32,4 +32,4 @@
 # src/libpmem/aarch64/sources.inc -- list of files for libpmem/arm64
 #
 
-SOURCE += init.c
+LIBPMEM_ARCH_SOURCE = init.c

--- a/src/libpmem/x86_64/sources.inc
+++ b/src/libpmem/x86_64/sources.inc
@@ -32,7 +32,7 @@
 # src/libpmem/x86_64/sources.inc -- list of files for libpmem/x86_64
 #
 
-SOURCE += init.c\
+LIBPMEM_ARCH_SOURCE = init.c\
 	cpu.c\
 	memcpy_nt_avx_clflush.c\
 	memcpy_nt_avx_clflushopt.c\
@@ -72,7 +72,7 @@ AVX512F_AVAILABLE := $(shell printf $(AVX512F_PROG) |\
 	$(CC) $(CFLAGS) -x c -mavx512f -o /dev/null - 2>/dev/null && echo y || echo n)
 
 ifeq ($(AVX512F_AVAILABLE), y)
-SOURCE += memcpy_nt_avx512f_clflush.c\
+LIBPMEM_ARCH_SOURCE += memcpy_nt_avx512f_clflush.c\
 	memcpy_nt_avx512f_clflushopt.c\
 	memcpy_nt_avx512f_clwb.c\
 	memcpy_nt_avx512f_empty.c\

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -38,8 +38,6 @@
 
 include ../common.inc
 
-ARCH := $(call get_arch)
-
 TEST_DEPS = \
 	unittest\
 	tools

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -56,15 +56,8 @@ EX_LIBPMEMCTO=$(EXAMPLES_DIR)/libpmemcto
 UT = ../unittest/libut.a
 LIBS += $(UT) $(LIBUUID)
 
-ifeq ($(USE_LIBUNWIND),1)
-LIBS += $(LIBDL) -lunwind
-else
-ifneq ($(USE_LIBUNWIND),0)
-UNWIND := $(call check_package, libunwind)
-ifeq ($(UNWIND),y)
-LIBS += $(LIBDL) $(shell $(PKG_CONFIG) --libs libunwind)
-endif
-endif
+ifeq ($(USE_LIBUNWIND),y)
+LIBS += $(LIBDL) $(LIBUNWIND_LIBS)
 endif
 
 LIBS += -L$(LIBS_DIR)/debug

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -70,10 +70,7 @@ endif
 LIBS += -L$(LIBS_DIR)/debug
 LIBS += -pthread $(LIBUTIL)
 
-# XXX: required by clock_gettime(), if glibc version < 2.17
-# The os_clock_gettime() function is now in OS abstraction layer,
-# linked to all the librariess, unit tests and benchmarks.
-ifeq ($(call check_librt), n)
+ifeq ($(LIBRT_NEEDED), y)
 LIBS += -lrt
 endif
 

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -40,8 +40,6 @@
 TOP := $(dir $(lastword $(MAKEFILE_LIST)))../..
 
 include $(TOP)/src/common.inc
-ARCH := $(call get_arch)
-include $(TOP)/src/libpmem/$(ARCH)/sources.inc
 
 INCS += $(OS_INCS)
 LDFLAGS += $(OS_LIBS)
@@ -184,6 +182,8 @@ OBJS +=\
 	$(TOP)/src/nondebug/libpmem/pmem.o\
 	$(TOP)/src/nondebug/libpmem/pmem_posix.o
 
+ARCH := $(call get_arch)
+include $(TOP)/src/libpmem/$(ARCH)/sources.inc
 OBJS_MEM = $(LIBPMEM_ARCH_SOURCE:.c=.o)
 OBJS += $(addprefix $(TOP)/src/nondebug/libpmem/, ${OBJS_MEM})
 
@@ -198,6 +198,8 @@ OBJS +=\
 	$(TOP)/src/debug/libpmem/pmem.o\
 	$(TOP)/src/debug/libpmem/pmem_posix.o
 
+ARCH := $(call get_arch)
+include $(TOP)/src/libpmem/$(ARCH)/sources.inc
 OBJS_MEM = $(LIBPMEM_ARCH_SOURCE:.c=.o)
 OBJS += $(addprefix $(TOP)/src/debug/libpmem/, ${OBJS_MEM})
 

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -184,7 +184,7 @@ OBJS +=\
 	$(TOP)/src/nondebug/libpmem/pmem.o\
 	$(TOP)/src/nondebug/libpmem/pmem_posix.o
 
-OBJS_MEM = $(SOURCE:.c=.o)
+OBJS_MEM = $(LIBPMEM_ARCH_SOURCE:.c=.o)
 OBJS += $(addprefix $(TOP)/src/nondebug/libpmem/, ${OBJS_MEM})
 
 INCS += -I$(TOP)/src/libpmem
@@ -198,7 +198,7 @@ OBJS +=\
 	$(TOP)/src/debug/libpmem/pmem.o\
 	$(TOP)/src/debug/libpmem/pmem_posix.o
 
-OBJS_MEM = $(SOURCE:.c=.o)
+OBJS_MEM = $(LIBPMEM_ARCH_SOURCE:.c=.o)
 OBJS += $(addprefix $(TOP)/src/debug/libpmem/, ${OBJS_MEM})
 
 INCS += -I$(TOP)/src/libpmem

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -172,7 +172,6 @@ OBJS +=\
 	$(TOP)/src/nondebug/libpmem/pmem.o\
 	$(TOP)/src/nondebug/libpmem/pmem_posix.o
 
-ARCH := $(call get_arch)
 include $(TOP)/src/libpmem/$(ARCH)/sources.inc
 OBJS_MEM = $(LIBPMEM_ARCH_SOURCE:.c=.o)
 OBJS += $(addprefix $(TOP)/src/nondebug/libpmem/, ${OBJS_MEM})
@@ -188,7 +187,6 @@ OBJS +=\
 	$(TOP)/src/debug/libpmem/pmem.o\
 	$(TOP)/src/debug/libpmem/pmem_posix.o
 
-ARCH := $(call get_arch)
 include $(TOP)/src/libpmem/$(ARCH)/sources.inc
 OBJS_MEM = $(LIBPMEM_ARCH_SOURCE:.c=.o)
 OBJS += $(addprefix $(TOP)/src/debug/libpmem/, ${OBJS_MEM})

--- a/src/test/pmem_deep_persist/Makefile
+++ b/src/test/pmem_deep_persist/Makefile
@@ -34,7 +34,6 @@
 # src/test/pmem_deep_persist/Makefile -- build pmem_deep_persist test
 #
 include ../../common.inc
-ARCH := $(call get_arch)
 
 TOP = ../../..
 vpath %.c $(TOP)/src/common

--- a/src/test/pmem_is_pmem_posix/Makefile
+++ b/src/test/pmem_is_pmem_posix/Makefile
@@ -34,7 +34,6 @@
 # src/test/pmem_is_pmem_posix/Makefile -- build pmem_is_pmem_posix unit test
 #
 include ../../common.inc
-ARCH := $(call get_arch)
 TOP = ../../..
 vpath %.c $(TOP)/src/common
 vpath %.c $(TOP)/src/libpmem

--- a/src/test/unittest/Makefile
+++ b/src/test/unittest/Makefile
@@ -80,15 +80,8 @@ CFLAGS += -Wcast-function-type
 endif
 endif
 
-ifeq ($(USE_LIBUNWIND),1)
-CFLAGS += -DUSE_LIBUNWIND
-else
-ifneq ($(USE_LIBUNWIND),0)
-UNWIND := $(call check_package, libunwind)
-ifeq ($(UNWIND),y)
+ifeq ($(USE_LIBUNWIND),y)
 CFLAGS += $(shell $(PKG_CONFIG) --cflags libunwind) -DUSE_LIBUNWIND
-endif
-endif
 endif
 
 ifeq ($(COVERAGE),1)

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -125,10 +125,7 @@ PMEMCTO_PRIV_OBJ=$(LIBSDIR_PRIV)/libpmemcto/libpmemcto_unscoped.o
 
 LIBS += $(LIBUUID)
 
-# XXX: required by clock_gettime(), if glibc version < 2.17
-# The os_clock_gettime() function is now in OS abstraction layer,
-# linked to all the librariess, unit tests and benchmarks.
-ifeq ($(call check_librt), n)
+ifeq ($(LIBRT_NEEDED), y)
 LIBS += -lrt
 endif
 


### PR DESCRIPTION
On my machine this patch set speeds up "make clean" from 78 seconds(!!!) to 13.5s.
Still a long way for sane times. For Valgrind, which has 3 times as much code, make clean takes 0.5s and for Linux kernel it's 3.4s. I don't think we can progress much without sane build system :(.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2970)
<!-- Reviewable:end -->
