### PR TITLE
 test: fix pmempool_sync/TEST27 test

### DIFF
--- a/src/test/pmempool_sync/TEST27
+++ b/src/test/pmempool_sync/TEST27
@@ -33,7 +33,7 @@
 #
 # pmempool_sync/TEST27 -- test for sync command with badblocks
 #                         - bad blocks in the regular file
-#                           blocks: offset: 0 length: 1
+#                           blocks: offset: 8 length: 1
 #
 
 # standard unit test setup
@@ -74,15 +74,17 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOL
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
+turn_on_checking_bad_blocks $POOLSET
+
 # inject bad block:
-FIRST_SECTOR=$(expect_normal_exit $EXTENTS $MOUNT_DIR/testfile1 -l 0)
+FIRST_SECTOR=$(expect_normal_exit $EXTENTS $MOUNT_DIR/testfile1 -l 8)
 ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_bad_blocks
 
 expect_normal_exit "$PMEMPOOL$EXESUFFIX info -k $POOLSET >> $LOG"
 
-turn_on_checking_bad_blocks $POOLSET
+expect_bad_blocks
 
 expect_abnormal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> /dev/null"
 

--- a/src/test/pmempool_sync/out27.log.match
+++ b/src/test/pmempool_sync/out27.log.match
@@ -17,7 +17,7 @@ type                     : regular file
 size                     : 10485760
 bad blocks:
 	offset		length
-	0		2
+	8		2
 part 2:
 path                     : $(nW)/testfile2
 type                     : regular file
@@ -56,6 +56,9 @@ Heap offset              : $(nW)
 Heap size                : $(nW)
 Checksum                 : $(*)
 Root offset              : $(nW)
+    "badblock_count":1,
+        "offset":$(N),
+        "length":1,
     "badblock_count":1,
         "offset":$(N),
         "length":1,


### PR DESCRIPTION
1) turn checking bad blocks on before injecting them
2) inject bad blocks at offset 8 to not zero features in the header
3) add expect_bad_blocks() before running pmempool-sync to make sure
   that bad blocks really exist

It fixes failing test on Jenkins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3318)
<!-- Reviewable:end -->
