### PR TITLE
common: fix windows mmap destructor

### DIFF
--- a/src/libpmem/libpmem_main.c
+++ b/src/libpmem/libpmem_main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017, Intel Corporation
+ * Copyright 2015-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,6 +38,8 @@
  * should be moved here.
  */
 
+#include "win_mmap.h"
+
 void libpmem_init(void);
 void libpmem_fini(void);
 
@@ -47,6 +49,7 @@ DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 	switch (dwReason) {
 	case DLL_PROCESS_ATTACH:
 		libpmem_init();
+		win_mmap_init();
 		break;
 
 	case DLL_THREAD_ATTACH:
@@ -54,6 +57,7 @@ DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 		break;
 
 	case DLL_PROCESS_DETACH:
+		win_mmap_fini();
 		libpmem_fini();
 		break;
 	}

--- a/src/libvmem/libvmem_main.c
+++ b/src/libvmem/libvmem_main.c
@@ -38,12 +38,13 @@
  * should be moved here.
  */
 
+#include "win_mmap.h"
+
 void vmem_init(void);
 void vmem_fini(void);
 
 void jemalloc_constructor(void);
 void jemalloc_destructor(void);
-
 
 int APIENTRY
 DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
@@ -52,6 +53,7 @@ DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 	case DLL_PROCESS_ATTACH:
 		jemalloc_constructor();
 		vmem_init();
+		win_mmap_init();
 		break;
 
 	case DLL_THREAD_ATTACH:
@@ -59,6 +61,7 @@ DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 		break;
 
 	case DLL_PROCESS_DETACH:
+		win_mmap_fini();
 		vmem_fini();
 		jemalloc_destructor();
 		break;

--- a/src/windows/include/win_mmap.h
+++ b/src/windows/include/win_mmap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017, Intel Corporation
+ * Copyright 2015-2018, Intel Corporation
  * Copyright (c) 2016, Microsoft Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,6 +42,9 @@
 
 #define roundup(x, y)	((((x) + ((y) - 1)) / (y)) * (y))
 #define rounddown(x, y)	(((x) / (y)) * (y))
+
+void win_mmap_init(void);
+void win_mmap_fini(void);
 
 /* allocation/mmap granularity */
 extern unsigned long long Mmap_align;

--- a/src/windows/win_mmap.c
+++ b/src/windows/win_mmap.c
@@ -193,12 +193,10 @@ mmap_unreserve(void *addr, size_t len)
 }
 
 /*
- * mmap_init -- (internal) load-time initialization of file mapping tracker
- *
- * Called automatically by the run-time loader.
+ * win_mmap_init -- initialization of file mapping tracker
  */
-static void
-mmap_init(void)
+void
+win_mmap_init(void)
 {
 	AcquireSRWLockExclusive(&FileMappingQLock);
 	SORTEDQ_INIT(&FileMappingQHead);
@@ -206,12 +204,10 @@ mmap_init(void)
 }
 
 /*
- * mmap_fini -- (internal) file mapping tracker cleanup routine
- *
- * Called automatically when the process terminates.
+ * win_mmap_fini -- file mapping tracker cleanup routine
  */
-static void
-mmap_fini(void)
+void
+win_mmap_fini(void)
 {
 	/*
 	 * Let's make sure that no one is in the middle of updating the
@@ -1129,9 +1125,3 @@ err:
 	ReleaseSRWLockShared(&FileMappingQLock);
 	return retval;
 }
-
-/*
- * library constructor/destructor functions
- */
-MSVC_CONSTR(mmap_init)
-MSVC_DESTR(mmap_fini)


### PR DESCRIPTION
and call it from DLL_PROCESS_DETACH, so that it is called
before out_fini(). This ensures that logs from destructor
goes through out_common

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3226)
<!-- Reviewable:end -->
