### PR TITLE
common: let style_check.sh find clang-format-3.8

### DIFF
--- a/utils/style_check.sh
+++ b/utils/style_check.sh
@@ -39,6 +39,8 @@ CSTYLE_ARGS=()
 CLANG_ARGS=()
 CHECK_TYPE=$1
 
+[ -z "$clang_format_bin" ] && which clang-format-3.8 >/dev/null &&
+	clang_format_bin=clang-format-3.8
 [ -z "$clang_format_bin" ] && clang_format_bin=clang-format
 
 #


### PR DESCRIPTION
Without this, it says: ``SKIP: requires clang-format version 3.8`` even if clang-format-3.8 is installed, on distributions where the default version of Clang is other than 3.8.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3398)
<!-- Reviewable:end -->
