### PR TITLE
examples: fix warnings in lifesaver

### DIFF
--- a/src/examples/libpmemcto/lifesaver/lifesaver.c
+++ b/src/examples/libpmemcto/lifesaver/lifesaver.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Intel Corporation
+ * Copyright 2017-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -97,7 +97,6 @@ ScreenSaverConfigureDialog(HWND hDlg, UINT message,
 {
 	static HWND hOK;
 	static HWND hPath;
-	HRESULT hr;
 	BOOL res;
 
 	switch (message) {

--- a/src/examples/libpmemcto/lifesaver/lifesaver.def
+++ b/src/examples/libpmemcto/lifesaver/lifesaver.def
@@ -1,6 +1,6 @@
 ;;;; Begin Copyright Notice
 ;
-; Copyright 2017, Intel Corporation
+; Copyright 2017-2018, Intel Corporation
 ;
 ; Redistribution and use in source and binary forms, with or without
 ; modification, are permitted provided that the following conditions
@@ -32,7 +32,7 @@
 ;
 ;;;;  End Copyright Notice
 
-NAME		LIFESAVER.SCR
+NAME		EX_LIFESAVER_LIFESAVER.SCR
 
 HEAPSIZE	1024
 STACKSIZE	4096


### PR DESCRIPTION
I deleted unreferenced local variable and updated the name of an output file in lifesaver.def

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3148)
<!-- Reviewable:end -->
