### PR TITLE
test: small SDS cleanups

### DIFF
--- a/src/test/obj_persist_count/TEST0
+++ b/src/test/obj_persist_count/TEST0
@@ -42,7 +42,6 @@ require_test_type medium
 
 require_fs_type non-pmem
 require_build_type debug nondebug
-require_sds ./obj_persist_count$EXESUFFIX
 
 # Pmemcheck would complain about making a store without adding to transaction
 # in this test. As the test counts the exact number of pmem_msync calls for

--- a/src/test/obj_persist_count/TEST1
+++ b/src/test/obj_persist_count/TEST1
@@ -42,7 +42,6 @@ require_test_type medium
 
 require_fs_type pmem
 require_build_type debug nondebug
-require_sds ./obj_persist_count$EXESUFFIX
 
 # Pmemcheck would complain about making a store without adding to transaction
 # in this test. As the test counts the exact number of pmem_persist calls for

--- a/src/test/pmempool_check/common.sh
+++ b/src/test/pmempool_check/common.sh
@@ -59,13 +59,13 @@ function pmempool_check_sds_init() {
 	create_poolset $POOLSET \
 		8M:$DIR/part00:x \
 		r 8M:$DIR/part10:x
-	expect_normal_exit $PMEMPOOL$EXESUFFIX create --layout=$LAYOUT obj $POOLSET
 
 	# enable SHUTDOWN_STATE feature
 	if [ "x$1" == "xenable-sds" ]; then
-		expect_normal_exit $PMEMPOOL$EXESUFFIX feature \
-			--enable "SHUTDOWN_STATE" $POOLSET
+		local conf="sds.at_create=1"
 	fi
+
+	PMEMOBJ_CONF="$conf" expect_normal_exit $PMEMPOOL$EXESUFFIX create --layout=$LAYOUT obj $POOLSET
 }
 
 # pmempool_check_sds -- perform shutdown state unittest


### PR DESCRIPTION
- remote unnecesary ```require_sds```
- enable SDS by ctl in pmempool_check unittests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3380)
<!-- Reviewable:end -->
