### PR TITLE
test: fix two pmempool_check tests

### DIFF
--- a/src/test/pmempool_check/TEST1
+++ b/src/test/pmempool_check/TEST1
@@ -50,7 +50,7 @@ echo "PMEMLOG: pool_hdr" >> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOL
 check_file $POOL
 $PMEMSPOIL -v $POOL pool_hdr.major=0x0\
-			pool_hdr.features.compat=0xff\
+			pool_hdr.features.compat=0xfe\
 			pool_hdr.features.incompat=0xff\
 			pool_hdr.features.ro_compat=0xff\
 			pool_hdr.unused=ERROR >> $LOG
@@ -70,7 +70,7 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX create -w blk 512 $POOL
 check_file $POOL
 $PMEMSPOIL -v $POOL pool_hdr.signature=ERROR\
 			pool_hdr.major=0xff\
-			pool_hdr.features.compat=0xff\
+			pool_hdr.features.compat=0xfe\
 			pool_hdr.features.incompat=0xff\
 			pool_hdr.features.ro_compat=0xff\
 			pool_hdr.unused=ERROR >> $LOG

--- a/src/test/pmempool_check/TEST9
+++ b/src/test/pmempool_check/TEST9
@@ -51,7 +51,7 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX check -vyr $POOL >> $LOG
 
 $PMEMSPOIL -v $POOL pool_hdr.major=0x0\
-			pool_hdr.features.compat=0xff\
+			pool_hdr.features.compat=0xfe\
 			pool_hdr.features.incompat=0xff\
 			pool_hdr.features.ro_compat=0xff\
 			pool_hdr.unused=ERROR >> $LOG

--- a/src/test/pmempool_check/TEST9.PS1
+++ b/src/test/pmempool_check/TEST9.PS1
@@ -50,7 +50,7 @@ expect_normal_exit $PMEMPOOL check -vyr $POOL >> $LOG
 
 &$PMEMSPOIL -v $POOL `
 	pool_hdr.major=0x0 `
-	pool_hdr.features.compat=0xff `
+	pool_hdr.features.compat=0xfe `
 	pool_hdr.features.incompat=0xff `
 	pool_hdr.features.ro_compat=0xff `
 	pool_hdr.unused=ERROR `

--- a/src/test/pmempool_check/out9.log.match
+++ b/src/test/pmempool_check/out9.log.match
@@ -4,7 +4,7 @@ checking pool header
 pool header correct
 $(nW)file.pool: consistent
 $(nW)file.pool: spoil: pool_hdr.major=0x0
-$(nW)file.pool: spoil: pool_hdr.features.compat=0xff
+$(nW)file.pool: spoil: pool_hdr.features.compat=0xfe
 $(nW)file.pool: spoil: pool_hdr.features.incompat=0xff
 $(nW)file.pool: spoil: pool_hdr.features.ro_compat=0xff
 $(nW)file.pool: spoil: pool_hdr.unused=ERROR


### PR DESCRIPTION
Do not set the CHECK_BAD_BLOCKS compat feature on
in two  pmempool_check tests.

This patch fixes regression introduced by 3db00327.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3277)
<!-- Reviewable:end -->
