### PR TITLE
obj: calc leftover run space for class selection

### DIFF
--- a/src/test/obj_fragmentation2/TEST8
+++ b/src/test/obj_fragmentation2/TEST8
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+
+require_fs_type pmem
+require_build_type static-nondebug
+
+setup
+
+PMEM_IS_PMEM_FORCE=1 PMEM_NO_FLUSH=1 expect_normal_exit\
+	./obj_fragmentation2$EXESUFFIX $DIR/testfile1 8 12345
+
+pass

--- a/src/test/obj_fragmentation2/obj_fragmentation2.c
+++ b/src/test/obj_fragmentation2/obj_fragmentation2.c
@@ -196,7 +196,7 @@ static workload *workloads[] = {
 };
 
 static float workloads_target[] = {
-	0.01f, 0.01f, 0.01f, 0.9f, 0.8f, 0.7f, 0.2f, 0.7f, 0.73f
+	0.01f, 0.01f, 0.01f, 0.9f, 0.8f, 0.7f, 0.2f, 0.7f, 0.1f
 };
 
 int


### PR DESCRIPTION
This patch very slightly alters the allocation class selection
algorithm to take into account the theoretical worst-case run
leftover space. This improves the effective internal fragmentation
of workloads which predominantly allocate a single size from a class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/2998)
<!-- Reviewable:end -->
