### PR TITLE
examples: add missing ndctl and daxctl links

### DIFF
--- a/src/examples/Makefile.inc
+++ b/src/examples/Makefile.inc
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2017, Intel Corporation
+# Copyright 2015-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -53,7 +53,45 @@ CXXFLAGS += -fsanitize=$(SANITIZE)
 LDFLAGS += -fsanitize=$(SANITIZE)
 endif
 INCS = -I$(INCDIR) -I. -I$(TOP_SRC)/examples $(OS_INCS)
+
 LIBS += $(OS_LIBS) $(LIBUUID)
+
+ifeq ($(LIBPMEMPOOL), y)
+LIBS += -lpmempool
+endif
+
+ifeq ($(LIBPMEMBLK), y)
+LIBS += -lpmemblk
+endif
+
+ifeq ($(LIBPMEMLOG), y)
+LIBS += -lpmemlog
+endif
+
+ifeq ($(LIBPMEMOBJ), y)
+LIBS += -lpmemobj
+endif
+
+ifeq ($(LIBPMEMCTO), y)
+LIBS += -lpmemcto
+endif
+
+ifeq ($(LIBRPMEM),y)
+LIBS += -lrpmem $(shell $(PKG_CONFIG) --libs libfabric)
+endif
+
+ifeq ($(LIBPMEM),y)
+LIBS += -lpmem
+endif
+
+ifeq ($(LIBVMEM),y)
+LIBS += -lvmem
+endif
+
+# If any of these libraries is required, we need to link libpthread
+ifneq ($(LIBPMEM)$(LIBRPMEM)$(LIBPMEMPOOL)$(LIBPMEMBLK)$(LIBPMEMLOG)$(LIBPMEMOBJ)$(LIBPMEMCTO)$(LIBVMEM),)
+LIBS += -pthread
+endif
 
 LINKER=$(CC)
 ifeq ($(COMPILE_LANG), cpp)

--- a/src/examples/Makefile.inc
+++ b/src/examples/Makefile.inc
@@ -93,6 +93,11 @@ ifneq ($(LIBPMEM)$(LIBRPMEM)$(LIBPMEMPOOL)$(LIBPMEMBLK)$(LIBPMEMLOG)$(LIBPMEMOBJ
 LIBS += -pthread
 endif
 
+# If any of these libraries is required, we need to link libndctl and libdaxctl
+ifneq ($(LIBPMEMPOOL)$(LIBPMEMBLK)$(LIBPMEMLOG)$(LIBPMEMOBJ)$(LIBPMEMCTO),)
+LIBS += $(LIBNDCTL)
+endif
+
 LINKER=$(CC)
 ifeq ($(COMPILE_LANG), cpp)
 LINKER=$(CXX)

--- a/src/examples/libpmem/Makefile
+++ b/src/examples/libpmem/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -36,7 +36,7 @@
 
 PROGS = manpage simple_copy full_copy
 
-LIBS = -lpmem -pthread
+LIBPMEM=y
 
 include ../Makefile.inc
 

--- a/src/examples/libpmemblk/Makefile
+++ b/src/examples/libpmemblk/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -36,7 +36,8 @@
 PROGS = manpage
 DIRS = assetdb
 
-LIBS = -lpmemblk -lpmem -pthread
+LIBPMEM=y
+LIBPMEMBLK=y
 
 include ../Makefile.inc
 

--- a/src/examples/libpmemblk/assetdb/Makefile
+++ b/src/examples/libpmemblk/assetdb/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -35,7 +35,8 @@
 #
 PROGS = asset_load asset_list asset_checkout asset_checkin
 
-LIBS = -lpmemblk -lpmem -pthread
+LIBPMEM=y
+LIBPMEMBLK=y
 
 include ../../Makefile.inc
 

--- a/src/examples/libpmemcto/Makefile
+++ b/src/examples/libpmemcto/Makefile
@@ -37,7 +37,8 @@
 PROGS = manpage
 DIRS = life libart
 
-LIBS = -lpmemcto -lpmem -pthread
+LIBPMEM=y
+LIBPMEMCTO=y
 
 include ../Makefile.inc
 

--- a/src/examples/libpmemcto/libart/Makefile
+++ b/src/examples/libpmemcto/libart/Makefile
@@ -54,7 +54,8 @@ PROGS = arttree
 LIBRARIES = art
 endif
 
-LIBS = -lpmem -lpmemcto
+LIBPMEM=y
+LIBPMEMCTO=y
 
 include ../../Makefile.inc
 

--- a/src/examples/libpmemcto/life/Makefile
+++ b/src/examples/libpmemcto/life/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +45,8 @@ $(info NOTE: Skipping pminvaders and pminvaders2 because ncurses is missing \
 -- see src/examples/libpmemcto/life/README for details.)
 endif
 
-LIBS = -lpmemcto -lpmem -pthread
+LIBPMEM=y
+LIBPMEMCTO=y
 
 ifeq ($(NCURSES),y)
 LIBS += $(shell $(PKG_CONFIG) --libs ncurses)

--- a/src/examples/libpmemlog/Makefile
+++ b/src/examples/libpmemlog/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -36,7 +36,8 @@
 PROGS = manpage
 DIRS = logfile
 
-LIBS = -lpmemlog -lpmem -pthread
+LIBPMEM=y
+LIBPMEMLOG=y
 
 include ../Makefile.inc
 

--- a/src/examples/libpmemlog/logfile/Makefile
+++ b/src/examples/libpmemlog/logfile/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2017, Intel Corporation
+# Copyright 2014-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -35,7 +35,8 @@
 #
 PROGS = addlog printlog
 
-LIBS = -lpmemlog -lpmem -pthread
+LIBPMEM=y
+LIBPMEMLOG=y
 
 include ../../Makefile.inc
 

--- a/src/examples/libpmemobj/Makefile
+++ b/src/examples/libpmemobj/Makefile
@@ -38,7 +38,9 @@ DIRS = pminvaders pmemlog pmemblk string_store string_store_tx\
 	string_store_tx_type hashmap tree_map pmemobjfs map libart array\
 	linkedlist list_map slab_allocator queue
 
-LIBS = -lpmemobj -lpmem -pthread -lm -pthread
+LIBS = -lm
+LIBPMEM=y
+LIBPMEMOBJ=y
 
 include ../Makefile.inc
 

--- a/src/examples/libpmemobj/array/Makefile
+++ b/src/examples/libpmemobj/array/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -35,7 +35,8 @@
 #
 PROGS = array
 
-LIBS = -lpmemobj -lpmem -pthread
+LIBPMEM=y
+LIBPMEMOBJ=y
 
 include ../../Makefile.inc
 

--- a/src/examples/libpmemobj/hashmap/Makefile
+++ b/src/examples/libpmemobj/hashmap/Makefile
@@ -32,7 +32,7 @@
 
 LIBRARIES = hashmap_atomic hashmap_tx hashmap_rp
 
-LIBS = -lpmemobj
+LIBPMEMOBJ=y
 
 include ../../Makefile.inc
 

--- a/src/examples/libpmemobj/libart/Makefile
+++ b/src/examples/libpmemobj/libart/Makefile
@@ -55,7 +55,7 @@ PROGS = arttree examine_arttree
 LIBRARIES = art
 endif
 
-LIBS = -lpmemobj
+LIBPMEMOBJ=y
 
 include ../../Makefile.inc
 

--- a/src/examples/libpmemobj/linkedlist/Makefile
+++ b/src/examples/libpmemobj/linkedlist/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,7 +33,8 @@
 #
 PROGS = fifo
 
-LIBS = -lpmemobj -lpmem -pthread
+LIBPMEM=y
+LIBPMEMOBJ=y
 
 include ../../Makefile.inc
 

--- a/src/examples/libpmemobj/list_map/Makefile
+++ b/src/examples/libpmemobj/list_map/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -35,7 +35,7 @@
 #
 LIBRARIES = skiplist_map
 
-LIBS = -lpmemobj
+LIBPMEMOBJ=y
 
 include ../../Makefile.inc
 

--- a/src/examples/libpmemobj/map/Makefile
+++ b/src/examples/libpmemobj/map/Makefile
@@ -49,7 +49,7 @@ $(info NOTE: Skipping kv_server because libuv is missing \
 -- see src/examples/libpmemobj/map/README for details.)
 endif
 
-LIBS = -lpmemobj -pthread
+LIBPMEMOBJ=y
 
 ifeq ($(LIBUV),y)
 LIBS += $(shell $(PKG_CONFIG) --libs libuv)

--- a/src/examples/libpmemobj/pmemblk/Makefile
+++ b/src/examples/libpmemobj/pmemblk/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -35,7 +35,8 @@
 #
 PROGS = obj_pmemblk
 
-LIBS = -lpmemobj -lpmem -pthread
+LIBPMEM=y
+LIBPMEMOBJ=y
 
 include ../../Makefile.inc
 

--- a/src/examples/libpmemobj/pmemlog/Makefile
+++ b/src/examples/libpmemobj/pmemlog/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -35,7 +35,8 @@
 #
 PROGS = obj_pmemlog obj_pmemlog_macros obj_pmemlog_minimal obj_pmemlog_simple
 
-LIBS = -lpmemobj -lpmem -pthread
+LIBPMEM=y
+LIBPMEMOBJ=y
 
 include ../../Makefile.inc
 

--- a/src/examples/libpmemobj/pmemobjfs/Makefile
+++ b/src/examples/libpmemobj/pmemobjfs/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -56,10 +56,10 @@ endif
 all-progs: $(LINKS)
 clean-progs: clean-links
 
+LIBPMEM=y
+LIBPMEMOBJ=y
+
 include ../../Makefile.inc
-
-
-LIBS += -lpmemobj -lpmem -pthread
 
 ifeq ($(FUSE), y)
 LIBS += $(shell $(PKG_CONFIG) --libs fuse)

--- a/src/examples/libpmemobj/pminvaders/Makefile
+++ b/src/examples/libpmemobj/pminvaders/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +45,8 @@ $(info NOTE: Skipping pminvaders and pminvaders2 because ncurses is missing \
 -- see src/examples/libpmemobj/pminvaders/README for details.)
 endif
 
-LIBS = -lpmemobj -lpmem -pthread
+LIBPMEM=y
+LIBPMEMOBJ=y
 
 ifeq ($(NCURSES),y)
 LIBS += $(shell $(PKG_CONFIG) --libs ncurses)

--- a/src/examples/libpmemobj/queue/Makefile
+++ b/src/examples/libpmemobj/queue/Makefile
@@ -35,7 +35,7 @@
 #
 PROGS = queue
 
-LIBS = -lpmemobj
+LIBPMEMOBJ=y
 
 include ../../Makefile.inc
 

--- a/src/examples/libpmemobj/slab_allocator/Makefile
+++ b/src/examples/libpmemobj/slab_allocator/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,7 +39,7 @@ include $(TOP)/src/common.inc
 PROGS = main
 LIBRARIES = slab_allocator
 
-LIBS = -lpmemobj
+LIBPMEMOBJ=y
 
 include ../../Makefile.inc
 

--- a/src/examples/libpmemobj/string_store/Makefile
+++ b/src/examples/libpmemobj/string_store/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -35,7 +35,8 @@
 #
 PROGS = writer reader
 
-LIBS = -lpmemobj -lpmem -pthread
+LIBPMEM=y
+LIBPMEMOBJ=y
 
 include ../../Makefile.inc
 

--- a/src/examples/libpmemobj/string_store_tx/Makefile
+++ b/src/examples/libpmemobj/string_store_tx/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -35,7 +35,8 @@
 #
 PROGS = writer reader
 
-LIBS = -lpmemobj -lpmem -pthread
+LIBPMEM=y
+LIBPMEMOBJ=y
 
 include ../../Makefile.inc
 

--- a/src/examples/libpmemobj/string_store_tx_type/Makefile
+++ b/src/examples/libpmemobj/string_store_tx_type/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -35,10 +35,10 @@
 #
 PROGS = writer reader
 
-LIBS = -lpmemobj -lpmem -pthread
+LIBPMEM=y
+LIBPMEMOBJ=y
 
 include ../../Makefile.inc
 
 writer: writer.o
 reader: reader.o
-

--- a/src/examples/libpmemobj/tree_map/Makefile
+++ b/src/examples/libpmemobj/tree_map/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2017, Intel Corporation
+# Copyright 2015-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -35,7 +35,7 @@
 #
 LIBRARIES = ctree_map btree_map rtree_map rbtree_map
 
-LIBS = -lpmemobj
+LIBPMEMOBJ=y
 
 include ../../Makefile.inc
 

--- a/src/examples/libpmempool/Makefile
+++ b/src/examples/libpmempool/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -36,7 +36,7 @@
 
 PROGS = manpage
 
-LIBS = -lpmempool -pthread
+LIBPMEMPOOL=y
 
 include ../Makefile.inc
 

--- a/src/examples/librpmem/Makefile
+++ b/src/examples/librpmem/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,7 +39,7 @@ include $(TOP)/src/common.inc
 ifeq ($(BUILD_RPMEM), y)
 PROGS = basic manpage
 
-LIBS = -lrpmem -pthread $(shell $(PKG_CONFIG) --libs libfabric)
+LIBRPMEM=y
 
 CFLAGS = $(shell $(PKG_CONFIG) --cflags libfabric)
 else

--- a/src/examples/libvmem/Makefile
+++ b/src/examples/libvmem/Makefile
@@ -36,9 +36,8 @@
 PROGS = manpage
 DIRS = libart
 
-LIBS = -lvmem -pthread
+LIBVMEM=y
 
 include ../Makefile.inc
 
 manpage: manpage.o
-

--- a/src/examples/libvmem/libart/Makefile
+++ b/src/examples/libvmem/libart/Makefile
@@ -54,9 +54,9 @@ PROGS = arttree
 LIBRARIES = art
 endif
 
-include ../../Makefile.inc
+LIBVMEM=y
 
-LIBS = -lvmem
+include ../../Makefile.inc
 
 $(PROGS): | $(DYNAMIC_LIBRARIES)
 $(PROGS): LDFLAGS += -Wl,-rpath=. -L. -lart

--- a/src/tools/daxio/Makefile
+++ b/src/tools/daxio/Makefile
@@ -44,9 +44,6 @@ OBJS = daxio.o
 LIBPMEM=y
 LIBPMEMCOMMON=y
 
-LIBS += $(LIBNDCTL)
-LIBS += $(LIBDAXCTL)
-
 MANPAGES = $(TOP)/doc/daxio.1
 
 # XXX: to be done


### PR DESCRIPTION
Examples using libpmemblk, libpmemlog, etc. require ndctl and daxctl libraries. At the same time:

- to make it easier to add dependencies in the future I have extended examples makefile to support LIBPMEMBLK, LIBPMEMLOG variables which are adding all required dependencies.
- I have removed redundancies from daxio makefile

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3151)
<!-- Reviewable:end -->
