### PR TITLE
test: add workaround in pmempool_sync_remote/TEST32 test

### DIFF
--- a/src/common/badblock_linux.c
+++ b/src/common/badblock_linux.c
@@ -145,6 +145,10 @@ os_badblocks_get(const char *file, struct badblocks *bbs)
 			bb_off = bb_beg + exts->extents[e].offset_logical
 					- exts->extents[e].offset_physical;
 
+			LOG(4,
+				"bad block found: physical offset: %llu, length: %llu",
+				bb_beg, bb_len);
+
 			/* check if offset is block-aligned */
 			not_block_aligned = bb_off & (exts->blksize - 1);
 			if (not_block_aligned) {
@@ -155,7 +159,8 @@ os_badblocks_get(const char *file, struct badblocks *bbs)
 			/* check if length is block-aligned */
 			bb_len = ALIGN_UP(bb_len, exts->blksize);
 
-			LOG(4, "bad block found: offset: %llu, length: %llu",
+			LOG(4,
+				"bad block found: logical offset: %llu, length: %llu",
 				bb_off, bb_len);
 
 			/*
@@ -275,8 +280,8 @@ os_badblocks_clear_file(const char *file, struct badblocks *bbs)
 		off_t length = (off_t)bbs->bbv[b].length;
 
 		LOG(10,
-			"clearing bad block: logical offset %li length %li (in 512B sectors)",
-			B2SEC(offset), B2SEC(length));
+			"clearing bad block: logical offset %li length %li (in 512B sectors) -- '%s'",
+			B2SEC(offset), B2SEC(length), file);
 
 		/* deallocate bad blocks */
 		if (fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,

--- a/src/common/extent_linux.c
+++ b/src/common/extent_linux.c
@@ -191,6 +191,8 @@ os_extents_get(const char *path, struct extents *exts)
 		goto error_free;
 	}
 
+	LOG(10, "path %s has %u extents:", path, fmap->fm_extent_count);
+
 	unsigned e;
 	for (e = 0; e < fmap->fm_extent_count; e++) {
 		exts->extents[e].offset_physical =
@@ -198,6 +200,12 @@ os_extents_get(const char *path, struct extents *exts)
 		exts->extents[e].offset_logical =
 						fmap->fm_extents[e].fe_logical;
 		exts->extents[e].length = fmap->fm_extents[e].fe_length;
+
+		LOG(10, "   #%u: off_phy: %lu off_log; %lu len: %lu",
+			e,
+			exts->extents[e].offset_physical,
+			exts->extents[e].offset_logical,
+			exts->extents[e].length);
 	}
 
 	ret = 0;

--- a/src/test/pmempool_sync_remote/TEST32
+++ b/src/test/pmempool_sync_remote/TEST32
@@ -139,6 +139,16 @@ expect_abnormal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $
 expect_bad_blocks_node 0
 
 expect_normal_exit run_on_node 0 "../pmempool sync -b -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+
+#
+# This doubled pmempool-sync call is a workaround for a kernel bug that sometimes occurs.
+# Two bad blocks (one bad block in each of two parts) are supposed to be fixed during
+# the 1st pmempool-sync call by unlinking and recreating the broken parts (because the headers are zeroed).
+# Sometimes happens that one of recreated parts has the same bad block inside again.
+# It should be cleared by the 2nd pmempool-sync call.
+#
+expect_normal_exit run_on_node 0 "../pmempool sync -b -v ${NODE_DIR[0]}$POOLSET_LOCAL &>> $LOG"
+
 expect_normal_exit run_on_node 0 "../obj_verify ${NODE_DIR[0]}$POOLSET_LOCAL $LAYOUT v &>> $LOG"
 
 ndctl_nfit_test_fini_node 0 $MOUNT_DIR


### PR DESCRIPTION
This doubled pmempool-sync call is a workaround for a kernel bug
that sometimes occurs. Two bad blocks (one bad block in each of two parts)
are supposed to be fixed during the 1st pmempool-sync call
by unlinking and recreating the broken parts (because the headers
are zeroed). Sometimes happens that one of recreated parts
has the same bad block inside again. It should be cleared
by the 2nd pmempool-sync call.

- logs from the 1st run of pmempool-sync:

[badblock_linux.c:150] bad block found: physical offset: 8636416, length: 512
[badblock_linux.c:164] bad block found: logical offset: 0, length: 1024
[badblock_linux.c:150] bad block found: physical offset: 1254400, length: 512
[badblock_linux.c:164] bad block found: logical offset: 0, length: 1024

- logs from the 2nd run of pmempool-sync:

[badblock_linux.c:150] bad block found: physical offset: 1254400, length: 512
[badblock_linux.c:164] bad block found: logical offset: 3363840, length: 1024

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3368)
<!-- Reviewable:end -->
