### PR TITLE
test: update match files to support ndctl v60.1-61.2

### DIFF
--- a/src/test/pmempool_check/out32.log.match
+++ b/src/test/pmempool_check/out32.log.match
@@ -1,6 +1,6 @@
-    "badblock_count":12,
-        "offset":$(N),
-        "length":12,
+    "badblock_count":$(N),
+        "offset":11,
+        "length":$(N),
 Poolset structure:
 Number of replicas       : 2
 Replica 0 (master) - local, 1 part(s):
@@ -11,7 +11,7 @@ size                     : $(N)
 alignment                : 4096
 bad blocks:
 	offset		length
-	11		12
+	11		$(N)
 Replica 1 - local, 1 part(s):
 part 0:
 path                     : $(nW)/testfile1
@@ -46,14 +46,14 @@ Heap offset              : $(nW)
 Heap size                : $(nW)
 Checksum                 : $(*)
 Root offset              : $(nW)
-    "badblock_count":12,
-        "offset":$(N),
-        "length":12,
+    "badblock_count":$(N),
+        "offset":11,
+        "length":$(N),
 poolset contains bad blocks, use 'pmempool info -k' to print or 'pmempool sync -b' to clear them
 $(nW)/testset1: cannot repair
-    "badblock_count":12,
-        "offset":$(N),
-        "length":12,
+    "badblock_count":$(N),
+        "offset":11,
+        "length":$(N),
 Poolset structure:
 Number of replicas       : 2
 Replica 0 (master) - local, 1 part(s):
@@ -64,7 +64,7 @@ size                     : $(N)
 alignment                : 4096
 bad blocks:
 	offset		length
-	11		12
+	11		$(N)
 Replica 1 - local, 1 part(s):
 part 0:
 path                     : $(nW)/testfile1
@@ -99,6 +99,6 @@ Heap offset              : $(nW)
 Heap size                : $(nW)
 Checksum                 : $(*)
 Root offset              : $(nW)
-    "badblock_count":12,
-        "offset":$(N),
-        "length":12,
+    "badblock_count":$(N),
+        "offset":11,
+        "length":$(N),

--- a/src/test/pmempool_info/out24.log.match
+++ b/src/test/pmempool_info/out24.log.match
@@ -8,7 +8,7 @@ size                     : $(nW)
 alignment                : 4096
 bad blocks:
 	offset		length
-	11		12
+	11		$(N)
 
 POOL Header:
 Signature                : PMEMOBJ

--- a/src/test/pmempool_sync/out27.log.match
+++ b/src/test/pmempool_sync/out27.log.match
@@ -1,6 +1,6 @@
-    "badblock_count":1,
+    "badblock_count":$(N),
         "offset":$(N),
-        "length":1,
+        "length":$(N),
 Poolset structure:
 Number of replicas       : 2
 Replica 0 (master) - local, 3 part(s):
@@ -53,9 +53,9 @@ Heap offset              : $(nW)
 Heap size                : $(nW)
 Checksum                 : $(*)
 Root offset              : $(nW)
-    "badblock_count":1,
+    "badblock_count":$(N),
         "offset":$(N),
-        "length":1,
+        "length":$(N),
 $(nW)/testset1: synchronized
 replica 0: checking shutdown state
 replica 0: shutdown state correct

--- a/src/test/pmempool_sync/out28.log.match
+++ b/src/test/pmempool_sync/out28.log.match
@@ -1,6 +1,6 @@
-    "badblock_count":12,
+    "badblock_count":$(N),
         "offset":$(N),
-        "length":12,
+        "length":$(N),
 Poolset structure:
 Number of replicas       : 2
 Replica 0 (master) - local, 1 part(s):
@@ -11,7 +11,7 @@ size                     : $(N)
 alignment                : 4096
 bad blocks:
 	offset		length
-	11		12
+	11		$(N)
 Replica 1 - local, 1 part(s):
 part 0:
 path                     : $(nW)/testfile1
@@ -46,9 +46,9 @@ Heap offset              : $(nW)
 Heap size                : $(nW)
 Checksum                 : $(*)
 Root offset              : $(nW)
-    "badblock_count":12,
+    "badblock_count":$(N),
         "offset":$(N),
-        "length":12,
+        "length":$(N),
 $(nW)/testset1: synchronized
 No bad blocks found
 replica 0: checking shutdown state

--- a/src/test/util_badblock/out3.log.match
+++ b/src/test/util_badblock/out3.log.match
@@ -1,5 +1,5 @@
 util_badblock$(nW)TEST3: START: util_badblock
  $(nW)util_badblock$(nW) /dev/dax$(N).0 l
 Found 1 bad block(s):
-11 12
+11 $(N)
 util_badblock$(nW)TEST3: DONE

--- a/src/test/util_badblock/out4.log.match
+++ b/src/test/util_badblock/out4.log.match
@@ -1,6 +1,6 @@
 util_badblock$(nW)TEST4: START: util_badblock
  $(nW)util_badblock$(nW) /dev/dax$(N).0 l c l
 Found 1 bad block(s):
-11 12
+11 $(N)
 No bad blocks found.
 util_badblock$(nW)TEST4: DONE


### PR DESCRIPTION
Update bad blocks match files to support
the range of the ndctl versions: 60.1-61.2,
because of the following commit:
https://github.com/pmem/ndctl/commit/7271760ce96c76c3f104c9ca40db61be8535fb62

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3043)
<!-- Reviewable:end -->
