### PR TITLE
test: run ldd with env

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -995,7 +995,7 @@ function require_unlimited_vm() {
 function require_linked_with_ndctl() {
 	[ "$1" == "" -o ! -x "$1" ] && \
 		fatal "$UNITTEST_NAME: ERROR: require_linked_with_ndctl() requires one argument - an executable file"
-	local lddndctl=$(expect_normal_exit ldd $1 | $GREP -ce "libndctl")
+	local lddndctl=$(LD_LIBRARY_PATH=$TEST_LD_LIBRARY_PATH ldd $1 | $GREP -ce "libndctl")
 	[ "$lddndctl" == "1" ] && return
 	msg "$UNITTEST_NAME: SKIP required: executable $1 linked with libndctl"
 	exit 0


### PR DESCRIPTION
expect_normal_exit should not be used prior to run setup.
Setting LD_LIBRARY_PATH is sufficient.

Ref: pmem/pmdk#3244
Ref: pmem/issues#952

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3337)
<!-- Reviewable:end -->
