### PR TITLE
test: set PMEM_IS_PMEM_FORCE=1 in obj_verify

### DIFF
--- a/src/test/pmempool_sync/TEST27
+++ b/src/test/pmempool_sync/TEST27
@@ -53,12 +53,6 @@ setup
 
 . ../common_badblock.sh
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 ndctl_nfit_test_init
 
 DEVICE=$(ndctl_nfit_test_get_block_device)

--- a/src/test/pmempool_sync/TEST28
+++ b/src/test/pmempool_sync/TEST28
@@ -53,12 +53,6 @@ setup
 
 . ../common_badblock.sh
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 ndctl_nfit_test_init
 
 DEVICE=$(ndctl_nfit_test_get_dax_device)

--- a/src/test/pmempool_sync/TEST30
+++ b/src/test/pmempool_sync/TEST30
@@ -53,12 +53,6 @@ setup
 
 . ../common_badblock.sh
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 ndctl_nfit_test_init
 
 DEVICE=$(ndctl_nfit_test_get_block_device)

--- a/src/test/pmempool_sync/TEST31
+++ b/src/test/pmempool_sync/TEST31
@@ -53,12 +53,6 @@ setup
 
 . ../common_badblock.sh
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 ndctl_nfit_test_init
 
 DEVICE=$(ndctl_nfit_test_get_dax_device)

--- a/src/test/pmempool_sync/TEST32
+++ b/src/test/pmempool_sync/TEST32
@@ -48,12 +48,6 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 LOG=out${UNITTEST_NUM}.log
 rm -f $LOG && touch $LOG
 

--- a/src/test/pmempool_sync/TEST33
+++ b/src/test/pmempool_sync/TEST33
@@ -48,12 +48,6 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 LOG=out${UNITTEST_NUM}.log
 rm -f $LOG && touch $LOG
 

--- a/src/test/pmempool_sync/TEST34
+++ b/src/test/pmempool_sync/TEST34
@@ -48,12 +48,6 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 LOG=out${UNITTEST_NUM}.log
 rm -f $LOG && touch $LOG
 

--- a/src/test/pmempool_sync/TEST35
+++ b/src/test/pmempool_sync/TEST35
@@ -48,12 +48,6 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 LOG=out${UNITTEST_NUM}.log
 rm -f $LOG && touch $LOG
 

--- a/src/test/pmempool_sync/TEST36
+++ b/src/test/pmempool_sync/TEST36
@@ -49,12 +49,6 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 LOG=out${UNITTEST_NUM}.log
 rm -f $LOG && touch $LOG
 

--- a/src/test/pmempool_sync/TEST37
+++ b/src/test/pmempool_sync/TEST37
@@ -49,12 +49,6 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 LOG=out${UNITTEST_NUM}.log
 rm -f $LOG && touch $LOG
 

--- a/src/test/pmempool_sync/TEST38
+++ b/src/test/pmempool_sync/TEST38
@@ -63,12 +63,6 @@ setup
 
 . ../common_badblock.sh
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 ndctl_nfit_test_init
 
 DEVICE=$(ndctl_nfit_test_get_block_device)

--- a/src/test/pmempool_sync/TEST39
+++ b/src/test/pmempool_sync/TEST39
@@ -63,12 +63,6 @@ setup
 
 . ../common_badblock.sh
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 ndctl_nfit_test_init
 
 DEVICE=$(ndctl_nfit_test_get_block_device)

--- a/src/test/pmempool_sync/TEST40
+++ b/src/test/pmempool_sync/TEST40
@@ -63,12 +63,6 @@ setup
 
 . ../common_badblock.sh
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 ndctl_nfit_test_init
 
 DEVICE=$(ndctl_nfit_test_get_block_device)

--- a/src/test/pmempool_sync/TEST41
+++ b/src/test/pmempool_sync/TEST41
@@ -63,12 +63,6 @@ setup
 
 . ../common_badblock.sh
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 ndctl_nfit_test_init
 
 DEVICE=$(ndctl_nfit_test_get_block_device)

--- a/src/test/pmempool_sync/TEST42
+++ b/src/test/pmempool_sync/TEST42
@@ -47,12 +47,6 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST43
+++ b/src/test/pmempool_sync/TEST43
@@ -47,12 +47,6 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST44
+++ b/src/test/pmempool_sync/TEST44
@@ -50,12 +50,6 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST45
+++ b/src/test/pmempool_sync/TEST45
@@ -50,12 +50,6 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST46
+++ b/src/test/pmempool_sync/TEST46
@@ -50,12 +50,6 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST47
+++ b/src/test/pmempool_sync/TEST47
@@ -49,12 +49,6 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST48
+++ b/src/test/pmempool_sync/TEST48
@@ -52,12 +52,6 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST49
+++ b/src/test/pmempool_sync/TEST49
@@ -53,12 +53,6 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST50
+++ b/src/test/pmempool_sync/TEST50
@@ -53,12 +53,6 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST51
+++ b/src/test/pmempool_sync/TEST51
@@ -54,12 +54,6 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST52
+++ b/src/test/pmempool_sync/TEST52
@@ -49,12 +49,6 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync/TEST53
+++ b/src/test/pmempool_sync/TEST53
@@ -51,12 +51,6 @@ require_linked_with_ndctl $PMEMPOOL$EXESUFFIX
 
 setup
 
-#
-# The tests using the 'obj_verify' tool on a non-pmem filesystem
-# should have this variable set, because they can time-out otherwise.
-#
-export PMEM_IS_PMEM_FORCE=1
-
 export PMEMPOOL_LOG_LEVEL=10
 
 LOG=out${UNITTEST_NUM}.log

--- a/src/test/pmempool_sync_remote/TEST24
+++ b/src/test/pmempool_sync_remote/TEST24
@@ -105,7 +105,7 @@ expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LA
 create_poolset $DIR/${POOLSET_LOCAL}_aux \
 	8M:${NODE_DIR[0]}/pool.local.part.0:x \
 	8M:${MOUNT_DIR}/pool.local.part.1:x \
-	8M:${NODE_DIR[0]}/pool.local.part.2:x \
+	8M:${NODE_DIR[0]}/pool.local.part.2:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/${POOLSET_LOCAL}_aux
 

--- a/src/test/pmempool_sync_remote/TEST25
+++ b/src/test/pmempool_sync_remote/TEST25
@@ -105,7 +105,7 @@ expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LA
 create_poolset $DIR/${POOLSET_LOCAL}_aux \
 	8M:${NODE_DIR[0]}/pool.local.part.0:x \
 	8M:${MOUNT_DIR}/pool.local.part.1:x \
-	8M:${NODE_DIR[0]}/pool.local.part.2:x \
+	8M:${NODE_DIR[0]}/pool.local.part.2:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/${POOLSET_LOCAL}_aux
 

--- a/src/test/pmempool_sync_remote/TEST26
+++ b/src/test/pmempool_sync_remote/TEST26
@@ -91,7 +91,7 @@ expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LA
 # and enable this compat feature on all nodes separately.
 
 create_poolset $DIR/${POOLSET_LOCAL}_aux \
-	10M:${NODE_DIR[0]}/pool.local:x \
+	10M:${NODE_DIR[0]}/pool.local:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/${POOLSET_LOCAL}_aux
 

--- a/src/test/pmempool_sync_remote/TEST27
+++ b/src/test/pmempool_sync_remote/TEST27
@@ -91,7 +91,7 @@ expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LA
 # and enable this compat feature on all nodes separately.
 
 create_poolset $DIR/${POOLSET_LOCAL}_aux \
-	10M:${NODE_DIR[0]}/pool.local:x \
+	10M:${NODE_DIR[0]}/pool.local:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/${POOLSET_LOCAL}_aux
 

--- a/src/test/pmempool_sync_remote/TEST28
+++ b/src/test/pmempool_sync_remote/TEST28
@@ -99,7 +99,7 @@ expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LA
 create_poolset $DIR/${POOLSET_LOCAL}_aux \
 	10M:${NODE_DIR[0]}/pool.local.part.0:x \
 	10M:${NODE_DIR[0]}/pool.local.part.1:x \
-	10M:${NODE_DIR[0]}/pool.local.part.2:x \
+	10M:${NODE_DIR[0]}/pool.local.part.2:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/${POOLSET_LOCAL}_aux
 

--- a/src/test/pmempool_sync_remote/TEST29
+++ b/src/test/pmempool_sync_remote/TEST29
@@ -99,7 +99,7 @@ expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LA
 create_poolset $DIR/${POOLSET_LOCAL}_aux \
 	10M:${NODE_DIR[0]}/pool.local.part.0:x \
 	10M:${NODE_DIR[0]}/pool.local.part.1:x \
-	10M:${NODE_DIR[0]}/pool.local.part.2:x \
+	10M:${NODE_DIR[0]}/pool.local.part.2:x
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/${POOLSET_LOCAL}_aux
 

--- a/src/test/tools/obj_verify/obj_verify.c
+++ b/src/test/tools/obj_verify/obj_verify.c
@@ -40,6 +40,7 @@
 
 #include "libpmemobj.h"
 #include "set.h"
+#include "os.h"
 
 #define SIGNATURE_LEN 10
 #define NUMBER_LEN 10
@@ -225,6 +226,13 @@ main(int argc, char *argv[])
 	const char *path = argv[1];
 	const char *layout = argv[2];
 	const char *op;
+
+	/*
+	 * This application can be very time-consuming
+	 * when it is run on an non-pmem filesystem,
+	 * so let's set PMEM_IS_PMEM_FORCE to 1 for this case.
+	 */
+	os_setenv("PMEM_IS_PMEM_FORCE", "1", 1 /* overwrite */);
 
 	/* go through all arguments one by one */
 	for (int arg = 3; arg < argc; arg++) {


### PR DESCRIPTION
obj_verify can be very time-consuming
when it is run on an non-pmem filesystem,
so let's set PMEM_IS_PMEM_FORCE to 1 for this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3310)
<!-- Reviewable:end -->
