### PR TITLE
test: speed up skipping remote tests with dax devices

### DIFF
--- a/src/test/libpmempool_rm_remote/TEST3
+++ b/src/test/libpmempool_rm_remote/TEST3
@@ -42,10 +42,9 @@
 require_test_type medium
 
 require_nodes 2
-
+require_node_dax_device 0 1
 require_node_libfabric 0 $RPMEM_PROVIDER
 require_node_libfabric 1 $RPMEM_PROVIDER
-require_node_dax_device 0 1
 
 setup
 

--- a/src/test/pmempool_sync_remote/TEST10
+++ b/src/test/pmempool_sync_remote/TEST10
@@ -45,10 +45,11 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_4KB
 require_node_dax_device_alignments 1 $SIZE_4KB $SIZE_4KB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_sync_remote/TEST11
+++ b/src/test/pmempool_sync_remote/TEST11
@@ -45,10 +45,11 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_4KB
 require_node_dax_device_alignments 1 $SIZE_4KB $SIZE_4KB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_sync_remote/TEST12
+++ b/src/test/pmempool_sync_remote/TEST12
@@ -46,10 +46,11 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_2MB
 require_node_dax_device_alignments 1 $SIZE_2MB $SIZE_2MB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_sync_remote/TEST13
+++ b/src/test/pmempool_sync_remote/TEST13
@@ -46,10 +46,11 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_2MB
 require_node_dax_device_alignments 1 $SIZE_2MB $SIZE_2MB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_sync_remote/TEST14
+++ b/src/test/pmempool_sync_remote/TEST14
@@ -46,10 +46,11 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_2MB
 require_node_dax_device_alignments 1 $SIZE_2MB $SIZE_4KB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_sync_remote/TEST15
+++ b/src/test/pmempool_sync_remote/TEST15
@@ -46,10 +46,11 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_2MB
 require_node_dax_device_alignments 1 $SIZE_2MB $SIZE_4KB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_sync_remote/TEST16
+++ b/src/test/pmempool_sync_remote/TEST16
@@ -45,9 +45,10 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_4KB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_sync_remote/TEST17
+++ b/src/test/pmempool_sync_remote/TEST17
@@ -45,9 +45,10 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_4KB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_sync_remote/TEST18
+++ b/src/test/pmempool_sync_remote/TEST18
@@ -46,9 +46,10 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_2MB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_sync_remote/TEST19
+++ b/src/test/pmempool_sync_remote/TEST19
@@ -46,9 +46,10 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_2MB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_sync_remote/TEST5
+++ b/src/test/pmempool_sync_remote/TEST5
@@ -40,9 +40,10 @@
 
 require_test_type medium
 
-. ./common.sh
-
+require_nodes 2
 require_node_dax_device 0 1
+
+. ./common.sh
 
 setup
 

--- a/src/test/pmempool_sync_remote/TEST6
+++ b/src/test/pmempool_sync_remote/TEST6
@@ -40,10 +40,11 @@
 
 require_test_type medium
 
-. ./common.sh
-
+require_nodes 2
 require_node_dax_device 0 1
 require_node_dax_device 1 1
+
+. ./common.sh
 
 setup
 

--- a/src/test/pmempool_transform_remote/TEST10
+++ b/src/test/pmempool_transform_remote/TEST10
@@ -45,10 +45,11 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 1 $SIZE_2MB $SIZE_2MB
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_2MB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_transform_remote/TEST11
+++ b/src/test/pmempool_transform_remote/TEST11
@@ -44,9 +44,10 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_4KB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_transform_remote/TEST12
+++ b/src/test/pmempool_transform_remote/TEST12
@@ -45,9 +45,10 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_2MB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_transform_remote/TEST13
+++ b/src/test/pmempool_transform_remote/TEST13
@@ -44,9 +44,10 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 1 $SIZE_4KB $SIZE_4KB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_transform_remote/TEST14
+++ b/src/test/pmempool_transform_remote/TEST14
@@ -45,9 +45,10 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 1 $SIZE_2MB $SIZE_2MB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_transform_remote/TEST15
+++ b/src/test/pmempool_transform_remote/TEST15
@@ -44,10 +44,11 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 1 $SIZE_4KB $SIZE_4KB
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_4KB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_transform_remote/TEST16
+++ b/src/test/pmempool_transform_remote/TEST16
@@ -45,10 +45,11 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 1 $SIZE_2MB $SIZE_2MB
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_2MB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_transform_remote/TEST17
+++ b/src/test/pmempool_transform_remote/TEST17
@@ -44,9 +44,10 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_4KB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_transform_remote/TEST18
+++ b/src/test/pmempool_transform_remote/TEST18
@@ -45,9 +45,10 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_2MB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_transform_remote/TEST19
+++ b/src/test/pmempool_transform_remote/TEST19
@@ -44,9 +44,10 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 1 $SIZE_4KB $SIZE_4KB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_transform_remote/TEST4
+++ b/src/test/pmempool_transform_remote/TEST4
@@ -40,9 +40,10 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device 0 1
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_transform_remote/TEST5
+++ b/src/test/pmempool_transform_remote/TEST5
@@ -40,9 +40,10 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device 0 1
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_transform_remote/TEST6
+++ b/src/test/pmempool_transform_remote/TEST6
@@ -44,10 +44,11 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 1 $SIZE_4KB $SIZE_4KB
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_4KB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_transform_remote/TEST7
+++ b/src/test/pmempool_transform_remote/TEST7
@@ -45,10 +45,11 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 1 $SIZE_2MB $SIZE_2MB
 require_node_dax_device_alignments 0 $SIZE_4KB $SIZE_4KB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_transform_remote/TEST8
+++ b/src/test/pmempool_transform_remote/TEST8
@@ -45,10 +45,11 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 1 $SIZE_4KB $SIZE_4KB
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_2MB
+
+. common.sh
 
 setup
 

--- a/src/test/pmempool_transform_remote/TEST9
+++ b/src/test/pmempool_transform_remote/TEST9
@@ -45,10 +45,11 @@
 require_test_type	medium
 require_fs_type		any
 
-. common.sh
-
+require_nodes 2
 require_node_dax_device_alignments 1 $SIZE_4KB $SIZE_2MB
 require_node_dax_device_alignments 0 $SIZE_2MB $SIZE_4KB
+
+. common.sh
 
 setup
 

--- a/src/test/rpmem_basic/TEST15
+++ b/src/test/rpmem_basic/TEST15
@@ -44,10 +44,11 @@ require_test_type medium
 require_fs_type any
 require_build_type nondebug debug
 
-. setup.sh
-
+require_nodes 2
 require_node_dax_device 0 1
 require_node_dax_device 1 1
+
+. setup.sh
 
 setup
 

--- a/src/test/rpmem_basic/TEST18
+++ b/src/test/rpmem_basic/TEST18
@@ -45,10 +45,11 @@ require_test_type medium
 require_fs_type any
 require_build_type nondebug debug
 
-. setup.sh
-
+require_nodes 2
 require_node_dax_device 0 1
 require_node_dax_device 1 1
+
+. setup.sh
 
 setup
 

--- a/src/test/rpmem_basic/TEST7
+++ b/src/test/rpmem_basic/TEST7
@@ -45,10 +45,11 @@ require_test_type medium
 require_fs_type any
 require_build_type nondebug debug
 
-. setup.sh
-
+require_nodes 2
 require_node_dax_device 0 1
 require_node_dax_device 1 1
+
+. setup.sh
 
 setup
 

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1247,7 +1247,7 @@ function get_node_devdax_size() {
 	ret=$?
 	restore_exit_on_error
 	if [ "$ret" != "0" ]; then
-		fatal "UNITTEST_NAME: stat on node $node: $out"
+		fatal "$UNITTEST_NAME: stat on node $node: $out"
 	fi
 	local major=$((16#$out))
 
@@ -1943,6 +1943,13 @@ function require_nodes() {
 
 	local N_NODES=${#NODE[@]}
 	local N=$1
+
+	[ -z "$N" ] \
+		&& fatal "require_nodes: missing reguired parameter: number of nodes"
+
+	# if it has already been called, check if number of required nodes is bigger than previously
+	[ -n "$NODES_MAX" ] \
+		&& [ $(($N - 1)) -le $NODES_MAX ] && return
 
 	[ $N -gt $N_NODES ] \
 		&& msg "$UNITTEST_NAME: SKIP: requires $N node(s), but $N_NODES node(s) provided" \


### PR DESCRIPTION
The requirements:
- require_node_dax_device,
- require_node_dax_device_alignments

should be checked before the initialization, because the initialization takes much time and it is useless to initilize nodes if requirements are not met.

This patch makes skipping remote tests with dax devices when one of these requirements are not met about 7 times faster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2989)
<!-- Reviewable:end -->
