### PR TITLE
test: change obj_fragmentation2 TEST8 into long

### DIFF
--- a/src/test/obj_fragmentation2/TEST8
+++ b/src/test/obj_fragmentation2/TEST8
@@ -35,7 +35,7 @@
 # standard unit test setup
 . ../unittest/unittest.sh
 
-require_test_type medium
+require_test_type long
 
 require_fs_type pmem
 require_build_type static-nondebug

--- a/src/test/obj_fragmentation2/TEST8.PS1
+++ b/src/test/obj_fragmentation2/TEST8.PS1
@@ -38,7 +38,7 @@
 # standard unit test setup
 . ..\unittest\unittest.ps1
 
-require_test_type medium
+require_test_type long
 
 require_fs_type pmem
 require_build_type nondebug


### PR DESCRIPTION
This test has the tendency to exceed our timeout threshold for medium
tests, so let's just make into a long.
It would be difficult to change the implementation, since it's
replicates a workload described in a research paper.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3356)
<!-- Reviewable:end -->
