### PR TITLE
doc: opening a pool can be aborted by the SIGBUS signal

### DIFF
--- a/doc/libpmemblk/pmemblk_create.3.md
+++ b/doc/libpmemblk/pmemblk_create.3.md
@@ -120,6 +120,12 @@ size used when the pool was created. Otherwise, _UW(pmemblk_open) will open
 the pool without verifying the block size. The *bsize* can be determined
 using the **pmemblk_bsize**(3) function.
 
+Be aware that if the pool contains bad blocks inside, opening can be aborted
+by the SIGBUS signal, because currently the pool is not checked against
+bad blocks during opening. It can be turned on by setting the CHECK_BAD_BLOCKS
+compat feature. For details see description of this feature
+in **pmempool-feature**(1).
+
 The **pmemblk_close**() function closes the memory pool
 indicated by *pbp* and deletes the memory pool handle.
 The block memory pool itself lives on in the file that contains it and may be

--- a/doc/libpmemcto/pmemcto_open.3.md
+++ b/doc/libpmemcto/pmemcto_open.3.md
@@ -122,6 +122,12 @@ be used to verify that the layout of the pool matches what was expected.
 The application must have permission to open the file and memory map it with
 read/write permissions.
 
+Be aware that if the pool contains bad blocks inside, opening can be aborted
+by the SIGBUS signal, because currently the pool is not checked against
+bad blocks during opening. It can be turned on by setting the CHECK_BAD_BLOCKS
+compat feature. For details see description of this feature
+in **pmempool-feature**(1).
+
 The **pmemcto_close**() function closes the memory pool indicated by *pcp*
 and deletes the memory pool handle.  The close-to-open memory pool itself
 lives on in the file that contains it and may be re-opened at a later time

--- a/doc/libpmemlog/pmemlog_create.3.md
+++ b/doc/libpmemlog/pmemlog_create.3.md
@@ -114,6 +114,12 @@ log memory pool file, or the *set* file used to create a pool set.
 The application must have permission to open the file and memory map the
 file or pool set with read/write permissions.
 
+Be aware that if the pool contains bad blocks inside, opening can be aborted
+by the SIGBUS signal, because currently the pool is not checked against
+bad blocks during opening. It can be turned on by setting the CHECK_BAD_BLOCKS
+compat feature. For details see description of this feature
+in **pmempool-feature**(1).
+
 The **pmemlog_close**() function closes the memory pool indicated by *plp*
 and deletes the memory pool handle. The log memory pool itself lives on in
 the file that contains it and may be re-opened at a later time using

--- a/doc/libpmemobj/pmemobj_open.3.md
+++ b/doc/libpmemobj/pmemobj_open.3.md
@@ -140,6 +140,12 @@ be used to verify that the layout of the pool matches what was expected.
 The application must have permission to open the file and memory map it with
 read/write permissions.
 
+Be aware that if the pool contains bad blocks inside, opening can be aborted
+by the SIGBUS signal, because currently the pool is not checked against
+bad blocks during opening. It can be turned on by setting the CHECK_BAD_BLOCKS
+compat feature. For details see description of this feature
+in **pmempool-feature**(1).
+
 The **pmemobj_close**() function closes the memory pool indicated by *pop* and
 deletes the memory pool handle. The object store itself lives on in the file
 that contains it and may be re-opened at a later time using

--- a/doc/librpmem/rpmem_create.3.md
+++ b/doc/librpmem/rpmem_create.3.md
@@ -105,6 +105,12 @@ Upon successful opening of the remote pool, \**nlanes* is set to the
 maximum number of lanes supported by both the local and remote nodes.
 See **LANES**, below, for details.
 
+Be aware that if the pool contains bad blocks inside, opening can be aborted
+by the SIGBUS signal, because currently the pool is not checked against
+bad blocks during opening. It can be turned on by setting the CHECK_BAD_BLOCKS
+compat feature. For details see description of this feature
+in **pmempool-feature**(1).
+
 The **rpmem_set_attr**() function overwrites the pool's attributes.
 The *attr* structure contains the attributes used for overwriting the remote
 pool attributes that were passed to **rpmem_create**() at pool creation.


### PR DESCRIPTION
A user should be aware that if the pool contains bad blocks inside,
opening can be aborted by the SIGBUS signal, because currently
the pool is not checked against bad blocks during opening.
It can be turned on by setting the CHECK_BAD_BLOCKS compat feature.