### PR TITLE
test: enable CHECK_BAD_BLOCKS feature in four pmempool_sync_remote tests

### DIFF
--- a/src/test/pmempool_sync_remote/TEST32
+++ b/src/test/pmempool_sync_remote/TEST32
@@ -99,6 +99,26 @@ copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE
 expect_normal_exit run_on_node 0 ../pmempool rm -sf ${NODE_DIR[0]}$POOLSET_LOCAL
 expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT c v &>> $LOG"
 
+###############################################################################
+# Enabling features in poolsets with remote replicas is not supported now,
+# so we have to use the following workaround to enable
+# the POOL_FEAT_CHECK_BAD_BLOCKS compat feature in such poolset.
+# We create the auxiliary poolset without the remote replica
+# and enable this compat feature on all nodes separately.
+
+POOLSET_LOCAL_AUX=${POOLSET_LOCAL}_aux
+
+create_poolset $DIR/${POOLSET_LOCAL_AUX} \
+	8M:${MOUNT_DIR}/pool.local.part.0:x \
+	8M:${MOUNT_DIR}/pool.local.part.1:x
+
+copy_files_to_node 0 ${NODE_DIR[0]} $DIR/${POOLSET_LOCAL_AUX}
+
+turn_on_checking_bad_blocks_node 0 ${NODE_DIR[0]}/${POOLSET_LOCAL_AUX}
+turn_on_checking_bad_blocks_node 1 ${NODE_DIR[1]}/${POOLSET_REMOTE}
+
+###############################################################################
+
 # inject bad block in the part #0
 FILE=${MOUNT_DIR}/pool.local.part.0
 FIRST_SECTOR=$(expect_normal_exit run_on_node 0 ../extents $FILE -l 0)

--- a/src/test/pmempool_sync_remote/TEST33
+++ b/src/test/pmempool_sync_remote/TEST33
@@ -99,6 +99,26 @@ copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE
 expect_normal_exit run_on_node 0 ../pmempool rm -sf ${NODE_DIR[0]}$POOLSET_LOCAL
 expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT c v &>> $LOG"
 
+###############################################################################
+# Enabling features in poolsets with remote replicas is not supported now,
+# so we have to use the following workaround to enable
+# the POOL_FEAT_CHECK_BAD_BLOCKS compat feature in such poolset.
+# We create the auxiliary poolset without the remote replica
+# and enable this compat feature on all nodes separately.
+
+POOLSET_LOCAL_AUX=${POOLSET_LOCAL}_aux
+
+create_poolset $DIR/${POOLSET_LOCAL_AUX} \
+	8M:${MOUNT_DIR}/pool.local.part.0:x \
+	8M:${MOUNT_DIR}/pool.local.part.1:x
+
+copy_files_to_node 0 ${NODE_DIR[0]} $DIR/${POOLSET_LOCAL_AUX}
+
+turn_on_checking_bad_blocks_node 0 ${NODE_DIR[0]}/${POOLSET_LOCAL_AUX}
+turn_on_checking_bad_blocks_node 1 ${NODE_DIR[1]}/${POOLSET_REMOTE}
+
+###############################################################################
+
 # inject bad block in the part #0
 FILE=${MOUNT_DIR}/pool.local.part.0
 FIRST_SECTOR=$(expect_normal_exit run_on_node 0 ../extents $FILE -l 1000)

--- a/src/test/pmempool_sync_remote/TEST34
+++ b/src/test/pmempool_sync_remote/TEST34
@@ -95,6 +95,25 @@ copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE
 expect_normal_exit run_on_node 0 ../pmempool rm -sf ${NODE_DIR[0]}$POOLSET_LOCAL
 expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT c v &>> $LOG"
 
+###############################################################################
+# Enabling features in poolsets with remote replicas is not supported now,
+# so we have to use the following workaround to enable
+# the POOL_FEAT_CHECK_BAD_BLOCKS compat feature in such poolset.
+# We create the auxiliary poolset without the remote replica
+# and enable this compat feature on all nodes separately.
+
+POOLSET_LOCAL_AUX=${POOLSET_LOCAL}_aux
+
+create_poolset $DIR/${POOLSET_LOCAL_AUX} \
+	8M:${NODE_DIR[0]}/pool.local:x
+
+copy_files_to_node 0 ${NODE_DIR[0]} $DIR/${POOLSET_LOCAL_AUX}
+
+turn_on_checking_bad_blocks_node 0 ${NODE_DIR[0]}/${POOLSET_LOCAL_AUX}
+turn_on_checking_bad_blocks_node 1 ${NODE_DIR[1]}/${POOLSET_REMOTE}
+
+###############################################################################
+
 # inject bad block:
 FILE=$MOUNT_DIR/pool.remote
 FIRST_SECTOR=$(expect_normal_exit run_on_node 1 ../extents $FILE -l 0)

--- a/src/test/pmempool_sync_remote/TEST35
+++ b/src/test/pmempool_sync_remote/TEST35
@@ -95,6 +95,25 @@ copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE
 expect_normal_exit run_on_node 0 ../pmempool rm -sf ${NODE_DIR[0]}$POOLSET_LOCAL
 expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT c v &>> $LOG"
 
+###############################################################################
+# Enabling features in poolsets with remote replicas is not supported now,
+# so we have to use the following workaround to enable
+# the POOL_FEAT_CHECK_BAD_BLOCKS compat feature in such poolset.
+# We create the auxiliary poolset without the remote replica
+# and enable this compat feature on all nodes separately.
+
+POOLSET_LOCAL_AUX=${POOLSET_LOCAL}_aux
+
+create_poolset $DIR/${POOLSET_LOCAL_AUX} \
+	8M:${NODE_DIR[0]}/pool.local:x
+
+copy_files_to_node 0 ${NODE_DIR[0]} $DIR/${POOLSET_LOCAL_AUX}
+
+turn_on_checking_bad_blocks_node 0 ${NODE_DIR[0]}/${POOLSET_LOCAL_AUX}
+turn_on_checking_bad_blocks_node 1 ${NODE_DIR[1]}/${POOLSET_REMOTE}
+
+###############################################################################
+
 # inject bad block:
 FILE=$MOUNT_DIR/pool.remote
 FIRST_SECTOR=$(expect_normal_exit run_on_node 1 ../extents $FILE -l 1000)


### PR DESCRIPTION
It fixes a regression:
- introduced by the commit: fbf58ac4
- than hidden by the commit: 3934541f
- and revealed again by the commit: ef225bf8

These four tests fail on Jenkins now. This patch fixes them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3353)
<!-- Reviewable:end -->
