### PR TITLE
test: fix path of resources of the nfit_test module

### DIFF
--- a/src/test/common_badblock.sh
+++ b/src/test/common_badblock.sh
@@ -216,8 +216,8 @@ function ndctl_nfit_test_grant_access() {
 	N=$(echo $REGION | cut -c7-)
 	expect_normal_exit "\
 		sudo chmod o+rw /dev/nmem$N && \
-		sudo chmod o+r /sys/devices/platform/$BUS/ndbus1/$REGION/*/resource && \
-		sudo chmod o+r /sys/devices/platform/$BUS/ndbus1/$REGION/resource"
+		sudo chmod o+r /sys/devices/platform/$BUS/ndbus?/$REGION/*/resource && \
+		sudo chmod o+r /sys/devices/platform/$BUS/ndbus?/$REGION/resource"
 }
 
 
@@ -238,8 +238,8 @@ function ndctl_nfit_test_grant_access_node() {
 	N=$(echo $REGION | cut -c7-)
 	expect_normal_exit run_on_node $1 "\
 		sudo chmod o+rw /dev/nmem$N && \
-		sudo chmod o+r /sys/devices/platform/$BUS/ndbus1/$REGION/*/resource && \
-		sudo chmod o+r /sys/devices/platform/$BUS/ndbus1/$REGION/resource"
+		sudo chmod o+r /sys/devices/platform/$BUS/ndbus?/$REGION/*/resource && \
+		sudo chmod o+r /sys/devices/platform/$BUS/ndbus?/$REGION/resource"
 }
 
 #


### PR DESCRIPTION
It fixes the following issue: https://github.com/pmem/pmdk/pull/3057#issuecomment-424260256

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3221)
<!-- Reviewable:end -->
