### PR TITLE
test: add Last shutdown to match files

### DIFF
--- a/src/test/pmempool_check/out31.log.match
+++ b/src/test/pmempool_check/out31.log.match
@@ -42,6 +42,7 @@ Alignment Descriptor     : $(nW)
 Class                    : 64
 Data                     : 2's complement, little endian
 Machine                  : AMD X86-64
+Last shutdown            : clean
 Checksum                 : $(*)
 
 PMEM OBJ Header:
@@ -101,6 +102,7 @@ Alignment Descriptor     : $(nW)
 Class                    : 64
 Data                     : 2's complement, little endian
 Machine                  : AMD X86-64
+Last shutdown            : clean
 Checksum                 : $(*)
 
 PMEM OBJ Header:

--- a/src/test/pmempool_check/out32.log.match
+++ b/src/test/pmempool_check/out32.log.match
@@ -35,6 +35,7 @@ Alignment Descriptor     : $(nW)
 Class                    : 64
 Data                     : 2's complement, little endian
 Machine                  : AMD X86-64
+Last shutdown            : clean
 Checksum                 : $(*)
 
 PMEM OBJ Header:
@@ -87,6 +88,7 @@ Alignment Descriptor     : $(nW)
 Class                    : 64
 Data                     : 2's complement, little endian
 Machine                  : AMD X86-64
+Last shutdown            : clean
 Checksum                 : $(*)
 
 PMEM OBJ Header:

--- a/src/test/pmempool_sync/out27.log.match
+++ b/src/test/pmempool_sync/out27.log.match
@@ -42,6 +42,7 @@ Alignment Descriptor     : $(nW)
 Class                    : 64
 Data                     : 2's complement, little endian
 Machine                  : AMD X86-64
+Last shutdown            : clean
 Checksum                 : $(*)
 
 PMEM OBJ Header:
@@ -107,6 +108,7 @@ Alignment Descriptor     : $(nW)
 Class                    : 64
 Data                     : 2's complement, little endian
 Machine                  : AMD X86-64
+Last shutdown            : clean
 Checksum                 : $(*)
 
 PMEM OBJ Header:

--- a/src/test/pmempool_sync/out28.log.match
+++ b/src/test/pmempool_sync/out28.log.match
@@ -35,6 +35,7 @@ Alignment Descriptor     : $(nW)
 Class                    : 64
 Data                     : 2's complement, little endian
 Machine                  : AMD X86-64
+Last shutdown            : clean
 Checksum                 : $(*)
 
 PMEM OBJ Header:
@@ -91,6 +92,7 @@ Alignment Descriptor     : $(nW)
 Class                    : 64
 Data                     : 2's complement, little endian
 Machine                  : AMD X86-64
+Last shutdown            : clean
 Checksum                 : $(*)
 
 PMEM OBJ Header:


### PR DESCRIPTION
It fixes regression caused by the commit f327365a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2997)
<!-- Reviewable:end -->
