### PR TITLE
test: fix create_poolset

### DIFF
--- a/src/test/unittest/unittest.ps1
+++ b/src/test/unittest/unittest.ps1
@@ -360,7 +360,7 @@ function create_poolset {
             # non-zeroed file, except 4K header
             'h' { create_nonzeroed_file $asize 4K $fpath }
             # create empty directory
-            'd' { new-item $fpath -itemtype directory >> $Env:PREP_LOG_FILE }
+            'd' { new-item $fpath -force -itemtype directory >> $Env:PREP_LOG_FILE }
         }
 
         # XXX: didn't convert chmod


### PR DESCRIPTION
In obj_extend/TEST8.PS1 we receive a warning:
An item with the specified name C:\temp\...\testdir10 already exists.
but the test passed.
Ref: pmem/pmdk#3130

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3147)
<!-- Reviewable:end -->
