### PR TITLE
obj: modify units_per_block for new alloc classes

### DIFF
--- a/doc/libpmemobj/pmemobj_ctl_get.3.md
+++ b/doc/libpmemobj/pmemobj_ctl_get.3.md
@@ -220,12 +220,14 @@ All objects have default alignment of 64 bytes, but the user data alignment
 is affected by the size of the chosen header.
 
 The `units_per_block` field defines how many units a single block of memory
-contains. This value will be rounded up to match the internal size of the
+contains. This value will be adjusted to match the internal size of the
 block (256 kilobytes or a multiple thereof). For example, given a class with
 a `unit_size` of 512 bytes and a `units_per_block` of 1000, a single block of
 memory for that class will have 512 kilobytes.
 This is relevant because the bigger the block size, the less frequently blocks
 need to be fetched, resulting in lower contention on global heap state.
+If the CTL call is being done at runtime, the `units_per_block` variable of the
+provided alloc class structure is modified to match the actual value.
 
 The `header_type` field defines the header of objects from the allocation class.
 There are three types:

--- a/src/libpmemobj/pmalloc.c
+++ b/src/libpmemobj/pmalloc.c
@@ -333,6 +333,7 @@ CTL_WRITE_HANDLER(desc)(void *ctx,
 	}
 
 	p->class_id = c->id;
+	p->units_per_block = c->run.nallocs;
 
 	return 0;
 }

--- a/src/test/obj_ctl_alloc_class/obj_ctl_alloc_class.c
+++ b/src/test/obj_ctl_alloc_class/obj_ctl_alloc_class.c
@@ -235,13 +235,14 @@ basic(const char *path)
 	struct pobj_alloc_class_desc alloc_class_tiny;
 	alloc_class_tiny.header_type = POBJ_HEADER_NONE;
 	alloc_class_tiny.unit_size = 7;
-	alloc_class_tiny.units_per_block = 1000;
+	alloc_class_tiny.units_per_block = 1;
 	alloc_class_tiny.class_id = 0;
 	alloc_class_tiny.alignment = 0;
 
 	ret = pmemobj_ctl_set(pop, "heap.alloc_class.new.desc",
 		&alloc_class_tiny);
 	UT_ASSERTeq(ret, 0);
+	UT_ASSERT(alloc_class_tiny.units_per_block > 1);
 
 	for (int i = 0; i < 1000; ++i) {
 		ret = pmemobj_xalloc(pop, &oid, 7, 0,


### PR DESCRIPTION
For custom allocation classes the units_per_block variable is
adjusted to minimize fragmentation and most likely differs from
the user-provided value. This patch will make it so that the actual
value is written back to the allocation class desc structure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3340)
<!-- Reviewable:end -->
