### PR TITLE
common: Workaround for FreeBSD munmap bug 169608

### DIFF
--- a/src/common/mmap.c
+++ b/src/common/mmap.c
@@ -148,6 +148,16 @@ util_unmap(void *addr, size_t len)
 {
 	LOG(3, "addr %p len %zu", addr, len);
 
+/*
+ * XXX Workaround for https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=169608
+ */
+#ifdef __FreeBSD__
+	if (!IS_PAGE_ALIGNED((uintptr_t)addr)) {
+		errno = EINVAL;
+		ERR("!munmap");
+		return -1;
+	}
+#endif
 	int retval = munmap(addr, len);
 	if (retval < 0)
 		ERR("!munmap");


### PR DESCRIPTION
Check for misaligned address in util_unmap() (see
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=169608)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3205)
<!-- Reviewable:end -->
