### PR TITLE
common: simplify reading unsafe shutdown count

### DIFF
--- a/src/common/os_dimm_ndctl.c
+++ b/src/common/os_dimm_ndctl.c
@@ -296,11 +296,6 @@ os_dimm_usc(const char *path, uint64_t *usc)
 			goto err;
 		}
 
-		if (ndctl_cmd_submit(cmd)) {
-			ERR("!ndctl_cmd_submit");
-			goto err;
-		}
-
 		if (!(ndctl_cmd_smart_get_flags(cmd) & USC_VALID_FLAG)) {
 			/* dimm doesn't support unsafe shutdown count */
 			continue;


### PR DESCRIPTION
Simplify reading unsafe shutdown count by removing a redundant code.

Ref: pmem/issues#957

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3322)
<!-- Reviewable:end -->
