### PR TITLE
pool: adding error handling of shutdown_state_add_part (fix)

### DIFF
--- a/src/common/shutdown_state.c
+++ b/src/common/shutdown_state.c
@@ -78,6 +78,8 @@ shutdown_state_init(struct shutdown_state *sds, struct pool_replica *rep)
 
 /*
  * shutdown_state_add_part -- adds file uuid and usc to shutdown_state struct
+ *
+ * if path does not exist it will fail which does NOT mean shutdown failure
  */
 int
 shutdown_state_add_part(struct shutdown_state *sds, const char *path,


### PR DESCRIPTION
Ref: pmem/pmdk#3175

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3207)
<!-- Reviewable:end -->
