### PR TITLE
common: fix ndctl integration (Travis & rpms/debs)

### DIFF
--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -465,6 +465,12 @@ EOF
 
 cp LICENSE debian/copyright
 
+if [ -n "$NDCTL_ENABLE" ]; then
+	pass_ndctl_enable="NDCTL_ENABLE=$NDCTL_ENABLE"
+else
+	pass_ndctl_enable=""
+fi
+
 cat << EOF > debian/rules
 #!/usr/bin/make -f
 #export DH_VERBOSE=1
@@ -474,8 +480,11 @@ cat << EOF > debian/rules
 override_dh_strip:
 	dh_strip --dbg-package=$PACKAGE_NAME-dbg
 
+override_dh_auto_build:
+	dh_auto_build -- EXPERIMENTAL=${EXPERIMENTAL} prefix=/$PREFIX libdir=/$LIB_DIR includedir=/$INC_DIR docdir=/$DOC_DIR man1dir=/$MAN1_DIR man3dir=/$MAN3_DIR man5dir=/$MAN5_DIR man7dir=/$MAN7_DIR sysconfdir=/etc NORPATH=1 ${pass_ndctl_enable}
+
 override_dh_auto_install:
-	dh_auto_install -- EXPERIMENTAL=${EXPERIMENTAL} prefix=/$PREFIX libdir=/$LIB_DIR includedir=/$INC_DIR docdir=/$DOC_DIR man1dir=/$MAN1_DIR man3dir=/$MAN3_DIR man5dir=/$MAN5_DIR man7dir=/$MAN7_DIR sysconfdir=/etc NORPATH=1
+	dh_auto_install -- EXPERIMENTAL=${EXPERIMENTAL} prefix=/$PREFIX libdir=/$LIB_DIR includedir=/$INC_DIR docdir=/$DOC_DIR man1dir=/$MAN1_DIR man3dir=/$MAN3_DIR man5dir=/$MAN5_DIR man7dir=/$MAN7_DIR sysconfdir=/etc NORPATH=1 ${pass_ndctl_enable}
 
 override_dh_install:
 	mkdir -p debian/tmp/usr/share/pmdk/

--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -838,7 +838,7 @@ then
 fi
 
 # daxio
-if [ "${NDCTL_ENABLE}" = "y" ]
+if [ "${NDCTL_ENABLE}" != "n" ]
 then
 	append_daxio_control;
 	daxio_install_triggers_overrides;

--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -86,6 +86,10 @@ do
 		TEST_CONFIG_FILE="$2"
 		shift 2
 		;;
+	-r)
+		BUILD_RPMEM="$2"
+		shift 2
+		;;
 	-n)
 		NDCTL_ENABLE="$2"
 		shift 2

--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -263,9 +263,7 @@ Package: daxio
 Section: misc
 Architecture: any
 Priority: optional
-Depends: libpmem (=\${binary:Version}), \${shlibs:Depends}, \${misc:Depends}
-Depends: libndctl (>= $NDCTL_MIN_VERSION), \${shlibs:Depends}, \${misc:Depends}
-Depends: libdaxctl (>= $NDCTL_MIN_VERSION), \${shlibs:Depends}, \${misc:Depends}
+Depends: libpmem (=\${binary:Version}), libndctl (>= $NDCTL_MIN_VERSION), libdaxctl (>= $NDCTL_MIN_VERSION), \${shlibs:Depends}, \${misc:Depends}
 Description: daxio utility
  The daxio utility performs I/O on Device DAX devices or zero
  a Device DAX device.  Since the standard I/O APIs (read/write) cannot be used

--- a/utils/build-rpm.sh
+++ b/utils/build-rpm.sh
@@ -244,12 +244,12 @@ else
 	RPMBUILD_OPTS+=(--without fabric)
 fi
 
-# daxio
-if [ "${NDCTL_ENABLE}" = "y" ]
+# daxio & RAS
+if [ "${NDCTL_ENABLE}" = "n" ]
 then
-	RPMBUILD_OPTS+=(--with ndctl)
-else
 	RPMBUILD_OPTS+=(--without ndctl)
+else
+	RPMBUILD_OPTS+=(--with ndctl)
 fi
 
 # use specified testconfig file or default

--- a/utils/docker/build-local.sh
+++ b/utils/docker/build-local.sh
@@ -88,6 +88,7 @@ else
 fi
 
 if [ -n "$DNS_SERVER" ]; then DNS_SETTING=" --dns=$DNS_SERVER "; fi
+if [ -z "$NDCTL_ENABLE" ]; then ndctl_enable=; else ndctl_enable="--env NDCTL_ENABLE=$NDCTL_ENABLE"; fi
 
 WORKDIR=/pmdk
 SCRIPTSDIR=$WORKDIR/utils/docker
@@ -116,7 +117,7 @@ docker run --privileged=true --name=$containerName -ti \
 	--env SCRIPTSDIR=$SCRIPTSDIR \
 	--env CLANG_FORMAT=clang-format-3.8 \
 	--env KEEP_TEST_CONFIG=$KEEP_TEST_CONFIG \
-	--env NDCTL_ENABLE=$NDCTL_ENABLE \
+	$ndctl_enable \
 	-v $HOST_WORKDIR:$WORKDIR \
 	-v /etc/localtime:/etc/localtime \
 	$DAX_SETTING \

--- a/utils/docker/build-travis.sh
+++ b/utils/docker/build-travis.sh
@@ -83,6 +83,7 @@ fi
 
 if [ -n "$DNS_SERVER" ]; then DNS_SETTING=" --dns=$DNS_SERVER "; fi
 if [[ $SKIP_CHECK -eq 1 ]]; then BUILD_PACKAGE_CHECK=n; else BUILD_PACKAGE_CHECK=y; fi
+if [ -z "$NDCTL_ENABLE" ]; then ndctl_enable=; else ndctl_enable="--env NDCTL_ENABLE=$NDCTL_ENABLE"; fi
 
 WORKDIR=/pmdk
 SCRIPTSDIR=$WORKDIR/utils/docker
@@ -116,7 +117,7 @@ docker run --rm --privileged=true --name=$containerName -ti \
 	--env TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE \
 	--env COVERITY_SCAN_TOKEN=$COVERITY_SCAN_TOKEN \
 	--env COVERITY_SCAN_NOTIFICATION_EMAIL=$COVERITY_SCAN_NOTIFICATION_EMAIL \
-	--env NDCTL_ENABLE=$NDCTL_ENABLE \
+	$ndctl_enable \
 	-v $HOST_WORKDIR:$WORKDIR \
 	-v /etc/localtime:/etc/localtime \
 	-w $SCRIPTSDIR \

--- a/utils/pmdk.spec.in
+++ b/utils/pmdk.spec.in
@@ -24,17 +24,7 @@
 %bcond_with fabric
 %endif
 
-# ndctl v59.2 is available on:
-#   openSUSE Tumbleweed, Leap >=42.3; SLE >=12 SP3
-#   Fedora >=26; RHEL >=7.6
-#%if (0%{?suse_version} > 1500) || (0%{?sle_version} >= 120300) || (0%{?fedora} >= 26) || (0%{?rhel} >= 7)
-#%bcond_without ndctl
-#%else
-#%bcond_with ndctl
-#%endif
-
-# XXX: by default build w/o ndctl, unless explicitly enabled
-%bcond_with ndctl
+%bcond_without ndctl
 
 %define min_libfabric_ver __LIBFABRIC_MIN_VER__
 %define min_ndctl_ver __NDCTL_MIN_VER__


### PR DESCRIPTION
Currently only one job on Travis actually tests ndctl code paths. While fixing this I noticed other severe bugs related to building packages. See each commit description for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3235)
<!-- Reviewable:end -->
