### PR TITLE
test: pmempool_sync_remotes fixes

### DIFF
--- a/src/test/pmempool_sync_remote/TEST22
+++ b/src/test/pmempool_sync_remote/TEST22
@@ -68,7 +68,7 @@ ndctl_nfit_test_init_node 0
 DEVICE=$(ndctl_nfit_test_get_block_device_node 0)
 NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device_node 0 $DEVICE)
 FULLDEV="/dev/$DEVICE"
-MOUNT_DIR="$DIR/mnt-pmem"
+MOUNT_DIR="${NODE_DIR[0]}/mnt-pmem"
 LAYOUT="layout"
 
 ndctl_nfit_test_mount_pmem_node 0 $FULLDEV $MOUNT_DIR
@@ -80,12 +80,12 @@ POOLSET_LOCAL="local_pool.set"
 POOLSET_REMOTE="remote_pool.set"
 
 create_poolset $DIR/$POOLSET_LOCAL \
-	8M:${MOUNT_DIR}/pool.local:z \
+	8M:${MOUNT_DIR}/pool.local:x \
 	M \
 	${NODE_ADDR[1]}:$POOLSET_REMOTE
 
 create_poolset $DIR/$POOLSET_REMOTE \
-	8M:${NODE_DIR[1]}/pool.remote:z
+	8M:${NODE_DIR[1]}/pool.remote:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
 copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE

--- a/src/test/pmempool_sync_remote/TEST23
+++ b/src/test/pmempool_sync_remote/TEST23
@@ -68,7 +68,7 @@ ndctl_nfit_test_init_node 0
 DEVICE=$(ndctl_nfit_test_get_block_device_node 0)
 NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device_node 0 $DEVICE)
 FULLDEV="/dev/$DEVICE"
-MOUNT_DIR="$DIR/mnt-pmem"
+MOUNT_DIR="${NODE_DIR[0]}/mnt-pmem"
 LAYOUT="layout"
 
 ndctl_nfit_test_mount_pmem_node 0 $FULLDEV $MOUNT_DIR
@@ -80,12 +80,12 @@ POOLSET_LOCAL="local_pool.set"
 POOLSET_REMOTE="remote_pool.set"
 
 create_poolset $DIR/$POOLSET_LOCAL \
-	8M:${MOUNT_DIR}/pool.local:z \
+	8M:${MOUNT_DIR}/pool.local:x \
 	M \
 	${NODE_ADDR[1]}:$POOLSET_REMOTE
 
 create_poolset $DIR/$POOLSET_REMOTE \
-	8M:${NODE_DIR[1]}/pool.remote:z
+	8M:${NODE_DIR[1]}/pool.remote:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
 copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE

--- a/src/test/pmempool_sync_remote/TEST24
+++ b/src/test/pmempool_sync_remote/TEST24
@@ -68,7 +68,7 @@ ndctl_nfit_test_init_node 0
 DEVICE=$(ndctl_nfit_test_get_block_device_node 0)
 NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device_node 0 $DEVICE)
 FULLDEV="/dev/$DEVICE"
-MOUNT_DIR="$DIR/mnt-pmem"
+MOUNT_DIR="${NODE_DIR[0]}/mnt-pmem"
 LAYOUT="layout"
 
 ndctl_nfit_test_mount_pmem_node 0 $FULLDEV $MOUNT_DIR
@@ -80,14 +80,14 @@ POOLSET_LOCAL="local_pool.set"
 POOLSET_REMOTE="remote_pool.set"
 
 create_poolset $DIR/$POOLSET_LOCAL \
-	8M:${NODE_DIR[0]}/pool.local.part.0:z \
-	8M:${MOUNT_DIR}/pool.local.part.1:z \
-	8M:${NODE_DIR[0]}/pool.local.part.2:z \
+	8M:${NODE_DIR[0]}/pool.local.part.0:x \
+	8M:${MOUNT_DIR}/pool.local.part.1:x \
+	8M:${NODE_DIR[0]}/pool.local.part.2:x \
 	M \
 	${NODE_ADDR[1]}:$POOLSET_REMOTE
 
 create_poolset $DIR/$POOLSET_REMOTE \
-	24M:${NODE_DIR[1]}/pool.remote:z
+	24M:${NODE_DIR[1]}/pool.remote:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
 copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE

--- a/src/test/pmempool_sync_remote/TEST25
+++ b/src/test/pmempool_sync_remote/TEST25
@@ -68,7 +68,7 @@ ndctl_nfit_test_init_node 0
 DEVICE=$(ndctl_nfit_test_get_block_device_node 0)
 NAMESPACE=$(ndctl_nfit_test_get_namespace_of_device_node 0 $DEVICE)
 FULLDEV="/dev/$DEVICE"
-MOUNT_DIR="$DIR/mnt-pmem"
+MOUNT_DIR="${NODE_DIR[0]}/mnt-pmem"
 LAYOUT="layout"
 
 ndctl_nfit_test_mount_pmem_node 0 $FULLDEV $MOUNT_DIR
@@ -80,14 +80,14 @@ POOLSET_LOCAL="local_pool.set"
 POOLSET_REMOTE="remote_pool.set"
 
 create_poolset $DIR/$POOLSET_LOCAL \
-	8M:${NODE_DIR[0]}/pool.local.part.0:z \
-	8M:${MOUNT_DIR}/pool.local.part.1:z \
-	8M:${NODE_DIR[0]}/pool.local.part.2:z \
+	8M:${NODE_DIR[0]}/pool.local.part.0:x \
+	8M:${MOUNT_DIR}/pool.local.part.1:x \
+	8M:${NODE_DIR[0]}/pool.local.part.2:x \
 	M \
 	${NODE_ADDR[1]}:$POOLSET_REMOTE
 
 create_poolset $DIR/$POOLSET_REMOTE \
-	24M:${NODE_DIR[1]}/pool.remote:z
+	24M:${NODE_DIR[1]}/pool.remote:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
 copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE

--- a/src/test/pmempool_sync_remote/TEST26
+++ b/src/test/pmempool_sync_remote/TEST26
@@ -67,12 +67,12 @@ POOLSET_REMOTE="remote_pool.set"
 RECOVERY_FILE=$DIR/${POOLSET_LOCAL}_r0_p0_badblocks.txt
 
 create_poolset $DIR/$POOLSET_LOCAL \
-	10M:${NODE_DIR[0]}/pool.local:z \
+	10M:${NODE_DIR[0]}/pool.local:x \
 	M \
 	${NODE_ADDR[1]}:$POOLSET_REMOTE
 
 create_poolset $DIR/$POOLSET_REMOTE \
-	10M:${NODE_DIR[1]}/pool.remote:z
+	10M:${NODE_DIR[1]}/pool.remote:x
 
 # create the recovery file
 echo "0 $((8 * 512))" > $RECOVERY_FILE

--- a/src/test/pmempool_sync_remote/TEST27
+++ b/src/test/pmempool_sync_remote/TEST27
@@ -67,12 +67,12 @@ POOLSET_REMOTE="remote_pool.set"
 RECOVERY_FILE=$DIR/${POOLSET_LOCAL}_r0_p0_badblocks.txt
 
 create_poolset $DIR/$POOLSET_LOCAL \
-	10M:${NODE_DIR[0]}/pool.local:z \
+	10M:${NODE_DIR[0]}/pool.local:x \
 	M \
 	${NODE_ADDR[1]}:$POOLSET_REMOTE
 
 create_poolset $DIR/$POOLSET_REMOTE \
-	10M:${NODE_DIR[1]}/pool.remote:z
+	10M:${NODE_DIR[1]}/pool.remote:x
 
 # create the recovery file
 echo "$((8000 * 512)) $((8 * 512))" > $RECOVERY_FILE

--- a/src/test/pmempool_sync_remote/TEST28
+++ b/src/test/pmempool_sync_remote/TEST28
@@ -69,14 +69,14 @@ RECOVERY_FILE_P1=$DIR/${POOLSET_LOCAL}_r0_p1_badblocks.txt
 RECOVERY_FILE_P2=$DIR/${POOLSET_LOCAL}_r0_p2_badblocks.txt
 
 create_poolset $DIR/$POOLSET_LOCAL \
-	10M:${NODE_DIR[0]}/pool.local.part.0:z \
-	10M:${NODE_DIR[0]}/pool.local.part.1:z \
-	10M:${NODE_DIR[0]}/pool.local.part.2:z \
+	10M:${NODE_DIR[0]}/pool.local.part.0:x \
+	10M:${NODE_DIR[0]}/pool.local.part.1:x \
+	10M:${NODE_DIR[0]}/pool.local.part.2:x \
 	M \
 	${NODE_ADDR[1]}:$POOLSET_REMOTE
 
 create_poolset $DIR/$POOLSET_REMOTE \
-	30M:${NODE_DIR[1]}/pool.remote:z
+	30M:${NODE_DIR[1]}/pool.remote:x
 
 # create the recovery file with bad block
 echo "0 $((8 * 512))" > $RECOVERY_FILE_P1

--- a/src/test/pmempool_sync_remote/TEST29
+++ b/src/test/pmempool_sync_remote/TEST29
@@ -69,14 +69,14 @@ RECOVERY_FILE_P1=$DIR/${POOLSET_LOCAL}_r0_p1_badblocks.txt
 RECOVERY_FILE_P2=$DIR/${POOLSET_LOCAL}_r0_p2_badblocks.txt
 
 create_poolset $DIR/$POOLSET_LOCAL \
-	10M:${NODE_DIR[0]}/pool.local.part.0:z \
-	10M:${NODE_DIR[0]}/pool.local.part.1:z \
-	10M:${NODE_DIR[0]}/pool.local.part.2:z \
+	10M:${NODE_DIR[0]}/pool.local.part.0:x \
+	10M:${NODE_DIR[0]}/pool.local.part.1:x \
+	10M:${NODE_DIR[0]}/pool.local.part.2:x \
 	M \
 	${NODE_ADDR[1]}:$POOLSET_REMOTE
 
 create_poolset $DIR/$POOLSET_REMOTE \
-	30M:${NODE_DIR[1]}/pool.remote:z
+	30M:${NODE_DIR[1]}/pool.remote:x
 
 # create the recovery file with bad block
 echo "$((8000 * 512)) $((8 * 512))" > $RECOVERY_FILE_P1

--- a/src/test/pmempool_sync_remote/TEST30
+++ b/src/test/pmempool_sync_remote/TEST30
@@ -68,14 +68,14 @@ RECOVERY_FILE_P1=$DIR/${POOLSET_LOCAL}_r0_p1_badblocks.txt
 RECOVERY_FILE_P2=$DIR/${POOLSET_LOCAL}_r0_p2_badblocks.txt
 
 create_poolset $DIR/$POOLSET_LOCAL \
-	10M:${NODE_DIR[0]}/pool.local.part.0:z \
-	10M:${NODE_DIR[0]}/pool.local.part.1:z \
-	10M:${NODE_DIR[0]}/pool.local.part.2:z \
+	10M:${NODE_DIR[0]}/pool.local.part.0:x \
+	10M:${NODE_DIR[0]}/pool.local.part.1:x \
+	10M:${NODE_DIR[0]}/pool.local.part.2:x \
 	M \
 	${NODE_ADDR[1]}:$POOLSET_REMOTE
 
 create_poolset $DIR/$POOLSET_REMOTE \
-	30M:${NODE_DIR[1]}/pool.remote:z
+	30M:${NODE_DIR[1]}/pool.remote:x
 
 # create the recovery files with bad block
 echo "0 $((8 * 512))" > $RECOVERY_FILE_P0

--- a/src/test/pmempool_sync_remote/TEST31
+++ b/src/test/pmempool_sync_remote/TEST31
@@ -68,14 +68,14 @@ RECOVERY_FILE_P1=$DIR/${POOLSET_LOCAL}_r0_p1_badblocks.txt
 RECOVERY_FILE_P2=$DIR/${POOLSET_LOCAL}_r0_p2_badblocks.txt
 
 create_poolset $DIR/$POOLSET_LOCAL \
-	10M:${NODE_DIR[0]}/pool.local.part.0:z \
-	10M:${NODE_DIR[0]}/pool.local.part.1:z \
-	10M:${NODE_DIR[0]}/pool.local.part.2:z \
+	10M:${NODE_DIR[0]}/pool.local.part.0:x \
+	10M:${NODE_DIR[0]}/pool.local.part.1:x \
+	10M:${NODE_DIR[0]}/pool.local.part.2:x \
 	M \
 	${NODE_ADDR[1]}:$POOLSET_REMOTE
 
 create_poolset $DIR/$POOLSET_REMOTE \
-	30M:${NODE_DIR[1]}/pool.remote:z
+	30M:${NODE_DIR[1]}/pool.remote:x
 
 # create the recovery files with bad block
 echo "$((8000 * 512)) $((8 * 512))" > $RECOVERY_FILE_P0

--- a/src/test/pmempool_sync_remote/TEST32
+++ b/src/test/pmempool_sync_remote/TEST32
@@ -85,13 +85,13 @@ POOLSET_LOCAL="local_pool.set"
 POOLSET_REMOTE="remote_pool.set"
 
 create_poolset $DIR/$POOLSET_LOCAL \
-	8M:${MOUNT_DIR}/pool.local.part.0:z \
-	8M:${MOUNT_DIR}/pool.local.part.1:z \
+	8M:${MOUNT_DIR}/pool.local.part.0:x \
+	8M:${MOUNT_DIR}/pool.local.part.1:x \
 	M \
 	${NODE_ADDR[1]}:$POOLSET_REMOTE
 
 create_poolset $DIR/$POOLSET_REMOTE \
-	24M:${NODE_DIR[1]}/pool.remote:z
+	24M:${NODE_DIR[1]}/pool.remote:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
 copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE

--- a/src/test/pmempool_sync_remote/TEST33
+++ b/src/test/pmempool_sync_remote/TEST33
@@ -85,13 +85,13 @@ POOLSET_LOCAL="local_pool.set"
 POOLSET_REMOTE="remote_pool.set"
 
 create_poolset $DIR/$POOLSET_LOCAL \
-	8M:${MOUNT_DIR}/pool.local.part.0:z \
-	8M:${MOUNT_DIR}/pool.local.part.1:z \
+	8M:${MOUNT_DIR}/pool.local.part.0:x \
+	8M:${MOUNT_DIR}/pool.local.part.1:x \
 	M \
 	${NODE_ADDR[1]}:$POOLSET_REMOTE
 
 create_poolset $DIR/$POOLSET_REMOTE \
-	24M:${NODE_DIR[1]}/pool.remote:z
+	24M:${NODE_DIR[1]}/pool.remote:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
 copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE

--- a/src/test/pmempool_sync_remote/TEST34
+++ b/src/test/pmempool_sync_remote/TEST34
@@ -82,12 +82,12 @@ POOLSET_LOCAL="local_pool.set"
 POOLSET_REMOTE="remote_pool.set"
 
 create_poolset $DIR/$POOLSET_LOCAL \
-	8M:${NODE_DIR[0]}/pool.local:z \
+	8M:${NODE_DIR[0]}/pool.local:x \
 	M \
 	${NODE_ADDR[1]}:$POOLSET_REMOTE
 
 create_poolset $DIR/$POOLSET_REMOTE \
-	8M:$MOUNT_DIR/pool.remote:z
+	8M:$MOUNT_DIR/pool.remote:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
 copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE

--- a/src/test/pmempool_sync_remote/TEST35
+++ b/src/test/pmempool_sync_remote/TEST35
@@ -82,12 +82,12 @@ POOLSET_LOCAL="local_pool.set"
 POOLSET_REMOTE="remote_pool.set"
 
 create_poolset $DIR/$POOLSET_LOCAL \
-	8M:${NODE_DIR[0]}/pool.local:z \
+	8M:${NODE_DIR[0]}/pool.local:x \
 	M \
 	${NODE_ADDR[1]}:$POOLSET_REMOTE
 
 create_poolset $DIR/$POOLSET_REMOTE \
-	8M:$MOUNT_DIR/pool.remote:z
+	8M:$MOUNT_DIR/pool.remote:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
 copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -992,7 +992,7 @@ function require_unlimited_vm() {
 function require_linked_with_ndctl() {
 	[ "$1" == "" -o ! -x "$1" ] && \
 		fatal "$UNITTEST_NAME: ERROR: require_linked_with_ndctl() requires one argument - an executable file"
-	local lddndctl=$(ldd $1 | $GREP -ce "libndctl")
+	local lddndctl=$(expect_normal_exit ldd $1 | $GREP -ce "libndctl")
 	[ "$lddndctl" == "1" ] && return
 	msg "$UNITTEST_NAME: SKIP required: executable $1 linked with libndctl"
 	exit 0


### PR DESCRIPTION
- run ldd with env
- do not truncate parts on non existing paths
- do not use $DIR as local directory on remote nodes

Ref: pmem/pmdk#2957

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3244)
<!-- Reviewable:end -->
