### PR TITLE
obj: modify pobj_action struct

### DIFF
--- a/src/include/libpmemobj/action_base.h
+++ b/src/include/libpmemobj/action_base.h
@@ -69,6 +69,15 @@ struct pobj_action {
 		} heap;
 		uint64_t data2[14];
 	};
+
+#ifdef __cplusplus
+	/*
+	 * Default constructor
+	 */
+	pobj_action() noexcept
+	{
+	}
+#endif
 };
 
 #define POBJ_ACTION_XRESERVE_VALID_FLAGS\


### PR DESCRIPTION
Add default ctor for pobj_action struct iff C++ compiler is used.
It will be used in C++ bindings for action API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3119)
<!-- Reviewable:end -->
