### PR TITLE
daxio: fix printing error when open fails

### DIFF
--- a/src/tools/daxio/daxio.c
+++ b/src/tools/daxio/daxio.c
@@ -346,8 +346,9 @@ setup_device(struct ndctl_ctx *ndctl_ctx, struct daxio_device *dev, int is_dst)
 			}
 			return 0;
 		} else {
+			ERR("failed to open '%s': %s\n", dev->path,
+				strerror(errno));
 			return -1;
-			FAIL("open");
 		}
 	}
 


### PR DESCRIPTION
Running daxio with not-existent input/otput file caused
program failure without any message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3258)
<!-- Reviewable:end -->
