### PR TITLE
daxio: add option to turn clearing bad blocks off

### DIFF
--- a/src/test/testconfig.sh.example
+++ b/src/test/testconfig.sh.example
@@ -55,6 +55,13 @@ NON_PMEM_FS_DIR=/tmp
 # those devices in an array format. For most tests one device is enough, but
 # some might require more.
 #
+# It is required to have R/W access to these devices and at least RO access
+# to all of the following resource files (containing physical addresses)
+# of NVDIMM devices (only root can read them by default):
+#
+# /sys/devices/platform/<pmem_device>/ndbus?/region?/resource
+# /sys/devices/platform/<pmem_device>/ndbus?/region?/dax?.0/resource
+#
 #DEVICE_DAX_PATH=(/dev/dax0.0)
 
 #

--- a/src/test/util_badblock/TEST1
+++ b/src/test/util_badblock/TEST1
@@ -44,20 +44,9 @@ require_fs_type any
 
 require_dax_devices 1
 
-#
-# Listing bad blocks on a DAX device requires superuser privileges.
-#
-require_sudo_allowed
-
 setup
 
-ENV="\
-LD_LIBRARY_PATH=${TEST_LD_LIBRARY_PATH} \
-UNITTEST_NUM=${UNITTEST_NUM} \
-UNITTEST_NAME=${UNITTEST_NAME} \
-UNITTEST_LOG_LEVEL=${UNITTEST_LOG_LEVEL}"
-
-expect_normal_exit sudo bash -c \"${ENV} ./util_badblock$EXESUFFIX ${DEVICE_DAX_PATH[0]} l \"
+expect_normal_exit ./util_badblock$EXESUFFIX ${DEVICE_DAX_PATH[0]} l
 
 check
 


### PR DESCRIPTION
Add the option '-b/--clear-bad-blocks=yes/no' to be able to turn clearing bad blocks off in a DAX device
(because it may require the super user privileges).

This patch fixes failing daxio unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3304)
<!-- Reviewable:end -->
