### PR TITLE
test: fix pmem_deep_flush mock

### DIFF
--- a/src/test/pmem_deep_persist/pmem_deep_persist.c
+++ b/src/test/pmem_deep_persist/pmem_deep_persist.c
@@ -134,7 +134,7 @@ FUNC_MOCK_RUN_DEFAULT {
 	if (strstr(path, "/sys/bus/nd/devices/region") &&
 			strstr(path, "/deep_flush")) {
 		UT_OUT("mocked open, path %s", path);
-		if (access(path, R_OK))
+		if (access(path, W_OK))
 			return 999;
 	}
 

--- a/src/test/testconfig.sh.example
+++ b/src/test/testconfig.sh.example
@@ -62,6 +62,8 @@ NON_PMEM_FS_DIR=/tmp
 # /sys/devices/platform/<pmem_device>/ndbus?/region?/resource
 # /sys/devices/platform/<pmem_device>/ndbus?/region?/dax?.0/resource
 #
+# Note: some tests require write access to '/sys/bus/nd/devices/regionX/deep_flush'.
+#
 #DEVICE_DAX_PATH=(/dev/dax0.0)
 
 #


### PR DESCRIPTION
Ref: pmem/issues#963

We need to write to deep_flush file, so we have to check write access.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3323)
<!-- Reviewable:end -->
