### PR TITLE
obj: bump block offset in memory block to 4 bytes

### DIFF
--- a/src/libpmemobj/container_seglists.c
+++ b/src/libpmemobj/container_seglists.c
@@ -50,7 +50,7 @@
 struct block_container_seglists {
 	struct block_container super;
 	struct memory_block m;
-	VECQ(, uint16_t) blocks[SEGLIST_BLOCK_LISTS];
+	VECQ(, uint32_t) blocks[SEGLIST_BLOCK_LISTS];
 	uint64_t nonempty_lists;
 };
 
@@ -108,7 +108,7 @@ container_seglists_get_rm_block_bestfit(struct block_container *bc,
 	/* finds the list that serves the smallest applicable size */
 	i = util_lssb_index64(v);
 
-	uint16_t block_offset = VECQ_DEQUEUE(&c->blocks[i]);
+	uint32_t block_offset = VECQ_DEQUEUE(&c->blocks[i]);
 
 	if (VECQ_SIZE(&c->blocks[i]) == 0) /* marks the list as empty */
 		c->nonempty_lists &= ~(1ULL << (i));

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -749,10 +749,10 @@ heap_split_block(struct palloc_heap *heap, struct bucket *b,
 	ASSERT(units > 0);
 
 	if (b->aclass->type == CLASS_RUN) {
-		ASSERT(m->block_off + units <= UINT16_MAX);
+		ASSERT((uint64_t)m->block_off + (uint64_t)units <= UINT32_MAX);
 		struct memory_block r = {m->chunk_id, m->zone_id,
-			m->size_idx - units, (uint16_t)(m->block_off + units),
-			0, NULL, NULL, 0, 0};
+			m->size_idx - units, (uint32_t)(m->block_off + units),
+			NULL, NULL, 0, 0};
 		memblock_rebuild_state(heap, &r);
 		if (bucket_insert_block(b, &r) != 0)
 			LOG(2,

--- a/src/libpmemobj/memblock.h
+++ b/src/libpmemobj/memblock.h
@@ -51,7 +51,7 @@ extern "C" {
 
 #define MEMORY_BLOCK_NONE \
 (struct memory_block)\
-{0, 0, 0, 0, 0, NULL, NULL, MAX_HEADER_TYPES, MAX_MEMORY_BLOCK}
+{0, 0, 0, 0, NULL, NULL, MAX_HEADER_TYPES, MAX_MEMORY_BLOCK}
 
 #define MEMORY_BLOCK_IS_NONE(_m)\
 ((_m).heap == NULL)
@@ -265,8 +265,7 @@ struct memory_block {
 	 * Number of preceding blocks in the chunk. In other words, the
 	 * position of this memory block in run bitmap.
 	 */
-	uint16_t block_off;
-	uint16_t padding;
+	uint32_t block_off;
 
 	/*
 	 * The variables below are associated with the memory block and are

--- a/src/test/obj_ctl_alloc_class/TEST0
+++ b/src/test/obj_ctl_alloc_class/TEST0
@@ -41,6 +41,6 @@ require_build_type debug
 
 setup
 
-expect_normal_exit ./obj_ctl_alloc_class$EXESUFFIX $DIR/testfile
+expect_normal_exit ./obj_ctl_alloc_class$EXESUFFIX $DIR/testfile b
 
 pass

--- a/src/test/obj_ctl_alloc_class/TEST0.PS1
+++ b/src/test/obj_ctl_alloc_class/TEST0.PS1
@@ -40,6 +40,7 @@ require_build_type debug
 
 setup
 
-expect_normal_exit $Env:EXE_DIR\obj_ctl_alloc_class$Env:EXESUFFIX $DIR\testfile
+expect_normal_exit `
+$Env:EXE_DIR\obj_ctl_alloc_class$Env:EXESUFFIX $DIR\testfile b
 
 pass


### PR DESCRIPTION
Up until recently the largest possible block offset inside of a run
was ~2500. This changed with the introduction of the flexible bitmap
and it allowed for creation of allocation classes with extremely
large "units_per_block" parameter. The new maximum is
max alloc size divided by the unit size. This new maximum exceeded
the uint16_t variable that stored this information in the runtime
state causing ASSERTs in debug builds and double allocation in
release ones. Instead of disallowing large units_per_block for certain
parameters, the runtime state variable has been changed to uint32_t
which is more than enough to store any possible units_per_block value.

Ref: pmem/issues#933

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3240)
<!-- Reviewable:end -->
