### PR TITLE
doc: small fixes in manpages

### DIFF
--- a/doc/libpmemblk/pmemblk_ctl_get.3.md
+++ b/doc/libpmemblk/pmemblk_ctl_get.3.md
@@ -49,7 +49,7 @@ date: pmemblk API version 1.1
 _UW(pmemblk_ctl_get),
 _UW(pmemblk_ctl_set),
 _UW(pmemblk_ctl_exec)
--- Query and modify libpmemblk internal behavior (EXPERIMENTAL)
+- Query and modify libpmemblk internal behavior (EXPERIMENTAL)
 
 
 # SYNOPSIS #

--- a/doc/pmempool/pmempool-sync.1.md
+++ b/doc/pmempool/pmempool-sync.1.md
@@ -82,7 +82,7 @@ When bad blocks are detected, special recovery files have to be created
 in order to fix them safely. A separate recovery file is created per each part
 containing bad blocks. The recovery files are created in the same directory
 where the poolset file is located using the following name pattern:
-\<poolset-file-name\>_r\<replica-number\>_p\<part-number\>_badblocks.txt
+\<poolset-file-name\> _r \<replica-number\> _p \<part-number\> _badblocks.txt
 These recovery files are automatically removed if the sync operation finishes
 successfully.
 If the last sync operation was interrupted and not finished correctly


### PR DESCRIPTION
use single "-" in NAME section (-- becomes \[en] in manpages, breaks
NAME section parsing)
+
too long word cause linitan warning manpage-has-errors-from-man "cannot
adjust line"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3247)
<!-- Reviewable:end -->
