### PR TITLE
Test: fix issue #964

### DIFF
--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -470,6 +470,13 @@ test: all
 
 TOOLS=../tools
 
+$(TOOLS)/anonymous_mapping/anonymous_mapping:
+	$(MAKE) -C $(TOOLS)/anonymous_mapping all
+
+ifeq ($(USE_ANONYMOUS_MAPPING), y)
+all: $(TOOLS)/anonymous_mapping/anonymous_mapping
+endif
+
 $(TOOLS)/pmemspoil/pmemspoil:
 	$(MAKE) -C $(TOOLS)/pmemspoil all
 

--- a/src/test/pmempool_check/TEST20
+++ b/src/test/pmempool_check/TEST20
@@ -45,6 +45,8 @@ require_fs_type any
 configure_valgrind memcheck force-enable $PMEMPOOL$EXESUFFIX
 require_valgrind 3.11
 
+require_mmap_under_valgrind
+
 setup
 
 dax_device_zero

--- a/src/test/tools/anonymous_mapping/.gitignore
+++ b/src/test/tools/anonymous_mapping/.gitignore
@@ -1,0 +1,1 @@
+anonymous_mapping

--- a/src/test/tools/anonymous_mapping/Makefile
+++ b/src/test/tools/anonymous_mapping/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2018, Intel Corporation
+# Copyright 2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,55 +31,15 @@
 #
 
 #
-# src/test/tools/Makefile -- build unit test helpers
+# src/test/tools/anonymous_mapping/Makefile -- Makefile for anonymous_mapping
 #
 
-TOP = ../../..
+TOP = ../../../..
 
-TESTCONFIG=$(TOP)/src/test/testconfig.sh
+TARGET = anonymous_mapping
+OBJS = anonymous_mapping.o
 
-DIRS = \
-       pmemspoil\
-       pmemwrite\
-       pmemalloc\
-       pmemobjcli\
-       pmemdetect\
-       ctrld\
-       bttcreate\
-       fip\
-       ddmap\
-       cmpmap\
-       extents\
-       fallocate_detect\
-       obj_verify\
-       anonymous_mapping
+LIBPMEM=y
+LIBPMEMCOMMON=y
 
-REMOTE_TOOLS = \
-	ctrld\
-	extents\
-	fip\
-	obj_verify\
-	pmemobjcli\
-	pmemspoil\
-	pmemdetect
-
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-cstyle  : TARGET = cstyle
-format  : TARGET = format
-sync-remotes : TARGET = sync-remotes
-sparse  : TARGET = sparse
-
-all test cstyle clean clobber format sparse: $(DIRS)
-
-$(TESTCONFIG):
-
-sync-remotes: $(REMOTE_TOOLS) $(TESTCONFIG)
-
-$(DIRS):
-	$(MAKE) -C $@ $(TARGET)
-
-check pcheck: all
-
-.PHONY: all clean clobber cstyle format check pcheck $(DIRS)
+include $(TOP)/src/tools/Makefile.inc

--- a/src/test/tools/anonymous_mapping/README
+++ b/src/test/tools/anonymous_mapping/README
@@ -1,0 +1,8 @@
+Persistent Memory Development Kit
+
+This is src/test/tools/anonymous_mapping/README.
+
+This directory contains a simple tool 'anonymous_mapping' for verifying ability
+for anonymously mapping (huge) amount of memory into the virtual address space.
+
+'anonymous_mapping' takes one argument - length in bytes

--- a/src/test/tools/anonymous_mapping/anonymous_mapping.c
+++ b/src/test/tools/anonymous_mapping/anonymous_mapping.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * anonymous_mapping.c -- tool for verifying if given memory length can be
+ * anonymously mapped
+ */
+
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <errno.h>
+
+#include "out.h"
+
+int
+main(int argc, char *argv[])
+{
+	out_init("ANONYMOUS_MAPPING", "ANONYMOUS_MAPPING", "", 1, 0);
+
+	if (argc != 2) {
+		out("Usage: %s <length>\n", argv[0]);
+		return -1;
+	}
+
+	const size_t length = (size_t)atoll(argv[1]);
+	char *addr = mmap(NULL, length, PROT_READ,
+				MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+	if (addr == MAP_FAILED) {
+		out("Failed to mmap length=%lu of memory, errno=%d\n",
+			length, errno);
+		return errno;
+	}
+
+	out_fini();
+
+	return 0;
+}


### PR DESCRIPTION
When the client application runs against the Valgrind, the Valgrind intercepts the mmap call made by the client. It then invokes the kernel's mmap function by setting the MAP_FIXED flag and also specifies the memory location to map. The Kernel will then try to map to this advised memory. When the advised location is not available for mapping, the Kernel returns failure (EINVAL) because the MAP_FIXED flag is set. With big length requests (i.e. in tests run on NVDIMMs) it becomes a limitation which must be handled by valgrind maintainers in the future. 
This commit provides a simple way to detect possible valgrind mmap issues and skip uncertain tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3351)
<!-- Reviewable:end -->
