### PR TITLE
bench: improve obj_direct tests

### DIFF
--- a/src/benchmarks/pmemobj_gen.cpp
+++ b/src/benchmarks/pmemobj_gen.cpp
@@ -542,9 +542,16 @@ pobj_direct_op(struct benchmark *bench, struct operation_info *info)
 	auto *bench_priv = (struct pobj_bench *)pmembench_get_priv(bench);
 	auto *pw = (struct pobj_worker *)info->worker->priv;
 	size_t idx = bench_priv->obj(info->index);
-	if (pmemobj_direct(pw->oids[idx]) == nullptr)
-		return -1;
+#define OBJ_DIRECT_NITER 1024
+	/*
+	 * As we measure a very fast operation, we need a loop inside the
+	 * test harness.
+	 */
+	for (int i = 0; i < OBJ_DIRECT_NITER; i++)
+		if (pmemobj_direct(pw->oids[idx]) == nullptr)
+			return -1;
 	return 0;
+#undef OBJ_DIRECT_NITER
 }
 
 /*

--- a/src/benchmarks/pmemobj_gen.cpp
+++ b/src/benchmarks/pmemobj_gen.cpp
@@ -542,14 +542,19 @@ pobj_direct_op(struct benchmark *bench, struct operation_info *info)
 	auto *bench_priv = (struct pobj_bench *)pmembench_get_priv(bench);
 	auto *pw = (struct pobj_worker *)info->worker->priv;
 	size_t idx = bench_priv->obj(info->index);
+	/* Query an invalid uuid:off pair to invalidate the cache. */
+	PMEMoid bad = {1, 1};
 #define OBJ_DIRECT_NITER 1024
 	/*
 	 * As we measure a very fast operation, we need a loop inside the
 	 * test harness.
 	 */
-	for (int i = 0; i < OBJ_DIRECT_NITER; i++)
+	for (int i = 0; i < OBJ_DIRECT_NITER; i++) {
 		if (pmemobj_direct(pw->oids[idx]) == nullptr)
 			return -1;
+		if (pmemobj_direct(bad) != nullptr)
+			return -1;
+	}
 	return 0;
 #undef OBJ_DIRECT_NITER
 }


### PR DESCRIPTION
As obj_direct calls are very fast compared to the test harness overhead, the results weren't visible in the noise — thus, we need to wrap them in a loop inside rather than outside the harness.  We also need to avoid the cache.

Here's also a simple Perl tool to compare the results of two benchmarks, giving a coloured overview.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3394)
<!-- Reviewable:end -->
