### PR TITLE
obj: fix invalid OOMs when zones are fully packed (1.4)

### DIFF
--- a/src/test/obj_zones/TEST0
+++ b/src/test/obj_zones/TEST0
@@ -44,8 +44,10 @@ setup
 
 create_holey_file 64G $DIR/testfile1
 
-expect_normal_exit ./obj_zones$EXESUFFIX $DIR/testfile1
+expect_normal_exit ./obj_zones$EXESUFFIX $DIR/testfile1 c
 
 check
+
+expect_normal_exit ./obj_zones$EXESUFFIX $DIR/testfile1 o
 
 pass

--- a/src/test/obj_zones/out0.log.match
+++ b/src/test/obj_zones/out0.log.match
@@ -1,4 +1,4 @@
 obj_zones$(nW)TEST0: START: obj_zones
- $(nW)obj_zones$(nW) $(nW)testfile1
-allocated: 508
+ $(nW)obj_zones$(nW) $(nW)testfile1 c
+allocated: 32
 obj_zones$(nW)TEST0: DONE


### PR DESCRIPTION
This patch changes the heap traversal algorithm to keep searching
for memory despite lack of free blocks in the first attempted
zone.
This fixes a bug where allocations incorrectly failed with OOM
in situations where the zone 0 had no empty memory blocks but
other zones might have had them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2972)
<!-- Reviewable:end -->
