### PR TITLE
obj: fix invalid OOMs when zones are fully packed

### DIFF
--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -642,13 +642,11 @@ heap_reclaim_run(struct palloc_heap *heap, struct memory_block *m)
 /*
  * heap_reclaim_zone_garbage -- (internal) creates volatile state of unused runs
  */
-static int
+static void
 heap_reclaim_zone_garbage(struct palloc_heap *heap, struct bucket *bucket,
 	uint32_t zone_id)
 {
 	struct zone *z = ZID_TO_ZONE(heap->layout, zone_id);
-
-	int rchunks = 0;
 
 	/*
 	 * Recreate all footers BEFORE any other operation takes place.
@@ -673,7 +671,6 @@ heap_reclaim_zone_garbage(struct palloc_heap *heap, struct bucket *bucket,
 
 	for (uint32_t i = 0; i < z->header.size_idx; ) {
 		struct chunk_header *hdr = &z->chunk_headers[i];
-		int rret = 0;
 		ASSERT(hdr->size_idx != 0);
 
 		struct memory_block m = MEMORY_BLOCK_NONE;
@@ -685,14 +682,12 @@ heap_reclaim_zone_garbage(struct palloc_heap *heap, struct bucket *bucket,
 
 		switch (hdr->type) {
 			case CHUNK_TYPE_RUN:
-				if ((rret = heap_reclaim_run(heap, &m)) != 0) {
-					rchunks += rret;
+				if (heap_reclaim_run(heap, &m) != 0) {
 					heap_run_into_free_chunk(heap, bucket,
 						&m);
 				}
 				break;
 			case CHUNK_TYPE_FREE:
-				rchunks += (int)m.size_idx;
 				heap_free_chunk_reuse(heap, bucket, &m);
 				break;
 			case CHUNK_TYPE_USED:
@@ -703,8 +698,6 @@ heap_reclaim_zone_garbage(struct palloc_heap *heap, struct bucket *bucket,
 
 		i = m.chunk_id + m.size_idx; /* hdr might have changed */
 	}
-
-	return rchunks == 0 ? ENOMEM : 0;
 }
 
 /*
@@ -715,6 +708,7 @@ heap_populate_bucket(struct palloc_heap *heap, struct bucket *bucket)
 {
 	struct heap_rt *h = heap->rt;
 
+	/* at this point we are sure that there's no more memory in the heap */
 	if (h->zones_exhausted == h->nzones)
 		return ENOMEM;
 
@@ -728,7 +722,14 @@ heap_populate_bucket(struct palloc_heap *heap, struct bucket *bucket)
 	if (z->header.magic != ZONE_HEADER_MAGIC)
 		heap_zone_init(heap, zone_id, 0);
 
-	return heap_reclaim_zone_garbage(heap, bucket, zone_id);
+	heap_reclaim_zone_garbage(heap, bucket, zone_id);
+
+	/*
+	 * It doesn't matter that this function might not have found any
+	 * free blocks because there is still potential that subsequent calls
+	 * will find something in later zones.
+	 */
+	return 0;
 }
 
 /*

--- a/src/test/obj_zones/TEST0
+++ b/src/test/obj_zones/TEST0
@@ -44,8 +44,10 @@ setup
 
 create_holey_file 64G $DIR/testfile1
 
-expect_normal_exit ./obj_zones$EXESUFFIX $DIR/testfile1
+expect_normal_exit ./obj_zones$EXESUFFIX $DIR/testfile1 c
 
 check
+
+expect_normal_exit ./obj_zones$EXESUFFIX $DIR/testfile1 o
 
 pass

--- a/src/test/obj_zones/out0.log.match
+++ b/src/test/obj_zones/out0.log.match
@@ -1,4 +1,4 @@
 obj_zones$(nW)TEST0: START: obj_zones
- $(nW)obj_zones$(nW) $(nW)testfile1
-allocated: 508
+ $(nW)obj_zones$(nW) $(nW)testfile1 c
+allocated: 32
 obj_zones$(nW)TEST0: DONE


### PR DESCRIPTION
This patch changes the heap traversal algorithm to keep searching
for memory despite lack of free blocks in the first attempted
zone.
This fixes a bug where allocations incorrectly failed with OOM
in situations where the zone 0 had no empty memory blocks but
other zones might have had them.

Reported by @vinser52

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2971)
<!-- Reviewable:end -->
