### PR TITLE
pool: look for a healthy replica in replica_check_poolset_health

### DIFF
--- a/src/test/pmempool_sync/out9.log.match
+++ b/src/test/pmempool_sync/out9.log.match
@@ -14,5 +14,5 @@ REPLICA
 10M $(nW)/part11
 error: failed to synchronize: some replicas are too small to hold synchronized data
 error: Invalid argument
-error: failed to synchronize: no healthy replica found - cannot synchronize
+error: failed to synchronize: no healthy replica found
 error: Invalid argument


### PR DESCRIPTION
A healthy replica has been looked for implicitly
in check_poolset_uuids() so far, but it should be looked for
explicitly in replica_check_poolset_health().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3052)
<!-- Reviewable:end -->
