### PR TITLE
test: add require_short_path in blk_pool/TEST26

### DIFF
--- a/src/test/blk_pool/TEST26.PS1
+++ b/src/test/blk_pool/TEST26.PS1
@@ -36,6 +36,8 @@
 . ..\unittest\unittest.ps1
 
 require_test_type medium
+# icacls does have problems with handling long paths in the correct way.
+require_short_path
 
 setup
 


### PR DESCRIPTION
This is required as icacls does have problems with handling long paths
in the correct way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2985)
<!-- Reviewable:end -->
