### PR TITLE
pool: replace assert by conditional expression

### DIFF
--- a/src/libpmempool/pool.c
+++ b/src/libpmempool/pool.c
@@ -794,7 +794,14 @@ pool_set_part_copy(struct pool_set_part *dpart, struct pool_set_part *spart,
 		goto out_sunmap;
 	}
 
-	ASSERT(dmapped >= smapped);
+#ifdef DEBUG
+	/* provide extra logging in case of wrong dmapped/smapped value */
+	if (dmapped < smapped) {
+		LOG(1, "dmapped < smapped: dmapped = %lu, smapped = %lu",
+			dmapped, smapped);
+		ASSERT(0);
+	}
+#endif
 
 	if (is_pmem) {
 		pmem_memcpy_persist(daddr, saddr, smapped);


### PR DESCRIPTION
with extra logging. Investigating ASSERT failure was impossbile
due to missing informations about dmapped and smapped.

Ref: pmem/issues#517

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3190)
<!-- Reviewable:end -->
