### PR TITLE
test: expand msg info from require_free_space and require_nfit_tests_enabled

### DIFF
--- a/src/test/unittest/unittest.ps1
+++ b/src/test/unittest/unittest.ps1
@@ -1297,7 +1297,7 @@ function require_free_space() {
 	$free_space = (gwmi Win32_Volume -Filter $filter | select FreeSpace).freespace
 	if ([INT64]$free_space -lt [INT64]$req_free_space)
 	{
-		msg "${Env:UNITTEST_NAME}: SKIP not enough free space"
+		msg "${Env:UNITTEST_NAME}: SKIP not enough free space ($Args[0] required)"
 		exit 0
 	}
 }

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -3438,7 +3438,7 @@ function require_free_space() {
 		exit 0
 	fi
 	if [ $free_space -lt $req_free_space ]; then
-		msg "$UNITTEST_NAME: SKIP: not enough free space"
+		msg "$UNITTEST_NAME: SKIP: not enough free space ($1 required)"
 		exit 0
 	fi
 }
@@ -3448,7 +3448,7 @@ function require_free_space() {
 #
 function require_nfit_tests_enabled() {
 	if [ "$ENABLE_NFIT_TESTS" != "y" ]; then
-		msg "$UNITTEST_NAME: SKIP: tests using the nfit_test kernel module are not enabled in testconfig.sh"
+		msg "$UNITTEST_NAME: SKIP: tests using the nfit_test kernel module are not enabled in testconfig.sh (ENABLE_NFIT_TESTS)"
 		exit 0
 	fi
 }


### PR DESCRIPTION
Adding precise info on how much free space is required to msg in require_free_space function, and additionally expanding msg in require_nfit_tests_enabled function to contain entry for testconfig.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3319)
<!-- Reviewable:end -->
