### PR TITLE
benchmark: handle nonexisting affinity_list

### DIFF
--- a/src/benchmarks/pmembench.cpp
+++ b/src/benchmarks/pmembench.cpp
@@ -584,7 +584,8 @@ pmembench_init_workers(struct benchmark_worker **workers,
 			int cpu;
 			os_cpu_set_t cpuset;
 
-			if (*args->affinity_list != '\0') {
+			if (args->affinity_list &&
+			    *args->affinity_list != '\0') {
 				cpu = pmembench_parse_affinity(
 					args->affinity_list, &saveptr);
 				if (cpu == -1) {


### PR DESCRIPTION
Turning on thread_affinity without providing affinity_list results in nonexisting affinity_list.
This patch handles nonexisting affinity_list case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3369)
<!-- Reviewable:end -->
