### PR TITLE
test: require ext4 for ctl_prefault

### DIFF
--- a/src/test/ctl_prefault/TEST0
+++ b/src/test/ctl_prefault/TEST0
@@ -39,6 +39,8 @@ require_test_type short
 
 setup
 
+require_fs_name ext4
+
 # create, don't prefault
 expect_normal_exit ./ctl_prefault$EXESUFFIX obj $DIR/testfile1 0 0
 pagefault_create_baseline=`cat out$UNITTEST_NUM.log | sed -n '3p'`

--- a/src/test/ctl_prefault/TEST1
+++ b/src/test/ctl_prefault/TEST1
@@ -39,6 +39,8 @@ require_test_type short
 
 setup
 
+require_fs_name ext4
+
 # create, don't prefault
 expect_normal_exit ./ctl_prefault$EXESUFFIX blk $DIR/testfile1 0 0
 pagefault_create_baseline=`cat out$UNITTEST_NUM.log | sed -n '3p'`

--- a/src/test/ctl_prefault/TEST2
+++ b/src/test/ctl_prefault/TEST2
@@ -39,6 +39,8 @@ require_test_type short
 
 setup
 
+require_fs_name ext4
+
 # create, don't prefault
 expect_normal_exit ./ctl_prefault$EXESUFFIX log $DIR/testfile1 0 0
 pagefault_create_baseline=`cat out$UNITTEST_NUM.log | sed -n '3p'`


### PR DESCRIPTION
Ref: pmem/issues#901

ext3 does not have fallocate support and posix_fallocate is emulated by
preforming multiple writes, which cause page faults on every create/open.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3169)
<!-- Reviewable:end -->
