### PR TITLE
test: add tool for checking mmap under valgrind

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -361,6 +361,9 @@ sparse  : TARGET = sparse
 
 DIR_SYNC=$(TOP)/src/test/.sync-dir
 SYNC_EXT=synced
+TESTCONFIG=$(TOP)/src/test/testconfig.sh
+UNITTEST=$(TOP)/src/test/unittest/unittest.sh
+FILE_MAX_DAX_DEVICES=$(TOP)/src/test/tools/anonymous_mmap/max_dax_devices
 
 all test format sparse: $(TESTS_BUILD)
 
@@ -391,11 +394,16 @@ memcheck-summary-errors:
 memcheck-summary-leaks:
 	grep "in use at exit" */memcheck*.log | grep -v " 0 bytes in 0 blocks" || true
 
-check: sync-remotes
+$(FILE_MAX_DAX_DEVICES): $(TESTCONFIG)
+	@./tools/anonymous_mmap/check_max_mmap.sh
+
+global-checks: $(UINTTEST) $(FILE_MAX_DAX_DEVICES)
+
+check: sync-remotes global-checks
 	@./RUNTESTS $(RUNTEST_OPTIONS) $(TESTS)
 	@echo "No failures."
 
-check-remote-quiet: sync-remotes
+check-remote-quiet: sync-remotes global-checks
 	@MAKEFLAGS="$(MAKEFLAGS)" ./RUNTESTS $(RUNTEST_OPTIONS) $(REMOTE_TESTS)
 
 sync-remotes: test
@@ -457,8 +465,6 @@ pcheck-remote: TARGET = pcheck
 pcheck-remote: $(REMOTE_TESTS)
 	@echo "No failures."
 
-TESTCONFIG=$(TOP)/src/test/testconfig.sh
-
 $(TESTCONFIG):
 
 SUPP_SYNC_FILES=$(shell echo *.supp | sed s/supp/$(SYNC_EXT)/g)
@@ -488,4 +494,5 @@ endif
 .PHONY: all check clean clobber cstyle pcheck pcheck-blk pcheck-log pcheck-obj\
 	 pcheck-other pcheck-pmem pcheck-pmempool pcheck-vmem pcheck-vmmalloc\
 	 test unittest tools check-remote format pcheck-libpmempool\
-	 pcheck-rpmem pcheck-local pcheck-remote sync-remotes $(TESTS_BUILD)
+	 pcheck-rpmem pcheck-local pcheck-remote sync-remotes $(TESTS_BUILD)\
+	 global-checks

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -472,6 +472,13 @@ test: all
 
 TOOLS=../tools
 
+$(TOOLS)/anonymous_mmap/anonymous_mmap:
+	$(MAKE) -C $(TOOLS)/anonymous_mmap all
+
+ifeq ($(USE_ANONYMOUS_MMAP), y)
+all: $(TOOLS)/anonymous_mmap/anonymous_mmap
+endif
+
 $(TOOLS)/pmemspoil/pmemspoil:
 	$(MAKE) -C $(TOOLS)/pmemspoil all
 

--- a/src/test/tools/anonymous_mmap/.gitignore
+++ b/src/test/tools/anonymous_mmap/.gitignore
@@ -1,0 +1,2 @@
+anonymous_mmap
+max_dax_devices

--- a/src/test/tools/anonymous_mmap/Makefile
+++ b/src/test/tools/anonymous_mmap/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2018, Intel Corporation
+# Copyright 2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,56 +31,15 @@
 #
 
 #
-# src/test/tools/Makefile -- build unit test helpers
+# src/test/tools/anonymous_mmap/Makefile -- Makefile for anonymous_mmap
 #
 
-TOP = ../../..
+TOP = ../../../..
 
-TESTCONFIG=$(TOP)/src/test/testconfig.sh
+TARGET = anonymous_mmap
+OBJS = anonymous_mmap.o
 
-DIRS = \
-       pmemspoil\
-       pmemwrite\
-       pmemalloc\
-       pmemobjcli\
-       pmemdetect\
-       ctrld\
-       bttcreate\
-       fip\
-       ddmap\
-       cmpmap\
-       extents\
-       fallocate_detect\
-       obj_verify\
-       usc_permission_check\
-       anonymous_mmap
+LIBPMEM=y
+LIBPMEMCOMMON=y
 
-REMOTE_TOOLS = \
-	ctrld\
-	extents\
-	fip\
-	obj_verify\
-	pmemobjcli\
-	pmemspoil\
-	pmemdetect
-
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-cstyle  : TARGET = cstyle
-format  : TARGET = format
-sync-remotes : TARGET = sync-remotes
-sparse  : TARGET = sparse
-
-all test cstyle clean clobber format sparse: $(DIRS)
-
-$(TESTCONFIG):
-
-sync-remotes: $(REMOTE_TOOLS) $(TESTCONFIG)
-
-$(DIRS):
-	$(MAKE) -C $@ $(TARGET)
-
-check pcheck: all
-
-.PHONY: all clean clobber cstyle format check pcheck $(DIRS)
+include $(TOP)/src/tools/Makefile.inc

--- a/src/test/tools/anonymous_mmap/README
+++ b/src/test/tools/anonymous_mmap/README
@@ -1,0 +1,8 @@
+Persistent Memory Development Kit
+
+This is src/test/tools/anonymous_mmap/README.
+
+This directory contains a simple tool 'anonymous_mmap' for verifying ability
+for anonymously mmapping (huge) amount of memory into the virtual address space.
+
+'anonymous_mmap' takes one argument - length in bytes

--- a/src/test/tools/anonymous_mmap/anonymous_mmap.c
+++ b/src/test/tools/anonymous_mmap/anonymous_mmap.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * anonymous_mmap.c -- tool for verifying if given memory length can be
+ *			anonymously mmapped
+ */
+
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <errno.h>
+
+#include "out.h"
+
+int
+main(int argc, char *argv[])
+{
+	out_init("ANONYMOUS_MMAP", "ANONYMOUS_MMAP", "", 1, 0);
+
+	if (argc != 2) {
+		out("Usage: %s <length>", argv[0]);
+		return -1;
+	}
+
+	const size_t length = (size_t)atoll(argv[1]);
+	char *addr = mmap(NULL, length, PROT_READ,
+				MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+	if (addr == MAP_FAILED) {
+		out("anonymous_mmap.c: Failed to mmap length=%lu of memory, "
+			"errno=%d", length, errno);
+		return errno;
+	}
+
+	out_fini();
+
+	return 0;
+}

--- a/src/test/tools/anonymous_mmap/check_max_mmap.sh
+++ b/src/test/tools/anonymous_mmap/check_max_mmap.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/tools/anonymous_mmap/check_max_mmap.sh -- checks how many DAX
+#               devices can be mapped under Valgrind and saves the number in
+#               src/test/tools/anonymous_mmap/max_mmap_file.
+#
+
+DIR_CHECK_MAX_MMAP="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+FILE_MAX_DAX_DEVICES="$DIR_CHECK_MAX_MMAP/max_dax_devices"
+ANONYMOUS_MMAP="$DIR_CHECK_MAX_MMAP/anonymous_mmap.static-nondebug"
+
+source "$DIR_CHECK_MAX_MMAP/../../testconfig.sh"
+
+#
+# get_devdax_size -- get the size of a device dax
+#
+function get_devdax_size() {
+	local device=$1
+	local path=${DEVICE_DAX_PATH[$device]}
+	local major_hex=$(stat -c "%t" $path)
+	local minor_hex=$(stat -c "%T" $path)
+	local major_dec=$((16#$major_hex))
+	local minor_dec=$((16#$minor_hex))
+	cat /sys/dev/char/$major_dec:$minor_dec/size
+}
+
+function fatal() {
+	echo "Exit check_max_mmap.sh: $*" >&2
+	exit 1
+}
+
+# check if DEVICE_DAX_PATH specifies at least one DAX device
+if [ ${#DEVICE_DAX_PATH[@]} -lt 1 ]; then
+	return
+fi
+
+# check if valgrind package is installed
+VALGRINDEXE=`which valgrind 2>/dev/null`
+ret=$?
+if [ $ret -ne 0 ]; then
+	return
+fi
+
+# check if memcheck tool is installed
+$VALGRINDEXE --tool=memcheck --help 2>&1 | grep -qi "memcheck is Copyright (c)" && true
+if [ $? -ne 0 ]; then
+	return
+fi
+
+# checks how many DAX devices can be mmapped under Valgrind and save the number
+# in $FILE_MAX_DAX_DEVICES file
+bytes="0"
+max_devices="0"
+for index in ${!DEVICE_DAX_PATH[@]}
+do
+	curr=$(get_devdax_size $index)
+	if [[ curr -eq 0 ]]; then
+		fatal "size of DAX device pointed by DEVICE_DAX_PATH[$index] equals 0. Invalid path is set in testconfig.sh."
+	fi
+
+	$VALGRINDEXE --tool=memcheck --quiet $ANONYMOUS_MMAP $((bytes + curr))
+	status=$?
+	if [[ status -ne 0 ]]; then
+		break
+	fi
+
+	((bytes = bytes + curr))
+	((max_devices++))
+done
+
+echo "$max_devices" > "$FILE_MAX_DAX_DEVICES"
+
+echo "check_max_mmap.sh: maximum possible anonymous mmap under Valgrind: $bytes bytes, equals to size of $max_devices DAX device(s). Value saved in $FILE_MAX_DAX_DEVICES."

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -96,6 +96,7 @@ LIB_TOOLS="../../tools"
 [ "$FALLOCATE_DETECT" ] || FALLOCATE_DETECT=$TOOLS/fallocate_detect/fallocate_detect.static-nondebug
 [ "$OBJ_VERIFY" ] || OBJ_VERIFY=$TOOLS/obj_verify/obj_verify
 [ "$USC_PERMISSION" ] || USC_PERMISSION=$TOOLS/usc_permission_check/usc_permission_check.static-nondebug
+[ "$ANONYMOUS_MMAP" ] || ANONYMOUS_MMAP=$TOOLS/anonymous_mmap/anonymous_mmap.static-nondebug
 
 # force globs to fail if they don't match
 shopt -s failglob
@@ -355,7 +356,6 @@ function disable_exit_on_error() {
 	store_exit_on_error
 	set +e
 }
-
 
 #
 # get_files -- print list of files in the current directory matching the given regex to stdout
@@ -1203,6 +1203,7 @@ function require_dev_dax_node() {
 # number of Device DAX devices
 #
 function require_dax_devices() {
+	REQUIRE_DAX_DEVICES=$1
 	require_dev_dax_node $1
 }
 
@@ -2530,6 +2531,31 @@ function create_holey_file_on_node() {
 }
 
 #
+# require_mmap_under_valgrind -- only allow script to continue if mapping is
+#				possible under Valgrind with required length
+#				(sum of required DAX devices size).
+#				This function is being called internally in
+#				setup() function.
+#
+function require_mmap_under_valgrind() {
+
+	local FILE_MAX_DAX_DEVICES="../tools/anonymous_mmap/max_dax_devices"
+
+	if [ -z "$REQUIRE_DAX_DEVICES" ]; then
+		return
+	fi
+
+	if [ ! -f "$FILE_MAX_DAX_DEVICES" ]; then
+		fatal "$FILE_MAX_DAX_DEVICES not found. Run make global-checks."
+	fi
+
+	if [ "$REQUIRE_DAX_DEVICES" -gt "$(< $FILE_MAX_DAX_DEVICES)" ]; then
+		msg "$UNITTEST_NAME: SKIP: anonymous mmap under Valgrind not possible for $REQUIRE_DAX_DEVICES DAX device(s)."
+		exit 0
+	fi
+}
+
+#
 # setup -- print message that test setup is commencing
 #
 function setup() {
@@ -2560,6 +2586,10 @@ function setup() {
 
 	if [ "$CHECK_TYPE" != "none" ]; then
 		require_valgrind
+
+		# detect possible Valgrind mmap issues and skip uncertain tests
+		require_mmap_under_valgrind
+
 		export VALGRIND_LOG_FILE=$CHECK_TYPE${UNITTEST_NUM}.log
 		MCSTR="/$CHECK_TYPE"
 	else


### PR DESCRIPTION
When the client application runs against the Valgrind, the Valgrind intercepts the mmap call made by the client. For big length requests (i.e. in tests run on NVDIMMs) Valgrind may fail and it becomes a limitation which must be handled by Valgrind maintainers in the future.
This commit provides a simple way to detect possible valgrind mmap issues and skip uncertain tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3395)
<!-- Reviewable:end -->
