### PR TITLE
test: set PMEM_IS_PMEM_FORCE in tests using obj_verify tool

### DIFF
--- a/src/test/pmempool_sync/TEST27
+++ b/src/test/pmempool_sync/TEST27
@@ -53,6 +53,12 @@ setup
 
 . ../common_badblock.sh
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 ndctl_nfit_test_init
 
 DEVICE=$(ndctl_nfit_test_get_block_device)

--- a/src/test/pmempool_sync/TEST28
+++ b/src/test/pmempool_sync/TEST28
@@ -53,6 +53,12 @@ setup
 
 . ../common_badblock.sh
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 ndctl_nfit_test_init
 
 DEVICE=$(ndctl_nfit_test_get_dax_device)

--- a/src/test/pmempool_sync/TEST30
+++ b/src/test/pmempool_sync/TEST30
@@ -53,6 +53,12 @@ setup
 
 . ../common_badblock.sh
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 ndctl_nfit_test_init
 
 DEVICE=$(ndctl_nfit_test_get_block_device)

--- a/src/test/pmempool_sync/TEST31
+++ b/src/test/pmempool_sync/TEST31
@@ -53,6 +53,12 @@ setup
 
 . ../common_badblock.sh
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 ndctl_nfit_test_init
 
 DEVICE=$(ndctl_nfit_test_get_dax_device)

--- a/src/test/pmempool_sync/TEST32
+++ b/src/test/pmempool_sync/TEST32
@@ -48,6 +48,12 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 LOG=out${UNITTEST_NUM}.log
 rm -f $LOG && touch $LOG
 

--- a/src/test/pmempool_sync/TEST33
+++ b/src/test/pmempool_sync/TEST33
@@ -48,6 +48,12 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 LOG=out${UNITTEST_NUM}.log
 rm -f $LOG && touch $LOG
 

--- a/src/test/pmempool_sync/TEST34
+++ b/src/test/pmempool_sync/TEST34
@@ -48,6 +48,12 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 LOG=out${UNITTEST_NUM}.log
 rm -f $LOG && touch $LOG
 

--- a/src/test/pmempool_sync/TEST35
+++ b/src/test/pmempool_sync/TEST35
@@ -48,6 +48,12 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 LOG=out${UNITTEST_NUM}.log
 rm -f $LOG && touch $LOG
 

--- a/src/test/pmempool_sync/TEST36
+++ b/src/test/pmempool_sync/TEST36
@@ -49,6 +49,12 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 LOG=out${UNITTEST_NUM}.log
 rm -f $LOG && touch $LOG
 

--- a/src/test/pmempool_sync/TEST37
+++ b/src/test/pmempool_sync/TEST37
@@ -49,6 +49,12 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 LOG=out${UNITTEST_NUM}.log
 rm -f $LOG && touch $LOG
 

--- a/src/test/pmempool_sync/TEST38
+++ b/src/test/pmempool_sync/TEST38
@@ -63,6 +63,12 @@ setup
 
 . ../common_badblock.sh
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 ndctl_nfit_test_init
 
 DEVICE=$(ndctl_nfit_test_get_block_device)

--- a/src/test/pmempool_sync/TEST39
+++ b/src/test/pmempool_sync/TEST39
@@ -63,6 +63,12 @@ setup
 
 . ../common_badblock.sh
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 ndctl_nfit_test_init
 
 DEVICE=$(ndctl_nfit_test_get_block_device)

--- a/src/test/pmempool_sync/TEST40
+++ b/src/test/pmempool_sync/TEST40
@@ -63,6 +63,12 @@ setup
 
 . ../common_badblock.sh
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 ndctl_nfit_test_init
 
 DEVICE=$(ndctl_nfit_test_get_block_device)

--- a/src/test/pmempool_sync/TEST41
+++ b/src/test/pmempool_sync/TEST41
@@ -63,6 +63,12 @@ setup
 
 . ../common_badblock.sh
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 ndctl_nfit_test_init
 
 DEVICE=$(ndctl_nfit_test_get_block_device)

--- a/src/test/pmempool_sync/TEST42
+++ b/src/test/pmempool_sync/TEST42
@@ -47,6 +47,12 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST43
+++ b/src/test/pmempool_sync/TEST43
@@ -47,6 +47,12 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST44
+++ b/src/test/pmempool_sync/TEST44
@@ -50,6 +50,12 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST45
+++ b/src/test/pmempool_sync/TEST45
@@ -50,6 +50,12 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST46
+++ b/src/test/pmempool_sync/TEST46
@@ -50,6 +50,12 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST47
+++ b/src/test/pmempool_sync/TEST47
@@ -49,6 +49,12 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST48
+++ b/src/test/pmempool_sync/TEST48
@@ -52,6 +52,12 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST49
+++ b/src/test/pmempool_sync/TEST49
@@ -53,6 +53,12 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST50
+++ b/src/test/pmempool_sync/TEST50
@@ -53,6 +53,12 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST51
+++ b/src/test/pmempool_sync/TEST51
@@ -54,6 +54,12 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST52
+++ b/src/test/pmempool_sync/TEST52
@@ -49,6 +49,12 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST53
+++ b/src/test/pmempool_sync/TEST53
@@ -51,6 +51,12 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
+#
+# The tests using the 'obj_verify' tool on a non-pmem filesystem
+# should have this variable set, because they can time-out otherwise.
+#
+PMEM_IS_PMEM_FORCE=1
+
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log


### PR DESCRIPTION
The tests using the 'obj_verify' tool on a non-pmem filesystem
should have the PMEM_IS_PMEM_FORCE variable set,
because they can time-out otherwise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3287)
<!-- Reviewable:end -->
