### PR TITLE
bench: fix two obj_direct scenarios crashing

### DIFF
--- a/src/benchmarks/pmembench_obj_gen.cfg
+++ b/src/benchmarks/pmembench_obj_gen.cfg
@@ -19,13 +19,14 @@ data-size = 1024
 objects = 1:*10:100000
 type-number = rand
 
-[obj_open_threads]
-bench = obj_open
-threads = 1:+1:10
-data-size = 1024
-min-size = 1
-objects = 1000
-type-number = rand
+# pmemobj_open/close are not yet thread-safe
+#[obj_open_threads]
+#bench = obj_open
+#threads = 1:+1:10
+#data-size = 1024
+#min-size = 1
+#objects = 1000
+#type-number = rand
 
 [obj_direct_threads_one_pool]
 bench = obj_direct

--- a/src/benchmarks/pmembench_obj_gen.cfg
+++ b/src/benchmarks/pmembench_obj_gen.cfg
@@ -30,16 +30,16 @@ type-number = rand
 [obj_direct_threads_one_pool]
 bench = obj_direct
 threads = 1:+1:10
-data-size = 1024
-min-size = 1
+data-size = 1025
+min-size = 1024
 type-number = rand
 one-pool = true
 
 [obj_direct_threads_many_pools]
 bench = obj_direct
 threads = 1:+1:10
-data-size = 1024
-min-size = 1
+data-size = 1025
+min-size = 1024
 type-number = rand
 
 [obj_direct_data_one_pool_one_obj]

--- a/src/benchmarks/pmemobj_gen.cpp
+++ b/src/benchmarks/pmemobj_gen.cpp
@@ -335,9 +335,8 @@ pobj_init(struct benchmark *bench, struct benchmark_args *args)
 	n_objs = bench_priv->args_priv->n_objs;
 	if (bench_priv->n_pools == 1)
 		n_objs *= args->n_threads;
-	psize = n_objs * args->dsize * args->n_threads * FACTOR;
-	if (psize < PMEMOBJ_MIN_POOL)
-		psize = PMEMOBJ_MIN_POOL;
+	psize = PMEMOBJ_MIN_POOL +
+		n_objs * args->dsize * args->n_threads * FACTOR;
 
 	/* assign type_number determining function */
 	bench_priv->type_mode =


### PR DESCRIPTION
They run afoul “recent” (Nov 2016) allocator optimizations that are not so optimal wrt taking randomly sized pieces out of a tiny pool.  As it's not what we benchmark here, just drop the randomization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3379)
<!-- Reviewable:end -->
