### PR TITLE
common: stop simulating PCOMMIT for pmemcheck

### DIFF
--- a/src/common/valgrind_internal.h
+++ b/src/common/valgrind_internal.h
@@ -171,16 +171,9 @@ extern unsigned _On_valgrind;
 		VALGRIND_PMC_DO_FENCE;\
 } while (0)
 
-#define VALGRIND_DO_COMMIT do {\
-	if (On_valgrind)\
-		VALGRIND_PMC_DO_COMMIT;\
-} while (0)
-
 #define VALGRIND_DO_PERSIST(addr, len) do {\
 	if (On_valgrind) {\
 		VALGRIND_PMC_DO_FLUSH((addr), (len));\
-		VALGRIND_PMC_DO_FENCE;\
-		VALGRIND_PMC_DO_COMMIT;\
 		VALGRIND_PMC_DO_FENCE;\
 	}\
 } while (0)
@@ -312,8 +305,6 @@ extern unsigned _On_valgrind;
 } while (0)
 
 #define VALGRIND_DO_FENCE do {} while (0)
-
-#define VALGRIND_DO_COMMIT do {} while (0)
 
 #define VALGRIND_DO_PERSIST(addr, len) do {\
 	(void) (addr);\

--- a/src/libpmem/pmem.c
+++ b/src/libpmem/pmem.c
@@ -205,9 +205,6 @@ pmem_drain(void)
 	LOG(15, NULL);
 
 	Funcs.predrain_fence();
-
-	VALGRIND_DO_COMMIT;
-	VALGRIND_DO_FENCE;
 }
 
 /*

--- a/utils/docker/images/push-image.sh
+++ b/utils/docker/images/push-image.sh
@@ -32,7 +32,7 @@
 
 #
 # push-image.sh <OS-VER> - pushes the Docker image tagged with OS-VER
-#                          to the Docker Hub.
+#                          to the Docker Hub
 #
 # The script utilizes $DOCKER_USER and $DOCKER_PASSWORD variables to log in to
 # Docker Hub. The variables can be set in the Travis project's configuration


### PR DESCRIPTION
pmem/valgrind#54 removes PCOMMIT (never shipped in any CPU, already deprecated) support from our Valgrind fork AND simplifies pmemcheck's state machine. As an unfortunate side effect pmemcheck can't distinguish pmem_flush from pmem_persist on pre-Skylake CPUs, because both translate to single CLFLUSH instruction. This means that one of our PMDK tests started to fail on pre-Skylake CPUs (pmem_valgr_simple verifies that pmemcheck finds missing pmem_drain after pmem_flush).

To fix that pmem/valgrind#54 introduces an option which tells pmemcheck to expect fence (real sfence or VALGRIND_PMC_DO_FENCE client request) after clflush.  VALGRIND_PMC_DO_FENCE is already emitted by pmem_drain (--expect-fence-after-clflush=yes).

This PR removes emission of fake PCOMMIT client request (real PCOMMIT support was removed long time ago) and enables --expect-fence-after-clflush=yes for all pmemcheck uses.

This should be merged after pmem/valgrind#54 is merged and without the last patch that temporarily switches to my Valgrind fork.

**After this PR is merged PMDK will require updated pmemcheck.**

**New pmemcheck is NOT backward compatible with older PMDK versions for pre-Skylake CPUs. This means that pmem_valgr_simple test in 1.4/pre-this-PR will fail on pre-Skylake CPUs.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3000)
<!-- Reviewable:end -->
