### PR TITLE
test: PMEM_IS_PMEM_FORCE has to be set if using 'obj_verify' tool

### DIFF
--- a/src/test/pmempool_sync/TEST27
+++ b/src/test/pmempool_sync/TEST27
@@ -54,8 +54,8 @@ setup
 . ../common_badblock.sh
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST28
+++ b/src/test/pmempool_sync/TEST28
@@ -54,8 +54,8 @@ setup
 . ../common_badblock.sh
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST29
+++ b/src/test/pmempool_sync/TEST29
@@ -43,6 +43,12 @@ require_build_type debug nondebug
 
 setup
 
+#
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
+#
+export PMEM_IS_PMEM_FORCE=1
+
 LOG=out${UNITTEST_NUM}.log
 rm -f $LOG && touch $LOG
 

--- a/src/test/pmempool_sync/TEST30
+++ b/src/test/pmempool_sync/TEST30
@@ -54,8 +54,8 @@ setup
 . ../common_badblock.sh
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST31
+++ b/src/test/pmempool_sync/TEST31
@@ -54,8 +54,8 @@ setup
 . ../common_badblock.sh
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST32
+++ b/src/test/pmempool_sync/TEST32
@@ -49,8 +49,8 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 setup
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST33
+++ b/src/test/pmempool_sync/TEST33
@@ -49,8 +49,8 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 setup
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST34
+++ b/src/test/pmempool_sync/TEST34
@@ -49,8 +49,8 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 setup
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST35
+++ b/src/test/pmempool_sync/TEST35
@@ -49,8 +49,8 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 setup
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST36
+++ b/src/test/pmempool_sync/TEST36
@@ -50,8 +50,8 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 setup
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST37
+++ b/src/test/pmempool_sync/TEST37
@@ -50,8 +50,8 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 setup
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST38
+++ b/src/test/pmempool_sync/TEST38
@@ -64,8 +64,8 @@ setup
 . ../common_badblock.sh
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST39
+++ b/src/test/pmempool_sync/TEST39
@@ -64,8 +64,8 @@ setup
 . ../common_badblock.sh
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST40
+++ b/src/test/pmempool_sync/TEST40
@@ -64,8 +64,8 @@ setup
 . ../common_badblock.sh
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST41
+++ b/src/test/pmempool_sync/TEST41
@@ -64,8 +64,8 @@ setup
 . ../common_badblock.sh
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST42
+++ b/src/test/pmempool_sync/TEST42
@@ -48,8 +48,8 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 setup
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST43
+++ b/src/test/pmempool_sync/TEST43
@@ -48,8 +48,8 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 setup
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST44
+++ b/src/test/pmempool_sync/TEST44
@@ -51,8 +51,8 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 setup
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST45
+++ b/src/test/pmempool_sync/TEST45
@@ -51,8 +51,8 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 setup
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST46
+++ b/src/test/pmempool_sync/TEST46
@@ -51,8 +51,8 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 setup
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST47
+++ b/src/test/pmempool_sync/TEST47
@@ -50,8 +50,8 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 setup
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST48
+++ b/src/test/pmempool_sync/TEST48
@@ -53,8 +53,8 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 setup
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST49
+++ b/src/test/pmempool_sync/TEST49
@@ -54,8 +54,8 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 setup
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST50
+++ b/src/test/pmempool_sync/TEST50
@@ -54,8 +54,8 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 setup
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST51
+++ b/src/test/pmempool_sync/TEST51
@@ -55,8 +55,8 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 setup
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST52
+++ b/src/test/pmempool_sync/TEST52
@@ -50,8 +50,8 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 setup
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync/TEST53
+++ b/src/test/pmempool_sync/TEST53
@@ -52,8 +52,8 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 setup
 
 #
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
 #
 export PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/pmempool_sync_remote/TEST22
+++ b/src/test/pmempool_sync_remote/TEST22
@@ -53,6 +53,12 @@ require_command_node 0 ndctl
 
 setup
 
+#
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
+#
+export PMEM_IS_PMEM_FORCE=1
+
 require_node_libfabric 0 $RPMEM_PROVIDER
 require_node_libfabric 1 $RPMEM_PROVIDER
 

--- a/src/test/pmempool_sync_remote/TEST23
+++ b/src/test/pmempool_sync_remote/TEST23
@@ -53,6 +53,12 @@ require_command_node 0 ndctl
 
 setup
 
+#
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
+#
+export PMEM_IS_PMEM_FORCE=1
+
 require_node_libfabric 0 $RPMEM_PROVIDER
 require_node_libfabric 1 $RPMEM_PROVIDER
 

--- a/src/test/pmempool_sync_remote/TEST24
+++ b/src/test/pmempool_sync_remote/TEST24
@@ -53,6 +53,12 @@ require_command_node 0 ndctl
 
 setup
 
+#
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
+#
+export PMEM_IS_PMEM_FORCE=1
+
 require_node_libfabric 0 $RPMEM_PROVIDER
 require_node_libfabric 1 $RPMEM_PROVIDER
 

--- a/src/test/pmempool_sync_remote/TEST24
+++ b/src/test/pmempool_sync_remote/TEST24
@@ -105,7 +105,7 @@ expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LA
 create_poolset $DIR/${POOLSET_LOCAL}_aux \
 	8M:${NODE_DIR[0]}/pool.local.part.0:x \
 	8M:${MOUNT_DIR}/pool.local.part.1:x \
-	8M:${NODE_DIR[0]}/pool.local.part.2:x \
+	8M:${NODE_DIR[0]}/pool.local.part.2:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/${POOLSET_LOCAL}_aux
 

--- a/src/test/pmempool_sync_remote/TEST25
+++ b/src/test/pmempool_sync_remote/TEST25
@@ -53,6 +53,12 @@ require_command_node 0 ndctl
 
 setup
 
+#
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
+#
+export PMEM_IS_PMEM_FORCE=1
+
 require_node_libfabric 0 $RPMEM_PROVIDER
 require_node_libfabric 1 $RPMEM_PROVIDER
 

--- a/src/test/pmempool_sync_remote/TEST25
+++ b/src/test/pmempool_sync_remote/TEST25
@@ -105,7 +105,7 @@ expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LA
 create_poolset $DIR/${POOLSET_LOCAL}_aux \
 	8M:${NODE_DIR[0]}/pool.local.part.0:x \
 	8M:${MOUNT_DIR}/pool.local.part.1:x \
-	8M:${NODE_DIR[0]}/pool.local.part.2:x \
+	8M:${NODE_DIR[0]}/pool.local.part.2:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/${POOLSET_LOCAL}_aux
 

--- a/src/test/pmempool_sync_remote/TEST26
+++ b/src/test/pmempool_sync_remote/TEST26
@@ -91,7 +91,7 @@ expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LA
 # and enable this compat feature on all nodes separately.
 
 create_poolset $DIR/${POOLSET_LOCAL}_aux \
-	10M:${NODE_DIR[0]}/pool.local:x \
+	10M:${NODE_DIR[0]}/pool.local:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/${POOLSET_LOCAL}_aux
 

--- a/src/test/pmempool_sync_remote/TEST26
+++ b/src/test/pmempool_sync_remote/TEST26
@@ -50,6 +50,12 @@ require_nodes 2
 
 setup
 
+#
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
+#
+export PMEM_IS_PMEM_FORCE=1
+
 require_node_libfabric 0 $RPMEM_PROVIDER
 require_node_libfabric 1 $RPMEM_PROVIDER
 

--- a/src/test/pmempool_sync_remote/TEST27
+++ b/src/test/pmempool_sync_remote/TEST27
@@ -91,7 +91,7 @@ expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LA
 # and enable this compat feature on all nodes separately.
 
 create_poolset $DIR/${POOLSET_LOCAL}_aux \
-	10M:${NODE_DIR[0]}/pool.local:x \
+	10M:${NODE_DIR[0]}/pool.local:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/${POOLSET_LOCAL}_aux
 

--- a/src/test/pmempool_sync_remote/TEST27
+++ b/src/test/pmempool_sync_remote/TEST27
@@ -50,6 +50,12 @@ require_nodes 2
 
 setup
 
+#
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
+#
+export PMEM_IS_PMEM_FORCE=1
+
 require_node_libfabric 0 $RPMEM_PROVIDER
 require_node_libfabric 1 $RPMEM_PROVIDER
 

--- a/src/test/pmempool_sync_remote/TEST28
+++ b/src/test/pmempool_sync_remote/TEST28
@@ -99,7 +99,7 @@ expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LA
 create_poolset $DIR/${POOLSET_LOCAL}_aux \
 	10M:${NODE_DIR[0]}/pool.local.part.0:x \
 	10M:${NODE_DIR[0]}/pool.local.part.1:x \
-	10M:${NODE_DIR[0]}/pool.local.part.2:x \
+	10M:${NODE_DIR[0]}/pool.local.part.2:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/${POOLSET_LOCAL}_aux
 

--- a/src/test/pmempool_sync_remote/TEST28
+++ b/src/test/pmempool_sync_remote/TEST28
@@ -50,6 +50,12 @@ require_nodes 2
 
 setup
 
+#
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
+#
+export PMEM_IS_PMEM_FORCE=1
+
 require_node_libfabric 0 $RPMEM_PROVIDER
 require_node_libfabric 1 $RPMEM_PROVIDER
 

--- a/src/test/pmempool_sync_remote/TEST29
+++ b/src/test/pmempool_sync_remote/TEST29
@@ -99,7 +99,7 @@ expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LA
 create_poolset $DIR/${POOLSET_LOCAL}_aux \
 	10M:${NODE_DIR[0]}/pool.local.part.0:x \
 	10M:${NODE_DIR[0]}/pool.local.part.1:x \
-	10M:${NODE_DIR[0]}/pool.local.part.2:x \
+	10M:${NODE_DIR[0]}/pool.local.part.2:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/${POOLSET_LOCAL}_aux
 

--- a/src/test/pmempool_sync_remote/TEST29
+++ b/src/test/pmempool_sync_remote/TEST29
@@ -50,6 +50,12 @@ require_nodes 2
 
 setup
 
+#
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
+#
+export PMEM_IS_PMEM_FORCE=1
+
 require_node_libfabric 0 $RPMEM_PROVIDER
 require_node_libfabric 1 $RPMEM_PROVIDER
 

--- a/src/test/pmempool_sync_remote/TEST30
+++ b/src/test/pmempool_sync_remote/TEST30
@@ -49,6 +49,12 @@ require_nodes 2
 
 setup
 
+#
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
+#
+export PMEM_IS_PMEM_FORCE=1
+
 require_node_libfabric 0 $RPMEM_PROVIDER
 require_node_libfabric 1 $RPMEM_PROVIDER
 

--- a/src/test/pmempool_sync_remote/TEST31
+++ b/src/test/pmempool_sync_remote/TEST31
@@ -49,6 +49,12 @@ require_nodes 2
 
 setup
 
+#
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
+#
+export PMEM_IS_PMEM_FORCE=1
+
 require_node_libfabric 0 $RPMEM_PROVIDER
 require_node_libfabric 1 $RPMEM_PROVIDER
 

--- a/src/test/pmempool_sync_remote/TEST32
+++ b/src/test/pmempool_sync_remote/TEST32
@@ -53,6 +53,12 @@ require_command_node 0 ndctl
 
 setup
 
+#
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
+#
+export PMEM_IS_PMEM_FORCE=1
+
 require_node_libfabric 0 $RPMEM_PROVIDER
 require_node_libfabric 1 $RPMEM_PROVIDER
 

--- a/src/test/pmempool_sync_remote/TEST33
+++ b/src/test/pmempool_sync_remote/TEST33
@@ -53,6 +53,12 @@ require_command_node 0 ndctl
 
 setup
 
+#
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
+#
+export PMEM_IS_PMEM_FORCE=1
+
 require_node_libfabric 0 $RPMEM_PROVIDER
 require_node_libfabric 1 $RPMEM_PROVIDER
 

--- a/src/test/pmempool_sync_remote/TEST34
+++ b/src/test/pmempool_sync_remote/TEST34
@@ -53,6 +53,12 @@ require_command_node 1 ndctl
 
 setup
 
+#
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
+#
+export PMEM_IS_PMEM_FORCE=1
+
 require_node_libfabric 0 $RPMEM_PROVIDER
 require_node_libfabric 1 $RPMEM_PROVIDER
 

--- a/src/test/pmempool_sync_remote/TEST35
+++ b/src/test/pmempool_sync_remote/TEST35
@@ -53,6 +53,12 @@ require_command_node 1 ndctl
 
 setup
 
+#
+# All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE
+# variable set, because they can time-out otherwise.
+#
+export PMEM_IS_PMEM_FORCE=1
+
 require_node_libfabric 0 $RPMEM_PROVIDER
 require_node_libfabric 1 $RPMEM_PROVIDER
 


### PR DESCRIPTION
All tests using the 'obj_verify' tool have to have the PMEM_IS_PMEM_FORCE variable set, because they can time-out otherwise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3305)
<!-- Reviewable:end -->