### PR TITLE
obj: use non-intrusive container for runs

### DIFF
--- a/src/test/obj_heap/obj_heap.c
+++ b/src/test/obj_heap/obj_heap.c
@@ -142,14 +142,12 @@ test_container(struct block_container *bc, struct palloc_heap *heap)
 {
 	UT_ASSERTne(bc, NULL);
 
-	struct memory_block a = {1, 0, 1, 0};
-	struct memory_block b = {2, 0, 2, 0};
-	struct memory_block c = {3, 0, 3, 0};
-	struct memory_block d = {5, 0, 5, 0};
+	struct memory_block a = {1, 0, 1, 4};
+	struct memory_block b = {1, 0, 2, 8};
+	struct memory_block c = {1, 0, 3, 16};
+	struct memory_block d = {1, 0, 5, 32};
+
 	init_run_with_score(heap->layout, 1, 128);
-	init_run_with_score(heap->layout, 2, 128);
-	init_run_with_score(heap->layout, 3, 128);
-	init_run_with_score(heap->layout, 5, 128);
 	memblock_rebuild_state(heap, &a);
 	memblock_rebuild_state(heap, &b);
 	memblock_rebuild_state(heap, &c);


### PR DESCRIPTION
Currently allocation classes smaller than ~128 bytes make
no sense because they leave a lot of unused memory. This will
soon change, and so, the run container, which currently uses an
intrusive data structure for memory blocks, needs to be changed
so that it can accomodate allocation classes as small as 1 byte.
This means that container can no longer embed internal metadata
in free memory blocks, as they can simply be too small.
This patch replaces the currently used STAILQ with a simple
array-based queue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3087)
<!-- Reviewable:end -->
