### PR TITLE
test: enable extra warnings in tests

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -53,31 +53,37 @@ DEFAULT_CFLAGS += -Wmissing-prototypes
 DEFAULT_CFLAGS += -Wpointer-arith
 DEFAULT_CFLAGS += -Wsign-conversion
 DEFAULT_CFLAGS += -Wsign-compare
-ifeq ($(call check_Wconversion), y)
+
+ifeq ($(WCONVERSION_AVAILABLE), y)
 DEFAULT_CFLAGS += -Wconversion
 endif
 
-ifeq ($(call check_compiler, icc), n)
+ifeq ($(IS_ICC), n)
 DEFAULT_CFLAGS += -Wunused-macros
 DEFAULT_CFLAGS += -Wmissing-field-initializers
-ifeq ($(call check_flag, -Wunreachable-code-return), y)
-DEFAULT_CFLAGS += -Wunreachable-code-return
-endif
-ifeq ($(call check_flag, -Wmissing-variable-declarations), y)
-DEFAULT_CFLAGS += -Wmissing-variable-declarations
-endif
-ifeq ($(call check_flag, -Wfloat-equal), y)
-DEFAULT_CFLAGS += -Wfloat-equal
-endif
-ifeq ($(call check_flag, -Wswitch-default), y)
-DEFAULT_CFLAGS += -Wswitch-default
-endif
-ifeq ($(call check_flag, -Wcast-function-type), y)
-DEFAULT_CFLAGS += -Wcast-function-type
-endif
 endif
 
-ifeq ($(call check_flag, -Wstringop-truncation), y)
+ifeq ($(WUNREACHABLE_CODE_RETURN_AVAILABLE), y)
+DEFAULT_CFLAGS += -Wunreachable-code-return
+endif
+
+ifeq ($(WMISSING_VARIABLE_DECLARATIONS_AVAILABLE), y)
+DEFAULT_CFLAGS += -Wmissing-variable-declarations
+endif
+
+ifeq ($(WFLOAT_EQUAL_AVAILABLE), y)
+DEFAULT_CFLAGS += -Wfloat-equal
+endif
+
+ifeq ($(WSWITCH_DEFAULT_AVAILABLE), y)
+DEFAULT_CFLAGS += -Wswitch-default
+endif
+
+ifeq ($(WCAST_FUNCTION_TYPE_AVAILABLE), y)
+DEFAULT_CFLAGS += -Wcast-function-type
+endif
+
+ifeq ($(WSTRINGOP_TRUNCATION_AVAILABLE), y)
 DEFAULT_CFLAGS += -DSTRINGOP_TRUNCATION_SUPPORTED
 endif
 

--- a/src/common.inc
+++ b/src/common.inc
@@ -116,6 +116,74 @@ else
 export LIBRT_NEEDED
 endif
 
+ifeq ($(IS_ICC),)
+export IS_ICC := $(call check_compiler, icc)
+else
+export IS_ICC
+endif
+
+ifeq ($(WCONVERSION_AVAILABLE),)
+export WCONVERSION_AVAILABLE := $(call check_Wconversion)
+else
+export WCONVERSION_AVAILABLE
+endif
+
+ifeq ($(WUNREACHABLE_CODE_RETURN_AVAILABLE),)
+ifeq ($(IS_ICC), n)
+export WUNREACHABLE_CODE_RETURN_AVAILABLE := $(call check_flag, -Wunreachable-code-return)
+else
+export WUNREACHABLE_CODE_RETURN_AVAILABLE := n
+endif
+else
+export WUNREACHABLE_CODE_RETURN_AVAILABLE
+endif
+
+ifeq ($(WMISSING_VARIABLE_DECLARATIONS_AVAILABLE),)
+ifeq ($(IS_ICC), n)
+export WMISSING_VARIABLE_DECLARATIONS_AVAILABLE := $(call check_flag, -Wmissing-variable-declarations)
+else
+export WMISSING_VARIABLE_DECLARATIONS_AVAILABLE := n
+endif
+else
+export WMISSING_VARIABLE_DECLARATIONS_AVAILABLE
+endif
+
+ifeq ($(WFLOAT_EQUAL_AVAILABLE),)
+ifeq ($(IS_ICC), n)
+export WFLOAT_EQUAL_AVAILABLE := $(call check_flag, -Wfloat-equal)
+else
+export WFLOAT_EQUAL_AVAILABLE := n
+endif
+else
+export WFLOAT_EQUAL_AVAILABLE
+endif
+
+ifeq ($(WSWITCH_DEFAULT_AVAILABLE),)
+ifeq ($(IS_ICC), n)
+export WSWITCH_DEFAULT_AVAILABLE := $(call check_flag, -Wswitch-default)
+else
+export WSWITCH_DEFAULT_AVAILABLE := n
+endif
+else
+export WSWITCH_DEFAULT_AVAILABLE
+endif
+
+ifeq ($(WCAST_FUNCTION_TYPE_AVAILABLE),)
+ifeq ($(IS_ICC), n)
+export WCAST_FUNCTION_TYPE_AVAILABLE := $(call check_flag, -Wcast-function-type)
+else
+export WCAST_FUNCTION_TYPE_AVAILABLE := n
+endif
+else
+export WCAST_FUNCTION_TYPE_AVAILABLE
+endif
+
+ifeq ($(WSTRINGOP_TRUNCATION_AVAILABLE),)
+export WSTRINGOP_TRUNCATION_AVAILABLE := $(call check_flag, -Wstringop-truncation)
+else
+export WSTRINGOP_TRUNCATION_AVAILABLE
+endif
+
 install_recursive = $(shell cd $(1) && find . -type f -exec install -m $(2) -D {} $(3)/{} \;)
 
 install_recursive_filter = $(shell cd $(1) && find . -type f -name "$(2)" -exec install -m $(3) -D {} $(4)/{} \;)

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -305,7 +305,7 @@ COMMON_FLAGS += -Wall
 COMMON_FLAGS += -Werror
 COMMON_FLAGS += -Wpointer-arith
 
-ifeq ($(call check_compiler, icc), n)
+ifeq ($(IS_ICC), n)
 COMMON_FLAGS += -Wunused-macros
 endif
 COMMON_FLAGS += -fno-common
@@ -319,23 +319,27 @@ CXXFLAGS += $(EXTRA_CXXFLAGS)
 CFLAGS  = -std=gnu99
 CFLAGS += -Wmissing-prototypes
 CFLAGS += $(COMMON_FLAGS)
+
 ifneq ($(USING_JEMALLOC_HEADERS),y)
 CFLAGS += -Wsign-conversion
 endif
-ifeq ($(call check_compiler, icc), n)
-ifeq ($(call check_flag, -Wunreachable-code-return), y)
+
+ifeq ($(WUNREACHABLE_CODE_RETURN_AVAILABLE), y)
 CFLAGS += -Wunreachable-code-return
 endif
-ifeq ($(call check_flag, -Wmissing-variable-declarations), y)
+
+ifeq ($(WMISSING_VARIABLE_DECLARATIONS_AVAILABLE), y)
 CFLAGS += -Wmissing-variable-declarations
 endif
-ifeq ($(call check_flag, -Wfloat-equal), y)
+
+ifeq ($(WFLOAT_EQUAL_AVAILABLE), y)
 CFLAGS += -Wfloat-equal
 endif
-ifeq ($(call check_flag, -Wcast-function-type), y)
+
+ifeq ($(WCAST_FUNCTION_TYPE_AVAILABLE), y)
 CFLAGS += -Wcast-function-type
 endif
-endif
+
 CFLAGS += $(EXTRA_CFLAGS)
 
 LDFLAGS = -Wl,--warn-common -Wl,--fatal-warnings $(EXTRA_LDFLAGS)

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -322,7 +322,20 @@ CFLAGS += $(COMMON_FLAGS)
 ifneq ($(USING_JEMALLOC_HEADERS),y)
 CFLAGS += -Wsign-conversion
 endif
-
+ifeq ($(call check_compiler, icc), n)
+ifeq ($(call check_flag, -Wunreachable-code-return), y)
+CFLAGS += -Wunreachable-code-return
+endif
+ifeq ($(call check_flag, -Wmissing-variable-declarations), y)
+CFLAGS += -Wmissing-variable-declarations
+endif
+ifeq ($(call check_flag, -Wfloat-equal), y)
+CFLAGS += -Wfloat-equal
+endif
+ifeq ($(call check_flag, -Wcast-function-type), y)
+CFLAGS += -Wcast-function-type
+endif
+endif
 CFLAGS += $(EXTRA_CFLAGS)
 
 LDFLAGS = -Wl,--warn-common -Wl,--fatal-warnings $(EXTRA_LDFLAGS)

--- a/src/test/obj_ctl_alignment/obj_ctl_alignment.c
+++ b/src/test/obj_ctl_alignment/obj_ctl_alignment.c
@@ -38,7 +38,7 @@
 
 #define LAYOUT "obj_ctl_alignment"
 
-PMEMobjpool *pop;
+static PMEMobjpool *pop;
 
 static void
 test_fail(void)

--- a/src/test/obj_direct_volatile/obj_direct_volatile.c
+++ b/src/test/obj_direct_volatile/obj_direct_volatile.c
@@ -35,7 +35,7 @@
  */
 #include "unittest.h"
 
-PMEMobjpool *pop;
+static PMEMobjpool *pop;
 
 struct test {
 	PMEMvlt(int) count;
@@ -43,7 +43,7 @@ struct test {
 
 #define TEST_OBJECTS 100
 #define TEST_WORKERS 10
-struct test *tests[TEST_OBJECTS];
+static struct test *tests[TEST_OBJECTS];
 
 static int
 test_constructor(void *ptr, void *arg)

--- a/src/test/obj_fragmentation2/obj_fragmentation2.c
+++ b/src/test/obj_fragmentation2/obj_fragmentation2.c
@@ -51,9 +51,9 @@
 #define RRAND(seed, max, min)\
 ((min) == (max) ? (min) : (os_rand_r(&(seed)) % ((max) - (min)) + (min)))
 
-uint64_t *objects;
-size_t nobjects;
-size_t allocated_current;
+static uint64_t *objects;
+static size_t nobjects;
+static size_t allocated_current;
 #define MAX_OBJECTS (200ULL * 1000000)
 
 #define ALLOC_TOTAL (5000ULL * MEGABYTE)

--- a/src/test/obj_persist_count/obj_persist_count.c
+++ b/src/test/obj_persist_count/obj_persist_count.c
@@ -53,8 +53,8 @@ struct ops_counter {
 	unsigned n_pot_cache_misses;
 };
 
-struct ops_counter ops_counter;
-struct ops_counter tx_counter;
+static struct ops_counter ops_counter;
+static struct ops_counter tx_counter;
 
 #define FLUSH_ALIGN ((uintptr_t)64)
 #define MOVNT_THRESHOLD	256

--- a/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
+++ b/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
@@ -48,9 +48,9 @@
 #define CHUNKSIZE (1 << 18)
 #define CHUNKS_PER_THREAD 3
 
-unsigned Threads;
-unsigned Ops_per_thread;
-unsigned Tx_per_thread;
+static unsigned Threads;
+static unsigned Ops_per_thread;
+static unsigned Tx_per_thread;
 
 struct root {
 	uint64_t offs[MAX_THREADS][MAX_OPS_PER_THREAD];

--- a/src/test/obj_tx_lock/obj_tx_lock.c
+++ b/src/test/obj_tx_lock/obj_tx_lock.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,7 +45,7 @@ struct transaction_data {
 	PMEMrwlock rwlocks[NUM_LOCKS];
 };
 
-PMEMobjpool *Pop;
+static PMEMobjpool *Pop;
 
 #define DO_LOCK(mtx, rwlock)\
 	pmemobj_tx_lock(TX_PARAM_MUTEX, &(mtx)[0]);\

--- a/src/test/obj_tx_locks/obj_tx_locks.c
+++ b/src/test/obj_tx_locks/obj_tx_locks.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017, Intel Corporation
+ * Copyright 2015-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -61,7 +61,7 @@ struct transaction_data {
 	int c;
 };
 
-PMEMobjpool *Pop;
+static PMEMobjpool *Pop;
 
 /*
  * do_tx -- (internal) thread-friendly transaction

--- a/src/test/pmem_is_pmem_posix/pmem_is_pmem_posix.c
+++ b/src/test/pmem_is_pmem_posix/pmem_is_pmem_posix.c
@@ -51,7 +51,6 @@ str2type(char *str)
 		return PMEM_MAP_SYNC;
 
 	FATAL("unknown type '%s'", str);
-	return MAX_PMEM_TYPE;
 }
 
 int

--- a/src/test/rpmem_basic/rpmem_basic.c
+++ b/src/test/rpmem_basic/rpmem_basic.c
@@ -103,14 +103,14 @@
 	.user_flags		= "\0\0\0\n~._ALT_FLAGS",\
 }
 
-const struct rpmem_pool_attr pool_attrs[] = {
+static const struct rpmem_pool_attr pool_attrs[] = {
 	POOL_ATTR_INIT,
 	POOL_ATTR_INIT_SINGLEHDR,
 	POOL_ATTR_ALT,
 	POOL_ATTR_ALT_SINGLEHDR
 };
 
-const char *pool_attr_names[] = {
+static const char *pool_attr_names[] = {
 	"init",
 	"init_singlehdr",
 	"alt",
@@ -133,7 +133,7 @@ struct pool_entry {
 };
 
 #define MAX_IDS	1024
-struct pool_entry pools[MAX_IDS];
+static struct pool_entry pools[MAX_IDS];
 
 /*
  * init_pool -- map local pool file or allocate memory region
@@ -724,7 +724,7 @@ enum wait_type {
 	NOWAIT
 };
 
-const char *wait_type_str[2] = {
+static const char *wait_type_str[2] = {
 	"wait",
 	"nowait"
 };

--- a/src/test/rpmem_fip/rpmem_fip_test.c
+++ b/src/test/rpmem_fip/rpmem_fip_test.c
@@ -62,8 +62,8 @@
 #define TOTAL_PER_LANE	(SIZE_PER_LANE * COUNT_PER_LANE)
 #define POOL_SIZE	(NLANES * TOTAL_PER_LANE)
 
-uint8_t lpool[POOL_SIZE];
-uint8_t rpool[POOL_SIZE];
+static uint8_t lpool[POOL_SIZE];
+static uint8_t rpool[POOL_SIZE];
 
 TEST_CASE_DECLARE(client_init);
 TEST_CASE_DECLARE(server_init);

--- a/src/test/rpmemd_config/rpmemd_config_test.c
+++ b/src/test/rpmemd_config/rpmemd_config_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -136,5 +136,4 @@ main(int argc, char *argv[])
 	rpmemd_config_free(&config);
 
 	DONE(NULL);
-	return 0;
 }

--- a/src/test/rpmemd_util/rpmemd_util_test.c
+++ b/src/test/rpmemd_util/rpmemd_util_test.c
@@ -49,9 +49,9 @@ struct result {
 };
 
 /* all values to test */
-const enum rpmem_persist_method pms[] =
+static const enum rpmem_persist_method pms[] =
 		{RPMEM_PM_GPSPM, RPMEM_PM_APM, MAX_RPMEM_PM};
-const int is_pmems[] = {0, 1};
+static const int is_pmems[] = {0, 1};
 
 enum mode {
 	MODE_VALID,
@@ -59,7 +59,7 @@ enum mode {
 	MODE_MAX
 };
 
-const int ranges[2][2][2] = {
+static const int ranges[2][2][2] = {
 	[MODE_VALID] = {
 		{0, ARRAY_SIZE(pms) - 1},
 		{0, ARRAY_SIZE(is_pmems)}
@@ -71,7 +71,7 @@ const int ranges[2][2][2] = {
 };
 
 /* expected results */
-const struct result exp_results[3][2] = {
+static const struct result exp_results[3][2] = {
 		{
 			/* GPSPM and is_pmem == false */
 			{0, RPMEM_PM_GPSPM, pmem_msync, memcpy},
@@ -169,5 +169,4 @@ main(int argc, char *argv[])
 	test(ranges[mode][0], ranges[mode][1]);
 
 	DONE(NULL);
-	return 0;
 }

--- a/src/test/unittest/Makefile
+++ b/src/test/unittest/Makefile
@@ -54,30 +54,35 @@ CFLAGS += -Wmissing-prototypes
 CFLAGS += -Wpointer-arith
 CFLAGS += -Wsign-conversion
 CFLAGS += -Wsign-compare
-ifeq ($(call check_Wconversion), y)
+ifeq ($(WCONVERSION_AVAILABLE), y)
 CFLAGS += -Wconversion
 endif
 CFLAGS += -pthread
 CFLAGS += -fno-common
 
-ifeq ($(call check_compiler, icc), n)
+ifeq ($(IS_ICC), n)
 CFLAGS += -Wunused-macros
 CFLAGS += -Wmissing-field-initializers
-ifeq ($(call check_flag, -Wunreachable-code-return), y)
+endif
+
+ifeq ($(WUNREACHABLE_CODE_RETURN_AVAILABLE), y)
 CFLAGS += -Wunreachable-code-return
 endif
-ifeq ($(call check_flag, -Wmissing-variable-declarations), y)
+
+ifeq ($(WMISSING_VARIABLE_DECLARATIONS_AVAILABLE), y)
 CFLAGS += -Wmissing-variable-declarations
 endif
-ifeq ($(call check_flag, -Wfloat-equal), y)
+
+ifeq ($(WFLOAT_EQUAL_AVAILABLE), y)
 CFLAGS += -Wfloat-equal
 endif
-ifeq ($(call check_flag, -Wswitch-default), y)
+
+ifeq ($(WSWITCH_DEFAULT_AVAILABLE), y)
 CFLAGS += -Wswitch-default
 endif
-ifeq ($(call check_flag, -Wcast-function-type), y)
+
+ifeq ($(WCAST_FUNCTION_TYPE_AVAILABLE), y)
 CFLAGS += -Wcast-function-type
-endif
 endif
 
 ifeq ($(USE_LIBUNWIND),y)

--- a/src/test/util_ctl/util_ctl.c
+++ b/src/test/util_ctl/util_ctl.c
@@ -75,7 +75,7 @@ CTL_WRITE_HANDLER(test_rw)(void *ctx, enum ctl_query_source source,
 	return 0;
 }
 
-struct ctl_argument CTL_ARG(test_rw) = CTL_ARG_INT;
+static struct ctl_argument CTL_ARG(test_rw) = CTL_ARG_INT;
 
 static int
 CTL_WRITE_HANDLER(test_wo)(void *ctx, enum ctl_query_source source,
@@ -88,7 +88,7 @@ CTL_WRITE_HANDLER(test_wo)(void *ctx, enum ctl_query_source source,
 	return 0;
 }
 
-struct ctl_argument CTL_ARG(test_wo) = CTL_ARG_INT;
+static struct ctl_argument CTL_ARG(test_wo) = CTL_ARG_INT;
 
 #define TEST_CONFIG_VALUE "abcd"
 
@@ -105,7 +105,7 @@ CTL_WRITE_HANDLER(test_config)(void *ctx, enum ctl_query_source source,
 	return 0;
 }
 
-struct ctl_argument CTL_ARG(test_config) = CTL_ARG_STRING(8);
+static struct ctl_argument CTL_ARG(test_config) = CTL_ARG_STRING(8);
 
 struct complex_arg {
 	int a;
@@ -136,7 +136,7 @@ CTL_WRITE_HANDLER(test_config_complex_arg)(void *ctx,
 	return 0;
 }
 
-struct ctl_argument CTL_ARG(test_config_complex_arg) = {
+static struct ctl_argument CTL_ARG(test_config_complex_arg) = {
 	.dest_size = sizeof(struct complex_arg),
 	.parsers = {
 		CTL_ARG_PARSER_STRUCT(struct complex_arg, a, ctl_arg_integer),
@@ -216,7 +216,7 @@ CTL_WRITE_HANDLER(gtest_config)(void *ctx, enum ctl_query_source source,
 	return 0;
 }
 
-struct ctl_argument CTL_ARG(gtest_config) = CTL_ARG_STRING(8);
+static struct ctl_argument CTL_ARG(gtest_config) = CTL_ARG_STRING(8);
 
 static int
 CTL_READ_HANDLER(gtest_ro)(void *ctx, enum ctl_query_source source,

--- a/src/test/util_poolset/util_poolset.c
+++ b/src/test/util_poolset/util_poolset.c
@@ -53,7 +53,7 @@
 
 #define TEST_FORMAT_INCOMPAT_CHECK POOL_FEAT_ALL
 
-size_t Extend_size = MIN_PART * 2;
+static size_t Extend_size = MIN_PART * 2;
 
 const char *Open_path = "";
 os_off_t Fallocate_len = -1;

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -47,31 +47,38 @@ CFLAGS += -Wmissing-prototypes
 CFLAGS += -Wpointer-arith
 CFLAGS += -Wsign-conversion
 CFLAGS += -Wsign-compare
-ifeq ($(call check_Wconversion), y)
+
+ifeq ($(WCONVERSION_AVAILABLE), y)
 CFLAGS += -Wconversion
 endif
+
 CFLAGS += -fno-common
 
 CFLAGS += -DSRCVERSION='"$(SRCVERSION)"'
 
-ifeq ($(call check_compiler, icc), n)
+ifeq ($(IS_ICC), n)
 CFLAGS += -Wunused-macros
 CFLAGS += -Wmissing-field-initializers
-ifeq ($(call check_flag, -Wunreachable-code-return), y)
+endif
+
+ifeq ($(WUNREACHABLE_CODE_RETURN_AVAILABLE), y)
 CFLAGS += -Wunreachable-code-return
 endif
-ifeq ($(call check_flag, -Wmissing-variable-declarations), y)
+
+ifeq ($(WMISSING_VARIABLE_DECLARATIONS_AVAILABLE), y)
 CFLAGS += -Wmissing-variable-declarations
 endif
-ifeq ($(call check_flag, -Wfloat-equal), y)
+
+ifeq ($(WFLOAT_EQUAL_AVAILABLE), y)
 CFLAGS += -Wfloat-equal
 endif
-ifeq ($(call check_flag, -Wswitch-default), y)
+
+ifeq ($(WSWITCH_DEFAULT_AVAILABLE), y)
 CFLAGS += -Wswitch-default
 endif
-ifeq ($(call check_flag, -Wcast-function-type), y)
+
+ifeq ($(WCAST_FUNCTION_TYPE_AVAILABLE), y)
 CFLAGS += -Wcast-function-type
-endif
 endif
 
 ifeq ($(DEBUG),1)

--- a/utils/check_license/Makefile
+++ b/utils/check_license/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -41,23 +41,30 @@ CFLAGS += -Wunused-macros
 CFLAGS += -Wmissing-field-initializers
 CFLAGS += -Wsign-conversion
 CFLAGS += -Wsign-compare
-ifeq ($(call check_Wconversion), y)
+
+ifeq ($(WCONVERSION_AVAILABLE), y)
 CFLAGS += -Wconversion
 endif
+
 CFLAGS += -fno-common
-ifeq ($(call check_flag, -Wunreachable-code-return), y)
+
+ifeq ($(WUNREACHABLE_CODE_RETURN_AVAILABLE), y)
 CFLAGS += -Wunreachable-code-return
 endif
-ifeq ($(call check_flag, -Wmissing-variable-declarations), y)
+
+ifeq ($(WMISSING_VARIABLE_DECLARATIONS_AVAILABLE), y)
 CFLAGS += -Wmissing-variable-declarations
 endif
-ifeq ($(call check_flag, -Wfloat-equal), y)
+
+ifeq ($(WFLOAT_EQUAL_AVAILABLE), y)
 CFLAGS += -Wfloat-equal
 endif
-ifeq ($(call check_flag, -Wswitch-default), y)
+
+ifeq ($(WSWITCH_DEFAULT_AVAILABLE), y)
 CFLAGS += -Wswitch-default
 endif
-ifeq ($(call check_flag, -Wcast-function-type), y)
+
+ifeq ($(WCAST_FUNCTION_TYPE_AVAILABLE), y)
 CFLAGS += -Wcast-function-type
 endif
 


### PR DESCRIPTION
Those warnings are enabled in our libraries but not in tests.
By enabling this, we can detect simple errors in our tests.

Enabled:
-Wunreachable-code-return
-Wmissing-variable-declarations
-Wfloat-equal
-Wcast-function-type

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3089)
<!-- Reviewable:end -->
