### PR TITLE
Allow pmdk to be built with musl

### DIFF
--- a/src/common.inc
+++ b/src/common.inc
@@ -76,6 +76,8 @@ GCOV_CFLAGS=-fprofile-arcs -ftest-coverage --coverage
 GCOV_LDFLAGS=-fprofile-arcs -ftest-coverage
 GCOV_LIBS=-lgcov
 
+LIBS += $(EXTRA_LIBS)
+
 ifeq ($(OS_KERNEL_NAME),)
 export OS_KERNEL_NAME := $(shell uname -s)
 endif

--- a/src/common/os_posix.c
+++ b/src/common/os_posix.c
@@ -287,7 +287,7 @@ os_setenv(const char *name, const char *value, int overwrite)
 /*
  * secure_getenv -- provide GNU secure_getenv for FreeBSD
  */
-#ifdef __FreeBSD__
+#ifndef __USE_GNU
 static char *
 secure_getenv(const char *name)
 {

--- a/src/tools/pmempool/info.c
+++ b/src/tools/pmempool/info.c
@@ -45,9 +45,6 @@
 #include <inttypes.h>
 #include <assert.h>
 #include <sys/param.h>
-#ifndef __FreeBSD__
-#define __USE_UNIX98
-#endif
 #include <unistd.h>
 #include <sys/mman.h>
 


### PR DESCRIPTION
These three patches allow pmdk to be built with the musl libc library (instead of glibc).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3210)
<!-- Reviewable:end -->
