### PR TITLE
[1.4] common: fix reported version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,6 @@
 # e.g.: "make install prefix=/usr"
 
 include src/common.inc
-include src/version.inc
 
 RPM_BUILDDIR=rpmbuild
 DPKG_BUILDDIR=dpkgbuild

--- a/src/Makefile
+++ b/src/Makefile
@@ -34,7 +34,6 @@
 #
 TOP := $(dir $(lastword $(MAKEFILE_LIST)))..
 include $(TOP)/src/common.inc
-include $(TOP)/src/version.inc
 
 TARGETS = libpmem libvmem libpmemblk libpmemlog libpmemobj libpmempool\
 		  libpmemcto libvmmalloc tools

--- a/src/common.inc
+++ b/src/common.inc
@@ -54,6 +54,16 @@ COVERAGE = 0
 PKG_CONFIG ?= pkg-config
 HEADERS = $(wildcard *.h) $(wildcard *.hpp)
 
+ifeq ($(SRCVERSION),)
+export SRCVERSION := $(shell $(TOP)/utils/version.sh $(TOP))
+else
+export SRCVERSION
+endif
+
+ifeq ($(SRCVERSION),)
+$(error Cannot evaluate version)
+endif
+
 ifeq ($(shell command -v clang-format-3.8 > /dev/null && echo y || echo n), y)
 CLANG_FORMAT ?= clang-format-3.8
 else

--- a/utils/version.sh
+++ b/utils/version.sh
@@ -65,21 +65,25 @@ if [ $PARSE_GIT_VERSION -eq 1 ]; then
 	fi
 fi
 
-GIT_DESCRIBE=$(git -C $1 describe 2>/dev/null) && true
+cd "$1"
+
+GIT_DESCRIBE=$(git describe 2>/dev/null) && true
 if [ -n "$GIT_DESCRIBE" ]; then
 	echo "$GIT_DESCRIBE"
 	exit 0
 fi
 
 # try commit it, git describe can fail when there are no tags (e.g. with shallow clone, like on Travis)
-GIT_COMMIT=$(git -C $1 log -1 --format=%h) && true
+GIT_COMMIT=$(git log -1 --format=%h) && true
 if [ -n "$GIT_COMMIT" ]; then
 	echo "$GIT_COMMIT"
 	exit 0
 fi
 
+cd - >/dev/null
+
 # If nothing works, try to get version from directory name
-VER=$(basename `realpath $1` | sed 's/pmdk[-]*\([0-9a-z.+-]*\).*/\1/')
+VER=$(basename `realpath "$1"` | sed 's/pmdk[-]*\([0-9a-z.+-]*\).*/\1/')
 if [ -n "$VER" ]; then
 	echo "$VER"
 	exit 0


### PR DESCRIPTION
There are many problems:

On Linux we were using git commit id of the parent repository if
zip/tar.gz package was uncompressed inside of git repository (and
this is the case for Fedora).

We can't rely on GIT_VERSION for releases, because its contents depends
on state of the branch the tag was created from.
This file contains all refs that point to the tagged commit, so
immediately after 1.4.1 release it contained both "1.4.1" and
"stable-1.4", but after merging the first PR to "stable-1.4" branch it
contained only "1.4.1". This means that the checksum of the released
version changed! This is why vcpkg build from master fails now (it
contains initial checksum).
The fix is to remove the automatically filled GIT_VERSION file and add
static VERSION file before the release and revert this commit after.

Version reported by debug libraries was empty if libraries were built
from directories other than / and /src.

On Windows reported version for point releases was wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3122)
<!-- Reviewable:end -->
