### PR TITLE
test: Fix FreeBSD compiler warning in vmmalloc_dummy_funcs

### DIFF
--- a/src/test/vmmalloc_dummy_funcs/vmmalloc_dummy_funcs.h
+++ b/src/test/vmmalloc_dummy_funcs/vmmalloc_dummy_funcs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017, Intel Corporation
+ * Copyright 2015-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,10 @@ void *memalign(size_t boundary, size_t size);
 void *pvalloc(size_t size);
 
 /* XXX These exist only to allow the tests to compile - they are never used */
+extern void (*__free_hook)(void *, const void *);
+extern void *(*__malloc_hook)(size_t size, const void *);
+extern void *(*__memalign_hook)(size_t alignment, size_t size, const void *);
+extern void *(*__realloc_hook)(void *ptr, size_t size, const void *);
 void (*__free_hook)(void *, const void *);
 void *(*__malloc_hook)(size_t size, const void *);
 void *(*__memalign_hook)(size_t alignment, size_t size, const void *);


### PR DESCRIPTION
Add extern declaration before dummy function definition in vmmalloc_dummy_funcs.