### PR TITLE
obj: change redo logs to offset-based entries

### DIFF
--- a/src/common/vecq.h
+++ b/src/common/vecq.h
@@ -58,6 +58,14 @@ struct name {\
 	(vec)->back = 0;\
 } while (0)
 
+#define VECQ_REINIT(vec) do {\
+	VALGRIND_ANNOTATE_NEW_MEMORY((vec), sizeof(*vec));\
+	VALGRIND_ANNOTATE_NEW_MEMORY((vec)->buffer,\
+		(sizeof(*(vec)->buffer) * ((vec)->capacity)));\
+	(vec)->front = 0;\
+	(vec)->back = 0;\
+} while (0)
+
 #define VECQ_FRONT_POS(vec)\
 ((vec)->front & ((vec)->capacity - 1))
 
@@ -106,6 +114,18 @@ VECQ_INSERT(vec, element))
 
 #define VECQ_CAPACITY(vec)\
 ((vec)->capacity)
+
+#define VECQ_FOREACH(el, vec)\
+for (size_t _vec_i = 0;\
+	_vec_i < VECQ_SIZE(vec) &&\
+	(((el) = (vec)->buffer[_vec_i & ((vec)->capacity - 1)]), 1);\
+	++_vec_i)
+
+#define VECQ_FOREACH_REVERSE(el, vec)\
+for (size_t _vec_i = VECQ_SIZE(vec);\
+	_vec_i > 0 &&\
+	(((el) = (vec)->buffer[(_vec_i - 1) & ((vec)->capacity - 1)]), 1);\
+	--_vec_i)
 
 #define VECQ_CLEAR(vec) do {\
 	(vec)->front = 0;\

--- a/src/libpmemobj/list.c
+++ b/src/libpmemobj/list.c
@@ -998,7 +998,8 @@ lane_list_recovery(PMEMobjpool *pop, void *data, unsigned length)
 	struct lane_list_layout *section = data;
 	ASSERT(sizeof(*section) <= length);
 
-	redo_log_recover(pop->redo, (struct redo_log *)&section->redo);
+	redo_log_recover((struct redo_log *)&section->redo,
+		OBJ_OFF_IS_VALID_FROM_CTX, &pop->p_ops);
 
 	return 0;
 }
@@ -1014,8 +1015,8 @@ lane_list_check(PMEMobjpool *pop, void *data, unsigned length)
 	struct lane_list_layout *section = data;
 
 	int ret = 0;
-	if ((ret = redo_log_check(pop->redo,
-			(struct redo_log *)&section->redo)) != 0) {
+	if ((ret = redo_log_check((struct redo_log *)&section->redo,
+			OBJ_OFF_IS_VALID_FROM_CTX, &pop->p_ops)) != 0) {
 		ERR("list lane: redo log check failed");
 		ASSERT(ret == 0 || ret == -1);
 		return ret;
@@ -1031,9 +1032,8 @@ static void *
 lane_list_construct_rt(PMEMobjpool *pop, void *data)
 {
 	struct lane_list_layout *layout = data;
-	return operation_new(pop, pop->redo,
-		(struct redo_log *)&layout->redo, LIST_REDO_LOG_SIZE,
-		NULL);
+	return operation_new((struct redo_log *)&layout->redo,
+		LIST_REDO_LOG_SIZE, NULL, &pop->p_ops);
 }
 
 /*

--- a/src/libpmemobj/list.h
+++ b/src/libpmemobj/list.h
@@ -46,8 +46,7 @@
 #include "pmalloc.h"
 #include "redo.h"
 
-
-#define LIST_REDO_LOG_SIZE 59 /* (lane size - redo log - 16) / entry size */
+#define LIST_REDO_LOG_SIZE 960 /* sizeof(lane) - sizeof(struct redo_log) */
 
 /*
  * lane_list_layout -- structure of list section in lane

--- a/src/libpmemobj/memops.h
+++ b/src/libpmemobj/memops.h
@@ -54,10 +54,9 @@ enum operation_log_type {
 
 struct operation_context;
 
-struct operation_context *operation_new(void *base,
-	const struct redo_ctx *redo_ctx,
-	struct redo_log *redo, size_t redo_base_capacity,
-	redo_extend_fn extend);
+struct operation_context *
+operation_new(struct redo_log *redo, size_t redo_base_nbytes,
+	redo_extend_fn extend, const struct pmem_ops *p_ops);
 
 void operation_init(struct operation_context *ctx);
 void operation_start(struct operation_context *ctx);
@@ -69,6 +68,7 @@ int operation_add_entry(struct operation_context *ctx,
 int operation_add_typed_entry(struct operation_context *ctx,
 	void *ptr, uint64_t value,
 	enum redo_operation_type type, enum operation_log_type log_type);
+
 int operation_reserve(struct operation_context *ctx, size_t new_capacity);
 void operation_process(struct operation_context *ctx);
 void operation_cancel(struct operation_context *ctx);

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1138,16 +1138,6 @@ obj_cleanup_remote(PMEMobjpool *pop)
 }
 
 /*
- * redo_log_check_offset -- (internal) check if offset is valid
- */
-static int
-redo_log_check_offset(void *ctx, uint64_t offset)
-{
-	PMEMobjpool *pop = ctx;
-	return OBJ_OFF_IS_VALID(pop, offset);
-}
-
-/*
  * obj_replica_init -- (internal) initialize runtime part of the replica
  */
 static int
@@ -1203,11 +1193,6 @@ obj_replica_init(PMEMobjpool *rep, struct pool_set *set, unsigned repidx,
 	if (ret)
 		return ret;
 
-	rep->redo = redo_log_config_new(rep->addr, &rep->p_ops,
-			redo_log_check_offset, rep);
-	if (!rep->redo)
-		return -1;
-
 	return 0;
 }
 
@@ -1221,8 +1206,6 @@ obj_replica_fini(struct pool_replica *repset)
 
 	if (repset->remote)
 		obj_cleanup_remote(rep);
-
-	redo_log_config_delete(rep->redo);
 }
 
 /*
@@ -1886,7 +1869,6 @@ obj_replicas_cleanup(struct pool_set *set)
 		struct pool_replica *rep = set->replica[r];
 
 		PMEMobjpool *pop = rep->part[0].addr;
-		redo_log_config_delete(pop->redo);
 
 		if (pop->rpp != NULL) {
 			/*

--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -161,7 +161,6 @@ struct pmemobjpool {
 
 	struct pool_set *set;		/* pool set info */
 	struct pmemobjpool *replica;	/* next replica */
-	struct redo_ctx *redo;
 
 	/* per-replica functions: pmem or non-pmem */
 	persist_local_fn persist_local;	/* persist function */
@@ -201,7 +200,7 @@ struct pmemobjpool {
 
 	/* padding to align size of this structure to page boundary */
 	/* sizeof(unused2) == 8192 - offsetof(struct pmemobjpool, unused2) */
-	char unused2[984];
+	char unused2[992];
 };
 
 /*
@@ -242,6 +241,13 @@ OBJ_OID_IS_VALID(PMEMobjpool *pop, PMEMoid oid)
 		(oid.pool_uuid_lo == pop->uuid_lo &&
 		    oid.off >= pop->heap_offset &&
 		    oid.off < pop->heap_offset + pop->heap_size);
+}
+
+static inline int
+OBJ_OFF_IS_VALID_FROM_CTX(void *ctx, uint64_t offset)
+{
+	PMEMobjpool *pop = (PMEMobjpool *)ctx;
+	return OBJ_OFF_IS_VALID(pop, offset);
 }
 
 void obj_init(void);

--- a/src/libpmemobj/pmalloc.h
+++ b/src/libpmemobj/pmalloc.h
@@ -45,13 +45,16 @@
 #include "palloc.h"
 
 /*
- * The maximum number of entries in redo log used by the allocator. The common
- * case is to use two, one for modification of the object destination memory
- * location and the second for applying the chunk metadata modifications.
+ * The maximum size of redo logs used by the allocator. The common
+ * case is to use two entries, one for modification of the object destination
+ * memory location and the second for applying the chunk metadata modifications.
+ * The remaining space is used whenever the memory operations is larger than
+ * a singe allocation.
  * These two values should be divisible by 8 to maintain cacheline alignment.
+ * The sum of these defines should be 1024 - (sizeof(struct redo_log) * 2).
  */
-#define ALLOC_REDO_EXTERNAL_SIZE 48
-#define ALLOC_REDO_INTERNAL_SIZE 8
+#define ALLOC_REDO_EXTERNAL_SIZE 640
+#define ALLOC_REDO_INTERNAL_SIZE 256
 
 struct lane_alloc_layout {
 	struct REDO_LOG(ALLOC_REDO_EXTERNAL_SIZE) external;

--- a/src/libpmemobj/redo.c
+++ b/src/libpmemobj/redo.c
@@ -44,99 +44,102 @@
 #include "valgrind_internal.h"
 
 /*
- * Operation flag at the two least significant bits
+ * Operation flag at the three least significant bits
  */
 #define REDO_OPERATION(op)		((uint64_t)(op))
-#define REDO_OPERATION_MASK		((uint64_t)(0b11))
+#define REDO_OPERATION_MASK		((uint64_t)(0b111))
 #define REDO_OPERATION_FROM_OFFSET(off)	((off) & REDO_OPERATION_MASK)
 #define REDO_OFFSET_MASK		(~(REDO_OPERATION_MASK))
 
 #define CACHELINE_ALIGN(size) ALIGN_UP(size, CACHELINE_SIZE)
 
-struct redo_ctx {
-	void *base;
-
-	struct pmem_ops p_ops;
-
-	redo_check_offset_fn check_offset;
-	void *check_offset_ctx;
-};
-
-typedef int (*redo_entry_cb)(const struct redo_ctx *ctx,
-	struct redo_log_entry *e, void *arg);
-
 /*
- * redo_log_config_new -- allocates redo context
- */
-struct redo_ctx *
-redo_log_config_new(void *base,
-		const struct pmem_ops *p_ops,
-		redo_check_offset_fn check_offset,
-		void *check_offset_ctx)
-{
-	struct redo_ctx *cfg = Malloc(sizeof(*cfg));
-	if (!cfg) {
-		ERR("!can't create redo log config");
-		return NULL;
-	}
-
-	cfg->base = base;
-	cfg->p_ops = *p_ops;
-	cfg->check_offset = check_offset;
-	cfg->check_offset_ctx = check_offset_ctx;
-
-	return cfg;
-}
-
-/*
- * redo_log_config_delete -- frees redo context
- */
-void
-redo_log_config_delete(struct redo_ctx *ctx)
-{
-	Free(ctx);
-}
-
-/*
- * redo_log_next_by_offset -- calculates the next pointer
+ * redo_log_next_by_offset -- (internal) calculates the next pointer
  */
 static struct redo_log *
-redo_log_next_by_offset(const struct redo_ctx *ctx, size_t offset)
+redo_log_next_by_offset(size_t offset, const struct pmem_ops *p_ops)
 {
 	return offset == 0 ? NULL :
-		(struct redo_log *)((char *)ctx->base + offset);
+		(struct redo_log *)((char *)p_ops->base + offset);
 }
 
 /*
- * redo_log_next -- retrieves the pointer to the next redo log
+ * redo_log_next -- (internal) retrieves the pointer to the next redo log
  */
 static struct redo_log *
-redo_log_next(const struct redo_ctx *ctx, struct redo_log *redo)
+redo_log_next(struct redo_log *redo, const struct pmem_ops *p_ops)
 {
-	return redo_log_next_by_offset(ctx, redo->next);
+	return redo_log_next_by_offset(redo->next, p_ops);
+}
+
+
+/*
+ * redo_log_operation -- returns the type of entry operation
+ */
+enum redo_operation_type
+redo_log_entry_type(const struct redo_log_entry_base *entry)
+{
+	return REDO_OPERATION_FROM_OFFSET(entry->offset);
+}
+
+/*
+ * redo_log_offset -- returns offset
+ */
+uint64_t
+redo_log_entry_offset(const struct redo_log_entry_base *entry)
+{
+	return entry->offset & REDO_OFFSET_MASK;
+}
+
+/*
+ * redo_log_entry_size -- returns the size of a redo log entry
+ */
+size_t
+redo_log_entry_size(const struct redo_log_entry_base *entry)
+{
+	enum redo_operation_type t = redo_log_entry_type(entry);
+
+	switch (t) {
+		case REDO_OPERATION_AND:
+		case REDO_OPERATION_OR:
+		case REDO_OPERATION_SET:
+			return sizeof(struct redo_log_entry_val);
+		default:
+			ASSERT(0);
+	}
+
+	return 0;
+}
+
+/*
+ * redo_log_entry_valid -- (internal) checks if a redo log entry is valid
+ */
+static int
+redo_log_entry_valid(const struct redo_log_entry_base *entry)
+{
+	return entry->offset != 0;
 }
 
 /*
  * redo_log_foreach_entry -- iterates over every existing entry in the redo log
  */
-static int
-redo_log_foreach_entry(const struct redo_ctx *ctx, struct redo_log *redo,
-	redo_entry_cb cb, void *arg)
+int
+redo_log_foreach_entry(struct redo_log *redo,
+	redo_entry_cb cb, void *arg, const struct pmem_ops *ops)
 {
-	struct redo_log_entry *e;
+	struct redo_log_entry_base *e;
 	int ret = 0;
-	size_t nentries = 0;
 
-	for (struct redo_log *r = redo; r != NULL; r = redo_log_next(ctx, r)) {
-		for (size_t i = 0; i < r->capacity; ++i) {
-			if (nentries == redo->nentries)
+	for (struct redo_log *r = redo; r != NULL; r = redo_log_next(r, ops)) {
+		for (size_t offset = 0; offset < r->capacity; ) {
+			e = (struct redo_log_entry_base *)(r->data + offset);
+			if (!redo_log_entry_valid(e))
 				return ret;
 
-			nentries++;
-
-			e = &r->entries[i];
-			if ((ret = cb(ctx, e, arg)) != 0)
+			if ((ret = cb(e, arg, ops)) != 0)
 				return ret;
+
+			offset += redo_log_entry_size(e);
 		}
 	}
 
@@ -144,25 +147,16 @@ redo_log_foreach_entry(const struct redo_ctx *ctx, struct redo_log *redo,
 }
 
 /*
- * redo_log_nentries -- returns number of entries in the redo log
- */
-size_t
-redo_log_nentries(struct redo_log *redo)
-{
-	return redo->nentries;
-}
-
-/*
  * redo_log_capacity -- (internal) returns the total capacity of the redo log
  */
 size_t
-redo_log_capacity(const struct redo_ctx *ctx,
-	struct redo_log *redo, size_t redo_base_capacity)
+redo_log_capacity(struct redo_log *redo, size_t redo_base_bytes,
+	const struct pmem_ops *p_ops)
 {
-	size_t capacity = redo_base_capacity;
+	size_t capacity = redo_base_bytes;
 
-	/* skip the first one, we count it in 'redo_base_capacity' */
-	while ((redo = redo_log_next(ctx, redo)) != NULL) {
+	/* skip the first one, we count it in 'redo_base_bytes' */
+	while ((redo = redo_log_next(redo, p_ops)) != NULL) {
 		capacity += redo->capacity;
 	}
 
@@ -173,36 +167,37 @@ redo_log_capacity(const struct redo_ctx *ctx,
  * redo_log_rebuild_next_vec -- rebuilds the vector of next entries
  */
 void
-redo_log_rebuild_next_vec(const struct redo_ctx *ctx,
-	struct redo_log *redo, struct redo_next *next)
+redo_log_rebuild_next_vec(struct redo_log *redo, struct redo_next *next,
+	const struct pmem_ops *p_ops)
 {
 	do {
 		if (redo->next != 0)
 			VEC_PUSH_BACK(next, redo->next);
-	} while ((redo = redo_log_next(ctx, redo)) != NULL);
+	} while ((redo = redo_log_next(redo, p_ops)) != NULL);
 }
 
 /*
- * redo_log_reserve -- (internal) reserves new capacity in the redo log
+ * redo_log_reserve -- reserves new capacity in the redo log
  */
 int
-redo_log_reserve(const struct redo_ctx *ctx, struct redo_log *redo,
-	size_t redo_base_capacity, size_t *new_capacity, redo_extend_fn extend,
-	struct redo_next *next)
+redo_log_reserve(struct redo_log *redo,
+	size_t redo_base_nbytes, size_t *new_capacity, redo_extend_fn extend,
+	struct redo_next *next,
+	const struct pmem_ops *p_ops)
 {
-	size_t capacity = redo_base_capacity;
+	size_t capacity = redo_base_nbytes;
 
 	uint64_t offset;
 	VEC_FOREACH(offset, next) {
-		redo = redo_log_next_by_offset(ctx, offset);
+		redo = redo_log_next_by_offset(offset, p_ops);
 		capacity += redo->capacity;
 	}
 
 	while (capacity < *new_capacity) {
-		if (extend(ctx->base, &redo->next) != 0)
+		if (extend(p_ops->base, &redo->next) != 0)
 			return -1;
 		VEC_PUSH_BACK(next, redo->next);
-		redo = redo_log_next(ctx, redo);
+		redo = redo_log_next(redo, p_ops);
 		capacity += redo->capacity;
 	}
 	*new_capacity = capacity;
@@ -214,22 +209,22 @@ redo_log_reserve(const struct redo_ctx *ctx, struct redo_log *redo,
  * redo_log_checksum -- (internal) calculates redo log checksum
  */
 static int
-redo_log_checksum(struct redo_log *redo, size_t nentries, int insert)
+redo_log_checksum(struct redo_log *redo, size_t redo_base_bytes, int insert)
 {
-	return util_checksum(redo, SIZEOF_REDO_LOG(nentries),
+	return util_checksum(redo, SIZEOF_REDO_LOG(redo_base_bytes),
 		&redo->checksum, insert, 0);
 }
 
 /*
- * redo_log_store -- (internal) stores the transient src redo log in the
+ * redo_log_store -- stores the transient src redo log in the
  *	persistent dest redo log
  *
  * The source and destination redo logs must be cacheline aligned.
  */
 void
-redo_log_store(const struct redo_ctx *ctx, struct redo_log *dest,
-	struct redo_log *src, size_t nentries, size_t redo_base_capacity,
-	struct redo_next *next)
+redo_log_store(struct redo_log *dest, struct redo_log *src, size_t nbytes,
+	size_t redo_base_nbytes, struct redo_next *next,
+	const struct pmem_ops *p_ops)
 {
 	/*
 	 * First, store all entries over the base capacity of the redo log in
@@ -238,113 +233,151 @@ redo_log_store(const struct redo_ctx *ctx, struct redo_log *dest,
 	 * worry about failsafety here.
 	 */
 	struct redo_log *redo = dest;
-	size_t offset = redo_base_capacity;
-	size_t dest_ncopy = MIN(nentries, redo_base_capacity);
-	size_t next_entries = nentries - dest_ncopy;
+	size_t offset = redo_base_nbytes;
+
+	/*
+	 * Copy at least 8 bytes more than needed. If the user always
+	 * properly uses entry creation functions, this will zero-out the
+	 * potential leftovers of the previous log. Since all we really need
+	 * to zero is the offset, sizeof(struct redo_log_entry_base) is enough.
+	 * If the nbytes is aligned, an entire cacheline needs to be addtionally
+	 * zeroed.
+	 * But the checksum must be calculated based solely on actual data.
+	 */
+	size_t checksum_nbytes = MIN(redo_base_nbytes, nbytes);
+	nbytes = CACHELINE_ALIGN(nbytes + sizeof(struct redo_log_entry_base));
+
+	size_t base_nbytes = MIN(redo_base_nbytes, nbytes);
+	size_t next_nbytes = nbytes - base_nbytes;
+
 	size_t nlog = 0;
 
-	while (next_entries > 0) {
-		redo = redo_log_next_by_offset(ctx, VEC_ARR(next)[nlog++]);
+	while (next_nbytes > 0) {
+		redo = redo_log_next_by_offset(VEC_ARR(next)[nlog++], p_ops);
 		ASSERTne(redo, NULL);
 
-		size_t ncopy = MIN(next_entries, redo->capacity);
-		next_entries -= ncopy;
+		size_t copy_nbytes = MIN(next_nbytes, redo->capacity);
+		next_nbytes -= copy_nbytes;
 
-		pmemops_memcpy(&ctx->p_ops,
-			redo->entries,
-			src->entries + offset,
-			CACHELINE_ALIGN(sizeof(struct redo_log_entry) * ncopy),
+		VALGRIND_ADD_TO_TX(redo->data, copy_nbytes);
+		pmemops_memcpy(p_ops,
+			redo->data,
+			src->data + offset,
+			copy_nbytes,
 			PMEMOBJ_F_MEM_WC |
 			PMEMOBJ_F_MEM_NODRAIN |
 			PMEMOBJ_F_RELAXED);
-		offset += ncopy;
+		VALGRIND_REMOVE_FROM_TX(redo->data, copy_nbytes);
+		offset += copy_nbytes;
 	}
 
 	if (nlog != 0)
-		pmemops_drain(&ctx->p_ops);
+		pmemops_drain(p_ops);
 
 	/*
 	 * Then, calculate the checksum and store the first part of the
 	 * redo log.
 	 */
 	src->next = VEC_SIZE(next) == 0 ? 0 : VEC_FRONT(next);
-	src->nentries = nentries; /* total number of entries */
-	redo_log_checksum(src, dest_ncopy, 1);
+	redo_log_checksum(src, checksum_nbytes, 1);
 
-	pmemops_memcpy(&ctx->p_ops, dest, src,
-		CACHELINE_ALIGN(SIZEOF_REDO_LOG(dest_ncopy)),
+	pmemops_memcpy(p_ops, dest, src,
+		SIZEOF_REDO_LOG(base_nbytes),
 		PMEMOBJ_F_MEM_WC);
 }
 
 /*
- * redo_log_entry_create -- creates a new transient redo log entry
+ * redo_log_entry_val_create -- creates a new log value entry in the redo
+ *
+ * This function requires at least a cacheline of space to be available in the
+ * redo log.
  */
-void
-redo_log_entry_create(const void *base,
-	struct redo_log_entry *entry, uint64_t *ptr, uint64_t value,
-	enum redo_operation_type type)
+struct redo_log_entry_val *
+redo_log_entry_val_create(struct redo_log *redo, size_t offset, uint64_t *dest,
+	uint64_t value, enum redo_operation_type type,
+	const struct pmem_ops *p_ops)
 {
-	entry->offset = (uint64_t)(ptr) - (uint64_t)base;
-	entry->offset |= REDO_OPERATION(type);
-	entry->value = value;
-}
+	struct redo_log_entry_val *e =
+		(struct redo_log_entry_val *)(redo->data + offset);
 
-/*
- * redo_log_operation -- returns the type of entry operation
- */
-enum redo_operation_type
-redo_log_operation(const struct redo_log_entry *entry)
-{
-	return REDO_OPERATION_FROM_OFFSET(entry->offset);
-}
+	struct {
+		struct redo_log_entry_val v;
+		struct redo_log_entry_base zeroes;
+	} data;
+	COMPILE_ERROR_ON(sizeof(data) != sizeof(data.v) + sizeof(data.zeroes));
 
-/*
- * redo_log_offset -- returns offset
- */
-uint64_t
-redo_log_offset(const struct redo_log_entry *entry)
-{
-	return entry->offset & REDO_OFFSET_MASK;
+	/*
+	 * Write a little bit more to the buffer so that the next entry that
+	 * resides in the log is erased. This will prevent leftovers from
+	 * a previous, clobbered, log from being incorrectly applied.
+	 */
+	data.zeroes.offset = 0;
+	data.v.base.offset = (uint64_t)(dest) - (uint64_t)p_ops->base;
+	data.v.base.offset |= REDO_OPERATION(type);
+	data.v.value = value;
+
+	pmemops_memcpy(p_ops, e, &data, sizeof(data),
+		PMEMOBJ_F_MEM_NOFLUSH | PMEMOBJ_F_RELAXED);
+
+	return e;
 }
 
 /*
  * redo_log_entry_apply -- applies modifications of a single redo log entry
  */
 void
-redo_log_entry_apply(void *base, const struct redo_log_entry *e,
-	flush_fn flush)
+redo_log_entry_apply(const struct redo_log_entry_base *e, int persist,
+	const struct pmem_ops *p_ops)
 {
-	enum redo_operation_type t = redo_log_operation(e);
-	uint64_t offset = redo_log_offset(e);
+	enum redo_operation_type t = redo_log_entry_type(e);
+	uint64_t offset = redo_log_entry_offset(e);
 
-	uint64_t *val = (uint64_t *)((uintptr_t)base + offset);
-	VALGRIND_ADD_TO_TX(val, sizeof(*val));
+	size_t dst_size = sizeof(uint64_t);
+	uint64_t *dst = (uint64_t *)((uintptr_t)p_ops->base + offset);
+
+	struct redo_log_entry_val *ev;
+
+	flush_fn f = persist ? p_ops->persist : p_ops->flush;
+
 	switch (t) {
 		case REDO_OPERATION_AND:
-			*val &= e->value;
+			ev = (struct redo_log_entry_val *)e;
+
+			VALGRIND_ADD_TO_TX(dst, dst_size);
+			*dst &= ev->value;
+			f(p_ops->base, dst, sizeof(uint64_t),
+				PMEMOBJ_F_RELAXED);
 		break;
 		case REDO_OPERATION_OR:
-			*val |= e->value;
+			ev = (struct redo_log_entry_val *)e;
+
+			VALGRIND_ADD_TO_TX(dst, dst_size);
+			*dst |= ev->value;
+			f(p_ops->base, dst, sizeof(uint64_t),
+				PMEMOBJ_F_RELAXED);
 		break;
 		case REDO_OPERATION_SET:
-			*val = e->value;
+			ev = (struct redo_log_entry_val *)e;
+
+			VALGRIND_ADD_TO_TX(dst, dst_size);
+			*dst = ev->value;
+			f(p_ops->base, dst, sizeof(uint64_t),
+				PMEMOBJ_F_RELAXED);
 		break;
 		default:
 			ASSERT(0);
 	}
-	VALGRIND_REMOVE_FROM_TX(val, sizeof(*val));
-
-	flush(base, val, sizeof(uint64_t), PMEMOBJ_F_RELAXED);
+	VALGRIND_REMOVE_FROM_TX(dst, dst_size);
 }
 
 /*
- * redo_log_process_entry -- processes a single redo log entry
+ * redo_log_process_entry -- (internal) processes a single redo log entry
  */
 static int
-redo_log_process_entry(const struct redo_ctx *ctx,
-	struct redo_log_entry *e, void *arg)
+redo_log_process_entry(struct redo_log_entry_base *e, void *arg,
+	const struct pmem_ops *p_ops)
 {
-	redo_log_entry_apply(ctx->base, e, ctx->p_ops.flush);
+	redo_log_entry_apply(e, 0, p_ops);
 
 	return 0;
 }
@@ -353,8 +386,8 @@ redo_log_process_entry(const struct redo_ctx *ctx,
  * redo_log_clobber -- zeroes the metadata of the redo log
  */
 void
-redo_log_clobber(const struct redo_ctx *ctx, struct redo_log *dest,
-	struct redo_next *next)
+redo_log_clobber(struct redo_log *dest, struct redo_next *next,
+	const struct pmem_ops *p_ops)
 {
 	struct redo_log empty;
 	memset(&empty, 0, sizeof(empty));
@@ -364,79 +397,104 @@ redo_log_clobber(const struct redo_ctx *ctx, struct redo_log *dest,
 	else
 		empty.next = dest->next;
 
-	pmemops_memcpy(&ctx->p_ops, dest, &empty, sizeof(empty),
+	pmemops_memcpy(p_ops, dest, &empty, sizeof(empty),
 		PMEMOBJ_F_MEM_WC);
 }
 
 /*
- * redo_log_process -- (internal) process redo log entries
+ * redo_log_process -- process redo log entries
  */
 void
-redo_log_process(const struct redo_ctx *ctx, struct redo_log *redo)
+redo_log_process(struct redo_log *redo, redo_check_offset_fn check,
+	const struct pmem_ops *p_ops)
 {
 	LOG(15, "redo %p", redo);
 
 #ifdef DEBUG
-	ASSERTeq(redo_log_check(ctx, redo), 0);
+	redo_log_check(redo, check, p_ops);
 #endif
-	redo_log_foreach_entry(ctx, redo, redo_log_process_entry, NULL);
+
+	redo_log_foreach_entry(redo, redo_log_process_entry, NULL, p_ops);
 }
 
 /*
- * redo_log_recover -- (internal) recovery of redo log
+ * redo_log_base_nbytes -- (internal) counts the actual of number of bytes
+ *	occupied by the redo log
+ */
+static size_t
+redo_log_base_nbytes(struct redo_log *redo)
+{
+	size_t offset = 0;
+	struct redo_log_entry_base *e;
+
+	for (offset = 0; offset < redo->capacity; ) {
+		e = (struct redo_log_entry_base *)(redo->data + offset);
+		if (!redo_log_entry_valid(e))
+			break;
+
+		offset += redo_log_entry_size(e);
+	}
+
+	return offset;
+}
+
+/*
+ * redo_log_recovery_needed -- checks if the logs needs recovery
+ */
+int
+redo_log_recovery_needed(struct redo_log *redo,
+	const struct pmem_ops *p_ops)
+{
+	size_t nbytes = MIN(redo_log_base_nbytes(redo), redo->capacity);
+	return nbytes != 0 && redo_log_checksum(redo, nbytes, 0);
+}
+
+/*
+ * redo_log_recover -- recovery of redo log
  *
  * The redo_log_recover shall be preceded by redo_log_check call.
  */
 void
-redo_log_recover(const struct redo_ctx *ctx, struct redo_log *redo)
+redo_log_recover(struct redo_log *redo, redo_check_offset_fn check,
+	const struct pmem_ops *p_ops)
 {
 	LOG(15, "redo %p", redo);
-	ASSERTne(ctx, NULL);
 
-	size_t nentries = MIN(redo->nentries, redo->capacity);
-	if (nentries != 0 && redo_log_checksum(redo, nentries, 0)) {
-		redo_log_process(ctx, redo);
-		redo_log_clobber(ctx, redo, NULL);
+	if (redo_log_recovery_needed(redo, p_ops)) {
+		redo_log_process(redo, check, p_ops);
+		redo_log_clobber(redo, NULL, p_ops);
 	}
 }
 
 /*
- * redo_log_check_entry -- checks consistency of a single redo log entry
+ * redo_log_check_entry --
+ *	(internal) checks consistency of a single redo log entry
  */
 static int
-redo_log_check_entry(const struct redo_ctx *ctx, struct redo_log_entry *e,
-	void *arg)
+redo_log_check_entry(struct redo_log_entry_base *e,
+	void *arg, const struct pmem_ops *p_ops)
 {
-	uint64_t offset = redo_log_offset(e);
-	if (!ctx->check_offset(ctx->check_offset_ctx, offset)) {
+	uint64_t offset = redo_log_entry_offset(e);
+	redo_check_offset_fn check = arg;
+
+	if (!check(p_ops->base, offset)) {
 		LOG(15, "redo %p invalid offset %" PRIu64,
 				e, e->offset);
 		return -1;
 	}
-	return 0;
+
+	return offset == 0 ? -1 : 0;
 }
 
 /*
  * redo_log_check -- (internal) check consistency of redo log entries
  */
 int
-redo_log_check(const struct redo_ctx *ctx, struct redo_log *redo)
+redo_log_check(struct redo_log *redo, redo_check_offset_fn check,
+	const struct pmem_ops *p_ops)
 {
 	LOG(15, "redo %p", redo);
-	ASSERTne(ctx, NULL);
 
-	if (redo->nentries != 0)
-		return redo_log_foreach_entry(ctx, redo,
-			redo_log_check_entry, NULL);
-
-	return 0;
-}
-
-/*
- * redo_get_pmem_ops -- returns pmem_ops
- */
-const struct pmem_ops *
-redo_get_pmem_ops(const struct redo_ctx *ctx)
-{
-	return &ctx->p_ops;
+	return redo_log_foreach_entry(redo,
+			redo_log_check_entry, check, p_ops);
 }

--- a/src/libpmemobj/redo.h
+++ b/src/libpmemobj/redo.h
@@ -43,78 +43,91 @@
 #include "vec.h"
 #include "pmemops.h"
 
-struct redo_ctx;
-
-/*
- * redo_log -- redo log entry
- */
-struct redo_log_entry {
-	uint64_t offset;	/* offset with operation type flag */
-	uint64_t value;
+struct redo_log_entry_base {
+	uint64_t offset; /* offset with operation type flag */
 };
 
-#define REDO_LOG(base_capacity) {\
+/*
+ * redo_log_entry_val -- redo log entry
+ */
+struct redo_log_entry_val {
+	struct redo_log_entry_base base;
+	uint64_t value; /* value to be applied */
+};
+
+#define REDO_LOG(capacity_bytes) {\
+	/* 64 bytes of metadata */\
 	uint64_t checksum; /* checksum of redo header and its entries */\
-	uint64_t nentries; /* total number of entries (incl. next redo) */\
 	uint64_t next; /* offset of redo log extension */\
-	uint64_t capacity; /* capacity of this redo log */\
-	uint64_t unused[4]; /* must be 0 */ \
-	struct redo_log_entry entries[base_capacity];\
+	uint64_t capacity; /* capacity of this redo in bytes */\
+	uint64_t unused[5]; /* must be 0 */\
+	/* N bytes of data */\
+	uint8_t data[capacity_bytes];\
 }\
 
 #define SIZEOF_REDO_LOG(base_capacity)\
-(sizeof(struct redo_log) + sizeof(struct redo_log_entry) * (base_capacity))
+(sizeof(struct redo_log) + base_capacity)
 
 struct redo_log REDO_LOG(0);
 
 VEC(redo_next, uint64_t);
 
 enum redo_operation_type {
-	REDO_OPERATION_SET	=	0b00,
-	REDO_OPERATION_AND	=	0b01,
-	REDO_OPERATION_OR	=	0b10,
+	REDO_OPERATION_SET	=	0b000,
+	REDO_OPERATION_AND	=	0b001,
+	REDO_OPERATION_OR	=	0b010,
 };
+
+#define REDO_BIT_OPERATIONS (REDO_OPERATION_AND | REDO_OPERATION_OR)
+#define REDO_VAL_OPERATIONS (REDO_BIT_OPERATIONS | REDO_OPERATION_SET)
 
 typedef int (*redo_check_offset_fn)(void *ctx, uint64_t offset);
 typedef int (*redo_extend_fn)(void *, uint64_t *);
+typedef int (*redo_entry_cb)(struct redo_log_entry_base *e, void *arg,
+	const struct pmem_ops *p_ops);
 
-struct redo_ctx *redo_log_config_new(void *base,
-		const struct pmem_ops *p_ops,
-		redo_check_offset_fn check_offset,
-		void *check_offset_ctx);
+size_t redo_log_capacity(struct redo_log *redo, size_t redo_base_bytes,
+	const struct pmem_ops *p_ops);
+void redo_log_rebuild_next_vec(struct redo_log *redo, struct redo_next *next,
+	const struct pmem_ops *p_ops);
 
-void redo_log_config_delete(struct redo_ctx *ctx);
+int redo_log_foreach_entry(struct redo_log *redo,
+	redo_entry_cb cb, void *arg, const struct pmem_ops *ops);
 
-size_t redo_log_capacity(const struct redo_ctx *ctx,
-	struct redo_log *redo, size_t redo_base_capacity);
-void redo_log_rebuild_next_vec(const struct redo_ctx *ctx,
-	struct redo_log *redo, struct redo_next *next);
+int redo_log_reserve(struct redo_log *redo,
+	size_t redo_base_nbytes, size_t *new_capacity_bytes,
+	redo_extend_fn extend, struct redo_next *next,
+	const struct pmem_ops *p_ops);
 
-int redo_log_reserve(const struct redo_ctx *ctx, struct redo_log *redo,
-	size_t redo_base_capacity, size_t *new_capacity, redo_extend_fn extend,
-	struct redo_next *next);
-void redo_log_store(const struct redo_ctx *ctx, struct redo_log *dest,
-	struct redo_log *src, size_t nentries, size_t redo_base_capacity,
-	struct redo_next *next);
-void redo_log_clobber(const struct redo_ctx *ctx, struct redo_log *dest,
-	struct redo_next *next);
-void redo_log_process(const struct redo_ctx *ctx, struct redo_log *redo);
+void redo_log_store(struct redo_log *dest,
+	struct redo_log *src, size_t nbytes, size_t redo_base_nbytes,
+	struct redo_next *next, const struct pmem_ops *p_ops);
 
-size_t redo_log_nentries(struct redo_log *redo);
+void redo_log_clobber(struct redo_log *dest, struct redo_next *next,
+	const struct pmem_ops *p_ops);
+void redo_log_process(struct redo_log *redo, redo_check_offset_fn check,
+	const struct pmem_ops *p_ops);
 
-uint64_t redo_log_offset(const struct redo_log_entry *entry);
-enum redo_operation_type redo_log_operation(const struct redo_log_entry *entry);
+int redo_log_recovery_needed(struct redo_log *redo,
+	const struct pmem_ops *p_ops);
 
-void redo_log_entry_create(const void *base,
-	struct redo_log_entry *entry, uint64_t *ptr, uint64_t value,
-	enum redo_operation_type type);
+uint64_t redo_log_entry_offset(const struct redo_log_entry_base *entry);
+enum redo_operation_type redo_log_entry_type(
+	const struct redo_log_entry_base *entry);
 
-void redo_log_entry_apply(void *base, const struct redo_log_entry *e,
-	flush_fn flush);
+struct redo_log_entry_val *redo_log_entry_val_create(struct redo_log *redo,
+	size_t offset, uint64_t *dest, uint64_t value,
+	enum redo_operation_type type,
+	const struct pmem_ops *p_ops);
 
-void redo_log_recover(const struct redo_ctx *ctx, struct redo_log *redo);
-int redo_log_check(const struct redo_ctx *ctx, struct redo_log *redo);
+void redo_log_entry_apply(const struct redo_log_entry_base *e, int persist,
+	const struct pmem_ops *p_ops);
 
-const struct pmem_ops *redo_get_pmem_ops(const struct redo_ctx *ctx);
+size_t redo_log_entry_size(const struct redo_log_entry_base *entry);
+
+void redo_log_recover(struct redo_log *redo, redo_check_offset_fn check,
+	const struct pmem_ops *p_ops);
+int redo_log_check(struct redo_log *redo, redo_check_offset_fn check,
+	const struct pmem_ops *p_ops);
 
 #endif

--- a/src/test/obj_layout/obj_layout.c
+++ b/src/test/obj_layout/obj_layout.c
@@ -66,8 +66,9 @@
 #define SIZEOF_PVECTOR_V3 (224)
 #define SIZEOF_TX_RANGE_META_V3 (16)
 #define SIZEOF_REDO_LOG_V4 (64)
-#define SIZEOF_REDO_LOG_ENTRY_V4 (16)
-#define SIZEOF_LANE_LIST_LAYOUT_V4 (1024 - 16)
+#define SIZEOF_REDO_LOG_BASE_ENTRY_V4 (8)
+#define SIZEOF_REDO_LOG_VAL_ENTRY_V4 (16)
+#define SIZEOF_LANE_LIST_LAYOUT_V4 (1024)
 #define SIZEOF_LANE_ALLOC_LAYOUT_V4 (1024)
 #define SIZEOF_LANE_TX_LAYOUT_V4 ((2 * SIZEOF_PVECTOR_V3))
 
@@ -161,7 +162,6 @@ main(int argc, char *argv[])
 
 	ASSERT_ALIGNED_BEGIN(struct redo_log);
 	ASSERT_ALIGNED_FIELD(struct redo_log, checksum);
-	ASSERT_ALIGNED_FIELD(struct redo_log, nentries);
 	ASSERT_ALIGNED_FIELD(struct redo_log, next);
 	ASSERT_ALIGNED_FIELD(struct redo_log, capacity);
 	ASSERT_ALIGNED_FIELD(struct redo_log, unused);
@@ -169,12 +169,18 @@ main(int argc, char *argv[])
 	UT_COMPILE_ERROR_ON(sizeof(struct redo_log) !=
 		SIZEOF_REDO_LOG_V4);
 
-	ASSERT_ALIGNED_BEGIN(struct redo_log_entry);
-	ASSERT_ALIGNED_FIELD(struct redo_log_entry, offset);
-	ASSERT_ALIGNED_FIELD(struct redo_log_entry, value);
-	ASSERT_ALIGNED_CHECK(struct redo_log_entry);
-	UT_COMPILE_ERROR_ON(sizeof(struct redo_log_entry) !=
-		SIZEOF_REDO_LOG_ENTRY_V4);
+	ASSERT_ALIGNED_BEGIN(struct redo_log_entry_base);
+	ASSERT_ALIGNED_FIELD(struct redo_log_entry_base, offset);
+	ASSERT_ALIGNED_CHECK(struct redo_log_entry_base);
+	UT_COMPILE_ERROR_ON(sizeof(struct redo_log_entry_base) !=
+		SIZEOF_REDO_LOG_BASE_ENTRY_V4);
+
+	ASSERT_ALIGNED_BEGIN(struct redo_log_entry_val);
+	ASSERT_ALIGNED_FIELD(struct redo_log_entry_val, base);
+	ASSERT_ALIGNED_FIELD(struct redo_log_entry_val, value);
+	ASSERT_ALIGNED_CHECK(struct redo_log_entry_val);
+	UT_COMPILE_ERROR_ON(sizeof(struct redo_log_entry_val) !=
+		SIZEOF_REDO_LOG_VAL_ENTRY_V4);
 
 	ASSERT_ALIGNED_BEGIN(PMEMoid);
 	ASSERT_ALIGNED_FIELD(PMEMoid, pool_uuid_lo);

--- a/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
+++ b/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
@@ -226,13 +226,6 @@ test_realloc(size_t org, size_t dest)
 	pfree(mock_pop, &addr->ptr);
 }
 
-static int
-redo_log_check_offset(void *ctx, uint64_t offset)
-{
-	PMEMobjpool *pop = ctx;
-	return OBJ_OFF_IS_VALID(pop, offset);
-}
-
 #define PMALLOC_EXTRA 20
 #define PALLOC_FLAG (1 << 15)
 
@@ -309,9 +302,6 @@ test_mock_pool_allocs(void)
 	mock_pop->set->options = 0;
 	mock_pop->set->directory_based = 0;
 
-	mock_pop->redo = redo_log_config_new(addr, &mock_pop->p_ops,
-			redo_log_check_offset, mock_pop);
-
 	void *heap_start = (char *)mock_pop + mock_pop->heap_offset;
 	uint64_t heap_size = MOCK_POOL_SIZE - mock_pop->heap_offset;
 
@@ -371,7 +361,6 @@ test_mock_pool_allocs(void)
 
 	stats_delete(mock_pop, s);
 	lane_cleanup(mock_pop);
-	redo_log_config_delete(mock_pop->redo);
 	heap_cleanup(&mock_pop->heap);
 
 	FREE(mock_pop->set);


### PR DESCRIPTION
This patch changes the redo log algorithm to use a variably-sized
byte buffer with entries (similarly to how it's done for undo logs)
instead of having a fixed number of entries per redo log. While
the new code is more flexible and allows for logs larger than
8 bytes, it also has the downside of being more complicated to
use - we no longer have access to array of entries.

One of the consequences of this change is the removal of 'nentries'
counter in the redo log metadata. From now on, the stopping criteria
for iterating over entries is whether or not the next entry offset
is zero. To make this work, when storing/creating logs the algorithm
writes zeroes to a cacheline ahead of the actual log.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3113)
<!-- Reviewable:end -->
