### PR TITLE
common: set errno when opening dev dax fails

### DIFF
--- a/src/benchmarks/blk.cpp
+++ b/src/benchmarks/blk.cpp
@@ -398,7 +398,10 @@ blk_init(struct blk_bench *bb, struct benchmark_args *args)
 		return -1;
 	}
 
-	if (bb->type == OP_TYPE_FILE && util_file_is_device_dax(args->fname)) {
+	int file_type = util_file_get_type_noent(path);
+	assert(file_type > 0);
+
+	if (bb->type == OP_TYPE_FILE && file_type == FILE_TYPE_DEVDAX) {
 		fprintf(stderr, "fileio not supported on device dax\n");
 		return -1;
 	}
@@ -425,7 +428,7 @@ blk_init(struct blk_bench *bb, struct benchmark_args *args)
 		return -1;
 	}
 
-	if (args->is_poolset || util_file_is_device_dax(args->fname)) {
+	if (args->is_poolset || file_type == FILE_TYPE_DEVDAX) {
 		if (args->fsize < ba->fsize) {
 			fprintf(stderr, "file size too large\n");
 			return -1;

--- a/src/benchmarks/log.cpp
+++ b/src/benchmarks/log.cpp
@@ -467,6 +467,9 @@ log_init(struct benchmark *bench, struct benchmark_args *args)
 	if (util_safe_strcpy(path, args->fname, sizeof(path)) != 0)
 		return -1;
 
+	int file_type = util_file_get_type_noent(path);
+	assert(file_type > 0);
+
 	auto *lb = (struct log_bench *)malloc(sizeof(struct log_bench));
 
 	if (!lb) {
@@ -500,7 +503,7 @@ log_init(struct benchmark *bench, struct benchmark_args *args)
 	if (lb->psize < PMEMLOG_MIN_POOL)
 		lb->psize = PMEMLOG_MIN_POOL;
 
-	if (args->is_poolset || util_file_is_device_dax(args->fname)) {
+	if (args->is_poolset || file_type == FILE_TYPE_DEVDAX) {
 		if (lb->args->fileio) {
 			fprintf(stderr, "fileio not supported on device dax "
 					"nor poolset\n");
@@ -566,7 +569,7 @@ log_init(struct benchmark *bench, struct benchmark_args *args)
 			: fileio_append;
 	}
 
-	if (!lb->args->no_warmup && !util_file_is_device_dax(args->fname)) {
+	if (!lb->args->no_warmup && file_type == FILE_TYPE_NORMAL) {
 		size_t warmup_nops = args->n_threads * args->n_ops_per_thread;
 		if (do_warmup(lb, warmup_nops)) {
 			fprintf(stderr, "warmup failed\n");

--- a/src/benchmarks/obj_lanes.cpp
+++ b/src/benchmarks/obj_lanes.cpp
@@ -105,7 +105,10 @@ lanes_init(struct benchmark *bench, struct benchmark_args *args)
 	ob->pa = (struct prog_args *)args->opts;
 	size_t psize;
 
-	if (args->is_poolset || util_file_is_device_dax(args->fname))
+	int file_type = util_file_get_type_noent(args->fname);
+	assert(file_type > 0);
+
+	if (args->is_poolset || file_type == FILE_TYPE_DEVDAX)
 		psize = 0;
 	else
 		psize = PMEMOBJ_MIN_POOL;

--- a/src/benchmarks/obj_locks.cpp
+++ b/src/benchmarks/obj_locks.cpp
@@ -676,6 +676,9 @@ locks_init(struct benchmark *bench, struct benchmark_args *args)
 	assert(bench != nullptr);
 	assert(args != nullptr);
 
+	int file_type = util_file_get_type_noent(args->fname);
+	assert(file_type > 0);
+
 	int ret = 0;
 	size_t poolsize;
 
@@ -705,7 +708,7 @@ locks_init(struct benchmark *bench, struct benchmark_args *args)
 	/* reserve some space for metadata */
 	poolsize = mb->pa->n_locks * sizeof(lock_t) + PMEMOBJ_MIN_POOL;
 
-	if (args->is_poolset || util_file_is_device_dax(args->fname)) {
+	if (args->is_poolset || file_type == FILE_TYPE_DEVDAX) {
 		if (args->fsize < poolsize) {
 			fprintf(stderr, "file size too large\n");
 			goto err_free_mb;

--- a/src/benchmarks/obj_pmalloc.cpp
+++ b/src/benchmarks/obj_pmalloc.cpp
@@ -149,7 +149,10 @@ obj_init(struct benchmark *bench, struct benchmark_args *args)
 	/* multiply by FACTOR for metadata, fragmentation, etc. */
 	poolsize = (size_t)(poolsize * FACTOR);
 
-	if (args->is_poolset || util_file_is_device_dax(args->fname)) {
+	int file_type = util_file_get_type_noent(args->fname);
+	assert(file_type > 0);
+
+	if (args->is_poolset || file_type == FILE_TYPE_DEVDAX) {
 		if (args->fsize < poolsize) {
 			fprintf(stderr, "file size too large\n");
 			goto free_ob;

--- a/src/benchmarks/pmem_flush.cpp
+++ b/src/benchmarks/pmem_flush.cpp
@@ -385,6 +385,9 @@ pmem_flush_init(struct benchmark *bench, struct benchmark_args *args)
 	pmb->pargs = (struct pmem_args *)args->opts;
 	assert(pmb->pargs != nullptr);
 
+	int file_type = util_file_get_type_noent(args->fname);
+	assert(file_type > 0);
+
 	int i = parse_op_type(pmb->pargs->operation);
 	if (i == -1) {
 		fprintf(stderr, "wrong operation: %s\n", pmb->pargs->operation);
@@ -414,7 +417,7 @@ pmem_flush_init(struct benchmark *bench, struct benchmark_args *args)
 	for (size_t i = 0; i < pmb->n_offsets; ++i)
 		pmb->offsets[i] = func_mode(pmb, i);
 
-	if (!util_file_is_device_dax(args->fname)) {
+	if (file_type == FILE_TYPE_NORMAL) {
 		file_size = pmb->fsize;
 		flags = PMEM_FILE_CREATE | PMEM_FILE_EXCL;
 	}

--- a/src/benchmarks/pmem_memcpy.cpp
+++ b/src/benchmarks/pmem_memcpy.cpp
@@ -398,6 +398,9 @@ pmem_memcpy_init(struct benchmark *bench, struct benchmark_args *args)
 
 	pmb->pargs->chunk_size = args->dsize;
 
+	int file_type = util_file_get_type_noent(args->fname);
+	assert(file_type > 0);
+
 	enum operation_type op_type;
 	/*
 	 * Assign file and buffer size depending on the operation type
@@ -429,7 +432,7 @@ pmem_memcpy_init(struct benchmark *bench, struct benchmark_args *args)
 	for (size_t i = 0; i < pmb->n_rand_offsets; ++i)
 		pmb->rand_offsets[i] = rand() % args->n_ops_per_thread;
 
-	if (!util_file_is_device_dax(args->fname)) {
+	if (file_type == FILE_TYPE_NORMAL) {
 		file_size = pmb->fsize;
 		flags = PMEM_FILE_CREATE | PMEM_FILE_EXCL;
 	}

--- a/src/benchmarks/pmem_memset.cpp
+++ b/src/benchmarks/pmem_memset.cpp
@@ -297,6 +297,9 @@ memset_init(struct benchmark *bench, struct benchmark_args *args)
 	mb->pargs = (struct memset_args *)args->opts;
 	mb->pargs->chunk_size = args->dsize;
 
+	int file_type = util_file_get_type_noent(args->fname);
+	assert(file_type > 0);
+
 	enum operation_mode op_mode = parse_op_mode(mb->pargs->mode);
 	if (op_mode == OP_MODE_UNKNOWN) {
 		fprintf(stderr, "Invalid operation mode argument '%s'\n",
@@ -320,7 +323,7 @@ memset_init(struct benchmark *bench, struct benchmark_args *args)
 	/* initialize memset() value */
 	mb->const_b = CONST_B;
 
-	if (!util_file_is_device_dax(args->fname)) {
+	if (file_type == FILE_TYPE_NORMAL) {
 		file_size = mb->fsize;
 		flags = PMEM_FILE_CREATE | PMEM_FILE_EXCL;
 	}
@@ -356,7 +359,7 @@ memset_init(struct benchmark *bench, struct benchmark_args *args)
 						   : libpmem_memset_nodrain;
 	}
 
-	if (!mb->pargs->no_warmup && !util_file_is_device_dax(args->fname)) {
+	if (!mb->pargs->no_warmup && file_type == FILE_TYPE_NORMAL) {
 		ret = warmup_func(mb);
 		if (ret) {
 			perror("Pool warmup failed");

--- a/src/benchmarks/pmembench.cpp
+++ b/src/benchmarks/pmembench.cpp
@@ -1276,6 +1276,7 @@ pmembench_run(struct pmembench *pb, struct benchmark *bench)
 {
 	char old_wd[PATH_MAX];
 	int ret = 0;
+	int file_type;
 
 	struct benchmark_args *args = nullptr;
 	struct total_results *total_res = nullptr;
@@ -1386,6 +1387,10 @@ pmembench_run(struct pmembench *pb, struct benchmark *bench)
 		} else {
 			args->is_poolset =
 				util_is_poolset_file(args->fname) == 1;
+
+			file_type = util_file_get_type_noent(args->fname);
+			assert(file_type > 0);
+
 			if (args->is_poolset) {
 				if (!bench->info->allow_poolset) {
 					fprintf(stderr, "poolset files not "
@@ -1398,7 +1403,7 @@ pmembench_run(struct pmembench *pb, struct benchmark *bench)
 						"invalid size of poolset\n");
 					goto out;
 				}
-			} else if (util_file_is_device_dax(args->fname)) {
+			} else if (file_type == FILE_TYPE_DEVDAX) {
 				args->fsize = util_file_get_size(args->fname);
 
 				if (!args->fsize) {

--- a/src/benchmarks/pmemobj_atomic_lists.cpp
+++ b/src/benchmarks/pmemobj_atomic_lists.cpp
@@ -855,6 +855,9 @@ obj_init(struct benchmark *bench, struct benchmark_args *args)
 	assert(args != nullptr);
 	assert(args->opts != nullptr);
 
+	int file_type = util_file_get_type_noent(args->fname);
+	assert(file_type > 0);
+
 	obj_bench.args = (struct obj_list_args *)args->opts;
 	obj_bench.min_len = obj_bench.args->list_len + 1;
 	obj_bench.max_len = args->n_ops_per_thread + obj_bench.min_len;
@@ -904,7 +907,7 @@ obj_init(struct benchmark *bench, struct benchmark_args *args)
 		size_t psize =
 			(args->n_ops_per_thread + obj_bench.min_len + 1) *
 			obj_size * args->n_threads * FACTOR;
-		if (args->is_poolset || util_file_is_device_dax(args->fname)) {
+		if (args->is_poolset || file_type == FILE_TYPE_DEVDAX) {
 			if (args->fsize < psize) {
 				fprintf(stderr, "file size too large\n");
 				goto free_all;

--- a/src/benchmarks/pmemobj_gen.cpp
+++ b/src/benchmarks/pmemobj_gen.cpp
@@ -296,6 +296,9 @@ pobj_init(struct benchmark *bench, struct benchmark_args *args)
 	assert(bench != nullptr);
 	assert(args != nullptr);
 
+	int file_type = util_file_get_type_noent(args->fname);
+	assert(file_type > 0);
+
 	auto *bench_priv =
 		(struct pobj_bench *)malloc(sizeof(struct pobj_bench));
 	if (bench_priv == nullptr) {
@@ -313,7 +316,7 @@ pobj_init(struct benchmark *bench, struct benchmark_args *args)
 	bench_priv->pool = bench_priv->n_pools > 1 ? diff_num : one_num;
 	bench_priv->obj = !bench_priv->args_priv->one_obj ? diff_num : one_num;
 
-	if ((args->is_poolset || util_file_is_device_dax(args->fname)) &&
+	if ((args->is_poolset || file_type == FILE_TYPE_DEVDAX) &&
 	    bench_priv->n_pools > 1) {
 		fprintf(stderr,
 			"cannot use poolset nor device dax for multiple pools,"
@@ -410,7 +413,7 @@ pobj_init(struct benchmark *bench, struct benchmark_args *args)
 			}
 		}
 	} else {
-		if (args->is_poolset || util_file_is_device_dax(args->fname)) {
+		if (args->is_poolset || file_type == FILE_TYPE_DEVDAX) {
 			if (args->fsize < psize) {
 				fprintf(stderr, "file size too large\n");
 				goto free_pools;

--- a/src/benchmarks/pmemobj_persist.cpp
+++ b/src/benchmarks/pmemobj_persist.cpp
@@ -173,6 +173,9 @@ obj_persist_init(struct benchmark *bench, struct benchmark_args *args)
 	assert(args != nullptr);
 	assert(args->opts != nullptr);
 
+	int file_type = util_file_get_type_noent(args->fname);
+	assert(file_type > 0);
+
 	auto *pa = (struct prog_args *)args->opts;
 	size_t poolsize;
 	if (pa->minsize >= args->dsize) {
@@ -205,7 +208,7 @@ obj_persist_init(struct benchmark *bench, struct benchmark_args *args)
 	/* multiply by FACTOR for metadata, fragmentation, etc. */
 	poolsize = poolsize * FACTOR;
 
-	if (args->is_poolset || util_file_is_device_dax(args->fname)) {
+	if (args->is_poolset || file_type == FILE_TYPE_DEVDAX) {
 		if (args->fsize < poolsize) {
 			fprintf(stderr, "file size too large\n");
 			goto free_ob;

--- a/src/benchmarks/pmemobj_tx.cpp
+++ b/src/benchmarks/pmemobj_tx.cpp
@@ -942,6 +942,9 @@ obj_tx_init(struct benchmark *bench, struct benchmark_args *args)
 	if (util_safe_strcpy(path, args->fname, sizeof(path)) != 0)
 		return -1;
 
+	int file_type = util_file_get_type_noent(path);
+	assert(file_type > 0);
+
 	pmembench_set_priv(bench, &obj_bench);
 
 	obj_bench.obj_args = (struct obj_tx_args *)args->opts;
@@ -1016,7 +1019,7 @@ obj_tx_init(struct benchmark *bench, struct benchmark_args *args)
 		return 0;
 
 	/* Create pmemobj pool. */
-	if (args->is_poolset || util_file_is_device_dax(args->fname)) {
+	if (args->is_poolset || file_type == FILE_TYPE_DEVDAX) {
 		if (args->fsize < psize) {
 			fprintf(stderr, "file size too large\n");
 			goto free_all;

--- a/src/benchmarks/vmem.cpp
+++ b/src/benchmarks/vmem.cpp
@@ -452,6 +452,9 @@ vmem_init(struct benchmark *bench, struct benchmark_args *args)
 	assert(bench != nullptr);
 	assert(args != nullptr);
 
+	int file_type = util_file_get_type_noent(args->fname);
+	assert(file_type > 0);
+
 	auto *vb = (struct vmem_bench *)calloc(1, sizeof(struct vmem_bench));
 	if (vb == nullptr) {
 		perror("malloc");
@@ -463,12 +466,12 @@ vmem_init(struct benchmark *bench, struct benchmark_args *args)
 	vb->alloc_sizes = nullptr;
 	vb->lib_mode = va->stdlib_alloc ? STDLIB_MODE : VMEM_MODE;
 
-	if (util_file_is_device_dax(args->fname) && va->pool_per_thread) {
+	if (file_type == FILE_TYPE_DEVDAX && va->pool_per_thread) {
 		fprintf(stderr, "cannot use device dax for multiple pools\n");
 		goto err;
 	}
 
-	if (!util_file_is_device_dax(args->fname) && !va->stdlib_alloc &&
+	if (file_type == FILE_TYPE_NORMAL && !va->stdlib_alloc &&
 	    mkdir(args->fname, DIR_MODE) != 0)
 		goto err;
 

--- a/src/common/badblock_linux.c
+++ b/src/common/badblock_linux.c
@@ -297,7 +297,11 @@ os_badblocks_clear(const char *file, struct badblocks *bbs)
 
 	ASSERTne(bbs, NULL);
 
-	if (util_file_is_device_dax(file))
+	int file_type = util_file_get_type(file);
+	if (file_type < 0)
+		return -1;
+
+	if (file_type == FILE_TYPE_DEVDAX)
 		return os_dimm_devdax_clear_badblocks(file, bbs);
 
 	return os_badblocks_clear_file(file, bbs);
@@ -312,7 +316,11 @@ os_badblocks_clear_all(const char *file)
 {
 	LOG(3, "file %s", file);
 
-	if (util_file_is_device_dax(file))
+	int file_type = util_file_get_type(file);
+	if (file_type < 0)
+		return -1;
+
+	if (file_type == FILE_TYPE_DEVDAX)
 		return os_dimm_devdax_clear_badblocks_all(file);
 
 	struct badblocks *bbs = badblocks_new();

--- a/src/common/extent_linux.c
+++ b/src/common/extent_linux.c
@@ -74,8 +74,12 @@ os_extents_common(const char *path, struct extents *exts,
 		exts->blksize = (uint64_t)st.st_blksize;
 	}
 
+	int fd_type = util_fd_get_type(fd);
+	if (fd_type < 0)
+		goto error_close;
+
 	/* devdax does not have any extents */
-	if (util_fd_is_device_dax(fd)) {
+	if (fd_type == FILE_TYPE_DEVDAX) {
 		close(fd);
 		return 0;
 	}

--- a/src/common/file.h
+++ b/src/common/file.h
@@ -67,12 +67,16 @@ struct dir_handle {
 #endif
 };
 
+#define FILE_TYPE_DEVDAX 1
+#define FILE_TYPE_NORMAL 2
+
 int util_file_dir_open(struct dir_handle *a, const char *path);
 int util_file_dir_next(struct dir_handle *a, struct file_info *info);
 int util_file_dir_close(struct dir_handle *a);
 int util_file_dir_remove(const char *path);
-int util_file_is_device_dax(const char *path);
-int util_fd_is_device_dax(int fd);
+int util_file_get_type(const char *path);
+int util_file_get_type_noent(const char *path);
+int util_fd_get_type(int fd);
 int util_ddax_region_find(const char *path);
 ssize_t util_file_get_size(const char *path);
 size_t util_file_device_dax_alignment(const char *path);

--- a/src/libpmem/pmem.c
+++ b/src/libpmem/pmem.c
@@ -418,7 +418,10 @@ pmem_map_fileU(const char *path, size_t len, int flags,
 	int fd;
 	int open_flags = O_RDWR;
 	int delete_on_err = 0;
-	int is_dev_dax = util_file_is_device_dax(path);
+
+	int file_type = util_file_get_type_noent(path);
+	if (file_type < 0)
+		return NULL;
 
 	if (flags & ~(PMEM_FILE_ALL_FLAGS)) {
 		ERR("invalid flag specified %x", flags);
@@ -426,7 +429,7 @@ pmem_map_fileU(const char *path, size_t len, int flags,
 		return NULL;
 	}
 
-	if (is_dev_dax) {
+	if (file_type == FILE_TYPE_DEVDAX) {
 		if (flags & ~(PMEM_DAX_VALID_FLAGS)) {
 			ERR("flag unsupported for Device DAX %x", flags);
 			errno = EINVAL;
@@ -525,7 +528,8 @@ pmem_map_fileU(const char *path, size_t len, int flags,
 		len = (size_t)actual_size;
 	}
 
-	void *addr = pmem_map_register(fd, len, path, is_dev_dax);
+	void *addr = pmem_map_register(fd, len, path,
+		file_type == FILE_TYPE_DEVDAX);
 	if (addr == NULL)
 		goto err;
 

--- a/src/libpmempool/pool.c
+++ b/src/libpmempool/pool.c
@@ -266,6 +266,10 @@ pool_params_parse(const PMEMpoolcheck *ppc, struct pool_params *params,
 	if (fd < 0)
 		return -1;
 
+	int fd_type = util_fd_get_type(fd);
+	if (fd_type < 0)
+		return -1;
+
 	int ret = 0;
 
 	os_stat_t stat_buf;
@@ -347,7 +351,7 @@ pool_params_parse(const PMEMpoolcheck *ppc, struct pool_params *params,
 			ret = -1;
 			goto out_close;
 		}
-		params->is_dev_dax = util_file_is_device_dax(ppc->path);
+		params->is_dev_dax = fd_type == FILE_TYPE_DEVDAX;
 		params->is_pmem = params->is_dev_dax || map_sync ||
 			pmem_is_pmem(addr, params->size);
 	}

--- a/src/test/pmem_memcpy/pmem_memcpy.c
+++ b/src/test/pmem_memcpy/pmem_memcpy.c
@@ -105,15 +105,18 @@ do_memcpy(int fd, char *dest, int dest_off, char *src, int src_off,
 	void *ret;
 	char *buf = MALLOC(bytes);
 
+	int fd_type = util_fd_get_type(fd);
+	UT_ASSERT(fd_type > 0);
+
 	memset(buf, 0, bytes);
 	memset(dest, 0, bytes);
 	memset(src, 0, bytes);
-	util_persist_auto(util_fd_is_device_dax(fd), src, bytes);
+	util_persist_auto(fd_type == FILE_TYPE_DEVDAX, src, bytes);
 
 	memset(src, 0x5A, bytes / 4);
-	util_persist_auto(util_fd_is_device_dax(fd), src, bytes / 4);
+	util_persist_auto(fd_type == FILE_TYPE_NORMAL, src, bytes / 4);
 	memset(src + bytes / 4, 0x46, bytes / 4);
-	util_persist_auto(util_fd_is_device_dax(fd), src + bytes / 4,
+	util_persist_auto(fd_type == FILE_TYPE_NORMAL, src + bytes / 4,
 			bytes / 4);
 
 	/* dest == src */
@@ -229,7 +232,11 @@ main(int argc, char *argv[])
 	}
 
 	memset(dest, 0, (2 * bytes));
-	util_persist_auto(util_fd_is_device_dax(fd), dest, 2 * bytes);
+
+	int fd_type = util_fd_get_type(fd);
+	UT_ASSERT(fd_type > 0);
+
+	util_persist_auto(fd_type == FILE_TYPE_DEVDAX, dest, 2 * bytes);
 	memset(src, 0, (2 * bytes));
 
 	do_memcpy_variants(fd, dest, dest_off, src, src_off, bytes, argv[1]);

--- a/src/test/pmem_memmove/pmem_memmove.c
+++ b/src/test/pmem_memmove/pmem_memmove.c
@@ -243,7 +243,8 @@ main(int argc, char *argv[])
 			avx512f ? "" : "!");
 
 	fd = OPEN(argv[1], O_RDWR);
-	int ddax = util_fd_is_device_dax(fd);
+	int fd_type = util_fd_get_type(fd);
+	UT_ASSERT(fd_type > 0);
 
 	if (argc < 3)
 		USAGE();
@@ -308,8 +309,8 @@ main(int argc, char *argv[])
 				UT_FATAL("cannot map files in memory order");
 		}
 
-		do_memmove_variants(ddax, dst, src, argv[1], dst_off, src_off,
-				bytes);
+		do_memmove_variants(fd_type == FILE_TYPE_DEVDAX, dst, src,
+				argv[1], dst_off, src_off, bytes);
 
 		/* dest > src */
 		swap_mappings(&dst, &src, mapped_len, fd);
@@ -317,8 +318,8 @@ main(int argc, char *argv[])
 		if (dst <= src)
 			UT_FATAL("cannot map files in memory order");
 
-		do_memmove_variants(ddax, dst, src, argv[1], dst_off, src_off,
-				bytes);
+		do_memmove_variants(fd_type == FILE_TYPE_DEVDAX, dst, src,
+				argv[1], dst_off, src_off, bytes);
 
 		int ret = pmem_unmap(dst, mapped_len);
 		UT_ASSERTeq(ret, 0);
@@ -331,9 +332,9 @@ main(int argc, char *argv[])
 			UT_FATAL("!Could not mmap %s: \n", argv[1]);
 
 		memset(dst, 0, bytes);
-		util_persist_auto(ddax, dst, bytes);
-		do_memmove_variants(ddax, dst, dst, argv[1], dst_off,
-				src_off, bytes);
+		util_persist_auto(fd_type == FILE_TYPE_DEVDAX, dst, bytes);
+		do_memmove_variants(fd_type == FILE_TYPE_DEVDAX, dst, dst,
+				argv[1], dst_off, src_off, bytes);
 
 		int ret = pmem_unmap(dst, mapped_len);
 		UT_ASSERTeq(ret, 0);

--- a/src/test/pmem_memset/pmem_memset.c
+++ b/src/test/pmem_memset/pmem_memset.c
@@ -59,13 +59,17 @@ pmem_memset_nodrain_wrapper(void *pmemdest, int c, size_t len, unsigned flags)
 static void
 do_memset(int fd, char *dest, const char *file_name, size_t dest_off,
 		size_t bytes, pmem_memset_fn fn, unsigned flags)
+
 {
 	char *buf = MALLOC(bytes);
 	char *dest1;
 	char *ret;
 
 	memset(dest, 0, bytes);
-	util_persist_auto(util_fd_is_device_dax(fd), dest, bytes);
+	int fd_type = util_fd_get_type(fd);
+	UT_ASSERT(fd_type > 0);
+
+	util_persist_auto(fd_type == FILE_TYPE_DEVDAX, dest, bytes);
 	dest1 = MALLOC(bytes);
 	memset(dest1, 0, bytes);
 

--- a/src/test/tools/pmemdetect/pmemdetect.c
+++ b/src/test/tools/pmemdetect/pmemdetect.c
@@ -217,7 +217,11 @@ is_dev_dax(const char *path)
 		return -1;
 	}
 
-	if (!util_file_is_device_dax(path)) {
+	int file_type = util_file_get_type(path);
+	if (file_type < 0)
+		return -1;
+
+	if (file_type == FILE_TYPE_NORMAL) {
 		printf("%s -- not device dax\n", path);
 		return 0;
 	}

--- a/src/test/util_poolset/out0.log.match
+++ b/src/test/util_poolset/out0.log.match
@@ -16,11 +16,9 @@ $(nW)/testset4: util_pool_create: Invalid argument
 $(nW)/testset5: util_pool_create: Invalid argument
 $(nW)/testset6: util_pool_create: No such file or directory
 mocked open: $(nW)/testfile72
-mocked open: $(nW)/testfile72
 $(nW)/testset7: util_pool_create: Permission denied
 mocked fallocate: 1073741824
 $(nW)/testset8: util_pool_create: No space left on device
-mocked open: $(nW)/testfile102
 mocked open: $(nW)/testfile102
 $(nW)/testset10: util_pool_create: Permission denied
 $(nW)/testset11: util_pool_create: Invalid argument
@@ -38,7 +36,6 @@ $(nW)/testset22: created: nreps 1 poolsize 8384512 zeroed 0
   replica[0]: nparts 2 nhdrs 2 repsize 8384512 is_pmem 0
     part[0] path $(nW)/testfile221 filesize 4194304 size 4194304
     part[1] path $(nW)/testfile222 filesize 4194304 size 4190208
-mocked open: $(nW)/testset23
 mocked open: $(nW)/testset23
 $(nW)/testset23: util_pool_create: Permission denied
 $(nW)/testset24: created: nreps 3 poolsize 8384512 zeroed 1

--- a/src/test/util_poolset/out1.log.match
+++ b/src/test/util_poolset/out1.log.match
@@ -3,14 +3,12 @@ util_poolset/TEST1: START: util_poolset
 $(nW)/testset0: util_pool_open: No such file or directory
 $(nW)/testset1: util_pool_open: Invalid argument
 mocked open: $(nW)/testset2
-mocked open: $(nW)/testset2
 $(nW)/testset2: util_pool_open: Permission denied
 $(nW)/testset3: util_pool_open: No such file or directory
 $(nW)/testset4: util_pool_open: No such file or directory
 $(nW)/testset5: util_pool_open: Invalid argument
 $(nW)/testset6: util_pool_open: Invalid argument
 $(nW)/testset7: util_pool_open: Invalid argument
-mocked open: $(nW)/testfile82
 mocked open: $(nW)/testfile82
 $(nW)/testset8: util_pool_open: Permission denied
 $(nW)/testset9: util_pool_open: Invalid argument

--- a/src/tools/pmempool/info.c
+++ b/src/tools/pmempool/info.c
@@ -619,8 +619,12 @@ pmempool_info_part(struct pmem_info *pip, unsigned repn, unsigned partn, int v)
 	outv_field(v, "path", "%s", path);
 
 	/* get type of the part file */
-	int is_dev_dax = util_file_is_device_dax(path);
-	const char *type_str = is_dev_dax ? "device dax" : "regular file";
+	int fd_type = util_file_get_type(path);
+	if (fd_type < 0)
+		return -1;
+
+	const char *type_str = fd_type == FILE_TYPE_DEVDAX ?
+		"device dax" : "regular file";
 	outv_field(v, "type", "%s", type_str);
 
 	/* get size of the part file */
@@ -633,7 +637,7 @@ pmempool_info_part(struct pmem_info *pip, unsigned repn, unsigned partn, int v)
 			pip->args.human));
 
 	/* get alignment of device dax */
-	if (is_dev_dax) {
+	if (fd_type == FILE_TYPE_DEVDAX) {
 		size_t alignment = util_file_device_dax_alignment(path);
 		outv_field(v, "alignment", "%s", out_get_size_str(alignment,
 				pip->args.human));


### PR DESCRIPTION
When os_open fails for reason other than ENOENT
we should set errno appropriately.

Ref: pmem/issues#815

Now, pmempool info prints "Permission denied" when
dev dax is either read only or write only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3180)
<!-- Reviewable:end -->
