### PR TITLE
obj: tighten memblock abstraction 

### DIFF
--- a/src/common/sys_util.h
+++ b/src/common/sys_util.h
@@ -87,6 +87,22 @@ util_mutex_lock(os_mutex_t *m)
 }
 
 /*
+ * util_mutex_trylock -- os_mutex_trylock variant that never fails from
+ * caller perspective (other than EBUSY). If util_mutex_trylock failed, this
+ * function aborts the program.
+ */
+static inline int
+util_mutex_trylock(os_mutex_t *m)
+{
+	int tmp = os_mutex_trylock(m);
+	if (tmp && tmp != EBUSY) {
+		errno = tmp;
+		FATAL("!os_mutex_trylock");
+	}
+	return tmp == EBUSY;
+}
+
+/*
  * util_mutex_unlock -- os_mutex_unlock variant that never fails from
  * caller perspective. If os_mutex_unlock failed, this function aborts
  * the program.

--- a/src/libpmemobj/alloc_class.c
+++ b/src/libpmemobj/alloc_class.c
@@ -115,12 +115,6 @@ static struct {
 #define SIZE_TO_CLASS_MAP_INDEX(_s, _g) (1 + (((_s) - 1) / (_g)))
 
 /*
- * Calculates the size in bytes of a single run instance
- */
-#define RUN_SIZE_BYTES(size_idx)\
-(RUNSIZE + (((size_idx) - 1) * CHUNKSIZE))
-
-/*
  * Target number of allocations per run instance.
  */
 #define RUN_MIN_NALLOCS 500
@@ -201,77 +195,6 @@ alloc_class_reservation_clear(struct alloc_class_collection *ac, int id)
 }
 
 /*
- * alloc_class_generate_run_proto -- generates the run bitmap-related
- *	information needed for the allocation class
- */
-void
-alloc_class_generate_run_proto(struct alloc_class_run_proto *dest,
-	size_t unit_size, uint32_t size_idx, size_t alignment)
-{
-	LOG(10, NULL);
-
-	ASSERTne(size_idx, 0);
-	dest->size_idx = size_idx;
-	dest->alignment = alignment;
-
-	/*
-	 * Here the bitmap definition is calculated based on the
-	 * size of the available memory and the size of
-	 * a memory block - the result of dividing those two
-	 * numbers is the number of possible allocations from
-	 * that block, and in other words, the amount of bits
-	 * in the bitmap.
-	 */
-	dest->bitmap_nallocs = (uint32_t)
-		(RUN_SIZE_BYTES(dest->size_idx) / unit_size);
-
-	while (dest->bitmap_nallocs > RUN_BITMAP_SIZE) {
-		LOG(3, "tried to create allocation class (%lu) with number "
-			"of units (%u) exceeding the bitmap size (%u)",
-			unit_size, dest->bitmap_nallocs, RUN_BITMAP_SIZE);
-		if (dest->size_idx > 1) {
-			dest->size_idx -= 1;
-			/* recalculate the number of allocations */
-			dest->bitmap_nallocs = (uint32_t)
-				(RUN_SIZE_BYTES(dest->size_idx) / unit_size);
-			LOG(3, "allocation class (%lu) was constructed with "
-				"fewer (%u) than requested chunks (%u)",
-				unit_size, dest->size_idx, dest->size_idx + 1);
-		} else {
-			LOG(3, "allocation class (%lu) was constructed with "
-				"fewer units (%u) than optimal (%u), "
-				"this might lead to "
-				"inefficient memory utilization!",
-				unit_size,
-				RUN_BITMAP_SIZE, dest->bitmap_nallocs);
-
-			dest->bitmap_nallocs = RUN_BITMAP_SIZE;
-		}
-	}
-
-	/*
-	 * The two other numbers that define our bitmap is the
-	 * size of the array that represents the bitmap and the
-	 * last value of that array with the bits that exceed
-	 * number of blocks marked as set (1).
-	 */
-	ASSERT(dest->bitmap_nallocs <= RUN_BITMAP_SIZE);
-	unsigned unused_bits = RUN_BITMAP_SIZE - dest->bitmap_nallocs;
-
-	unsigned unused_values = unused_bits / BITS_PER_VALUE;
-
-	ASSERT(MAX_BITMAP_VALUES >= unused_values);
-	dest->bitmap_nval = MAX_BITMAP_VALUES - unused_values;
-
-	ASSERT(unused_bits >= unused_values * BITS_PER_VALUE);
-	unused_bits -= unused_values * BITS_PER_VALUE;
-
-	dest->bitmap_lastval = unused_bits ?
-		(((1ULL << unused_bits) - 1ULL) <<
-			(BITS_PER_VALUE - unused_bits)) : 0;
-}
-
-/*
  * alloc_class_new -- creates a new allocation class
  */
 struct alloc_class *
@@ -298,12 +221,14 @@ alloc_class_new(int id, struct alloc_class_collection *ac,
 			id = DEFAULT_ALLOC_CLASS_ID;
 			break;
 		case CLASS_RUN:
-			alloc_class_generate_run_proto(&c->run, unit_size,
-				size_idx, alignment);
+			c->run.alignment = alignment;
+			c->run.nallocs = memblock_run_nallocs(&size_idx,
+				c->flags, unit_size, alignment);
+			c->run.size_idx = size_idx;
 
 			uint8_t slot = (uint8_t)id;
 			if (id < 0 && alloc_class_find_first_free_slot(ac,
-			    &slot) != 0)
+					&slot) != 0)
 				goto error_class_alloc;
 			id = slot;
 
@@ -311,8 +236,7 @@ alloc_class_new(int id, struct alloc_class_collection *ac,
 				ac->granularity);
 			ASSERT(map_idx <= UINT32_MAX);
 			uint32_t map_idx_s = (uint32_t)map_idx;
-			ASSERT(c->run.size_idx <= UINT16_MAX);
-			uint16_t size_idx_s = (uint16_t)c->run.size_idx;
+			uint16_t size_idx_s = (uint16_t)size_idx;
 			uint16_t flags_s = (uint16_t)c->flags;
 			uint64_t k = RUN_CLASS_KEY_PACK(map_idx_s,
 				flags_s, size_idx_s);
@@ -549,8 +473,8 @@ alloc_class_collection_new()
 	 * The actual run might contain less unit blocks than the theoretical
 	 * unit max variable. This may be the case for very large unit sizes.
 	 */
-	size_t real_unit_max = c->run.bitmap_nallocs < RUN_UNIT_MAX_ALLOC ?
-		c->run.bitmap_nallocs : RUN_UNIT_MAX_ALLOC;
+	size_t real_unit_max = c->run.nallocs < RUN_UNIT_MAX_ALLOC ?
+		c->run.nallocs : RUN_UNIT_MAX_ALLOC;
 
 	size_t theoretical_run_max_size = c->unit_size * real_unit_max;
 
@@ -701,7 +625,7 @@ alloc_class_calc_size_idx(struct alloc_class *c, size_t size)
 			return -1;
 		else if (size_idx > RUN_UNIT_MAX)
 			return -1;
-		else if (size_idx > c->run.bitmap_nallocs)
+		else if (size_idx > c->run.nallocs)
 			return -1;
 	}
 

--- a/src/libpmemobj/alloc_class.h
+++ b/src/libpmemobj/alloc_class.h
@@ -40,7 +40,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <sys/types.h>
-#include "memblock.h"
+#include "heap_layout.h"
 
 #define MAX_ALLOCATION_CLASSES (UINT8_MAX)
 #define DEFAULT_ALLOC_CLASS_ID (0)
@@ -56,33 +56,6 @@ enum alloc_class_type {
 	MAX_ALLOC_CLASS_TYPES
 };
 
-struct alloc_class_run_proto {
-	/*
-	 * Last value of a bitmap representing completely free
-	 * run from this bucket.
-	 */
-	uint64_t bitmap_lastval;
-
-	/*
-	 * Number of 8 byte values this run bitmap is
-	 * composed of.
-	 */
-	unsigned bitmap_nval;
-
-	/*
-	 * Number of allocations that can be performed from a
-	 * single run.
-	 */
-	unsigned bitmap_nallocs;
-
-	/*
-	 * The size index of a single run instance.
-	 */
-	uint32_t size_idx;
-
-	size_t alignment;
-};
-
 struct alloc_class {
 	uint8_t id;
 	uint16_t flags;
@@ -92,17 +65,16 @@ struct alloc_class {
 	enum header_type header_type;
 	enum alloc_class_type type;
 
-	union {
-		/* struct { ... } huge; */
-		struct alloc_class_run_proto run;
-	};
+	/* run specific data */
+	struct {
+		uint32_t size_idx; /* size index of a single run instance */
+		size_t alignment; /* required alignment of objects */
+		unsigned nallocs; /* number of allocs per run */
+	} run;
 };
 
 struct alloc_class_collection *alloc_class_collection_new(void);
 void alloc_class_collection_delete(struct alloc_class_collection *ac);
-
-void alloc_class_generate_run_proto(struct alloc_class_run_proto *dest,
-	size_t unit_size, uint32_t size_idx, size_t alignment);
 
 struct alloc_class *alloc_class_by_run(
 	struct alloc_class_collection *ac,

--- a/src/libpmemobj/bucket.c
+++ b/src/libpmemobj/bucket.c
@@ -91,7 +91,7 @@ error_active_alloc:
  * bucket_insert_block -- inserts a block into the bucket
  */
 int
-bucket_insert_block(struct bucket *b, const struct memory_block *m)
+bucket_insert_block(const struct memory_block *m, struct bucket *b)
 {
 #if VG_MEMCHECK_ENABLED || VG_HELGRIND_ENABLED || VG_DRD_ENABLED
 	if (On_valgrind) {

--- a/src/libpmemobj/bucket.h
+++ b/src/libpmemobj/bucket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017, Intel Corporation
+ * Copyright 2015-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -64,7 +64,7 @@ struct bucket *bucket_new(struct block_container *c,
 
 int *bucket_current_resvp(struct bucket *b);
 
-int bucket_insert_block(struct bucket *b, const struct memory_block *m);
+int bucket_insert_block(const struct memory_block *m, struct bucket *b);
 
 void bucket_delete(struct bucket *b);
 

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -56,7 +56,7 @@
 #define SIZEOF_RUN(runp, size_idx)\
 	(sizeof(*(runp)) + (((size_idx) - 1) * CHUNKSIZE))
 
-#define MAX_RUN_LOCKS 1024
+#define MAX_RUN_LOCKS MAX_CHUNK
 
 /*
  * This is the value by which the heap might grow once we hit an OOM.

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -428,33 +428,46 @@ heap_run_init(struct palloc_heap *heap, struct bucket *b,
 }
 
 /*
- * heap_run_insert -- (internal) inserts and splits a block of memory into a run
+ * heap_run_process_bitmap_value -- (internal) looks for unset bits in the
+ * value, creates a valid memory block out of them and inserts that
+ * block into the given bucket.
  */
-static void
-heap_run_insert(struct palloc_heap *heap, struct bucket *b,
-	const struct memory_block *m, uint32_t size_idx, uint16_t block_off)
+static uint32_t
+heap_run_process_bitmap_value(struct bucket *b, struct memory_block *m,
+	uint64_t value, uint16_t base_offset)
 {
-	struct alloc_class *c = b->aclass;
-	ASSERTeq(c->type, CLASS_RUN);
-
-	ASSERT(size_idx <= BITS_PER_VALUE);
-	ASSERT(block_off + size_idx <= c->run.bitmap_nallocs);
-
-	uint32_t unit_max = RUN_UNIT_MAX;
-	struct memory_block nm = *m;
-	nm.size_idx = unit_max - (block_off % unit_max);
-	nm.block_off = block_off;
-	if (nm.size_idx > size_idx)
-		nm.size_idx = size_idx;
+	uint64_t shift = 0;
+	uint32_t inserted = 0;
 
 	do {
-		bucket_insert_block(b, &nm);
-		ASSERT(nm.size_idx <= UINT16_MAX);
-		ASSERT(nm.block_off + nm.size_idx <= UINT16_MAX);
-		nm.block_off = (uint16_t)(nm.block_off + (uint16_t)nm.size_idx);
-		size_idx -= nm.size_idx;
-		nm.size_idx = size_idx > unit_max ? unit_max : size_idx;
-	} while (size_idx != 0);
+		uint64_t shifted = ~(value >> shift);
+		if (shifted == UINT64_MAX) {
+			inserted += (uint32_t)(BITS_PER_VALUE - shift);
+
+			m->block_off = (uint16_t)(base_offset + shift);
+			m->size_idx = (uint32_t)(BITS_PER_VALUE - shift);
+			bucket_insert_block(b, m);
+
+			break;
+		} else if (shifted == 0) {
+			break;
+		}
+
+		unsigned off = (unsigned)util_lssb_index64(shifted);
+		unsigned size = (unsigned)util_lssb_index64(~shifted);
+
+		shift += off + size;
+
+		if (size != 0) {
+			inserted += (uint32_t)(size);
+
+			m->block_off = (uint16_t)(base_offset + (shift - size));
+			m->size_idx = (uint32_t)(size);
+			bucket_insert_block(b, m);
+		}
+	} while (shift != BITS_PER_VALUE);
+	
+	return inserted;
 }
 
 /*
@@ -469,54 +482,20 @@ heap_run_process_metadata(struct palloc_heap *heap, struct bucket *b,
 	ASSERTeq(m->size_idx, c->run.size_idx);
 
 	uint16_t block_off = 0;
-	uint16_t block_size_idx = 0;
 	uint32_t inserted_blocks = 0;
 
 	struct chunk_run *run = heap_get_chunk_run(heap, m);
 
 	ASSERTeq(run->block_size, c->unit_size);
 
+	struct memory_block nm = *m;
 	for (unsigned i = 0; i < c->run.bitmap_nval; ++i) {
 		ASSERT(i < MAX_BITMAP_VALUES);
 		uint64_t v = run->bitmap[i];
 		ASSERT(BITS_PER_VALUE * i <= UINT16_MAX);
 		block_off = (uint16_t)(BITS_PER_VALUE * i);
-		if (v == 0) {
-			heap_run_insert(heap, b, m, BITS_PER_VALUE, block_off);
-			inserted_blocks += BITS_PER_VALUE;
-			continue;
-		} else if (v == UINT64_MAX) {
-			continue;
-		}
-
-		for (unsigned j = 0; j < BITS_PER_VALUE; ++j) {
-			if (BIT_IS_CLR(v, j)) {
-				block_size_idx++;
-			} else if (block_size_idx != 0) {
-				ASSERT(block_off >= block_size_idx);
-
-				heap_run_insert(heap, b, m,
-					block_size_idx,
-					(uint16_t)(block_off - block_size_idx));
-				inserted_blocks += block_size_idx;
-				block_size_idx = 0;
-			}
-
-			if ((block_off++) == c->run.bitmap_nallocs) {
-				i = MAX_BITMAP_VALUES;
-				break;
-			}
-		}
-
-		if (block_size_idx != 0) {
-			ASSERT(block_off >= block_size_idx);
-
-			heap_run_insert(heap, b, m,
-					block_size_idx,
-					(uint16_t)(block_off - block_size_idx));
-			inserted_blocks += block_size_idx;
-			block_size_idx = 0;
-		}
+		inserted_blocks += heap_run_process_bitmap_value(b, &nm, v,
+			block_off);
 	}
 
 	return inserted_blocks;

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -52,10 +52,6 @@
 #include "os_thread.h"
 #include "set.h"
 
-/* calculates the size of the entire run, including any additional chunks */
-#define SIZEOF_RUN(runp, size_idx)\
-	(sizeof(*(runp)) + (((size_idx) - 1) * CHUNKSIZE))
-
 #define MAX_RUN_LOCKS MAX_CHUNK
 
 /*
@@ -289,47 +285,6 @@ zone_calc_size_idx(uint32_t zone_id, unsigned max_zone, size_t heap_size)
 }
 
 /*
- * heap_chunk_write_footer -- writes a chunk footer
- */
-static void
-heap_chunk_write_footer(struct chunk_header *hdr, uint32_t size_idx)
-{
-	if (size_idx == 1) /* that would overwrite the header */
-		return;
-
-	VALGRIND_DO_MAKE_MEM_UNDEFINED(hdr + size_idx - 1, sizeof(*hdr));
-
-	struct chunk_header f = *hdr;
-	f.type = CHUNK_TYPE_FOOTER;
-	f.size_idx = size_idx;
-	*(hdr + size_idx - 1) = f;
-	/* no need to persist, footers are recreated in heap_populate_buckets */
-	VALGRIND_SET_CLEAN(hdr + size_idx - 1, sizeof(f));
-}
-
-/*
- * heap_chunk_init -- (internal) writes chunk header
- */
-static void
-heap_chunk_init(struct palloc_heap *heap, struct chunk_header *hdr,
-	uint16_t type, uint32_t size_idx)
-{
-	struct chunk_header nhdr = {
-		.type = type,
-		.flags = 0,
-		.size_idx = size_idx
-	};
-	VALGRIND_DO_MAKE_MEM_UNDEFINED(hdr, sizeof(*hdr));
-	VALGRIND_ANNOTATE_NEW_MEMORY(hdr, sizeof(*hdr));
-
-	*hdr = nhdr; /* write the entire header (8 bytes) at once */
-
-	pmemops_persist(&heap->p_ops, hdr, sizeof(*hdr));
-
-	heap_chunk_write_footer(hdr, size_idx);
-}
-
-/*
  * heap_zone_init -- (internal) writes zone's first chunk and header
  */
 static void
@@ -342,163 +297,15 @@ heap_zone_init(struct palloc_heap *heap, uint32_t zone_id,
 
 	ASSERT(size_idx - first_chunk_id > 0);
 
-	heap_chunk_init(heap, &z->chunk_headers[first_chunk_id],
-		CHUNK_TYPE_FREE, size_idx - first_chunk_id);
+	memblock_huge_init(heap, first_chunk_id, zone_id,
+		size_idx - first_chunk_id);
 
 	struct zone_header nhdr = {
 		.size_idx = size_idx,
 		.magic = ZONE_HEADER_MAGIC,
 	};
-	z->header = nhdr;  /* write the entire header (8 bytes) at once */
+	z->header = nhdr; /* write the entire header (8 bytes) at once */
 	pmemops_persist(&heap->p_ops, &z->header, sizeof(z->header));
-}
-
-/*
- * heap_run_init -- (internal) creates a run based on a chunk
- */
-static void
-heap_run_init(struct palloc_heap *heap, struct bucket *b,
-	const struct memory_block *m)
-{
-	struct alloc_class *c = b->aclass;
-	ASSERTeq(c->type, CLASS_RUN);
-
-	struct zone *z = ZID_TO_ZONE(heap->layout, m->zone_id);
-
-	struct chunk_run *run = (struct chunk_run *)&z->chunks[m->chunk_id];
-	ASSERTne(m->size_idx, 0);
-	size_t runsize = SIZEOF_RUN(run, m->size_idx);
-
-	VALGRIND_DO_MAKE_MEM_UNDEFINED(run, runsize);
-
-	/* add/remove chunk_run and chunk_header to valgrind transaction */
-	VALGRIND_ADD_TO_TX(run, runsize);
-	run->block_size = c->unit_size;
-	run->alignment = c->run.alignment;
-
-	/* set all the bits */
-	memset(run->bitmap, 0xFF, sizeof(run->bitmap));
-
-	unsigned nval = c->run.bitmap_nval;
-	ASSERT(nval > 0);
-	/* clear only the bits available for allocations from this bucket */
-	memset(run->bitmap, 0, sizeof(uint64_t) * (nval - 1));
-	run->bitmap[nval - 1] = c->run.bitmap_lastval;
-
-	VALGRIND_REMOVE_FROM_TX(run, runsize);
-
-	pmemops_flush(&heap->p_ops, run,
-		sizeof(run->block_size) +
-		sizeof(run->alignment) +
-		sizeof(run->bitmap));
-
-	struct chunk_header run_data_hdr;
-	run_data_hdr.type = CHUNK_TYPE_RUN_DATA;
-	run_data_hdr.flags = 0;
-
-	VALGRIND_ADD_TO_TX(&z->chunk_headers[m->chunk_id],
-		sizeof(struct chunk_header) * m->size_idx);
-
-	struct chunk_header *data_hdr;
-	for (unsigned i = 1; i < m->size_idx; ++i) {
-		data_hdr = &z->chunk_headers[m->chunk_id + i];
-		VALGRIND_DO_MAKE_MEM_UNDEFINED(data_hdr, sizeof(*data_hdr));
-		VALGRIND_ANNOTATE_NEW_MEMORY(data_hdr, sizeof(*data_hdr));
-		run_data_hdr.size_idx = i;
-		*data_hdr = run_data_hdr;
-	}
-	pmemops_persist(&heap->p_ops,
-		&z->chunk_headers[m->chunk_id + 1],
-		sizeof(struct chunk_header) * (m->size_idx - 1));
-
-	struct chunk_header *hdr = &z->chunk_headers[m->chunk_id];
-	ASSERT(hdr->type == CHUNK_TYPE_FREE);
-
-	VALGRIND_ANNOTATE_NEW_MEMORY(hdr, sizeof(*hdr));
-
-	struct chunk_header run_hdr;
-	run_hdr.size_idx = hdr->size_idx;
-	run_hdr.type = CHUNK_TYPE_RUN;
-	run_hdr.flags = c->flags;
-	*hdr = run_hdr;
-	pmemops_persist(&heap->p_ops, hdr, sizeof(*hdr));
-
-	VALGRIND_REMOVE_FROM_TX(&z->chunk_headers[m->chunk_id],
-		sizeof(struct chunk_header) * m->size_idx);
-}
-
-/*
- * heap_run_process_bitmap_value -- (internal) looks for unset bits in the
- * value, creates a valid memory block out of them and inserts that
- * block into the given bucket.
- */
-static uint32_t
-heap_run_process_bitmap_value(struct bucket *b, struct memory_block *m,
-	uint64_t value, uint16_t base_offset)
-{
-	uint64_t shift = 0;
-	uint32_t inserted = 0;
-
-	do {
-		uint64_t shifted = ~(value >> shift);
-		if (shifted == UINT64_MAX) {
-			inserted += (uint32_t)(BITS_PER_VALUE - shift);
-
-			m->block_off = (uint16_t)(base_offset + shift);
-			m->size_idx = (uint32_t)(BITS_PER_VALUE - shift);
-			bucket_insert_block(b, m);
-
-			break;
-		} else if (shifted == 0) {
-			break;
-		}
-
-		unsigned off = (unsigned)util_lssb_index64(shifted);
-		unsigned size = (unsigned)util_lssb_index64(~shifted);
-
-		shift += off + size;
-
-		if (size != 0) {
-			inserted += (uint32_t)(size);
-
-			m->block_off = (uint16_t)(base_offset + (shift - size));
-			m->size_idx = (uint32_t)(size);
-			bucket_insert_block(b, m);
-		}
-	} while (shift != BITS_PER_VALUE);
-
-	return inserted;
-}
-
-/*
- * heap_run_process_metadata -- (internal) parses the run bitmap
- */
-static uint32_t
-heap_run_process_metadata(struct palloc_heap *heap, struct bucket *b,
-	const struct memory_block *m)
-{
-	struct alloc_class *c = b->aclass;
-	ASSERTeq(c->type, CLASS_RUN);
-	ASSERTeq(m->size_idx, c->run.size_idx);
-
-	uint16_t block_off = 0;
-	uint32_t inserted_blocks = 0;
-
-	struct chunk_run *run = heap_get_chunk_run(heap, m);
-
-	ASSERTeq(run->block_size, c->unit_size);
-
-	struct memory_block nm = *m;
-	for (unsigned i = 0; i < c->run.bitmap_nval; ++i) {
-		ASSERT(i < MAX_BITMAP_VALUES);
-		uint64_t v = run->bitmap[i];
-		ASSERT(BITS_PER_VALUE * i <= UINT16_MAX);
-		block_off = (uint16_t)(BITS_PER_VALUE * i);
-		inserted_blocks += heap_run_process_bitmap_value(b, &nm, v,
-			block_off);
-	}
-
-	return inserted_blocks;
 }
 
 /*
@@ -508,15 +315,18 @@ static void
 heap_run_create(struct palloc_heap *heap, struct bucket *b,
 	struct memory_block *m)
 {
-	heap_run_init(heap, b, m);
-	memblock_rebuild_state(heap, m);
-	heap_run_process_metadata(heap, b, m);
+	*m = memblock_run_init(heap,
+		m->chunk_id, m->zone_id, m->size_idx,
+		b->aclass->flags, b->aclass->unit_size,
+		b->aclass->run.alignment);
+
+	m->m_ops->iterate_free(m, (object_callback)bucket_insert_block, b);
 }
 
 /*
  * heap_run_reuse -- (internal) reuses existing run
  */
-static uint32_t
+static void
 heap_run_reuse(struct palloc_heap *heap, struct bucket *b,
 	const struct memory_block *m)
 {
@@ -525,14 +335,13 @@ heap_run_reuse(struct palloc_heap *heap, struct bucket *b,
 
 	util_mutex_lock(lock);
 
-	uint32_t ret = heap_run_process_metadata(heap, b, m);
+	m->m_ops->iterate_free(m, (object_callback)bucket_insert_block, b);
 
 	util_mutex_unlock(lock);
 
 	b->active_memory_block->m = *m;
 	b->is_active = 1;
 
-	return ret;
 }
 
 /*
@@ -559,7 +368,7 @@ heap_free_chunk_reuse(struct palloc_heap *heap,
 
 	*m = nm;
 
-	bucket_insert_block(bucket, m);
+	bucket_insert_block(m, bucket);
 }
 
 /*
@@ -587,8 +396,7 @@ heap_run_into_free_chunk(struct palloc_heap *heap,
 	os_mutex_t *lock = m->m_ops->get_lock(m);
 	util_mutex_lock(lock);
 
-	heap_chunk_init(heap, hdr, CHUNK_TYPE_FREE, m->size_idx);
-	memblock_rebuild_state(heap, m);
+	*m = memblock_huge_init(heap, m->chunk_id, m->zone_id, m->size_idx);
 
 	heap_free_chunk_reuse(heap, bucket, m);
 
@@ -612,14 +420,15 @@ heap_reclaim_run(struct palloc_heap *heap, struct memory_block *m)
 
 	struct recycler_element e = recycler_element_new(heap, m);
 	if (c == NULL) {
-		struct alloc_class_run_proto run_proto;
-		alloc_class_generate_run_proto(&run_proto,
-			run->block_size, m->size_idx, run->alignment);
+		uint32_t size_idx = m->size_idx;
+		unsigned nallocs = memblock_run_nallocs(&size_idx,
+			hdr->flags, run->block_size, run->alignment);
+		ASSERTeq(size_idx, m->size_idx);
 
-		return e.free_space == run_proto.bitmap_nallocs;
+		return e.free_space == nallocs;
 	}
 
-	if (e.free_space == c->run.bitmap_nallocs)
+	if (e.free_space == c->run.nallocs)
 		return 1;
 
 	if (recycler_put(heap->rt->recyclers[c->id], m, e) < 0)
@@ -638,28 +447,6 @@ heap_reclaim_zone_garbage(struct palloc_heap *heap, struct bucket *bucket,
 	struct zone *z = ZID_TO_ZONE(heap->layout, zone_id);
 
 	int rchunks = 0;
-
-	/*
-	 * Recreate all footers BEFORE any other operation takes place.
-	 * The heap_init_free_chunk call expects the footers to be created.
-	 */
-	for (uint32_t i = 0; i < z->header.size_idx; ) {
-		struct chunk_header *hdr = &z->chunk_headers[i];
-		switch (hdr->type) {
-			case CHUNK_TYPE_FREE:
-			case CHUNK_TYPE_USED:
-				heap_chunk_write_footer(hdr,
-					hdr->size_idx);
-				break;
-			case CHUNK_TYPE_RUN:
-				break;
-			default:
-				ASSERT(0);
-		}
-
-		i += hdr->size_idx;
-	}
-
 	for (uint32_t i = 0; i < z->header.size_idx; ) {
 		struct chunk_header *hdr = &z->chunk_headers[i];
 		int rret = 0;
@@ -671,6 +458,7 @@ heap_reclaim_zone_garbage(struct palloc_heap *heap, struct bucket *bucket,
 		m.size_idx = hdr->size_idx;
 
 		memblock_rebuild_state(heap, &m);
+		m.m_ops->reinit_chunk(&m);
 
 		switch (hdr->type) {
 			case CHUNK_TYPE_RUN:
@@ -921,46 +709,32 @@ heap_memblock_on_free(struct palloc_heap *heap, const struct memory_block *m)
 }
 
 /*
- * heap_resize_chunk -- (internal) splits the chunk into two smaller ones
+ * heap_split_block -- (internal) splits unused part of the memory block
  */
 static void
-heap_resize_chunk(struct palloc_heap *heap, struct bucket *bucket,
-	uint32_t chunk_id, uint32_t zone_id, uint32_t new_size_idx)
-{
-	uint32_t new_chunk_id = chunk_id + new_size_idx;
-	ASSERTne(new_chunk_id, chunk_id);
-
-	struct zone *z = ZID_TO_ZONE(heap->layout, zone_id);
-	struct chunk_header *old_hdr = &z->chunk_headers[chunk_id];
-	struct chunk_header *new_hdr = &z->chunk_headers[new_chunk_id];
-
-	uint32_t rem_size_idx = old_hdr->size_idx - new_size_idx;
-	heap_chunk_init(heap, new_hdr, CHUNK_TYPE_FREE, rem_size_idx);
-	heap_chunk_init(heap, old_hdr, CHUNK_TYPE_FREE, new_size_idx);
-
-	struct memory_block m = {new_chunk_id, zone_id, rem_size_idx, 0,
-		0, NULL, NULL, 0, 0};
-	memblock_rebuild_state(heap, &m);
-	bucket_insert_block(bucket, &m);
-}
-
-/*
- * heap_recycle_block -- (internal) recycles unused part of the memory block
- */
-static void
-heap_recycle_block(struct palloc_heap *heap, struct bucket *b,
+heap_split_block(struct palloc_heap *heap, struct bucket *b,
 		struct memory_block *m, uint32_t units)
 {
+	ASSERT(units <= UINT16_MAX);
+	ASSERT(units > 0);
+
 	if (b->aclass->type == CLASS_RUN) {
-		ASSERT(units <= UINT16_MAX);
 		ASSERT(m->block_off + units <= UINT16_MAX);
 		struct memory_block r = {m->chunk_id, m->zone_id,
 			m->size_idx - units, (uint16_t)(m->block_off + units),
 			0, NULL, NULL, 0, 0};
 		memblock_rebuild_state(heap, &r);
-		bucket_insert_block(b, &r);
+		bucket_insert_block(&r, b);
 	} else {
-		heap_resize_chunk(heap, b, m->chunk_id, m->zone_id, units);
+		uint32_t new_chunk_id = m->chunk_id + units;
+		uint32_t new_size_idx = m->size_idx - units;
+
+		*m = memblock_huge_init(heap, m->chunk_id, m->zone_id, units);
+
+		struct memory_block n = memblock_huge_init(heap,
+			new_chunk_id, m->zone_id, new_size_idx);
+
+		bucket_insert_block(&n, b);
 	}
 
 	m->size_idx = units;
@@ -989,7 +763,7 @@ heap_get_bestfit_block(struct palloc_heap *heap, struct bucket *b,
 	ASSERT(m->size_idx >= units);
 
 	if (units != m->size_idx)
-		heap_recycle_block(heap, b, m, units);
+		heap_split_block(heap, b, m, units);
 
 	m->m_ops->ensure_header_type(m, b->aclass->header_type);
 	m->header_type = b->aclass->header_type;
@@ -1129,8 +903,7 @@ heap_create_alloc_class_buckets(struct palloc_heap *heap, struct alloc_class *c)
 	struct heap_rt *h = heap->rt;
 
 	if (c->type == CLASS_RUN) {
-		h->recyclers[c->id] = recycler_new(heap,
-			c->run.bitmap_nallocs);
+		h->recyclers[c->id] = recycler_new(heap, c->run.nallocs);
 		if (h->recyclers[c->id] == NULL)
 			goto error_recycler_new;
 	}
@@ -1561,7 +1334,7 @@ heap_check(void *heap_start, uint64_t heap_size)
 
 /*
  * heap_check_remote -- verifies if the heap of a remote pool is consistent
- *                      and can be opened properly
+ *	and can be opened properly
  *
  * If successful function returns zero. Otherwise an error number is returned.
  */
@@ -1610,83 +1383,6 @@ out:
 }
 
 /*
- * heap_run_foreach_object -- (internal) iterates through objects in a run
- */
-int
-heap_run_foreach_object(struct palloc_heap *heap, object_callback cb,
-		void *arg, struct memory_block *m)
-{
-	uint16_t i = m->block_off / BITS_PER_VALUE;
-	uint16_t block_start = m->block_off % BITS_PER_VALUE;
-	uint16_t block_off;
-
-	struct chunk_run *run = heap_get_chunk_run(heap, m);
-
-	struct alloc_class_run_proto run_proto;
-	alloc_class_generate_run_proto(&run_proto,
-		run->block_size, m->size_idx, run->alignment);
-
-	for (; i < run_proto.bitmap_nval; ++i) {
-		uint64_t v = run->bitmap[i];
-		block_off = (uint16_t)(BITS_PER_VALUE * i);
-
-		for (uint16_t j = block_start; j < BITS_PER_VALUE; ) {
-			if (block_off + j >= (uint16_t)run_proto.bitmap_nallocs)
-				break;
-
-			if (!BIT_IS_CLR(v, j)) {
-				m->block_off = (uint16_t)(block_off + j);
-
-				/*
-				 * The size index of this memory block cannot be
-				 * retrieved at this time because the header
-				 * might not be initialized in valgrind yet.
-				 */
-				m->size_idx = 0;
-
-				if (cb(m, arg)
-						!= 0)
-					return 1;
-
-				m->size_idx = CALC_SIZE_IDX(run->block_size,
-					m->m_ops->get_real_size(m));
-				j = (uint16_t)(j + m->size_idx);
-			} else {
-				++j;
-			}
-		}
-		block_start = 0;
-	}
-
-	return 0;
-}
-
-/*
- * heap_chunk_foreach_object -- (internal) iterates through objects in a chunk
- */
-static int
-heap_chunk_foreach_object(struct palloc_heap *heap, object_callback cb,
-	void *arg, struct memory_block *m)
-{
-	struct chunk_header *hdr = heap_get_chunk_hdr(heap, m);
-	memblock_rebuild_state(heap, m);
-	m->size_idx = hdr->size_idx;
-
-	switch (hdr->type) {
-		case CHUNK_TYPE_FREE:
-			return 0;
-		case CHUNK_TYPE_USED:
-			return cb(m, arg);
-		case CHUNK_TYPE_RUN:
-			return heap_run_foreach_object(heap, cb, arg, m);
-		default:
-			ASSERT(0);
-	}
-
-	return 0;
-}
-
-/*
  * heap_zone_foreach_object -- (internal) iterates through objects in a zone
  */
 static int
@@ -1698,14 +1394,15 @@ heap_zone_foreach_object(struct palloc_heap *heap, object_callback cb,
 		return 0;
 
 	for (; m->chunk_id < zone->header.size_idx; ) {
-		if (heap_chunk_foreach_object(heap, cb, arg, m) != 0)
+		struct chunk_header *hdr = heap_get_chunk_hdr(heap, m);
+		memblock_rebuild_state(heap, m);
+		m->size_idx = hdr->size_idx;
+
+		if (m->m_ops->iterate_used(m, cb, arg) != 0)
 			return 1;
 
-		m->chunk_id += zone->chunk_headers[m->chunk_id].size_idx;
-
-		/* reset the starting position of memblock */
+		m->chunk_id += m->size_idx;
 		m->block_off = 0;
-		m->size_idx = 0;
 	}
 
 	return 0;
@@ -1727,43 +1424,6 @@ heap_foreach_object(struct palloc_heap *heap, object_callback cb, void *arg,
 }
 
 #if VG_MEMCHECK_ENABLED
-
-/*
- * heap_vg_open_chunk -- (internal) notifies Valgrind about chunk layout
- */
-static void
-heap_vg_open_chunk(struct palloc_heap *heap,
-	object_callback cb, void *arg, int objects,
-	struct memory_block *m)
-{
-	void *chunk = heap_get_chunk(heap, m);
-	memblock_rebuild_state(heap, m);
-
-	if (m->type == MEMORY_BLOCK_RUN) {
-		struct chunk_run *run = chunk;
-
-		ASSERTne(m->size_idx, 0);
-		VALGRIND_DO_MAKE_MEM_NOACCESS(run,
-			SIZEOF_RUN(run, m->size_idx));
-
-		/* set the run metadata as defined */
-		VALGRIND_DO_MAKE_MEM_DEFINED(run,
-			sizeof(*run) - sizeof(run->data));
-
-		if (objects) {
-			int ret = heap_run_foreach_object(heap, cb, arg, m);
-			ASSERTeq(ret, 0);
-		}
-	} else {
-		size_t size = m->m_ops->get_real_size(m);
-		VALGRIND_DO_MAKE_MEM_NOACCESS(chunk, size);
-
-		if (objects && m->m_ops->get_state(m) == MEMBLOCK_ALLOCATED) {
-			int ret = cb(m, arg);
-			ASSERTeq(ret, 0);
-		}
-	}
-}
 
 /*
  * heap_vg_open -- notifies Valgrind about heap layout
@@ -1797,37 +1457,19 @@ heap_vg_open(struct palloc_heap *heap, object_callback cb,
 
 		for (uint32_t c = 0; c < chunks; ) {
 			struct chunk_header *hdr = &z->chunk_headers[c];
-			m.chunk_id = c;
 
+			/* define the header before rebuilding state */
 			VALGRIND_DO_MAKE_MEM_DEFINED(hdr, sizeof(*hdr));
 
+			m.chunk_id = c;
 			m.size_idx = hdr->size_idx;
-			heap_vg_open_chunk(heap, cb, arg, objects, &m);
+
+			memblock_rebuild_state(heap, &m);
+
+			m.m_ops->vg_init(&m, objects, cb, arg);
 			m.block_off = 0;
 
 			ASSERT(hdr->size_idx > 0);
-
-			if (hdr->type == CHUNK_TYPE_RUN) {
-				/*
-				 * Mark run data headers as defined.
-				 */
-				for (unsigned j = 1; j < hdr->size_idx; ++j) {
-					struct chunk_header *data_hdr =
-						&z->chunk_headers[c + j];
-					VALGRIND_DO_MAKE_MEM_DEFINED(data_hdr,
-						sizeof(struct chunk_header));
-					ASSERTeq(data_hdr->type,
-						CHUNK_TYPE_RUN_DATA);
-				}
-			} else {
-				/*
-				 * Mark unused chunk headers as not accessible.
-				 */
-				VALGRIND_DO_MAKE_MEM_NOACCESS(
-					&z->chunk_headers[c + 1],
-					(hdr->size_idx - 1) *
-					sizeof(struct chunk_header));
-			}
 
 			c += hdr->size_idx;
 		}

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -521,8 +521,18 @@ heap_run_reuse(struct palloc_heap *heap, struct bucket *b,
 	const struct memory_block *m)
 {
 	ASSERTeq(m->type, MEMORY_BLOCK_RUN);
+	os_mutex_t *lock = m->m_ops->get_lock(m);
 
-	return heap_run_process_metadata(heap, b, m);
+	util_mutex_lock(lock);
+
+	uint32_t ret = heap_run_process_metadata(heap, b, m);
+
+	util_mutex_unlock(lock);
+
+	b->active_memory_block->m = *m;
+	b->is_active = 1;
+
+	return ret;
 }
 
 /*
@@ -803,17 +813,16 @@ heap_reuse_from_recycler(struct palloc_heap *heap,
 	m.size_idx = units;
 
 	struct recycler *r = heap->rt->recyclers[b->aclass->id];
+	if (!force && recycler_get(r, &m) == 0) {
+		heap_run_reuse(heap, b, &m);
+
+		return 0;
+	}
+
 	heap_recycle_unused(heap, r, NULL, force);
 
 	if (recycler_get(r, &m) == 0) {
-		os_mutex_t *lock = m.m_ops->get_lock(&m);
-
-		util_mutex_lock(lock);
 		heap_run_reuse(heap, b, &m);
-		util_mutex_unlock(lock);
-
-		b->active_memory_block->m = m;
-		b->is_active = 1;
 
 		return 0;
 	}

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -466,7 +466,7 @@ heap_run_process_bitmap_value(struct bucket *b, struct memory_block *m,
 			bucket_insert_block(b, m);
 		}
 	} while (shift != BITS_PER_VALUE);
-	
+
 	return inserted;
 }
 
@@ -721,16 +721,20 @@ static int
 heap_recycle_unused(struct palloc_heap *heap, struct recycler *recycler,
 	struct bucket *defb, int force)
 {
-	ASSERTeq(defb->aclass->type, CLASS_HUGE);
-
 	struct empty_runs r = recycler_recalc(recycler, force);
 	if (VEC_SIZE(&r) == 0)
 		return ENOMEM;
 
+	struct bucket *nb = defb == NULL ? heap_bucket_acquire_by_id(heap,
+		DEFAULT_ALLOC_CLASS_ID) : NULL;
+
 	struct memory_block *nm;
 	VEC_FOREACH_BY_PTR(nm, &r) {
-		heap_run_into_free_chunk(heap, defb, nm);
+		heap_run_into_free_chunk(heap, nb ? nb : defb, nm);
 	}
+
+	if (nb != NULL)
+		heap_bucket_release(heap, nb);
 
 	VEC_DELETE(&r);
 
@@ -793,15 +797,13 @@ heap_ensure_huge_bucket_filled(struct palloc_heap *heap, struct bucket *bucket)
  */
 static int
 heap_reuse_from_recycler(struct palloc_heap *heap,
-	struct bucket *b, struct bucket *defb, uint32_t units, int force)
+	struct bucket *b, uint32_t units, int force)
 {
 	struct memory_block m = MEMORY_BLOCK_NONE;
 	m.size_idx = units;
 
-	ASSERTeq(defb->aclass->type, CLASS_HUGE);
-
 	struct recycler *r = heap->rt->recyclers[b->aclass->id];
-	heap_recycle_unused(heap, r, defb, force);
+	heap_recycle_unused(heap, r, NULL, force);
 
 	if (recycler_get(r, &m) == 0) {
 		os_mutex_t *lock = m.m_ops->get_lock(&m);
@@ -829,9 +831,6 @@ heap_ensure_run_bucket_filled(struct palloc_heap *heap, struct bucket *b,
 	ASSERTeq(b->aclass->type, CLASS_RUN);
 	int ret = 0;
 
-	struct bucket *defb = heap_bucket_acquire_by_id(heap,
-		DEFAULT_ALLOC_CLASS_ID);
-
 	/* get rid of the active block in the bucket */
 	if (b->is_active) {
 		b->c_ops->rm_all(b->container);
@@ -843,35 +842,46 @@ heap_ensure_run_bucket_filled(struct palloc_heap *heap, struct bucket *b,
 		} else {
 			struct memory_block *m = &b->active_memory_block->m;
 			if (heap_reclaim_run(heap, m)) {
+				struct bucket *defb =
+					heap_bucket_acquire_by_id(heap,
+					DEFAULT_ALLOC_CLASS_ID);
+
 				heap_run_into_free_chunk(heap, defb, m);
+
+				heap_bucket_release(heap, defb);
 			}
 		}
 		b->is_active = 0;
 	}
 
-	if (heap_reuse_from_recycler(heap, b, defb, units, 0) == 0)
+	if (heap_reuse_from_recycler(heap, b, units, 0) == 0)
 		goto out;
 
 	struct memory_block m = MEMORY_BLOCK_NONE;
 	m.size_idx = b->aclass->run.size_idx;
 
+	struct bucket *defb = heap_bucket_acquire_by_id(heap,
+		DEFAULT_ALLOC_CLASS_ID);
 	/* cannot reuse an existing run, create a new one */
 	if (heap_get_bestfit_block(heap, defb, &m) == 0) {
+
 		ASSERTeq(m.block_off, 0);
 		heap_run_create(heap, b, &m);
 
 		b->active_memory_block->m = m;
 		b->is_active = 1;
 
+		heap_bucket_release(heap, defb);
+
 		goto out;
 	}
+	heap_bucket_release(heap, defb);
 
-	if (heap_reuse_from_recycler(heap, b, defb, units, 0) == 0)
+	if (heap_reuse_from_recycler(heap, b, units, 0) == 0)
 		goto out;
 
 	ret = ENOMEM;
 out:
-	heap_bucket_release(heap, defb);
 
 	return ret;
 }

--- a/src/libpmemobj/heap.h
+++ b/src/libpmemobj/heap.h
@@ -47,7 +47,6 @@
 #include "palloc.h"
 #include "os_thread.h"
 
-#define MAX_RUN_LOCKS 1024
 
 #define HEAP_OFF_TO_PTR(heap, off) ((void *)((char *)((heap)->base) + (off)))
 #define HEAP_PTR_TO_OFF(heap, ptr)\

--- a/src/libpmemobj/heap.h
+++ b/src/libpmemobj/heap.h
@@ -41,7 +41,6 @@
 #include <stdint.h>
 
 #include "bucket.h"
-#include "heap_layout.h"
 #include "memblock.h"
 #include "memops.h"
 #include "palloc.h"
@@ -96,9 +95,6 @@ void
 heap_free_chunk_reuse(struct palloc_heap *heap,
 	struct bucket *bucket, struct memory_block *m);
 
-int
-heap_run_foreach_object(struct palloc_heap *heap, object_callback cb,
-	void *arg, struct memory_block *m);
 void heap_foreach_object(struct palloc_heap *heap, object_callback cb,
 	void *arg, struct memory_block start);
 

--- a/src/libpmemobj/heap_layout.h
+++ b/src/libpmemobj/heap_layout.h
@@ -56,15 +56,25 @@
 
 #define BITS_PER_VALUE 64U
 #define MAX_CACHELINE_ALIGNMENT 40 /* run alignment, 5 cachelines */
-#define RUN_METASIZE (MAX_CACHELINE_ALIGNMENT * 8)
-#define MAX_BITMAP_VALUES (MAX_CACHELINE_ALIGNMENT - 2)
-#define RUN_BITMAP_SIZE (BITS_PER_VALUE * MAX_BITMAP_VALUES)
-#define RUNSIZE (CHUNKSIZE - RUN_METASIZE)
+#define RUN_BASE_METADATA_SIZE (sizeof(uint64_t) * 2)
+
+#define DEFAULT_BITMAP_SIZE (sizeof(uint64_t) * DEFAULT_BITMAP_VALUES)
+#define DEFAULT_BITMAP_VALUES (MAX_CACHELINE_ALIGNMENT - 2)
+#define DEFAULT_RUN_BITMAP_NBITS (BITS_PER_VALUE * DEFAULT_BITMAP_VALUES)
+
+#define RUNSIZE (CHUNKSIZE - RUN_BASE_METADATA_SIZE - DEFAULT_BITMAP_SIZE)
+#define RUN_CONTENT_SIZE (CHUNKSIZE - (sizeof(uint64_t) * 2))
 #define MIN_RUN_SIZE 128
 #define RUN_BASE_ALIGNMENT 64
 
 #define CHUNK_MASK ((CHUNKSIZE) - 1)
 #define CHUNK_ALIGN_UP(value) ((((value) + CHUNK_MASK) & ~CHUNK_MASK))
+
+/*
+ * Calculates the size in bytes of a single run instance
+ */
+#define RUN_SIZE_BYTES(size_idx)\
+(RUNSIZE + (((size_idx) - 1) * CHUNKSIZE))
 
 enum chunk_flags {
 	CHUNK_FLAG_COMPACT_HEADER	=	0x0001,
@@ -96,8 +106,7 @@ struct chunk {
 struct chunk_run {
 	uint64_t block_size;
 	uint64_t alignment; /* valid only /w CHUNK_FLAG_ALIGNED */
-	uint64_t bitmap[MAX_BITMAP_VALUES];
-	uint8_t data[RUNSIZE];
+	uint8_t content[RUN_CONTENT_SIZE]; /* bitmap + data */
 };
 
 struct chunk_header {
@@ -148,6 +157,26 @@ struct allocation_header_legacy {
 struct allocation_header_compact {
 	uint64_t size;
 	uint64_t extra;
+};
+
+enum header_type {
+	HEADER_LEGACY,
+	HEADER_COMPACT,
+	HEADER_NONE,
+
+	MAX_HEADER_TYPES
+};
+
+static const size_t header_type_to_size[MAX_HEADER_TYPES] = {
+	sizeof(struct allocation_header_legacy),
+	sizeof(struct allocation_header_compact),
+	0
+};
+
+static const enum chunk_flags header_type_to_flag[MAX_HEADER_TYPES] = {
+	0,
+	CHUNK_FLAG_COMPACT_HEADER,
+	CHUNK_FLAG_HEADER_NONE
 };
 
 static inline struct zone *

--- a/src/libpmemobj/memblock.c
+++ b/src/libpmemobj/memblock.c
@@ -53,17 +53,9 @@
 #include "out.h"
 #include "valgrind_internal.h"
 
-const size_t header_type_to_size[MAX_HEADER_TYPES] = {
-	sizeof(struct allocation_header_legacy),
-	sizeof(struct allocation_header_compact),
-	0
-};
-
-const enum chunk_flags header_type_to_flag[MAX_HEADER_TYPES] = {
-	0,
-	CHUNK_FLAG_COMPACT_HEADER,
-	CHUNK_FLAG_HEADER_NONE
-};
+/* calculates the size of the entire run, including any additional chunks */
+#define SIZEOF_RUN(runp, size_idx)\
+	(sizeof(*(runp)) + (((size_idx) - 1) * CHUNKSIZE))
 
 /*
  * memblock_header_type -- determines the memory block's header type
@@ -403,6 +395,67 @@ static struct {
 };
 
 /*
+ * memblock_run_nallocs -- returns the number of memory blocks available in the
+ *	in a run with given parameters
+ */
+unsigned
+memblock_run_nallocs(uint32_t *size_idx, uint16_t flags,
+	uint64_t unit_size, uint64_t alignment)
+{
+	unsigned nallocs = (unsigned)(RUN_SIZE_BYTES(*size_idx) / unit_size);
+
+	while (nallocs > DEFAULT_RUN_BITMAP_NBITS) {
+		LOG(3, "tried to create a run (%lu) with number "
+			"of units (%u) exceeding the bitmap size (%u)",
+			unit_size, nallocs, DEFAULT_RUN_BITMAP_NBITS);
+		if (*size_idx > 1) {
+			*size_idx -= 1;
+			/* recalculate the number of allocations */
+			nallocs = (uint32_t)
+				(RUN_SIZE_BYTES(*size_idx) / unit_size);
+			LOG(3, "run (%lu) was constructed with "
+				"fewer (%u) than requested chunks (%u)",
+				unit_size, *size_idx, *size_idx + 1);
+		} else {
+			LOG(3, "run (%lu) was constructed with "
+				"fewer units (%u) than optimal (%u), "
+				"this might lead to "
+				"inefficient memory utilization!",
+				unit_size,
+				DEFAULT_RUN_BITMAP_NBITS, nallocs);
+
+			nallocs = DEFAULT_RUN_BITMAP_NBITS;
+		}
+	}
+
+	return nallocs;
+}
+
+/*
+ * run_get_bitmap -- initializes run bitmap information
+ */
+static void
+run_get_bitmap(const struct memory_block *m, struct run_bitmap *b)
+{
+	struct chunk_run *run = heap_get_chunk_run(m->heap, m);
+	struct chunk_header *hdr = heap_get_chunk_hdr(m->heap, m);
+
+	size_t unit_size = run->block_size;
+
+	b->size = DEFAULT_BITMAP_SIZE;
+	uint32_t size_idx = hdr->size_idx;
+	b->nbits = memblock_run_nallocs(&size_idx, hdr->flags,
+		unit_size, run->alignment);
+	ASSERTeq(size_idx, hdr->size_idx);
+
+	unsigned unused_bits = DEFAULT_RUN_BITMAP_NBITS - b->nbits;
+	unsigned unused_values = unused_bits / BITS_PER_VALUE;
+	b->nvalues = DEFAULT_BITMAP_VALUES - unused_values;
+
+	b->values = (uint64_t *)run->content;
+}
+
+/*
  * huge_block_size -- returns the compile-time constant which defines the
  *	huge memory block size.
  */
@@ -438,32 +491,38 @@ huge_get_real_data(const struct memory_block *m)
  *	allocations in a run
  */
 static char *
-run_get_data_start(struct chunk_header *hdr, struct chunk_run *run,
-	enum header_type htype)
+run_get_data_start(const struct memory_block *m)
 {
+	struct chunk_header *hdr = heap_get_chunk_hdr(m->heap, m);
+	struct chunk_run *run = heap_get_chunk_run(m->heap, m);
+
+	struct run_bitmap b;
+	run_get_bitmap(m, &b);
+
 	if (hdr->flags & CHUNK_FLAG_ALIGNED) {
 		/*
 		 * Alignment is property of user data in allocations. And
 		 * since objects have headers, we need to take them into
 		 * account when calculating the address.
 		 */
-		uintptr_t hsize = header_type_to_size[htype];
-		uintptr_t base = (uintptr_t)run->data + hsize;
+		uintptr_t hsize = header_type_to_size[m->header_type];
+		uintptr_t base = (uintptr_t)run->content +
+			b.size + hsize;
 		return (char *)(ALIGN_UP(base, run->alignment) - hsize);
 	} else {
-		return (char *)&run->data;
+		return (char *)&run->content + b.size;
 	}
 }
 
 /*
- * run_get_alignment_padding -- (internal) returns the number of bytes of
- *	padding in aligned runs
+ * run_get_data_offset -- (internal) returns the number of bytes between
+ *	run base metadata and data
  */
 static size_t
-run_get_alignment_padding(struct chunk_header *hdr, struct chunk_run *run,
-	enum header_type htype)
+run_get_data_offset(const struct memory_block *m)
 {
-	return (size_t)run_get_data_start(hdr, run, htype) - (size_t)&run->data;
+	struct chunk_run *run = heap_get_chunk_run(m->heap, m);
+	return (size_t)run_get_data_start(m) - (size_t)&run->content;
 }
 
 /*
@@ -473,11 +532,9 @@ static void *
 run_get_real_data(const struct memory_block *m)
 {
 	struct chunk_run *run = heap_get_chunk_run(m->heap, m);
-	struct chunk_header *hdr = heap_get_chunk_hdr(m->heap, m);
 	ASSERT(run->block_size != 0);
 
-	return run_get_data_start(hdr, run, m->header_type) +
-		(run->block_size * m->block_off);
+	return run_get_data_start(m) + (run->block_size * m->block_off);
 }
 
 /*
@@ -569,8 +626,6 @@ static void
 run_prep_operation_hdr(const struct memory_block *m, enum memblock_state op,
 	struct operation_context *ctx)
 {
-	struct chunk_run *r = heap_get_chunk_run(m->heap, m);
-
 	ASSERT(m->size_idx <= BITS_PER_VALUE);
 
 	/*
@@ -597,12 +652,15 @@ run_prep_operation_hdr(const struct memory_block *m, enum memblock_state op,
 	 */
 	int bpos = m->block_off / BITS_PER_VALUE;
 
+	struct run_bitmap b;
+	run_get_bitmap(m, &b);
+
 	/* the bit mask is applied immediately by the add entry operations */
 	if (op == MEMBLOCK_ALLOCATED) {
-		operation_add_entry(ctx, &r->bitmap[bpos],
+		operation_add_entry(ctx, &b.values[bpos],
 			bmask, OPERATION_OR);
 	} else if (op == MEMBLOCK_FREE) {
-		operation_add_entry(ctx, &r->bitmap[bpos],
+		operation_add_entry(ctx, &b.values[bpos],
 			~bmask, OPERATION_AND);
 	} else {
 		ASSERT(0);
@@ -652,20 +710,17 @@ huge_get_state(const struct memory_block *m)
 static enum memblock_state
 run_get_state(const struct memory_block *m)
 {
-	struct zone *z = ZID_TO_ZONE(m->heap->layout, m->zone_id);
-	struct chunk_header *hdr = &z->chunk_headers[m->chunk_id];
-	ASSERTeq(hdr->type, CHUNK_TYPE_RUN);
-
-	struct chunk_run *r = (struct chunk_run *)&z->chunks[m->chunk_id];
+	struct run_bitmap b;
+	run_get_bitmap(m, &b);
 
 	unsigned v = m->block_off / BITS_PER_VALUE;
-	uint64_t bitmap = r->bitmap[v];
-	unsigned b = m->block_off % BITS_PER_VALUE;
+	uint64_t bitmap = b.values[v];
+	unsigned bit = m->block_off % BITS_PER_VALUE;
 
-	unsigned b_last = b + m->size_idx;
-	ASSERT(b_last <= BITS_PER_VALUE);
+	unsigned bit_last = bit + m->size_idx;
+	ASSERT(bit_last <= BITS_PER_VALUE);
 
-	for (unsigned i = b; i < b_last; ++i) {
+	for (unsigned i = bit; i < bit_last; ++i) {
 		if (!BIT_IS_CLR(bitmap, i)) {
 			return MEMBLOCK_ALLOCATED;
 		}
@@ -798,6 +853,299 @@ block_get_flags(const struct memory_block *m)
 	return memblock_header_ops[m->header_type].get_flags(m);
 }
 
+/*
+ * heap_run_process_bitmap_value -- (internal) looks for unset bits in the
+ * value, creates a valid memory block out of them and inserts that
+ * block into the given bucket.
+ */
+static void
+run_process_bitmap_value(const struct memory_block *m,
+	uint64_t value, uint16_t base_offset, object_callback cb, void *arg)
+{
+	uint64_t shift = 0;
+	struct memory_block s = *m;
+
+	do {
+		uint64_t shifted = ~(value >> shift);
+		if (shifted == UINT64_MAX) {
+			s.block_off = (uint16_t)(base_offset + shift);
+			s.size_idx = (uint32_t)(BITS_PER_VALUE - shift);
+
+			cb(&s, arg);
+
+			break;
+		} else if (shifted == 0) {
+			break;
+		}
+
+		unsigned off = (unsigned)util_lssb_index64(shifted);
+		unsigned size = (unsigned)util_lssb_index64(~shifted);
+
+		shift += off + size;
+
+		if (size != 0) {
+			s.block_off = (uint16_t)(base_offset + (shift - size));
+			s.size_idx = (uint32_t)(size);
+
+			memblock_rebuild_state(m->heap, &s);
+			cb(&s, arg);
+		}
+	} while (shift != BITS_PER_VALUE);
+}
+
+/*
+ * run_iterate_free -- iterates over free blocks in a run
+ */
+static int
+run_iterate_free(const struct memory_block *m, object_callback cb, void *arg)
+{
+	uint16_t block_off = 0;
+
+	struct run_bitmap b;
+	run_get_bitmap(m, &b);
+
+	struct memory_block nm = *m;
+	for (unsigned i = 0; i < b.nvalues; ++i) {
+		uint64_t v = b.values[i];
+		ASSERT(BITS_PER_VALUE * i <= UINT16_MAX);
+		block_off = (uint16_t)(BITS_PER_VALUE * i);
+		run_process_bitmap_value(&nm, v, block_off, cb, arg);
+	}
+
+	return 0;
+}
+
+/*
+ * run_iterate_used -- iterates over used blocks in a run
+ */
+static int
+run_iterate_used(const struct memory_block *m, object_callback cb, void *arg)
+{
+	uint16_t i = m->block_off / BITS_PER_VALUE;
+	uint16_t block_start = m->block_off % BITS_PER_VALUE;
+	uint16_t block_off;
+
+	struct chunk_run *run = heap_get_chunk_run(m->heap, m);
+
+	struct memory_block iter = *m;
+
+	struct run_bitmap b;
+	run_get_bitmap(m, &b);
+
+	for (; i < b.nvalues; ++i) {
+		uint64_t v = b.values[i];
+		block_off = (uint16_t)(BITS_PER_VALUE * i);
+
+		for (uint16_t j = block_start; j < BITS_PER_VALUE; ) {
+			if (block_off + j >= (uint16_t)b.nbits)
+				break;
+
+			if (!BIT_IS_CLR(v, j)) {
+				iter.block_off = (uint16_t)(block_off + j);
+
+				/*
+				 * The size index of this memory block cannot be
+				 * retrieved at this time because the header
+				 * might not be initialized in valgrind yet.
+				 */
+				iter.size_idx = 0;
+
+				if (cb(&iter, arg) != 0)
+					return 1;
+
+				iter.size_idx = CALC_SIZE_IDX(run->block_size,
+					iter.m_ops->get_real_size(&iter));
+				j = (uint16_t)(j + iter.size_idx);
+			} else {
+				++j;
+			}
+		}
+		block_start = 0;
+	}
+
+	return 0;
+}
+
+/*
+ * huge_iterate_free -- calls cb on memory block if it's free
+ */
+static int
+huge_iterate_free(const struct memory_block *m, object_callback cb, void *arg)
+{
+	struct chunk_header *hdr = heap_get_chunk_hdr(m->heap, m);
+
+	return hdr->type == CHUNK_TYPE_FREE ? cb(m, arg) : 0;
+}
+
+/*
+ * huge_iterate_free -- calls cb on memory block if it's used
+ */
+static int
+huge_iterate_used(const struct memory_block *m, object_callback cb, void *arg)
+{
+	struct chunk_header *hdr = heap_get_chunk_hdr(m->heap, m);
+
+	return hdr->type == CHUNK_TYPE_USED ? cb(m, arg) : 0;
+}
+
+/*
+ * huge_vg_init -- initalizes chunk metadata in memcheck state
+ */
+static void
+huge_vg_init(const struct memory_block *m, int objects,
+	object_callback cb, void *arg)
+{
+	struct zone *z = ZID_TO_ZONE(m->heap->layout, m->zone_id);
+	struct chunk_header *hdr = heap_get_chunk_hdr(m->heap, m);
+	struct chunk *chunk = heap_get_chunk(m->heap, m);
+	VALGRIND_DO_MAKE_MEM_DEFINED(hdr, sizeof(*hdr));
+
+	/*
+	 * Mark unused chunk headers as not accessible.
+	 */
+	VALGRIND_DO_MAKE_MEM_NOACCESS(
+		&z->chunk_headers[m->chunk_id + 1],
+		(m->size_idx - 1) *
+		sizeof(struct chunk_header));
+
+	size_t size = block_get_real_size(m);
+	VALGRIND_DO_MAKE_MEM_NOACCESS(chunk, size);
+
+	if (objects && huge_get_state(m) == MEMBLOCK_ALLOCATED) {
+		int ret = cb(m, arg);
+		ASSERTeq(ret, 0);
+	}
+}
+
+/*
+ * run_vg_init -- initalizes run metadata in memcheck state
+ */
+static void
+run_vg_init(const struct memory_block *m, int objects,
+	object_callback cb, void *arg)
+{
+	struct zone *z = ZID_TO_ZONE(m->heap->layout, m->zone_id);
+	struct chunk_header *hdr = heap_get_chunk_hdr(m->heap, m);
+	struct chunk_run *run = heap_get_chunk_run(m->heap, m);
+	VALGRIND_DO_MAKE_MEM_DEFINED(hdr, sizeof(*hdr));
+
+	struct run_bitmap b;
+	run_get_bitmap(m, &b);
+
+	/*
+	 * Mark run data headers as defined.
+	 */
+	for (unsigned j = 1; j < m->size_idx; ++j) {
+		struct chunk_header *data_hdr =
+			&z->chunk_headers[m->chunk_id + j];
+		VALGRIND_DO_MAKE_MEM_DEFINED(data_hdr,
+			sizeof(struct chunk_header));
+		ASSERTeq(data_hdr->type,
+			CHUNK_TYPE_RUN_DATA);
+	}
+
+	VALGRIND_DO_MAKE_MEM_NOACCESS(run,
+		SIZEOF_RUN(run, m->size_idx));
+
+	/* set the run metadata as defined */
+	VALGRIND_DO_MAKE_MEM_DEFINED(run,
+		RUN_BASE_METADATA_SIZE + b.size);
+
+	if (objects) {
+		int ret = run_iterate_used(m, cb, arg);
+		ASSERTeq(ret, 0);
+	}
+}
+
+/*
+ * run_reinit_chunk -- run reinitialization on first zone traversal
+ */
+static void
+run_reinit_chunk(const struct memory_block *m)
+{
+	/* noop */
+}
+
+/*
+ * huge_write_footer -- (internal) writes a chunk footer
+ */
+static void
+huge_write_footer(struct chunk_header *hdr, uint32_t size_idx)
+{
+	if (size_idx == 1) /* that would overwrite the header */
+		return;
+
+	VALGRIND_DO_MAKE_MEM_UNDEFINED(hdr + size_idx - 1, sizeof(*hdr));
+
+	struct chunk_header f = *hdr;
+	f.type = CHUNK_TYPE_FOOTER;
+	f.size_idx = size_idx;
+	*(hdr + size_idx - 1) = f;
+	/* no need to persist, footers are recreated in heap_populate_buckets */
+	VALGRIND_SET_CLEAN(hdr + size_idx - 1, sizeof(f));
+}
+
+/*
+ * huge_reinit_chunk -- chunk reinitialization on first zone traversal
+ */
+static void
+huge_reinit_chunk(const struct memory_block *m)
+{
+	struct chunk_header *hdr = heap_get_chunk_hdr(m->heap, m);
+	if (hdr->type == CHUNK_TYPE_USED)
+		huge_write_footer(hdr, hdr->size_idx);
+}
+
+/*
+ * run_calc_free -- calculates the number of free units in a run
+ */
+static void
+run_calc_free(const struct memory_block *m,
+	uint32_t *free_space, uint32_t *max_free_block)
+{
+	struct run_bitmap b;
+	run_get_bitmap(m, &b);
+	for (unsigned i = 0; i < b.nvalues; ++i) {
+		uint64_t value = ~b.values[i];
+		if (value == 0)
+			continue;
+
+		uint32_t free_in_value = util_popcount64(value);
+		*free_space = *free_space + free_in_value;
+
+		/*
+		 * If this value has less free blocks than already found max,
+		 * there's no point in calculating.
+		 */
+		if (free_in_value < *max_free_block)
+			continue;
+
+		/* if the entire value is empty, no point in calculating */
+		if (free_in_value == BITS_PER_VALUE) {
+			*max_free_block = BITS_PER_VALUE;
+			continue;
+		}
+
+		/* if already at max, no point in calculating */
+		if (*max_free_block == BITS_PER_VALUE)
+			continue;
+
+		/*
+		 * Calculate the biggest free block in the bitmap.
+		 * This algorithm is not the most clever imaginable, but it's
+		 * easy to implement and fast enough.
+		 */
+		uint16_t n = 0;
+		while (value != 0) {
+			value &= (value << 1ULL);
+			n++;
+		}
+
+		if (n > *max_free_block)
+			*max_free_block = n;
+	}
+}
+
 static const struct memory_block_ops mb_ops[MAX_MEMORY_BLOCK] = {
 	[MEMORY_BLOCK_HUGE] = {
 		.block_size = huge_block_size,
@@ -813,8 +1161,14 @@ static const struct memory_block_ops mb_ops[MAX_MEMORY_BLOCK] = {
 		.invalidate = block_invalidate,
 		.ensure_header_type = huge_ensure_header_type,
 		.reinit_header = block_reinit_header,
+		.vg_init = huge_vg_init,
 		.get_extra = block_get_extra,
 		.get_flags = block_get_flags,
+		.iterate_free = huge_iterate_free,
+		.iterate_used = huge_iterate_used,
+		.reinit_chunk = huge_reinit_chunk,
+		.calc_free = NULL,
+		.get_bitmap = NULL,
 	},
 	[MEMORY_BLOCK_RUN] = {
 		.block_size = run_block_size,
@@ -830,10 +1184,140 @@ static const struct memory_block_ops mb_ops[MAX_MEMORY_BLOCK] = {
 		.invalidate = block_invalidate,
 		.ensure_header_type = run_ensure_header_type,
 		.reinit_header = block_reinit_header,
+		.vg_init = run_vg_init,
 		.get_extra = block_get_extra,
 		.get_flags = block_get_flags,
+		.iterate_free = run_iterate_free,
+		.iterate_used = run_iterate_used,
+		.reinit_chunk = run_reinit_chunk,
+		.calc_free = run_calc_free,
+		.get_bitmap = run_get_bitmap,
 	}
 };
+
+/*
+ * memblock_huge_init -- initializes a new huge memory block
+ */
+struct memory_block
+memblock_huge_init(struct palloc_heap *heap,
+	uint32_t chunk_id, uint32_t zone_id, uint32_t size_idx)
+{
+	struct memory_block m = MEMORY_BLOCK_NONE;
+	m.chunk_id = chunk_id;
+	m.zone_id = zone_id;
+	m.size_idx = size_idx;
+	m.heap = heap;
+
+	struct chunk_header nhdr = {
+		.type = CHUNK_TYPE_FREE,
+		.flags = 0,
+		.size_idx = size_idx
+	};
+
+	struct chunk_header *hdr = heap_get_chunk_hdr(heap, &m);
+
+	VALGRIND_DO_MAKE_MEM_UNDEFINED(hdr, sizeof(*hdr));
+	VALGRIND_ANNOTATE_NEW_MEMORY(hdr, sizeof(*hdr));
+
+	*hdr = nhdr; /* write the entire header (8 bytes) at once */
+
+	pmemops_persist(&heap->p_ops, hdr, sizeof(*hdr));
+
+	huge_write_footer(hdr, size_idx);
+
+	memblock_rebuild_state(heap, &m);
+
+	return m;
+}
+
+/*
+ * memblock_run_init -- initializes a new run memory block
+ */
+struct memory_block
+memblock_run_init(struct palloc_heap *heap,
+	uint32_t chunk_id, uint32_t zone_id, uint32_t size_idx, uint16_t flags,
+	uint64_t unit_size, uint64_t alignment)
+{
+	ASSERTne(size_idx, 0);
+
+	struct memory_block m = MEMORY_BLOCK_NONE;
+	m.chunk_id = chunk_id;
+	m.zone_id = zone_id;
+	m.size_idx = size_idx;
+	m.heap = heap;
+
+	struct zone *z = ZID_TO_ZONE(heap->layout, zone_id);
+
+	struct chunk_run *run = heap_get_chunk_run(heap, &m);
+	size_t runsize = SIZEOF_RUN(run, size_idx);
+
+	VALGRIND_DO_MAKE_MEM_UNDEFINED(run, runsize);
+
+	/* add/remove chunk_run and chunk_header to valgrind transaction */
+	VALGRIND_ADD_TO_TX(run, runsize);
+	run->block_size = unit_size;
+	run->alignment = alignment;
+
+	struct run_bitmap b;
+	run_get_bitmap(&m, &b);
+
+	size_t bitmap_size = b.size;
+
+	/* set all the bits */
+	memset(b.values, 0xFF, bitmap_size);
+
+	/* clear only the bits available for allocations from this bucket */
+	memset(b.values, 0, sizeof(*b.values) * (b.nvalues - 1));
+	unsigned unused_bits = (b.nvalues * BITS_PER_VALUE) - b.nbits;
+	uint64_t last_value = unused_bits ? (((1ULL << unused_bits) - 1ULL) <<
+		(BITS_PER_VALUE - unused_bits)) : 0;
+	b.values[b.nvalues - 1] = last_value;
+
+	VALGRIND_REMOVE_FROM_TX(run, runsize);
+
+	pmemops_flush(&heap->p_ops, run,
+		sizeof(run->block_size) +
+		sizeof(run->alignment) +
+		bitmap_size);
+
+	struct chunk_header run_data_hdr;
+	run_data_hdr.type = CHUNK_TYPE_RUN_DATA;
+	run_data_hdr.flags = 0;
+
+	VALGRIND_ADD_TO_TX(&z->chunk_headers[chunk_id],
+		sizeof(struct chunk_header) * size_idx);
+
+	struct chunk_header *data_hdr;
+	for (unsigned i = 1; i < size_idx; ++i) {
+		data_hdr = &z->chunk_headers[chunk_id + i];
+		VALGRIND_DO_MAKE_MEM_UNDEFINED(data_hdr, sizeof(*data_hdr));
+		VALGRIND_ANNOTATE_NEW_MEMORY(data_hdr, sizeof(*data_hdr));
+		run_data_hdr.size_idx = i;
+		*data_hdr = run_data_hdr;
+	}
+	pmemops_persist(&heap->p_ops,
+		&z->chunk_headers[chunk_id + 1],
+		sizeof(struct chunk_header) * (size_idx - 1));
+
+	struct chunk_header *hdr = &z->chunk_headers[chunk_id];
+	ASSERT(hdr->type == CHUNK_TYPE_FREE);
+
+	VALGRIND_ANNOTATE_NEW_MEMORY(hdr, sizeof(*hdr));
+
+	struct chunk_header run_hdr;
+	run_hdr.size_idx = hdr->size_idx;
+	run_hdr.type = CHUNK_TYPE_RUN;
+	run_hdr.flags = flags;
+	*hdr = run_hdr;
+	pmemops_persist(&heap->p_ops, hdr, sizeof(*hdr));
+
+	VALGRIND_REMOVE_FROM_TX(&z->chunk_headers[chunk_id],
+		sizeof(struct chunk_header) * size_idx);
+
+	memblock_rebuild_state(heap, &m);
+
+	return m;
+}
 
 /*
  * memblock_detect_type -- looks for the corresponding chunk header and
@@ -896,10 +1380,8 @@ memblock_from_offset_opt(struct palloc_heap *heap, uint64_t off, int size)
 	uint64_t unit_size = m.m_ops->block_size(&m);
 
 	if (off != 0) { /* run */
-		struct chunk_run *run = heap_get_chunk_run(heap, &m);
-
-		off -= run_get_alignment_padding(hdr, run, m.header_type);
-		off -= RUN_METASIZE;
+		off -= run_get_data_offset(&m);
+		off -= RUN_BASE_METADATA_SIZE;
 		m.block_off = (uint16_t)(off / unit_size);
 		off -= m.block_off * unit_size;
 	}
@@ -984,11 +1466,9 @@ memblock_validate_offset(struct palloc_heap *heap, uint64_t off)
 	uint64_t unit_size = m.m_ops->block_size(&m);
 
 	if (off != 0) { /* run */
-		off -= RUN_METASIZE;
-		struct chunk_run *run = (struct chunk_run *)
-			&z->chunks[m.chunk_id];
+		off -= RUN_BASE_METADATA_SIZE;
 
-		off -= run_get_alignment_padding(hdr, run, m.header_type);
+		off -= run_get_data_offset(&m);
 		m.block_off = (uint16_t)(off / unit_size);
 		off -= m.block_off * unit_size;
 	}

--- a/src/libpmemobj/memblock.h
+++ b/src/libpmemobj/memblock.h
@@ -155,16 +155,15 @@ enum memblock_state {
 	MAX_MEMBLOCK_STATE,
 };
 
-enum header_type {
-	HEADER_LEGACY,
-	HEADER_COMPACT,
-	HEADER_NONE,
+/* runtime bitmap information for a run */
+struct run_bitmap {
+	unsigned nvalues; /* number of 8 byte values - size of values array */
+	unsigned nbits; /* number of valid bits */
 
-	MAX_HEADER_TYPES
+	size_t size; /* total size of the bitmap in bytes */
+
+	uint64_t *values; /* pointer to the bitmap's values array */
 };
-
-extern const size_t header_type_to_size[MAX_HEADER_TYPES];
-extern const enum chunk_flags header_type_to_flag[MAX_HEADER_TYPES];
 
 struct memory_block_ops {
 	/* returns memory block size */
@@ -223,6 +222,32 @@ struct memory_block_ops {
 
 	/* returns the flags of an allocation */
 	uint16_t (*get_flags)(const struct memory_block *m);
+
+	/* initializes memblock in valgrind */
+	void (*vg_init)(const struct memory_block *m, int objects,
+		object_callback cb, void *arg);
+
+	/* iterates over every free block */
+	int (*iterate_free)(const struct memory_block *m,
+		object_callback cb, void *arg);
+
+	/* iterates over every used block */
+	int (*iterate_used)(const struct memory_block *m,
+		object_callback cb, void *arg);
+
+	/* calculates number of free units, valid only for runs */
+	void (*calc_free)(const struct memory_block *m,
+		uint32_t *free_space, uint32_t *max_free_block);
+
+	/* this is called exactly once for every existing chunk */
+	void (*reinit_chunk)(const struct memory_block *m);
+
+	/*
+	 * Initializes bitmap data for a run.
+	 * Do *not* use this function unless absolutely necessery, it breaks
+	 * the abstraction layer by exposing implementation details.
+	 */
+	void (*get_bitmap)(const struct memory_block *m, struct run_bitmap *b);
 };
 
 struct memory_block {
@@ -281,5 +306,15 @@ struct memory_block memblock_from_offset(struct palloc_heap *heap,
 struct memory_block memblock_from_offset_opt(struct palloc_heap *heap,
 	uint64_t off, int size);
 void memblock_rebuild_state(struct palloc_heap *heap, struct memory_block *m);
+
+struct memory_block memblock_huge_init(struct palloc_heap *heap,
+	uint32_t chunk_id, uint32_t zone_id, uint32_t size_idx);
+
+struct memory_block memblock_run_init(struct palloc_heap *heap,
+	uint32_t chunk_id, uint32_t zone_id, uint32_t size_idx, uint16_t flags,
+	uint64_t unit_size, uint64_t alignment);
+
+unsigned memblock_run_nallocs(uint32_t *size_idx, uint16_t flags,
+	uint64_t unit_size, uint64_t alignment);
 
 #endif

--- a/src/libpmemobj/palloc.c
+++ b/src/libpmemobj/palloc.c
@@ -236,7 +236,7 @@ palloc_reservation_create(struct palloc_heap *heap, size_t size,
 		 * the memory block reservation has to be rolled back.
 		 */
 		if (new_block->type == MEMORY_BLOCK_HUGE) {
-			bucket_insert_block(b, new_block);
+			bucket_insert_block(new_block, b);
 		}
 		err = ECANCELED;
 		goto out;

--- a/src/libpmemobj/pmalloc.c
+++ b/src/libpmemobj/pmalloc.c
@@ -391,7 +391,7 @@ CTL_WRITE_HANDLER(desc)(PMEMobjpool *pop,
 
 	size_t runsize_bytes =
 		CHUNK_ALIGN_UP((p->units_per_block * p->unit_size) +
-		RUN_METASIZE);
+		RUN_BASE_METADATA_SIZE);
 
 	/* aligning the buffer might require up-to to 'alignment' bytes */
 	if (p->alignment != 0)
@@ -490,7 +490,7 @@ CTL_READ_HANDLER(desc)(PMEMobjpool *pop,
 	}
 
 	struct pobj_alloc_class_desc *p = arg;
-	p->units_per_block = c->type == CLASS_HUGE ? 0 : c->run.bitmap_nallocs;
+	p->units_per_block = c->type == CLASS_HUGE ? 0 : c->run.nallocs;
 	p->header_type = user_htype;
 	p->unit_size = c->unit_size;
 	p->class_id = c->id;

--- a/src/libpmemobj/recycler.c
+++ b/src/libpmemobj/recycler.c
@@ -164,55 +164,17 @@ recycler_element_new(struct palloc_heap *heap, const struct memory_block *m)
 	os_mutex_t *lock = m->m_ops->get_lock(m);
 	util_mutex_lock(lock);
 
-	struct chunk_run *run = heap_get_chunk_run(heap, m);
-
-	uint16_t free_space = 0;
-	uint16_t max_block = 0;
-
-	for (int i = 0; i < MAX_BITMAP_VALUES; ++i) {
-		uint64_t value = ~run->bitmap[i];
-		if (value == 0)
-			continue;
-
-		uint16_t free_in_value = util_popcount64(value);
-		free_space = (uint16_t)(free_space + free_in_value);
-
-		/*
-		 * If this value has less free blocks than already found max,
-		 * there's no point in searching.
-		 */
-		if (free_in_value < max_block)
-			continue;
-
-		/* if the entire value is empty, no point in searching */
-		if (free_in_value == BITS_PER_VALUE) {
-			max_block = BITS_PER_VALUE;
-			continue;
-		}
-
-		/*
-		 * Find the biggest free block in the bitmap.
-		 * This algorithm is not the most clever imaginable, but it's
-		 * easy to implement and fast enough.
-		 */
-		uint16_t n = 0;
-		while (value != 0) {
-			value &= (value << 1ULL);
-			n++;
-		}
-
-		if (n > max_block)
-			max_block = n;
-	}
-
-	util_mutex_unlock(lock);
-
-	return (struct recycler_element){
-		.free_space = free_space,
-		.max_free_block = max_block,
+	struct recycler_element e = {
+		.free_space = 0,
+		.max_free_block = 0,
 		.chunk_id = m->chunk_id,
 		.zone_id = m->zone_id,
 	};
+	m->m_ops->calc_free(m, &e.free_space, &e.max_free_block);
+
+	util_mutex_unlock(lock);
+
+	return e;
 }
 
 /*

--- a/src/libpmemobj/recycler.c
+++ b/src/libpmemobj/recycler.c
@@ -43,7 +43,7 @@
 #include "ravl.h"
 #include "valgrind_internal.h"
 
-#define THRESHOLD_MUL 2
+#define THRESHOLD_MUL 4
 
 /*
  * recycler_element_cmp -- compares two recycler elements
@@ -83,10 +83,10 @@ struct recycler {
 	 * The value is not meant to be accurate, but rather a rough measure on
 	 * how often should the memory block scores be recalculated.
 	 */
-	size_t unaccounted_units;
+	size_t unaccounted_units[MAX_CHUNK];
+	size_t unaccounted_total;
 	size_t nallocs;
 	size_t recalc_threshold;
-	int recalc_inprogress;
 
 	VEC(, struct recycler_element) recalc;
 	VEC(, struct memory_block_reserved *) pending;
@@ -112,8 +112,9 @@ recycler_new(struct palloc_heap *heap, size_t nallocs)
 	r->heap = heap;
 	r->nallocs = nallocs;
 	r->recalc_threshold = nallocs * THRESHOLD_MUL;
-	r->unaccounted_units = 0;
-	r->recalc_inprogress = 0;
+	r->unaccounted_total = 0;
+	memset(&r->unaccounted_units, 0, sizeof(r->unaccounted_units));
+
 	VEC_INIT(&r->recalc);
 	VEC_INIT(&r->pending);
 
@@ -301,8 +302,10 @@ void
 recycler_pending_put(struct recycler *r,
 	struct memory_block_reserved *m)
 {
+	util_mutex_lock(&r->lock);
 	if (VEC_PUSH_BACK(&r->pending, m) != 0)
 		ASSERT(0); /* XXX: fix after refactoring */
+	util_mutex_unlock(&r->lock);
 }
 
 /*
@@ -315,15 +318,13 @@ recycler_recalc(struct recycler *r, int force)
 	struct empty_runs runs;
 	VEC_INIT(&runs);
 
-	uint64_t units = r->unaccounted_units;
+	uint64_t units = r->unaccounted_total;
 
-	if (r->recalc_inprogress || (!force && units < (r->recalc_threshold)))
+	if (!force && units < (r->recalc_threshold))
 		return runs;
 
-	if (!util_bool_compare_and_swap32(&r->recalc_inprogress, 0, 1))
+	if (util_mutex_trylock(&r->lock) != 0)
 		return runs;
-
-	util_mutex_lock(&r->lock);
 
 	/* If the search is forced, recalculate everything */
 	uint64_t search_limit = force ? UINT64_MAX : units;
@@ -331,20 +332,25 @@ recycler_recalc(struct recycler *r, int force)
 	uint64_t found_units = 0;
 	struct memory_block nm = MEMORY_BLOCK_NONE;
 	struct ravl_node *n;
-	struct recycler_element empty = {0, 0, 0, 0};
+	struct recycler_element next = {0, 0, 0, 0};
+	enum ravl_predicate p = RAVL_PREDICATE_GREATER_EQUAL;
 	do {
-		if ((n = ravl_find(r->runs, &empty,
-			RAVL_PREDICATE_GREATER_EQUAL)) == NULL)
+		if ((n = ravl_find(r->runs, &next, p)) == NULL)
 			break;
 
+		p = RAVL_PREDICATE_GREATER;
+
 		struct recycler_element *ne = ravl_data(n);
-		nm.chunk_id = ne->chunk_id;
-		nm.zone_id = ne->zone_id;
+		next = *ne;
+
+		uint64_t chunk_units = r->unaccounted_units[ne->chunk_id];
+		if (!force && chunk_units == 0)
+			continue;
 
 		uint32_t existing_free_space = ne->free_space;
 
-		ravl_remove(r->runs, n);
-
+		nm.chunk_id = ne->chunk_id;
+		nm.zone_id = ne->zone_id;
 		memblock_rebuild_state(r->heap, &nm);
 
 		struct recycler_element e = recycler_element_new(r->heap, &nm);
@@ -352,6 +358,14 @@ recycler_recalc(struct recycler *r, int force)
 		ASSERT(e.free_space >= existing_free_space);
 		uint64_t free_space_diff = e.free_space - existing_free_space;
 		found_units += free_space_diff;
+
+		util_fetch_and_sub64(&r->unaccounted_units[nm.chunk_id],
+			MIN(chunk_units, free_space_diff + r->nallocs));
+
+		if (free_space_diff == 0)
+			continue;
+
+		ravl_remove(r->runs, n);
 
 		if (e.free_space == r->nallocs) {
 			memblock_rebuild_state(r->heap, &nm);
@@ -371,9 +385,7 @@ recycler_recalc(struct recycler *r, int force)
 
 	util_mutex_unlock(&r->lock);
 
-	util_fetch_and_sub64(&r->unaccounted_units, units);
-	int ret = util_bool_compare_and_swap32(&r->recalc_inprogress, 1, 0);
-	ASSERTeq(ret, 1);
+	util_fetch_and_sub64(&r->unaccounted_total, units);
 
 	return runs;
 }
@@ -385,5 +397,7 @@ recycler_recalc(struct recycler *r, int force)
 void
 recycler_inc_unaccounted(struct recycler *r, const struct memory_block *m)
 {
-	util_fetch_and_add64(&r->unaccounted_units, m->size_idx);
+	util_fetch_and_add64(&r->unaccounted_total, m->size_idx);
+	util_fetch_and_add64(&r->unaccounted_units[m->chunk_id],
+		m->size_idx);
 }

--- a/src/test/obj_bucket/obj_bucket.c
+++ b/src/test/obj_bucket/obj_bucket.c
@@ -149,7 +149,7 @@ test_bucket_insert_get(void)
 
 	UT_ASSERT(b->c_ops->get_rm_bestfit(b->container, &m) != 0);
 
-	UT_ASSERT(bucket_insert_block(b, &m) == 0);
+	UT_ASSERT(bucket_insert_block(&m, b) == 0);
 
 	UT_ASSERT(b->c_ops->get_rm_bestfit(b->container, &m) == 0);
 
@@ -171,7 +171,7 @@ test_bucket_remove(void)
 		TEST_SIZE_IDX, TEST_BLOCK_OFF};
 	m.m_ops = &mock_ops;
 
-	UT_ASSERT(bucket_insert_block(b, &m) == 0);
+	UT_ASSERT(bucket_insert_block(&m, b) == 0);
 
 	UT_ASSERT(b->c_ops->get_rm_exact(b->container, &m) == 0);
 

--- a/src/test/obj_fragmentation2/obj_fragmentation2.c
+++ b/src/test/obj_fragmentation2/obj_fragmentation2.c
@@ -192,7 +192,7 @@ static workload *workloads[] = {
 };
 
 static float workloads_target[] = {
-	0.01f, 0.01f, 0.01f, 0.9f, 0.8f, 0.7f, 0.2f, 0.8f
+	0.01f, 0.01f, 0.01f, 0.9f, 0.8f, 0.7f, 0.3f, 0.8f
 };
 
 int

--- a/src/test/obj_fragmentation2/obj_fragmentation2.c
+++ b/src/test/obj_fragmentation2/obj_fragmentation2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Intel Corporation
+ * Copyright 2017-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -192,7 +192,7 @@ static workload *workloads[] = {
 };
 
 static float workloads_target[] = {
-	0.01f, 0.01f, 0.01f, 0.9f, 0.8f, 0.7f, 0.2f, 0.7f
+	0.01f, 0.01f, 0.01f, 0.9f, 0.8f, 0.7f, 0.2f, 0.8f
 };
 
 int

--- a/src/test/obj_heap/obj_heap.c
+++ b/src/test/obj_heap/obj_heap.c
@@ -97,12 +97,13 @@ init_run_with_score(struct heap_layout *l, uint32_t chunk_id, int score)
 	VALGRIND_DO_MAKE_MEM_UNDEFINED(run, sizeof(*run));
 
 	run->block_size = 1024;
-	memset(run->bitmap, 0xFF, sizeof(run->bitmap));
+	memset(run->content, 0xFF, DEFAULT_BITMAP_SIZE);
 	UT_ASSERTeq(score % 64, 0);
 	score /= 64;
 
+	uint64_t *bitmap = (uint64_t *)run->content;
 	for (; score > 0; --score) {
-		run->bitmap[score] = 0;
+		bitmap[score] = 0;
 	}
 }
 
@@ -117,24 +118,13 @@ init_run_with_max_block(struct heap_layout *l, uint32_t chunk_id)
 		&l->zone0.chunks[chunk_id];
 	VALGRIND_DO_MAKE_MEM_UNDEFINED(run, sizeof(*run));
 
+	uint64_t *bitmap = (uint64_t *)run->content;
 	run->block_size = 1024;
-	memset(run->bitmap, 0xFF, sizeof(run->bitmap));
+	memset(bitmap, 0xFF, DEFAULT_BITMAP_SIZE);
 
 	/* the biggest block is 10 bits */
-	run->bitmap[3] =
+	bitmap[3] =
 	0b1000001110111000111111110000111111000000000011111111110000000011;
-}
-
-static void
-test_alloc_class_bitmap_correctness(void)
-{
-	struct alloc_class_run_proto proto;
-	alloc_class_generate_run_proto(&proto, RUNSIZE / 10, 1, 0);
-	/* 54 set (not available for allocations), and 10 clear (available) */
-	uint64_t bitmap_lastval =
-	0b1111111111111111111111111111111111111111111111111111110000000000;
-
-	UT_ASSERTeq(proto.bitmap_lastval, bitmap_lastval);
 }
 
 static void
@@ -247,8 +237,6 @@ test_heap(void)
 		pop, p_ops, s, pop->set) == 0);
 	UT_ASSERT(heap_buckets_init(heap) == 0);
 	UT_ASSERT(pop->heap.rt != NULL);
-
-	test_alloc_class_bitmap_correctness();
 
 	test_container((struct block_container *)container_new_ravl(heap),
 		heap);

--- a/src/test/obj_layout/obj_layout.c
+++ b/src/test/obj_layout/obj_layout.c
@@ -94,8 +94,7 @@ main(int argc, char *argv[])
 	ASSERT_ALIGNED_BEGIN(struct chunk_run);
 	ASSERT_ALIGNED_FIELD(struct chunk_run, block_size);
 	ASSERT_ALIGNED_FIELD(struct chunk_run, alignment);
-	ASSERT_ALIGNED_FIELD(struct chunk_run, bitmap);
-	ASSERT_ALIGNED_FIELD(struct chunk_run, data);
+	ASSERT_ALIGNED_FIELD(struct chunk_run, content);
 	ASSERT_ALIGNED_CHECK(struct chunk_run);
 	UT_COMPILE_ERROR_ON(sizeof(struct chunk_run) != SIZEOF_CHUNK_V3);
 

--- a/src/test/obj_locks/TEST1
+++ b/src/test/obj_locks/TEST1
@@ -38,7 +38,7 @@
 # standard unit test setup
 . ../unittest/unittest.sh
 
-require_test_type medium
+require_test_type all
 
 require_build_type debug
 require_valgrind 3.10

--- a/src/test/obj_memblock/obj_memblock.c
+++ b/src/test/obj_memblock/obj_memblock.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -154,9 +154,10 @@ test_prep_hdr(void)
 
 	struct chunk_run *run = (struct chunk_run *)&layout->zone0.chunks[2];
 
-	run->bitmap[0] = 0b1111;
-	run->bitmap[1] = ~0ULL;
-	run->bitmap[2] = 0ULL;
+	uint64_t *bitmap = (uint64_t *)run->content;
+	bitmap[0] = 0b1111;
+	bitmap[1] = ~0ULL;
+	bitmap[2] = 0ULL;
 
 	memblock_rebuild_state(heap, &mhuge_used);
 	memblock_rebuild_state(heap, &mhuge_free);
@@ -173,17 +174,17 @@ test_prep_hdr(void)
 	UT_ASSERTeq(layout->zone0.chunk_headers[1].type, CHUNK_TYPE_USED);
 
 	mrun_used.m_ops->prep_hdr(&mrun_used, MEMBLOCK_FREE, NULL);
-	UT_ASSERTeq(run->bitmap[0], 0ULL);
+	UT_ASSERTeq(bitmap[0], 0ULL);
 
 	mrun_free.m_ops->prep_hdr(&mrun_free, MEMBLOCK_ALLOCATED, NULL);
-	UT_ASSERTeq(run->bitmap[0], 0b11110000);
+	UT_ASSERTeq(bitmap[0], 0b11110000);
 
 	mrun_large_used.m_ops->prep_hdr(&mrun_large_used, MEMBLOCK_FREE, NULL);
-	UT_ASSERTeq(run->bitmap[1], 0ULL);
+	UT_ASSERTeq(bitmap[1], 0ULL);
 
 	mrun_large_free.m_ops->prep_hdr(&mrun_large_free,
 		MEMBLOCK_ALLOCATED, NULL);
-	UT_ASSERTeq(run->bitmap[2], ~0ULL);
+	UT_ASSERTeq(bitmap[2], ~0ULL);
 }
 
 int

--- a/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
+++ b/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
@@ -394,8 +394,6 @@ test_spec_compliance(void)
 		sizeof(struct allocation_header_legacy);
 
 	UT_ASSERTeq(max_alloc, PMEMOBJ_MAX_ALLOC_SIZE);
-	UT_COMPILE_ERROR_ON(offsetof(struct chunk_run, data) <
-		MAX_CACHELINE_ALIGNMENT);
 }
 
 int

--- a/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
+++ b/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
@@ -136,8 +136,13 @@ tx_worker(void *arg)
 	 * will automatically abort and all of the objects will be freed.
 	 */
 	TX_BEGIN(a->pop) {
-		for (;;) /* this is NOT an infinite loop */
+		for (int n = 0; ; ++n) { /* this is NOT an infinite loop */
 			pmemobj_tx_alloc(ALLOC_SIZE, a->idx);
+			if (Ops_per_thread != MAX_OPS_PER_THREAD &&
+			    n == Ops_per_thread) {
+				pmemobj_tx_abort(0);
+			}
+		}
 	} TX_END
 
 	return NULL;

--- a/src/test/obj_tx_locks/TEST1
+++ b/src/test/obj_tx_locks/TEST1
@@ -38,7 +38,7 @@
 # standard unit test setup
 . ../unittest/unittest.sh
 
-require_test_type medium
+require_test_type long
 
 unset PMEM_LOG_LEVEL
 unset PMEM_LOG_FILE

--- a/src/test/tools/pmemspoil/spoil.c
+++ b/src/test/tools/pmemspoil/spoil.c
@@ -612,6 +612,25 @@ pmemspoil_process_char(struct pmemspoil *psp, struct pmemspoil_list *pfp,
 }
 
 /*
+ * pmemspoil_process_uint8_t -- process value as uint8
+ */
+static int
+pmemspoil_process_uint8_t(struct pmemspoil *psp, struct pmemspoil_list *pfp,
+		uint8_t *valp, size_t size, int le)
+{
+	uint8_t v;
+	if (sscanf(pfp->value, "0x%" SCNx8, &v) != 1 &&
+	    sscanf(pfp->value, "%" SCNu8, &v) != 1)
+		return -1;
+
+	*valp = v;
+
+	pmemspoil_persist(valp, sizeof(*valp));
+
+	return 0;
+}
+
+/*
  * pmemspoil_process_uint16_t -- process value as uint16
  */
 static int
@@ -1093,7 +1112,7 @@ pmemspoil_process_run(struct pmemspoil *psp, struct pmemspoil_list *pfp,
 
 	PROCESS_BEGIN(psp, pfp) {
 		PROCESS_FIELD(run, block_size, uint64_t);
-		PROCESS_FIELD_ARRAY(run, bitmap, uint64_t, MAX_BITMAP_VALUES);
+		PROCESS_FIELD_ARRAY(run, content, uint8_t, RUN_CONTENT_SIZE);
 	} PROCESS_END
 
 	return PROCESS_RET;

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -658,6 +658,7 @@ function valgrind_ignore_warnings() {
 		-e "brk segment overflow" \
 		-e "see section Limitations in user manual" \
 		-e "Warning: set address range perms: large range"\
+		-e "further instances of this message will not be shown"\
 		>  $1.tmp
 	mv $1.tmp $1
 }

--- a/src/tools/pmempool/common.c
+++ b/src/tools/pmempool/common.c
@@ -1153,48 +1153,6 @@ util_heap_max_zone(size_t size)
 }
 
 /*
- * util_heap_get_bitmap_params -- return bitmap parameters of given block size
- *
- * The function returns the following values:
- * - number of allocations
- * - number of used values in bitmap
- * - initial value of last used entry
- */
-int
-util_heap_get_bitmap_params(uint64_t block_size, uint64_t *nallocsp,
-		uint64_t *nvalsp, uint64_t *last_valp)
-{
-	assert(RUNSIZE / block_size <= UINT32_MAX);
-	uint32_t nallocs = (uint32_t)(RUNSIZE / block_size);
-
-	assert(nallocs <= RUN_BITMAP_SIZE);
-	unsigned unused_bits = RUN_BITMAP_SIZE - nallocs;
-
-	unsigned unused_values = unused_bits / BITS_PER_VALUE;
-
-	assert(MAX_BITMAP_VALUES >= unused_values);
-	uint64_t nvals = MAX_BITMAP_VALUES - unused_values;
-
-	assert(unused_bits >= unused_values * BITS_PER_VALUE);
-	unused_bits -= unused_values * BITS_PER_VALUE;
-
-	uint64_t last_val = unused_bits ? (((1ULL << unused_bits) - 1ULL) <<
-				(BITS_PER_VALUE - unused_bits)) : 0;
-
-	if (nvals >= MAX_BITMAP_VALUES || nvals == 0)
-		return -1;
-
-	if (nallocsp)
-		*nallocsp = nallocs;
-	if (nvalsp)
-		*nvalsp = nvals;
-	if (last_valp)
-		*last_valp = last_val;
-
-	return 0;
-}
-
-/*
  * pool_set_file_open -- opens pool set file or regular file
  */
 struct pool_set_file *

--- a/src/tools/pmempool/common.h
+++ b/src/tools/pmempool/common.h
@@ -232,8 +232,6 @@ char ask_yn(char op, char def_ans, const char *fmt, va_list ap);
 char ask_Yn(char op, const char *fmt, ...) FORMAT_PRINTF(2, 3);
 char ask_yN(char op, const char *fmt, ...) FORMAT_PRINTF(2, 3);
 unsigned util_heap_max_zone(size_t size);
-int util_heap_get_bitmap_params(uint64_t block_size, uint64_t *nallocsp,
-		uint64_t *nvalsp, uint64_t *last_valp);
 
 int util_pool_clear_badblocks(const char *path, int create);
 

--- a/src/tools/pmempool/info_obj.c
+++ b/src/tools/pmempool/info_obj.c
@@ -150,28 +150,6 @@ lane_need_recovery(struct pmem_info *pip, struct lane_layout *lane)
 	return alloc || list || tx;
 }
 
-/*
- * get_bitmap_reserved -- get number of reserved blocks in chunk run
- */
-static int
-get_bitmap_reserved(struct chunk_run *run, uint32_t *reserved)
-{
-	uint64_t nvals = 0;
-	uint64_t last_val = 0;
-	if (util_heap_get_bitmap_params(run->block_size, NULL, &nvals,
-			&last_val))
-		return -1;
-
-	uint32_t ret = 0;
-	for (uint64_t i = 0; i < nvals - 1; i++)
-		ret += util_popcount64(run->bitmap[i]);
-	ret += util_popcount64(run->bitmap[nvals - 1] & ~last_val);
-
-	*reserved = ret;
-
-	return 0;
-}
-
 #define RUN_BITMAP_SEPARATOR_DISTANCE 8
 
 /*
@@ -572,26 +550,20 @@ info_obj_object(struct pmem_info *pip, const struct memory_block *m,
  * info_obj_run_bitmap -- print chunk run's bitmap
  */
 static void
-info_obj_run_bitmap(int v, struct chunk_run *run, uint32_t bsize)
+info_obj_run_bitmap(int v, const struct memory_block *m)
 {
-	if (outv_check(v) && outv_check(VERBOSE_MAX)) {
-		/* print all values from bitmap for higher verbosity */
-		for (int i = 0; i < MAX_BITMAP_VALUES; i++) {
-			outv(VERBOSE_MAX, "%s\n",
-					get_bitmap_str(run->bitmap[i],
-						BITS_PER_VALUE));
-		}
-	} else {
-		/* print only used values for lower verbosity */
-		uint32_t i;
-		for (i = 0; i < bsize / BITS_PER_VALUE; i++)
-			outv(v, "%s\n", get_bitmap_str(run->bitmap[i],
-						BITS_PER_VALUE));
+	struct run_bitmap b;
+	m->m_ops->get_bitmap(m, &b);
 
-		unsigned mod = bsize % BITS_PER_VALUE;
-		if (mod != 0) {
-			outv(v, "%s\n", get_bitmap_str(run->bitmap[i], mod));
-		}
+	/* print only used values for lower verbosity */
+	uint32_t i;
+	for (i = 0; i < b.nbits / BITS_PER_VALUE; i++)
+		outv(v, "%s\n", get_bitmap_str(b.values[i],
+					BITS_PER_VALUE));
+
+	unsigned mod = b.nbits % BITS_PER_VALUE;
+	if (mod != 0) {
+		outv(v, "%s\n", get_bitmap_str(b.values[i], mod));
 	}
 }
 
@@ -672,7 +644,8 @@ info_obj_chunk(struct pmem_info *pip, uint64_t c, uint64_t z,
 		struct chunk_run *run = (struct chunk_run *)chunk;
 
 		outv_hexdump(v && pip->args.vhdrdump, run,
-				sizeof(run->block_size) + sizeof(run->bitmap),
+				sizeof(run->block_size) +
+				sizeof(run->alignment),
 				PTR_TO_OFF(pop, run), 1);
 
 		struct alloc_class *aclass = alloc_class_by_run(
@@ -683,22 +656,20 @@ info_obj_chunk(struct pmem_info *pip, uint64_t c, uint64_t z,
 					out_get_size_str(run->block_size,
 						pip->args.human));
 
-			uint32_t units = aclass->run.bitmap_nallocs;
+			uint32_t units = aclass->run.nallocs;
+			uint32_t free_space;
+			uint32_t max_free_block;
+			m.m_ops->calc_free(&m, &free_space, &max_free_block);
 			uint32_t used = 0;
-			if (get_bitmap_reserved(run,  &used)) {
-				outv_field(v, "Bitmap", "[error]");
-			} else {
-				stats->class_stats[aclass->id].n_units += units;
-				stats->class_stats[aclass->id].n_used += used;
 
-				outv_field(v, "Bitmap", "%u / %u", used, units);
-			}
+			stats->class_stats[aclass->id].n_units += units;
+			stats->class_stats[aclass->id].n_used += used;
 
-			info_obj_run_bitmap(v && pip->args.obj.vbitmap,
-				run, units);
+			outv_field(v, "Bitmap", "%u / %u", used, units);
 
-			heap_run_foreach_object(pip->obj.heap, info_obj_run_cb,
-				pip, &m);
+			info_obj_run_bitmap(v && pip->args.obj.vbitmap, &m);
+
+			m.m_ops->iterate_used(&m, info_obj_run_cb, pip);
 		} else {
 			outv_field(v, "Block size", "%s [invalid!]",
 					out_get_size_str(run->block_size,


### PR DESCRIPTION
This patch refactors *everything* that relates to the internal
implementation of chunks (either huge or runs) and moves it
into the memblock abstraction, these changes include:
 - generalized interface for block iteration, so that the bitmap
   related details are hidden
 - memory block initialization
 - optimized information queries (e.g., free space in runs)

This finishes the effort of abstracting away the storage layer
details of the allocator. It will now be easier to make small
layout-related changes without affecting the frontend or any
other modules of the allocator.

This PR contains #2884, review only the last commit