### PR TITLE
obj: don't read just written ulog entry

### DIFF
--- a/src/libpmemobj/memops.c
+++ b/src/libpmemobj/memops.c
@@ -394,7 +394,8 @@ operation_add_buffer(struct operation_context *ctx,
 		ctx->ulog_curr_offset,
 		dest, src, data_size,
 		type, ctx->p_ops);
-	size_t entry_size = ulog_entry_size(&e->base);
+	size_t entry_size = ALIGN_UP(curr_size, CACHELINE_SIZE);
+	ASSERT(entry_size == ulog_entry_size(&e->base));
 	ASSERT(entry_size <= ctx->ulog_curr_capacity);
 
 	ctx->total_logged += entry_size;


### PR DESCRIPTION
Reading data that was just written with non-temporal instructions
isn't the best idea ;)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3262)
<!-- Reviewable:end -->
