### PR TITLE
test: fix pmem_deep_persist/TEST2

### DIFF
--- a/src/test/pmem_deep_persist/Makefile
+++ b/src/test/pmem_deep_persist/Makefile
@@ -54,7 +54,7 @@ endif
 
 LIBPMEMOBJ=y
 LIBPMEM=y
-LIBPMEMCOMMON=y
+LIBPMEMCOMMON=internal-debug
 
 include ../Makefile.inc
 

--- a/src/test/rpmemd_config/Makefile
+++ b/src/test/rpmemd_config/Makefile
@@ -48,4 +48,3 @@ include ../Makefile.inc
 
 CFLAGS += -I../../tools/rpmemd
 CFLAGS += -DSRCVERSION='"$(SRCVERSION)"'
-LDFLAGS += $(call extract_funcs, rpmemd_config_test.c)


### PR DESCRIPTION
In ead799bde23fd649525203fb36bd33ca57e4a058 in pmem_deep_persist test
I replaced manually added list of pmemcommon files with a single line
that says "link-to-pmemcommon=y".
This had a side effect of braking this test on Device DAX (which I don't
regularly test on and Travis can't), because mocks rely on the ability
to compile each file with special flag that says "replace all references
to this symbol by __wrap_$(symbol)". Linking with already built
libpmemcommon instance (LIBPMEMCOMMON=y) broke that.
Instead of going back to the old and verbose method of linking use the
new clean syntax (LIBPMEMCOMMON=internal-debug) which does exactly what
is needed, using less code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2979)
<!-- Reviewable:end -->
