### PR TITLE
rpmem: do not use tab character in rpmemd log

### DIFF
--- a/src/tools/rpmemd/rpmemd.c
+++ b/src/tools/rpmemd/rpmemd.c
@@ -702,13 +702,15 @@ rpmemd_print_info(struct rpmemd *rpmemd)
 			rpmem_persist_method_to_str(rpmemd->persist_method));
 	RPMEMD_LOG(NOTICE, RPMEMD_LOG_INDENT "number of threads: %lu",
 			rpmemd->config.nthreads);
-	RPMEMD_DBG("\tpersist APM: %s",
-		bool2str(rpmemd->config.persist_apm));
-	RPMEMD_DBG("\tpersist GPSPM: %s",
-		bool2str(rpmemd->config.persist_general));
-	RPMEMD_DBG("\tuse syslog: %s", bool2str(rpmemd->config.use_syslog));
-	RPMEMD_DBG("\tlog file: %s", _str(rpmemd->config.log_file));
-	RPMEMD_DBG("\tlog level: %s",
+	RPMEMD_DBG(RPMEMD_LOG_INDENT "persist APM: %s",
+			bool2str(rpmemd->config.persist_apm));
+	RPMEMD_DBG(RPMEMD_LOG_INDENT "persist GPSPM: %s",
+			bool2str(rpmemd->config.persist_general));
+	RPMEMD_DBG(RPMEMD_LOG_INDENT "use syslog: %s",
+			bool2str(rpmemd->config.use_syslog));
+	RPMEMD_DBG(RPMEMD_LOG_INDENT "log file: %s",
+			_str(rpmemd->config.log_file));
+	RPMEMD_DBG(RPMEMD_LOG_INDENT "log level: %s",
 			rpmemd_log_level_to_str(rpmemd->config.log_level));
 }
 

--- a/src/tools/rpmemd/rpmemd_log.h
+++ b/src/tools/rpmemd/rpmemd_log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,8 +40,9 @@
 #define FORMAT_PRINTF(a, b) __attribute__((__format__(__printf__, (a), (b))))
 
 /*
- * A tab character is not allowed in rpmemd log because it is not well handled
- * by syslog. Please use RPMEMD_LOG_INDENT instead.
+ * The tab character is not allowed in rpmemd log,
+ * because it is not well handled by syslog.
+ * Please use RPMEMD_LOG_INDENT instead.
  */
 #define RPMEMD_LOG_INDENT "    "
 


### PR DESCRIPTION
The tab character is not allowed in rpmemd log,
because it is not well handled by syslog.
RPMEMD_LOG_INDENT has to be used instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3177)
<!-- Reviewable:end -->
