### PR TITLE
test: move require_kernel_module nfit_test

### DIFF
--- a/src/test/pmempool_check/TEST31
+++ b/src/test/pmempool_check/TEST31
@@ -41,10 +41,11 @@
 require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
+
+require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl
 require_superuser
-require_kernel_module nfit_test
 
 setup
 

--- a/src/test/pmempool_check/TEST32
+++ b/src/test/pmempool_check/TEST32
@@ -41,10 +41,11 @@
 require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
+
+require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl
 require_superuser
-require_kernel_module nfit_test
 
 setup
 

--- a/src/test/pmempool_create/TEST10
+++ b/src/test/pmempool_create/TEST10
@@ -41,10 +41,11 @@
 require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
+
+require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl
 require_superuser
-require_kernel_module nfit_test
 
 setup
 

--- a/src/test/pmempool_create/TEST11
+++ b/src/test/pmempool_create/TEST11
@@ -41,10 +41,11 @@
 require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
+
+require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl
 require_superuser
-require_kernel_module nfit_test
 
 setup
 

--- a/src/test/pmempool_create/TEST12
+++ b/src/test/pmempool_create/TEST12
@@ -42,10 +42,11 @@
 require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
+
+require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl
 require_superuser
-require_kernel_module nfit_test
 
 setup
 

--- a/src/test/pmempool_info/TEST24
+++ b/src/test/pmempool_info/TEST24
@@ -41,10 +41,11 @@
 require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
+
+require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl
 require_superuser
-require_kernel_module nfit_test
 
 setup
 

--- a/src/test/pmempool_info/TEST25
+++ b/src/test/pmempool_info/TEST25
@@ -41,10 +41,11 @@
 require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
+
+require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl
 require_superuser
-require_kernel_module nfit_test
 
 setup
 

--- a/src/test/pmempool_sync/TEST27
+++ b/src/test/pmempool_sync/TEST27
@@ -41,10 +41,11 @@
 require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
+
+require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl
 require_superuser
-require_kernel_module nfit_test
 
 setup
 

--- a/src/test/pmempool_sync/TEST28
+++ b/src/test/pmempool_sync/TEST28
@@ -41,10 +41,11 @@
 require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
+
+require_kernel_module nfit_test
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 require_command ndctl
 require_superuser
-require_kernel_module nfit_test
 
 setup
 

--- a/src/test/util_badblock/TEST2
+++ b/src/test/util_badblock/TEST2
@@ -42,10 +42,11 @@
 
 require_test_type medium
 require_fs_type any
+
+require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX
 require_command ndctl
 require_superuser
-require_kernel_module nfit_test
 
 setup
 

--- a/src/test/util_badblock/TEST3
+++ b/src/test/util_badblock/TEST3
@@ -42,10 +42,11 @@
 
 require_test_type medium
 require_fs_type any
+
+require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX
 require_command ndctl
 require_superuser
-require_kernel_module nfit_test
 
 setup
 

--- a/src/test/util_badblock/TEST4
+++ b/src/test/util_badblock/TEST4
@@ -43,10 +43,11 @@
 
 require_test_type medium
 require_fs_type any
+
+require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX
 require_command ndctl
 require_superuser
-require_kernel_module nfit_test
 
 setup
 

--- a/src/test/util_badblock/TEST5
+++ b/src/test/util_badblock/TEST5
@@ -42,10 +42,11 @@
 
 require_test_type medium
 require_fs_type any
+
+require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX
 require_command ndctl
 require_superuser
-require_kernel_module nfit_test
 
 setup
 

--- a/src/test/util_badblock/TEST6
+++ b/src/test/util_badblock/TEST6
@@ -42,10 +42,11 @@
 
 require_test_type medium
 require_fs_type any
+
+require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX
 require_command ndctl
 require_superuser
-require_kernel_module nfit_test
 
 setup
 

--- a/src/test/util_badblock/TEST7
+++ b/src/test/util_badblock/TEST7
@@ -43,10 +43,11 @@
 
 require_test_type medium
 require_fs_type any
+
+require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX
 require_command ndctl
 require_superuser
-require_kernel_module nfit_test
 
 setup
 

--- a/src/test/util_badblock/TEST8
+++ b/src/test/util_badblock/TEST8
@@ -42,10 +42,11 @@
 
 require_test_type medium
 require_fs_type any
+
+require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX
 require_command ndctl
 require_superuser
-require_kernel_module nfit_test
 
 setup
 

--- a/src/test/util_badblock/TEST9
+++ b/src/test/util_badblock/TEST9
@@ -42,10 +42,11 @@
 
 require_test_type medium
 require_fs_type any
+
+require_kernel_module nfit_test
 require_linked_with_ndctl ./util_badblock$EXESUFFIX
 require_command ndctl
 require_superuser
-require_kernel_module nfit_test
 
 setup
 


### PR DESCRIPTION
Move 'require_kernel_module nfit_test'
to the top of the specific requirements,
because it is the most difficult to fullfill.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2980)
<!-- Reviewable:end -->
