### PR TITLE
common: add VALGRIND_EMIT_LOG support

### DIFF
--- a/src/common/valgrind/pmemcheck.h
+++ b/src/common/valgrind/pmemcheck.h
@@ -81,6 +81,7 @@ typedef
        VG_USERREQ__PMC_REMOVE_THREAD_FROM_TX_N,
        VG_USERREQ__PMC_ADD_TO_GLOBAL_TX_IGNORE,
        VG_USERREQ__PMC_DEFAULT_REORDER,
+       VG_USERREQ__PMC_EMIT_LOG,
    } Vg_PMemCheckClientRequest;
 
 
@@ -190,6 +191,12 @@ typedef
     VALGRIND_DO_CLIENT_REQUEST_EXPR(0 /* default return */,                 \
                             VG_USERREQ__PMC_SET_CLEAN,                      \
                             (_qzz_addr), (_qzz_len), 0, 0, 0)
+
+/** Emit user log */
+#define VALGRIND_PMC_EMIT_LOG(_qzz_emit_log)                                \
+    VALGRIND_DO_CLIENT_REQUEST_EXPR(0 /* default return */,                 \
+                            VG_USERREQ__PMC_EMIT_LOG,                       \
+                            (_qzz_emit_log), 0, 0, 0, 0)
 
 /** Support for transactions */
 

--- a/src/common/valgrind_internal.h
+++ b/src/common/valgrind_internal.h
@@ -208,6 +208,11 @@ extern unsigned _On_valgrind;
 		VALGRIND_PMC_REMOVE_LOG_REGION((addr), (len));\
 } while (0)
 
+#define VALGRIND_EMIT_LOG(emit_log) do {\
+	if (On_valgrind)\
+		VALGRIND_PMC_EMIT_LOG((emit_log));\
+} while (0)
+
 #define VALGRIND_FULL_REORDER do {\
 	if (On_valgrind)\
 		VALGRIND_PMC_FULL_REORDER;\
@@ -335,6 +340,10 @@ extern unsigned _On_valgrind;
 #define VALGRIND_REMOVE_LOG_REGION(addr, len) do {\
 	(void) (addr);\
 	(void) (len);\
+} while (0)
+
+#define VALGRIND_EMIT_LOG(emit_log) do {\
+	(void) (emit_log);\
 } while (0)
 
 #define VALGRIND_FULL_REORDER do {} while (0)

--- a/src/test/obj_reorder_basic/obj_reorder_basic.c
+++ b/src/test/obj_reorder_basic/obj_reorder_basic.c
@@ -105,7 +105,7 @@ main(int argc, char *argv[])
 	UT_ASSERT(pop != NULL);
 
 	char opt = argv[1][0];
-	VALGRIND_PARTIAL_REORDER;
+	VALGRIND_EMIT_LOG("PREORDER");
 	switch (opt) {
 		case 'w':
 		{

--- a/src/test/pmem_reorder_simple/pmem_reorder_simple.c
+++ b/src/test/pmem_reorder_simple/pmem_reorder_simple.c
@@ -121,8 +121,8 @@ main(int argc, char *argv[])
 
 	VALGRIND_LOG_STORES;
 	/* verify that VALGRIND_DEFAULT_REORDER restores default engine */
-	VALGRIND_PARTIAL_REORDER;
-	VALGRIND_DEFAULT_REORDER;
+	VALGRIND_EMIT_LOG("PREORDER");
+	VALGRIND_EMIT_LOG("DEFAULT_REORDER");
 
 	switch (opt) {
 		case 'g':


### PR DESCRIPTION
Merge after https://github.com/pmem/valgrind/pull/58 (by that time it will fail on travis)

This is part of changes related to new VALGRIND_EMIT_LOG macro.
For more details see:
https://github.com/pmem/valgrind/pull/59

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3094)
<!-- Reviewable:end -->
