### PR TITLE
daxio: refactor checking and adjusting length

### DIFF
--- a/src/test/daxio/TEST1
+++ b/src/test/daxio/TEST1
@@ -74,10 +74,13 @@ DEVSIZE=`$PMEMDETECT -z ${DEVICE_DAX_PATH[0]}`
 
 expect_abnormal_exit $DAXIO$EXESUFFIX -i ${DEVICE_DAX_PATH[0]} -o /dev/null -k $(($DEVSIZE + 100)) &>>$LOG
 expect_abnormal_exit $DAXIO$EXESUFFIX -o ${DEVICE_DAX_PATH[0]} -i /dev/zero -s $(($DEVSIZE + 1)) &>>$LOG
-expect_abnormal_exit $DAXIO$EXESUFFIX -o ${DEVICE_DAX_PATH[0]} -i /dev/zero -l $(($DEVSIZE + 1000)) &>>$LOG
-# this succeeds, but copies less bytes than requested
+
+# these succeed, but copy less bytes than requested
+expect_normal_exit $DAXIO$EXESUFFIX -o ${DEVICE_DAX_PATH[0]} -i /dev/zero -l $(($DEVSIZE + 1000)) &>>$LOG
 expect_normal_exit $DAXIO$EXESUFFIX -i ${DEVICE_DAX_PATH[0]} -o /dev/null -k $(($DEVSIZE / 2)) -l $DEVSIZE &>>$LOG
-expect_abnormal_exit $DAXIO$EXESUFFIX -o ${DEVICE_DAX_PATH[0]} -i /dev/zero -s $(($DEVSIZE - 100)) -l $DEVSIZE &>>$LOG
+expect_normal_exit $DAXIO$EXESUFFIX -o ${DEVICE_DAX_PATH[0]} -i /dev/zero -s $(($DEVSIZE - 100)) -l $DEVSIZE &>>$LOG
+expect_normal_exit $DAXIO$EXESUFFIX -i ${DEVICE_DAX_PATH[0]} -o $DIR/dummy_out -k $(($DEVSIZE - 100)) -l $DEVSIZE &>>$LOG
+expect_normal_exit $DAXIO$EXESUFFIX -o ${DEVICE_DAX_PATH[0]} -i $DIR/dummy -s $(($DEVSIZE - 100)) -l $DEVSIZE &>>$LOG
 
 check
 

--- a/src/test/daxio/out1.log.match
+++ b/src/test/daxio/out1.log.match
@@ -5,13 +5,13 @@ daxio: zeroing flag specified but no output file provided
 daxio: an input file and/or an output file must be provided
 daxio: skip offset specified but no input file provided
 daxio: seek offset specified but no output file provided
-daxio: neither input or output is device dax
+daxio: neither input nor output is device dax
 daxio: requested size 8192 larger than source
 daxio: copied 4000 bytes to device "$(nW)"
 daxio: '$(N)' -- offset beyond device size ($(N))
 daxio: '$(N)' -- offset beyond device size ($(N))
-daxio: do_io:$(N): read: Bad address
-daxio: failed to perform I/O
+daxio: copied $(N) bytes to device "$(nW)"
 daxio: copied $(N) bytes to device "/dev/null"
-daxio: do_io:$(N): read: Bad address
-daxio: failed to perform I/O
+daxio: copied 100 bytes to device "$(nW)"
+daxio: copied 100 bytes to device "$(nW)"
+daxio: copied 100 bytes to device "$(nW)"


### PR DESCRIPTION
Behaviour of daxio was changed for cases when seek/skip + length
is beyond device size. Now, it is similiar to behaviour of dd.

Ref: pmem/issues#931

Failing test from the issue was caused by lack of adjusting len in some cases.
Tests without valgrind didn't detect that because /dev/null was used as an output device
and `write()`, which would normally fail, succeeded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3237)
<!-- Reviewable:end -->
