### PR TITLE
[1.4] common: win: fix getopt returning "option is ambiguous"

### DIFF
--- a/src/windows/getopt/getopt.c
+++ b/src/windows/getopt/getopt.c
@@ -229,6 +229,11 @@ int getopt_long(int argc, char* const argv[], const char* optstring,
     if (strncmp(o->name, current_argument, argument_name_length) == 0) {
       match = o;
       ++num_matches;
+      if (strlen(o->name) == argument_name_length) {
+        /* found match is exactly the one which we are looking for */
+        num_matches = 1;
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
getopt was returning "option '%s' is ambiguous" when one long option
is a substring of the second.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3208)
<!-- Reviewable:end -->
