### PR TITLE
test: extract heavy part of obj_root test to separate "long" test

### DIFF
--- a/src/test/obj_root/TEST1
+++ b/src/test/obj_root/TEST1
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #
 # Copyright 2018, Intel Corporation
 #
@@ -31,13 +32,13 @@
 #
 
 #
-# src/test/obj_root/TEST0 -- unit test for pmemobj_root
+# src/test/obj_root/TEST1 -- unit test for pmemobj_root
 #
 
 # standard unit test setup
-. ..\unittest\unittest.ps1
+. ../unittest/unittest.sh
 
-require_test_type medium
+require_test_type long
 
 setup
 
@@ -45,8 +46,8 @@ setup
 # will run
 require_free_space 18G
 
-create_holey_file 17G $DIR\testfile
+create_holey_file 17G $DIR/testfile
 
-expect_normal_exit $Env:EXE_DIR\obj_root$Env:EXESUFFIX $DIR\testfile
+expect_normal_exit ./obj_root$EXESUFFIX $DIR/testfile l
 
 pass

--- a/src/test/obj_root/TEST1.PS1
+++ b/src/test/obj_root/TEST1.PS1
@@ -31,13 +31,15 @@
 #
 
 #
-# src/test/obj_root/TEST0 -- unit test for pmemobj_root
+# src/test/obj_root/TEST1 -- unit test for pmemobj_root
 #
 
 # standard unit test setup
 . ..\unittest\unittest.ps1
 
-require_test_type medium
+# test type is long, because test freezes the system during execution
+# on AppVeyor service
+require_test_type long
 
 setup
 
@@ -47,6 +49,6 @@ require_free_space 18G
 
 create_holey_file 17G $DIR\testfile
 
-expect_normal_exit $Env:EXE_DIR\obj_root$Env:EXESUFFIX $DIR\testfile
+expect_normal_exit $Env:EXE_DIR\obj_root$Env:EXESUFFIX $DIR\testfile l
 
 pass

--- a/src/test/obj_root/obj_root.c
+++ b/src/test/obj_root/obj_root.c
@@ -42,12 +42,16 @@ int
 main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_root");
-	if (argc != 2)
-		UT_FATAL("usage: obj_root <file>");
+	if (argc < 2)
+		UT_FATAL("usage: obj_root <file> [l]");
 
 	const char *path = argv[1];
 	PMEMobjpool *pop = NULL;
 	os_stat_t st;
+	int long_test = 0;
+
+	if (argc >= 3 && argv[2][0] == 'l')
+		long_test = 1;
 
 	os_stat(path, &st);
 	UT_ASSERTeq(st.st_size, FILE_SIZE);
@@ -60,8 +64,10 @@ main(int argc, char *argv[])
 	UT_ASSERT(OID_EQUALS(oid, OID_NULL));
 	UT_ASSERTeq(errno, EINVAL);
 
-	oid = pmemobj_root(pop, PMEMOBJ_MAX_ALLOC_SIZE);
-	UT_ASSERT(!OID_EQUALS(oid, OID_NULL));
+	if (long_test) {
+		oid = pmemobj_root(pop, PMEMOBJ_MAX_ALLOC_SIZE);
+		UT_ASSERT(!OID_EQUALS(oid, OID_NULL));
+	}
 
 	oid = pmemobj_root(pop, 1);
 	UT_ASSERT(!OID_EQUALS(oid, OID_NULL));


### PR DESCRIPTION
This test causes heavy swapping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3236)
<!-- Reviewable:end -->
