### PR TITLE
test: do not require the verbs provider when it is not tested

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -2112,7 +2112,7 @@ function require_node_libfabric() {
 
 	require_pkg libfabric "$version"
 	require_node_pkg $N libfabric "$version"
-	if [ "$RPMEM_DISABLE_LIBIBVERBS" != "y" ]; then
+	if [ "$RPMEM_PROVIDER" == "verbs" ]; then
 		if ! fi_info --list | grep -q verbs; then
 			msg "$UNITTEST_NAME: SKIP libfabric not compiled with verbs provider"
 			exit 0

--- a/utils/docker/run-build-package.sh
+++ b/utils/docker/run-build-package.sh
@@ -40,9 +40,6 @@ set -e
 # Prepare build enviromnent
 ./prepare-for-build.sh
 
-# Build librpmem even if libfabric is not compiled with ibverbs
-export RPMEM_DISABLE_LIBIBVERBS=y
-
 # Create fake tag, so that package has proper 'version' field
 git config user.email "test@package.com"
 git config user.name "test package"

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,9 +39,6 @@ set -e
 
 # Prepare build environment
 ./prepare-for-build.sh
-
-# Build librpmem even if libfabric is not compiled with ibverbs
-export RPMEM_DISABLE_LIBIBVERBS=y
 
 # Build all and run tests
 cd $WORKDIR

--- a/utils/docker/run-coverage.sh
+++ b/utils/docker/run-coverage.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,9 +39,6 @@ set -e
 
 # Get and prepare PMDK source
 ./prepare-for-build.sh
-
-# Build librpmem even if libfabric is not compiled with ibverbs
-export RPMEM_DISABLE_LIBIBVERBS=y
 
 # Hush error messages, mainly from Valgrind
 export UT_DUMP_LINES=0

--- a/utils/docker/run-coverity.sh
+++ b/utils/docker/run-coverity.sh
@@ -44,9 +44,6 @@ echo -n | openssl s_client -connect scan.coverity.com:443 | \
 	sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | \
 	sudo tee -a /etc/ssl/certs/ca-;
 
-# Build librpmem even if libfabric is not compiled with ibverbs
-export RPMEM_DISABLE_LIBIBVERBS=y
-
 export COVERITY_SCAN_PROJECT_NAME="$TRAVIS_REPO_SLUG"
 [[ "$TRAVIS_EVENT_TYPE" == "cron" ]] \
 	&& export COVERITY_SCAN_BRANCH_PATTERN="master" \


### PR DESCRIPTION
I have TEST_PROVIDERS=sockets set in testconfig.sh and when I ran obj_rpmem_basic_integration/TEST0 I got:

SETUP (medium/pmem/debug/sockets/GPSPM)
SKIP libfabric not compiled with verbs provider
SETUP (medium/pmem/debug/sockets/APM)
SKIP libfabric not compiled with verbs provider

This patch fixes this issue and removes the RPMEM_DISABLE_LIBIBVERBS variable, because it is not needed any more since this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3399)
<!-- Reviewable:end -->
