### PR TITLE
test: tests using sudo have to be enabled deliberately

### DIFF
--- a/src/test/testconfig.sh.example
+++ b/src/test/testconfig.sh.example
@@ -119,6 +119,12 @@ TM=1
 #PMDK_LIB_PATH_DEBUG=/usr/lib/x86_64-linux-gnu/pmdk_dbg
 
 #
+# Tests using the 'sudo' command can be potentially very harmful,
+# so they have to be enabled deliberately.
+#
+#ENABLE_SUDO_TESTS=y
+
+#
 # The 'nfit' tests test the code handling bad blocks.
 # They use the 'sudo' command many times and insert the 'nfit_test' kernel
 # module, so they can be considered as POTENTIALLY DANGEROUS

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1007,6 +1007,11 @@ function require_linked_with_ndctl() {
 # require_sudo_allowed -- require sudo command is allowed
 #
 function require_sudo_allowed() {
+	if [ "$ENABLE_SUDO_TESTS" != "y" ]; then
+		msg "$UNITTEST_NAME: SKIP: tests using 'sudo' are not enabled in testconfig.sh (ENABLE_SUDO_TESTS)"
+		exit 0
+	fi
+
 	if ! timeout --signal=SIGKILL --kill-after=3s 3s sudo date >/dev/null 2>&1
 	then
 		msg "$UNITTEST_NAME: SKIP required: sudo allowed"
@@ -1020,6 +1025,11 @@ function require_sudo_allowed() {
 # usage: require_sudo_allowed_node <node-number>
 #
 function require_sudo_allowed_node() {
+	if [ "$ENABLE_SUDO_TESTS" != "y" ]; then
+		msg "$UNITTEST_NAME: SKIP: tests using 'sudo' are not enabled in testconfig.sh (ENABLE_SUDO_TESTS)"
+		exit 0
+	fi
+
 	if ! run_on_node $1 "timeout --signal=SIGKILL --kill-after=3s 3s sudo date" >/dev/null 2>&1
 	then
 		msg "$UNITTEST_NAME: SKIP required: sudo allowed on node $1"

--- a/utils/docker/configure-tests.sh
+++ b/utils/docker/configure-tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -46,6 +46,7 @@ NON_PMEM_FS_DIR=/tmp
 PMEM_FS_DIR=/tmp
 PMEM_FS_DIR_FORCE_PMEM=1
 TEST_BUILD="debug nondebug"
+ENABLE_SUDO_TESTS=y
 TM=1
 EOF
 


### PR DESCRIPTION
Tests using the 'sudo' command can be potentially very harmful,
so they have to be enabled deliberately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3289)
<!-- Reviewable:end -->
