### PR TITLE
 obj: reduce the number flushes at create

### DIFF
--- a/src/libpmemobj/lane.c
+++ b/src/libpmemobj/lane.c
@@ -332,12 +332,7 @@ error_lanes_malloc:
 void
 lane_init_data(PMEMobjpool *pop)
 {
-	struct lane_layout *layout = lane_get_layout(pop, 0);
-
-	/* first, zero out all lanes */
-	pmemops_memset(&pop->p_ops, layout, 0,
-		pop->nlanes * sizeof(struct lane_layout),
-		PMEMOBJ_F_MEM_NONTEMPORAL);
+	struct lane_layout *layout;
 
 	for (uint64_t i = 0; i < pop->nlanes; ++i) {
 		layout = lane_get_layout(pop, i);
@@ -348,6 +343,10 @@ lane_init_data(PMEMobjpool *pop)
 		ulog_construct(OBJ_PTR_TO_OFF(pop, &layout->undo),
 			LANE_UNDO_SIZE, 0, &pop->p_ops);
 	}
+	layout = lane_get_layout(pop, 0);
+	pmemops_xpersist(&pop->p_ops, layout,
+		pop->nlanes * sizeof(struct lane_layout),
+		PMEMOBJ_F_RELAXED);
 }
 
 /*

--- a/src/libpmemobj/ulog.h
+++ b/src/libpmemobj/ulog.h
@@ -108,7 +108,7 @@ typedef void (*ulog_free_fn)(void *base, uint64_t *next);
 
 struct ulog *ulog_next(struct ulog *ulog, const struct pmem_ops *p_ops);
 
-void ulog_construct(uint64_t offset, size_t capacity, int zero_data,
+void ulog_construct(uint64_t offset, size_t capacity, int flush,
 	const struct pmem_ops *p_ops);
 
 size_t ulog_capacity(struct ulog *ulog, size_t ulog_base_bytes,

--- a/src/test/obj_lane/obj_lane.c
+++ b/src/test/obj_lane/obj_lane.c
@@ -67,6 +67,15 @@ mock_flush(void *ctx, const void *addr, size_t len, unsigned flags)
 }
 
 /*
+ * mock_persist -- mock flush for lanes
+ */
+static int
+mock_persist(void *ctx, const void *addr, size_t len, unsigned flags)
+{
+	return 0;
+}
+
+/*
  * mock_memset -- mock memset for lanes
  */
 static void *
@@ -99,6 +108,7 @@ test_lane_boot_cleanup_ok(void)
 	pop->p.p_ops.flush = mock_flush;
 	pop->p.p_ops.memset = mock_memset;
 	pop->p.p_ops.drain = mock_drain;
+	pop->p.p_ops.persist = mock_persist;
 
 	lane_init_data(&pop->p);
 	lane_info_boot();
@@ -257,6 +267,7 @@ test_lane_cleanup_in_separate_thread(void)
 	pop->p.p_ops.flush = mock_flush;
 	pop->p.p_ops.memset = mock_memset;
 	pop->p.p_ops.drain = mock_drain;
+	pop->p.p_ops.persist = mock_persist;
 
 	base_ptr = &pop->p;
 

--- a/src/test/obj_persist_count/out0.log.match
+++ b/src/test/obj_persist_count/out0.log.match
@@ -1,7 +1,7 @@
 obj_persist_count$(nW)TEST0: START: obj_persist_count
  $(nW)obj_persist_count$(nW) $(nW)testfile
 task           cl(all) drain(all) pmem_persist pmem_msync pmem_flush pmem_drain pmem_memcpy_cls pmem_memcpy_drain pmem_memset_cls pmem_memset_drain potential_cache_misses 
-pool_create    296075  3091       0            3091       0          0          0               0                 0               0                 296075                 
+pool_create    50315   19         0            19         0          0          0               0                 0               0                 50315                  
 root_alloc     454     7          0            7          0          0          0               0                 0               0                 454                    
 atomic_alloc   129     2          0            2          0          0          0               0                 0               0                 129                    
 atomic_free    64      1          0            1          0          0          0               0                 0               0                 64                     

--- a/src/test/obj_persist_count/out1.log.match
+++ b/src/test/obj_persist_count/out1.log.match
@@ -1,7 +1,7 @@
 obj_persist_count$(nW)TEST1: START: obj_persist_count
  $(nW)obj_persist_count$(nW) $(nW)testfile
 task           cl(all) drain(all) pmem_persist pmem_msync pmem_flush pmem_drain pmem_memcpy_cls pmem_memcpy_drain pmem_memset_cls pmem_memset_drain potential_cache_misses 
-pool_create    52674   3096       10           5          3072       3077       0               0                 49163           4                 3515                   
+pool_create    49602   24         11           5          0          5          0               0                 11              3                 49595                  
 root_alloc     9       4          0            0          3          1          4               2                 2               1                 5                      
 atomic_alloc   2       2          1            0          0          1          1               0                 0               0                 1                      
 atomic_free    1       2          1            0          0          1          0               0                 0               0                 1                      
@@ -12,7 +12,7 @@ tx_free        1       1          1            0          0          0          
 tx_free_next   1       1          1            0          0          0          0               0                 0               0                 1                      
 tx_add         3       3          1            0          0          1          1               0                 1               1                 1                      
 tx_add_next    3       3          1            0          0          1          1               0                 1               1                 1                      
-tx_add_large   850     14         6            0          4          3          165             2                 675             3                 10                     
+tx_add_large   850     13         6            0          4          3          165             2                 675             2                 10                     
 tx_add_lnext   323     5          1            0          0          2          161             0                 161             2                 1                      
 pmalloc        6       3          0            0          2          1          4               2                 0               0                 2                      
 pfree          5       3          0            0          2          1          3               2                 0               0                 2                      


### PR DESCRIPTION
The ulog_construct function, which is called three times
for every lane at pmemobj_create, was severly impacting
test times due to prolonged lane initialization.
This patch reduces the number of persists, which
should improve overall pmemobj_create performance on very
slow storage and with remote replication.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3239)
<!-- Reviewable:end -->
