### PR TITLE
obj: extend action API

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -110,7 +110,7 @@ MANPAGES_3_DUMMY = pmem_drain.3 pmem_has_hw_drain.3 pmem_has_auto_flush.3 \
 		   pmemobj_next.3 pobj_first_type_num.3 pobj_first.3 pobj_next_type_num.3 pobj_next.3 pobj_foreach.3 pobj_foreach_safe.3 pobj_foreach_type.3 pobj_foreach_safe_type.3 \
 		   pmemobj_root_construct.3 pobj_root.3 pmemobj_root_size.3 \
 		   pmemobj_check_version.3 pmemobj_check.3 pmemobj_errormsg.3 pmemobj_set_funcs.3 \
-		   pmemobj_reserve.3 pmemobj_xreserve.3 pmemobj_defer_free.3 pmemobj_set_value.3 pmemobj_publish.3 pmemobj_tx_publish.3 pmemobj_cancel.3 pobj_reserve_new.3 pobj_reserve_alloc.3 \
+		   pmemobj_reserve.3 pmemobj_xreserve.3 pmemobj_defer_free.3 pmemobj_set_value.3 pmemobj_publish.3 pmemobj_tx_publish.3 pmemobj_cancel.3 pobj_reserve_new.3 pobj_reserve_alloc.3 pobj_xreserve_new.3 pobj_xreserve_alloc.3 \
 		   pmemcto_close.3 pmemcto_create.3 \
 		   pmemcto_check.3 \
 		   pmemcto_calloc.3 pmemcto_realloc.3 pmemcto_free.3 \

--- a/doc/generated/pobj_xreserve_alloc.3
+++ b/doc/generated/pobj_xreserve_alloc.3
@@ -1,0 +1,1 @@
+.so pmemobj_action.3

--- a/doc/generated/pobj_xreserve_new.3
+++ b/doc/generated/pobj_xreserve_new.3
@@ -1,0 +1,1 @@
+.so pmemobj_action.3

--- a/doc/libpmemobj/pmemobj_action.3.md
+++ b/doc/libpmemobj/pmemobj_action.3.md
@@ -48,7 +48,8 @@ date: pmemobj API version 2.3
 
 **pmemobj_reserve**(), **pmemobj_xreserve**(), **pmemobj_defer_free**(),
 **pmemobj_set_value**(), **pmemobj_publish**(), **pmemobj_tx_publish**(),
-**pmemobj_cancel**(), **POBJ_RESERVE_NEW**(), **POBJ_RESERVE_ALLOC**()
+**pmemobj_cancel**(), **POBJ_RESERVE_NEW**(), **POBJ_RESERVE_ALLOC**(),
+**POBJ_XRESERVE_NEW**(),**POBJ_XRESERVE_ALLOC**()
 -- Delayed atomicity actions (EXPERIMENTAL)
 
 
@@ -72,6 +73,8 @@ pmemobj_cancel(PMEMobjpool *pop, struct pobj_action *actv,
 
 POBJ_RESERVE_NEW(pop, t, act) (EXPERIMENTAL)
 POBJ_RESERVE_ALLOC(pop, t, size, act) (EXPERIMENTAL)
+POBJ_XRESERVE_NEW(pop, t, act, flags) (EXPERIMENTAL)
+POBJ_XRESERVE_ALLOC(pop, t, size, act, flags) (EXPERIMENTAL)
 ```
 
 # DESCRIPTION #
@@ -110,7 +113,7 @@ of the object must be manually persisted, just like in the case of the atomic AP
 **pmemobj_xreserve**() is equivalent to **pmemobj_reserve**(), but with an
 additional *flags* argument that is a bitmask of the following values:
 
-+ **POBJ_XALLOC_ZERO** - zero the object
++ **POBJ_XALLOC_ZERO** - zero the object (and persist it)
 
 + **POBJ_CLASS_ID(class_id)** - allocate the object from allocation class
 *class_id*. The class id cannot be 0.
@@ -139,6 +142,10 @@ The size of the reservation is determined from the provided type *t*.
 
 The **POBJ_RESERVE_ALLOC** macro is a typed variant of **pmemobj_reserve**.
 The *size* of the reservation is user-provided.
+
+The **POBJ_XRESERVE_NEW** and the **POBJ_XRESERVE_ALLOC** macros are equivalent
+to **POBJ_RESERVE_NEW** and the **POBJ_RESERVE_ALLOC**, but with an additional
+*flags* argument defined for **pmemobj_xreserve**().
 
 # EXAMPLES #
 

--- a/src/include/libpmemobj/action.h
+++ b/src/include/libpmemobj/action.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Intel Corporation
+ * Copyright 2017-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,6 +48,12 @@ extern "C" {
 
 #define POBJ_RESERVE_ALLOC(pop, t, size, act)\
 ((TOID(t))pmemobj_reserve(pop, act, size, TOID_TYPE_NUM(t)))
+
+#define POBJ_XRESERVE_NEW(pop, t, act, flags)\
+((TOID(t))pmemobj_xreserve(pop, act, sizeof(t), TOID_TYPE_NUM(t), flags))
+
+#define POBJ_XRESERVE_ALLOC(pop, t, size, act, flags)\
+((TOID(t))pmemobj_xreserve(pop, act, size, TOID_TYPE_NUM(t), flags))
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
add POBJ_XRESERVE_NEW and POBJ_XRESERVE_ALLOC to action.h API in libpmemobj and update documentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3022)
<!-- Reviewable:end -->
