### PR TITLE
daxio: fix ndctl detection

### DIFF
--- a/src/tools/daxio/Makefile
+++ b/src/tools/daxio/Makefile
@@ -32,6 +32,7 @@
 #
 
 TOP = ../../..
+include $(TOP)/src/common.inc
 
 ifeq ($(NDCTL_ENABLE),y)
 


### PR DESCRIPTION
Fixes regression from a96763968edaf735aeb7bc7de09601767f2abf65.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3060)
<!-- Reviewable:end -->
