### PR TITLE
obj: bump major layout version to 5

### DIFF
--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -58,7 +58,7 @@ extern "C" {
 
 /* attributes of the obj memory pool format for the pool header */
 #define OBJ_HDR_SIG "PMEMOBJ"	/* must be 8 bytes including '\0' */
-#define OBJ_FORMAT_MAJOR 4
+#define OBJ_FORMAT_MAJOR 5
 
 #define OBJ_FORMAT_FEAT_DEFAULT \
 	{0x0000, POOL_FEAT_INCOMPAT_DEFAULT, 0x0000}

--- a/src/test/magic/out0.log.match
+++ b/src/test/magic/out0.log.match
@@ -1,5 +1,5 @@
 $(*): Persistent Memory Pool file, type: BLK, version 0x1
 $(*): Persistent Memory Pool file, type: LOG, version 0x1
-$(*): Persistent Memory Pool file, type: OBJ, version 0x4
+$(*): Persistent Memory Pool file, type: OBJ, version 0x5
 $(*): Persistent Memory Poolset file
 $(*): Persistent Memory Poolset file with replica

--- a/src/test/obj_rpmem_basic_integration/node_0_rpmemd20.log.match
+++ b/src/test/obj_rpmem_basic_integration/node_0_rpmemd20.log.match
@@ -13,7 +13,7 @@ create request:
     buff_size: $(nW)
 pool attributes:
     signature: 'PMEMOBJ'
-    major: 4
+    major: $(*)
     compat_features: 0x$(X)
     incompat_features: 0x$(X)
     ro_compat_features: 0x$(X)


### PR DESCRIPTION
Due to extensive changes to the lane layout we need to bump up
the layout version, making the old lane recovery incompatible.
Old pools will have to be converted using `pmempool convert`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3251)
<!-- Reviewable:end -->
