### PR TITLE
pool: zero all features in pmempool_check_init()

### DIFF
--- a/src/libpmempool/check_util.c
+++ b/src/libpmempool/check_util.c
@@ -99,16 +99,11 @@ check_data_alloc(void)
 {
 	LOG(3, NULL);
 
-	struct check_data *data = malloc(sizeof(*data));
+	struct check_data *data = calloc(1, sizeof(*data));
 	if (data == NULL) {
-		ERR("!malloc");
+		ERR("!calloc");
 		return NULL;
 	}
-
-	memset(&data->step_data, 0, sizeof(location));
-	data->check_status_cache = NULL;
-	data->error = NULL;
-	data->step = 0;
 
 	TAILQ_INIT(&data->infos);
 	TAILQ_INIT(&data->questions);

--- a/src/libpmempool/libpmempool.c
+++ b/src/libpmempool/libpmempool.c
@@ -181,17 +181,12 @@ pmempool_errormsgW(void)
 static void
 pmempool_ppc_set_default(PMEMpoolcheck *ppc)
 {
+	/* all other fields should be zeroed */
 	const PMEMpoolcheck ppc_default = {
 		.args		= {
-			.path		= NULL,
-			.backup_path	= NULL,
 			.pool_type	= PMEMPOOL_POOL_TYPE_DETECT,
-			.flags		= 0
 		},
-		.data		= NULL,
-		.pool		= NULL,
 		.result		= CHECK_RESULT_CONSISTENT,
-		.sync_required	= false
 	};
 	*ppc = ppc_default;
 }
@@ -253,9 +248,9 @@ pmempool_check_initU(struct pmempool_check_argsU *args, size_t args_size)
 		return NULL;
 	}
 
-	PMEMpoolcheck *ppc = malloc(sizeof(*ppc));
+	PMEMpoolcheck *ppc = calloc(1, sizeof(*ppc));
 	if (ppc == NULL) {
-		ERR("!malloc");
+		ERR("!calloc");
 		return NULL;
 	}
 

--- a/src/libpmempool/pool.c
+++ b/src/libpmempool/pool.c
@@ -505,18 +505,14 @@ pool_data_alloc(PMEMpoolcheck *ppc)
 {
 	LOG(3, NULL);
 
-	struct pool_data *pool = malloc(sizeof(*pool));
+	struct pool_data *pool = calloc(1, sizeof(*pool));
 	if (!pool) {
-		ERR("!malloc");
+		ERR("!calloc");
 		return NULL;
 	}
 
 	TAILQ_INIT(&pool->arenas);
-	pool->narenas = 0;
-	pool->blk_no_layout = 0;
 	pool->uuid_op = UUID_NOP;
-	pool->set_file = NULL;
-	pool->bttc.valid = false;
 
 	if (pool_params_parse(ppc, &pool->params, 0))
 		goto error;


### PR DESCRIPTION
This patch fixes regression introduced by 3db00327.
The libpmempool_bttdev tests run on pmem FS fail without this fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3283)
<!-- Reviewable:end -->
