### PR TITLE
common: pmreorder: rm engines related macros

### DIFF
--- a/src/common/valgrind_internal.h
+++ b/src/common/valgrind_internal.h
@@ -213,31 +213,6 @@ extern unsigned _On_valgrind;
 		VALGRIND_PMC_EMIT_LOG((emit_log));\
 } while (0)
 
-#define VALGRIND_FULL_REORDER do {\
-	if (On_valgrind)\
-		VALGRIND_PMC_FULL_REORDER;\
-} while (0)
-
-#define VALGRIND_PARTIAL_REORDER do {\
-	if (On_valgrind)\
-		VALGRIND_PMC_PARTIAL_REORDER;\
-} while (0)
-
-#define VALGRIND_ONLY_FAULT do {\
-	if (On_valgrind)\
-		VALGRIND_PMC_ONLY_FAULT;\
-} while (0)
-
-#define VALGRIND_DEFAULT_REORDER do {\
-	if (On_valgrind)\
-		VALGRIND_PMC_DEFAULT_REORDER;\
-} while (0)
-
-#define VALGRIND_STOP_REORDER_FAULT do {\
-	if (On_valgrind)\
-		VALGRIND_PMC_STOP_REORDER_FAULT;\
-} while (0)
-
 #define VALGRIND_START_TX do {\
 	if (On_valgrind)\
 		VALGRIND_PMC_START_TX;\
@@ -345,16 +320,6 @@ extern unsigned _On_valgrind;
 #define VALGRIND_EMIT_LOG(emit_log) do {\
 	(void) (emit_log);\
 } while (0)
-
-#define VALGRIND_FULL_REORDER do {} while (0)
-
-#define VALGRIND_PARTIAL_REORDER do {} while (0)
-
-#define VALGRIND_DEFAULT_REORDER do {} while (0)
-
-#define VALGRIND_ONLY_FAULT do {} while (0)
-
-#define VALGRIND_STOP_REORDER_FAULT do {} while (0)
 
 #define VALGRIND_START_TX do {} while (0)
 


### PR DESCRIPTION
This is part of changes related to new VALGRIND_EMIT_LOG macro.
For more details see:
https://github.com/pmem/valgrind/pull/59


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3098)
<!-- Reviewable:end -->
