### PR TITLE
test: SMART does not work in nfit_test module

### DIFF
--- a/src/common/os_dimm_ndctl.c
+++ b/src/common/os_dimm_ndctl.c
@@ -233,7 +233,6 @@ os_dimm_usc(const char *path, uint64_t *usc)
 
 	os_stat_t st;
 	struct ndctl_ctx *ctx;
-	int ret = -1;
 	*usc = 0;
 
 	if (os_stat(path, &st)) {
@@ -275,11 +274,22 @@ os_dimm_usc(const char *path, uint64_t *usc)
 
 		*usc += ndctl_cmd_smart_get_shutdown_count(cmd);
 	}
+
 out:
-	ret = 0;
+	ndctl_unref(ctx);
+	return 0;
+
 err:
 	ndctl_unref(ctx);
-	return ret;
+
+	char *e = os_getenv("TEST_USE_NFIT_TEST");
+	if (e && strcmp(e, "1") == 0) {
+		/* SMART does not work in the nfit_test module */
+		errno = 0;
+		return 0;
+	}
+
+	return -1;
 }
 
 /*

--- a/src/test/common_badblock.sh
+++ b/src/test/common_badblock.sh
@@ -38,6 +38,11 @@
 #                                - pmempool_info
 #
 
+# We are using the nfit_test module to test bad blocks.
+# Do not error out because of the SMART feature,
+# because it does not work in the nfit_test module.
+export TEST_USE_NFIT_TEST=1
+
 LOG=out${UNITTEST_NUM}.log
 
 #


### PR DESCRIPTION
Do not error out because of SMART when using the nfit_test module,
because the SMART feature does not work in the nfit_test module.

This patch adds the TEST_USE_NFIT_TEST environment variable,
that has to be set in tests using the nfit_test module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3006)
<!-- Reviewable:end -->
