### PR TITLE
test: do not enable the SHUTDOWN_STATE incompat feature

### DIFF
--- a/src/test/pmempool_check/TEST1
+++ b/src/test/pmempool_check/TEST1
@@ -51,7 +51,7 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOL
 check_file $POOL
 $PMEMSPOIL -v $POOL pool_hdr.major=0x0\
 			pool_hdr.features.compat=0xfe\
-			pool_hdr.features.incompat=0xff\
+			pool_hdr.features.incompat=0xfb\
 			pool_hdr.features.ro_compat=0xff\
 			pool_hdr.unused=ERROR >> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX check -vry $POOL >> $LOG
@@ -71,7 +71,7 @@ check_file $POOL
 $PMEMSPOIL -v $POOL pool_hdr.signature=ERROR\
 			pool_hdr.major=0xff\
 			pool_hdr.features.compat=0xfe\
-			pool_hdr.features.incompat=0xff\
+			pool_hdr.features.incompat=0xfb\
 			pool_hdr.features.ro_compat=0xff\
 			pool_hdr.unused=ERROR >> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX check -vry $POOL >> $LOG

--- a/src/test/pmempool_check/TEST1.PS1
+++ b/src/test/pmempool_check/TEST1.PS1
@@ -47,7 +47,11 @@ $LOG="out$Env:UNITTEST_NUM.log"
 echo "PMEMLOG: pool_hdr" > $LOG
 expect_normal_exit $PMEMPOOL create log $POOL
 check_file $POOL
-Invoke-Expression "$PMEMSPOIL -v $POOL pool_hdr.major=0x0 pool_hdr.features.compat=0xff pool_hdr.features.incompat=0xff pool_hdr.features.ro_compat=0xff pool_hdr.unused=ERROR >> $LOG"
+# pool_hdr.features.incompat on Windows has to have SHUTDOWN_STATE feature enabled
+# otherwise pmempool check will fail because of dirty shutdown state structures
+# which are expected to be zeroed if SHUTDOWN_STATE feature is disabled
+# 0xfe == 0xfb | SHUTDOWN_STATE
+Invoke-Expression "$PMEMSPOIL -v $POOL pool_hdr.major=0x0 pool_hdr.features.compat=0xff pool_hdr.features.incompat=0xfe pool_hdr.features.ro_compat=0xff pool_hdr.unused=ERROR >> $LOG"
 expect_normal_exit $PMEMPOOL check -vry $POOL >> $LOG
 
 echo "PMEMLOG: pmemlog" >> $LOG
@@ -61,7 +65,7 @@ echo "PMEMBLK: pool_hdr" >> $LOG
 rm $POOL -Force
 expect_normal_exit $PMEMPOOL create -w blk 512 $POOL
 check_file $POOL
-Invoke-Expression "$PMEMSPOIL -v $POOL pool_hdr.signature=ERROR	pool_hdr.major=0xff	pool_hdr.features.compat=0xff pool_hdr.features.incompat=0xff pool_hdr.features.ro_compat=0xff pool_hdr.unused=ERROR >> $LOG"
+Invoke-Expression "$PMEMSPOIL -v $POOL pool_hdr.signature=ERROR	pool_hdr.major=0xff	pool_hdr.features.compat=0xff pool_hdr.features.incompat=0xfb pool_hdr.features.ro_compat=0xff pool_hdr.unused=ERROR >> $LOG"
 expect_normal_exit $PMEMPOOL check -vry $POOL >> $LOG
 
 echo "PMEMBLK: pmemblk" >> $LOG

--- a/src/test/pmempool_check/TEST1.PS1
+++ b/src/test/pmempool_check/TEST1.PS1
@@ -51,7 +51,7 @@ check_file $POOL
 # otherwise pmempool check will fail because of dirty shutdown state structures
 # which are expected to be zeroed if SHUTDOWN_STATE feature is disabled
 # 0xfe == 0xfb | SHUTDOWN_STATE
-Invoke-Expression "$PMEMSPOIL -v $POOL pool_hdr.major=0x0 pool_hdr.features.compat=0xff pool_hdr.features.incompat=0xfe pool_hdr.features.ro_compat=0xff pool_hdr.unused=ERROR >> $LOG"
+Invoke-Expression "$PMEMSPOIL -v $POOL pool_hdr.major=0x0 pool_hdr.features.compat=0xfe pool_hdr.features.incompat=0xfe pool_hdr.features.ro_compat=0xff pool_hdr.unused=ERROR >> $LOG"
 expect_normal_exit $PMEMPOOL check -vry $POOL >> $LOG
 
 echo "PMEMLOG: pmemlog" >> $LOG
@@ -65,7 +65,7 @@ echo "PMEMBLK: pool_hdr" >> $LOG
 rm $POOL -Force
 expect_normal_exit $PMEMPOOL create -w blk 512 $POOL
 check_file $POOL
-Invoke-Expression "$PMEMSPOIL -v $POOL pool_hdr.signature=ERROR	pool_hdr.major=0xff	pool_hdr.features.compat=0xff pool_hdr.features.incompat=0xfb pool_hdr.features.ro_compat=0xff pool_hdr.unused=ERROR >> $LOG"
+Invoke-Expression "$PMEMSPOIL -v $POOL pool_hdr.signature=ERROR	pool_hdr.major=0xff	pool_hdr.features.compat=0xfe pool_hdr.features.incompat=0xfb pool_hdr.features.ro_compat=0xff pool_hdr.unused=ERROR >> $LOG"
 expect_normal_exit $PMEMPOOL check -vry $POOL >> $LOG
 
 echo "PMEMBLK: pmemblk" >> $LOG

--- a/src/test/pmempool_check/TEST9
+++ b/src/test/pmempool_check/TEST9
@@ -52,7 +52,7 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX check -vyr $POOL >> $LOG
 
 $PMEMSPOIL -v $POOL pool_hdr.major=0x0\
 			pool_hdr.features.compat=0xfe\
-			pool_hdr.features.incompat=0xff\
+			pool_hdr.features.incompat=0xfb\
 			pool_hdr.features.ro_compat=0xff\
 			pool_hdr.unused=ERROR >> $LOG
 

--- a/src/test/pmempool_check/TEST9.PS1
+++ b/src/test/pmempool_check/TEST9.PS1
@@ -48,10 +48,14 @@ expect_normal_exit $PMEMPOOL create obj $POOL
 
 expect_normal_exit $PMEMPOOL check -vyr $POOL >> $LOG
 
+# pool_hdr.features.incompat on Windows has to have SHUTDOWN_STATE feature enabled
+# otherwise pmempool check will fail because of dirty shutdown state structures
+# which are expected to be zeroed if SHUTDOWN_STATE feature is disabled
+# 0xfe == 0xfb | SHUTDOWN_STATE
 &$PMEMSPOIL -v $POOL `
 	pool_hdr.major=0x0 `
 	pool_hdr.features.compat=0xfe `
-	pool_hdr.features.incompat=0xff `
+	pool_hdr.features.incompat=0xfe `
 	pool_hdr.features.ro_compat=0xff `
 	pool_hdr.unused=ERROR `
 	>> $LOG

--- a/src/test/pmempool_check/common.sh
+++ b/src/test/pmempool_check/common.sh
@@ -77,19 +77,19 @@ function pmempool_check_sds() {
 	pmemspoil_corrupt_replica_sds 1
 
 	# verify it is corrupted
-	expect_abnormal_exit $PMEMPOOL$EXESUFFIX check $POOLSET >> $LOG
+	expect_abnormal_exit $PMEMPOOL$EXESUFFIX check $POOLSET >> $LOG 2>/dev/null
 	exit_func=expect_normal_exit
 
 	# perform fixes
 	case "$1" in
 	fix_second_replica_only)
-		echo -e "n\ny\n" | expect_normal_exit $PMEMPOOL$EXESUFFIX check -vr $POOLSET >> $LOG
+		echo -e "n\ny\n" | expect_normal_exit $PMEMPOOL$EXESUFFIX check -vr $POOLSET >> $LOG 2>/dev/null
 		;;
 	fix_first_replica)
-		echo -e "y\n" | expect_normal_exit $PMEMPOOL$EXESUFFIX check -vr $POOLSET >> $LOG
+		echo -e "y\n" | expect_normal_exit $PMEMPOOL$EXESUFFIX check -vr $POOLSET >> $LOG 2>/dev/null
 		;;
 	fix_no_replicas)
-		echo -e "n\nn\n" | expect_abnormal_exit $PMEMPOOL$EXESUFFIX check -vr $POOLSET >> $LOG
+		echo -e "n\nn\n" | expect_abnormal_exit $PMEMPOOL$EXESUFFIX check -vr $POOLSET >> $LOG 2>/dev/null
 		exit_func=expect_abnormal_exit
 		;;
 	*)
@@ -98,5 +98,5 @@ function pmempool_check_sds() {
 	esac
 
 	#verify result
-	$exit_func $PMEMPOOL$EXESUFFIX check $POOLSET >> $LOG
+	$exit_func $PMEMPOOL$EXESUFFIX check $POOLSET >> $LOG 2>/dev/null
 }

--- a/src/test/pmempool_check/out9.log.match
+++ b/src/test/pmempool_check/out9.log.match
@@ -5,7 +5,8 @@ pool header correct
 $(nW)file.pool: consistent
 $(nW)file.pool: spoil: pool_hdr.major=0x0
 $(nW)file.pool: spoil: pool_hdr.features.compat=0xfe
-$(nW)file.pool: spoil: pool_hdr.features.incompat=0xff
+$(OPT)$(nW)file.pool: spoil: pool_hdr.features.incompat=0xfb
+$(OPX)$(nW)file.pool: spoil: pool_hdr.features.incompat=0xfe
 $(nW)file.pool: spoil: pool_hdr.features.ro_compat=0xff
 $(nW)file.pool: spoil: pool_hdr.unused=ERROR
 checking shutdown state


### PR DESCRIPTION
Do not enable the SHUTDOWN_STATE incompat feature in two pmempool_check tests: TEST1 and TEST9.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3336)
<!-- Reviewable:end -->
