### PR TITLE
test: tests using nfit_test module should be run on non-pmem filesystem

### DIFF
--- a/src/test/pmempool_check/TEST31
+++ b/src/test/pmempool_check/TEST31
@@ -39,7 +39,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 
 require_nfit_tests_enabled

--- a/src/test/pmempool_check/TEST32
+++ b/src/test/pmempool_check/TEST32
@@ -39,7 +39,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 
 require_nfit_tests_enabled

--- a/src/test/pmempool_create/TEST10
+++ b/src/test/pmempool_create/TEST10
@@ -39,7 +39,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 
 require_nfit_tests_enabled

--- a/src/test/pmempool_create/TEST11
+++ b/src/test/pmempool_create/TEST11
@@ -39,7 +39,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 
 require_nfit_tests_enabled

--- a/src/test/pmempool_create/TEST12
+++ b/src/test/pmempool_create/TEST12
@@ -40,7 +40,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 
 require_nfit_tests_enabled

--- a/src/test/pmempool_info/TEST24
+++ b/src/test/pmempool_info/TEST24
@@ -39,7 +39,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 
 require_nfit_tests_enabled

--- a/src/test/pmempool_info/TEST25
+++ b/src/test/pmempool_info/TEST25
@@ -39,7 +39,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 
 require_nfit_tests_enabled

--- a/src/test/pmempool_sync/TEST27
+++ b/src/test/pmempool_sync/TEST27
@@ -40,7 +40,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 
 require_nfit_tests_enabled

--- a/src/test/pmempool_sync/TEST28
+++ b/src/test/pmempool_sync/TEST28
@@ -40,7 +40,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 
 require_nfit_tests_enabled

--- a/src/test/pmempool_sync/TEST30
+++ b/src/test/pmempool_sync/TEST30
@@ -40,7 +40,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 
 require_nfit_tests_enabled

--- a/src/test/pmempool_sync/TEST31
+++ b/src/test/pmempool_sync/TEST31
@@ -40,7 +40,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 
 require_nfit_tests_enabled

--- a/src/test/pmempool_sync/TEST38
+++ b/src/test/pmempool_sync/TEST38
@@ -45,7 +45,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 
 # must be non-static debug release of the binary because the test relies on the
 # gdb ability to interrupt the program at a static method inside

--- a/src/test/pmempool_sync/TEST39
+++ b/src/test/pmempool_sync/TEST39
@@ -45,7 +45,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 
 # must be non-static debug release of the binary because the test relies on the
 # gdb ability to interrupt the program at a static method inside

--- a/src/test/pmempool_sync/TEST40
+++ b/src/test/pmempool_sync/TEST40
@@ -45,7 +45,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 
 # must be non-static debug release of the binary because the test relies on the
 # gdb ability to interrupt the program at a static method inside

--- a/src/test/pmempool_sync/TEST41
+++ b/src/test/pmempool_sync/TEST41
@@ -45,7 +45,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 
 # must be non-static debug release of the binary because the test relies on the
 # gdb ability to interrupt the program at a static method inside

--- a/src/test/pmempool_sync_remote/TEST22
+++ b/src/test/pmempool_sync_remote/TEST22
@@ -41,7 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 

--- a/src/test/pmempool_sync_remote/TEST23
+++ b/src/test/pmempool_sync_remote/TEST23
@@ -41,7 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 

--- a/src/test/pmempool_sync_remote/TEST24
+++ b/src/test/pmempool_sync_remote/TEST24
@@ -41,7 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 

--- a/src/test/pmempool_sync_remote/TEST25
+++ b/src/test/pmempool_sync_remote/TEST25
@@ -41,7 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 

--- a/src/test/pmempool_sync_remote/TEST32
+++ b/src/test/pmempool_sync_remote/TEST32
@@ -41,7 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 

--- a/src/test/pmempool_sync_remote/TEST33
+++ b/src/test/pmempool_sync_remote/TEST33
@@ -41,7 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 

--- a/src/test/pmempool_sync_remote/TEST34
+++ b/src/test/pmempool_sync_remote/TEST34
@@ -41,7 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 

--- a/src/test/pmempool_sync_remote/TEST35
+++ b/src/test/pmempool_sync_remote/TEST35
@@ -41,7 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 require_build_type debug nondebug
 require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 

--- a/src/test/util_badblock/TEST2
+++ b/src/test/util_badblock/TEST2
@@ -41,7 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 
 require_nfit_tests_enabled
 require_sudo_allowed

--- a/src/test/util_badblock/TEST3
+++ b/src/test/util_badblock/TEST3
@@ -41,7 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 
 require_nfit_tests_enabled
 require_sudo_allowed

--- a/src/test/util_badblock/TEST4
+++ b/src/test/util_badblock/TEST4
@@ -42,7 +42,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 
 require_nfit_tests_enabled
 require_sudo_allowed

--- a/src/test/util_badblock/TEST5
+++ b/src/test/util_badblock/TEST5
@@ -41,7 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 
 require_nfit_tests_enabled
 require_sudo_allowed

--- a/src/test/util_badblock/TEST6
+++ b/src/test/util_badblock/TEST6
@@ -41,7 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 
 require_nfit_tests_enabled
 require_sudo_allowed

--- a/src/test/util_badblock/TEST7
+++ b/src/test/util_badblock/TEST7
@@ -42,7 +42,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 
 require_nfit_tests_enabled
 require_sudo_allowed

--- a/src/test/util_badblock/TEST8
+++ b/src/test/util_badblock/TEST8
@@ -41,7 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 
 require_nfit_tests_enabled
 require_sudo_allowed

--- a/src/test/util_badblock/TEST9
+++ b/src/test/util_badblock/TEST9
@@ -41,7 +41,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
+require_fs_type non-pmem
 
 require_nfit_tests_enabled
 require_sudo_allowed


### PR DESCRIPTION
If a test using nfit_test module is run on a pmem filesystem,
the following error may occur:
"replica #0 part 1 not mapped with MAP_SYNC"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3286)
<!-- Reviewable:end -->
