### PR TITLE
test: check whether log exists prior to cat it

### DIFF
--- a/src/test/libpmempool_feature/common.PS1
+++ b/src/test/libpmempool_feature/common.PS1
@@ -70,7 +70,9 @@ function libpmempool_feature_enable($arg1, $arg2) {
 	& $exit_func $Env:EXE_DIR\libpmempool_feature$Env:EXESUFFIX $DIR\pool.obj e $arg1 2>&1 `
 		| Select-String "$arg1" | %{$_.Line} >> $LOG
 	if ( "$exit_func" -eq "expect_abnormal_exit" ) {
-		cat $Env:PMEMPOOL_LOG_FILE | Select-String "$ERROR_PATTERN" | %{$_.Line} >> $LOG
+		if ( Test-Path $Env:PMEMPOOL_LOG_FILE ) {
+			cat $Env:PMEMPOOL_LOG_FILE | Select-String "$ERROR_PATTERN" | %{$_.Line} >> $LOG
+		}
 	}
 	if ( "$arg2" -ne "no-query" ){
 		libpmempool_feature_query $arg1


### PR DESCRIPTION
Log files from libraries under Release are not created so it is required to check its existance prior to grep its content. Otherwise output is polluted with Exceptions.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3348)
<!-- Reviewable:end -->
