### PR TITLE
[1.4] common: reenable daxio

### DIFF
--- a/src/benchmarks/Makefile
+++ b/src/benchmarks/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2017, Intel Corporation
+# Copyright 2014-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -110,7 +110,7 @@ else
 LIBS += ../debug/libpmemcommon.a
 endif
 LIBS += -lpmemobj -lpmemlog -lpmemblk -lpmem -lvmem -pthread -lm \
-	$(LIBDL) $(LIBUUID) $(LIBNDCTL)
+	$(LIBDL) $(LIBUUID)
 ifeq ($(call check_librt), n)
 LIBS += -lrt
 endif

--- a/src/common.inc
+++ b/src/common.inc
@@ -268,9 +268,6 @@ LIBUTIL=
 LIBUUID=
 LIBCXXABI=-lc++abi
 
-# XXX: disable building with ndctl, unless explicitly enabled
-NDCTL_ENABLE ?= n
-
 # Detect libndctl if not disabled.
 ifneq ($(NDCTL_ENABLE),n)
 HAS_NDCTL :=  $(shell echo "int main() {struct ndctl_cmd *cmd; ndctl_cmd_smart_get_shutdown_count(cmd);return 0;}" | \
@@ -295,10 +292,10 @@ ifeq ($(HAS_DAXCTL),n)
 $(error libdaxclt(version >= $(NDCTL_MIN_VERSION)) is missing -- see README)
 endif
 LIBNDCTL = $(shell $(PKG_CONFIG) --libs libndctl libdaxctl)
-OS_DIMM=ndctl
 else
-OS_DIMM=none
 LIBNDCTL=
 endif
+
+OS_DIMM=none
 
 endif

--- a/src/libpmemblk/Makefile
+++ b/src/libpmemblk/Makefile
@@ -45,4 +45,4 @@ SOURCE +=\
 
 include ../Makefile.inc
 
-LIBS += -pthread -lpmem $(LIBNDCTL)
+LIBS += -pthread -lpmem

--- a/src/libpmemcto/Makefile
+++ b/src/libpmemcto/Makefile
@@ -52,6 +52,6 @@ INCS += -I../../libpmemcto
 INCS += -I$(JEMALLOC_DIR)/include/jemalloc
 INCS += -I$(JEMALLOC_OBJDIR)/include/jemalloc
 EXTRA_OBJS += $(JEMALLOC_LIB)
-LIBS += -pthread -lpmem $(LIBNDCTL)
+LIBS += -pthread -lpmem
 
 include ../Makefile.inc

--- a/src/libpmemlog/Makefile
+++ b/src/libpmemlog/Makefile
@@ -44,4 +44,4 @@ SOURCE +=\
 
 include ../Makefile.inc
 
-LIBS += -pthread -lpmem $(LIBNDCTL)
+LIBS += -pthread -lpmem

--- a/src/libpmemobj/Makefile
+++ b/src/libpmemobj/Makefile
@@ -68,4 +68,4 @@ include ../Makefile.inc
 
 CFLAGS += -DUSE_LIBDL -D_PMEMOBJ_INTRNL
 
-LIBS += -pthread -lpmem $(LIBDL) $(LIBNDCTL)
+LIBS += -pthread -lpmem $(LIBDL)

--- a/src/libpmempool/Makefile
+++ b/src/libpmempool/Makefile
@@ -76,7 +76,7 @@ LIBPMEMBLK_PRIV_FUNCS=btt_info_set btt_arena_datasize btt_flog_size\
 
 include ../Makefile.inc
 
-LIBS += -pthread -lpmem $(LIBDL) $(LIBNDCTL)
+LIBS += -pthread -lpmem $(LIBDL)
 CFLAGS += -DUSE_LIBDL
 CFLAGS += -DUSE_RPMEM
 

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -283,11 +283,6 @@ ifneq ($(LIBPMEMCOMMON)$(LIBPMEMPOOL)$(LIBPMEMOBJ),)
 LIBS += $(LIBDL)
 endif
 
-ifneq ($(LIBPMEMCOMMON)$(LIBPMEMPOOL)$(LIBPMEMBLK)$(LIBPMEMLOG)$(LIBPMEMOBJ)$(LIBPMEMCTO),)
-LIBS += $(LIBNDCTL)
-endif
-
-
 #
 # This is a helper function to be combined with usage of macros available
 # in the unittest framework. It scans the code for functions that should be

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -132,7 +132,6 @@ DYNAMIC_LIBS += $(LIBSDIR_DEBUG)/libpmemcommon.a
 STATIC_DEBUG_LIBS += $(LIBSDIR_DEBUG)/libpmemcommon.a
 STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libpmemcommon.a
 CFLAGS += -I$(TOP)/src/common
-LIBS += $(LIBNDCTL)
 endif
 
 ifeq ($(LIBPMEMPOOL), y)


### PR DESCRIPTION
In 1.4 we made a mistake of using one flag (NDCTL_ENABLE) for
2 independent features: RAS and daxio. We set NDCTL_ENABLE to "n" just
before 1.4 release to disable RAS (it is incomplete and affects pool
layout), but didn't take into account that it alse disabled daxio.
    
This patch completely disables RAS (it was possible to force enable it)
and reenables daxio. NDCTL_ENABLE is now used only for daxio.
    
Ref: pmem/issues#892

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2994)
<!-- Reviewable:end -->
