### PR TITLE
pmreorder: remove -t param

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -3067,7 +3067,6 @@ function pmreorder_run_tool()
 	disable_exit_on_error
 	eval LD_LIBRARY_PATH=$TEST_LD_LIBRARY_PATH $PYTHON_EXE $PMREORDER \
 		-l store_log$UNITTEST_NUM.log \
-		-t file \
 		-o pmreorder$UNITTEST_NUM.log \
 		-r $1 \
 		-c $2 \

--- a/src/tools/pmreorder/loggingfacility.py
+++ b/src/tools/pmreorder/loggingfacility.py
@@ -30,7 +30,6 @@
 
 import logging
 
-loggers = ["print", "file"]
 log_levels = ["debug", "info", "warning", "error", "critical"]
 
 
@@ -90,7 +89,7 @@ class DefaultPrintLogger(LoggingBase):
         print("CRITICAL:", text)
 
 
-def get_logger(logger_type, log_output, log_level=None):
+def get_logger(log_output, log_level=None):
     logger = None
     # check if log_level is valid
     log_level = "warning" if log_level is None else log_level
@@ -98,8 +97,8 @@ def get_logger(logger_type, log_output, log_level=None):
     if not isinstance(numeric_level, int):
         raise ValueError('Invalid log level: %s'.format(log_level.upper()))
 
-    if logger_type == "print":
+    if log_output is None:
         logger = DefaultPrintLogger()
-    elif logger_type == "file":
+    else:
         logger = DefaultFileLogger(filename=log_output, level=numeric_level)
     return logger

--- a/src/tools/pmreorder/pmreorder.py
+++ b/src/tools/pmreorder/pmreorder.py
@@ -58,11 +58,8 @@ def main():
     parser.add_argument("-n", "--name",
                         help="consistency check function " +
                         "for the 'lib' checker")
-    parser.add_argument("-t", "--output_type",
-                        choices=loggingfacility.loggers, default="print",
-                        help='choose logger type, default="print"')
     parser.add_argument("-o", "--output",
-                        help="set the logger output")
+                        help="set the logger output file")
     parser.add_argument("-e", "--output_level",
                         choices=loggingfacility.log_levels,
                         help="set the output log level")
@@ -74,7 +71,6 @@ def main():
     args = parser.parse_args()
 
     logger = loggingfacility.get_logger(
-                                        args.output_type,
                                         args.output,
                                         args.output_level)
     checker = consistencycheckwrap.get_checker(


### PR DESCRIPTION
This patch removes `-t` option from pmreorder tool.
But `-o` takes over its functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3095)
<!-- Reviewable:end -->
