### PR TITLE
common: accept ARCH=amd64

### DIFF
--- a/src/common.inc
+++ b/src/common.inc
@@ -88,6 +88,12 @@ get_arch = $(shell $(CC) -dumpmachine | awk -F'[/-]' '{print $$1}')
 ifeq ($(ARCH),)
 export ARCH := $(call get_arch)
 endif
+ifeq ($(ARCH),amd64)
+override ARCH := x86_64
+endif
+ifeq ($(ARCH),arm64)
+override ARCH := aarch64
+endif
 
 ifeq ($(PKG_CONFIG_CHECKED),)
 ifeq ($(shell command -v $(PKG_CONFIG) && echo y || echo n), n)


### PR DESCRIPTION
Distributions use names like "amd64" or "arm64" that are distinct from GNU triplets.  People tend to use those instead of what our makefiles expect.  Let's accept them.

Ref: pmem/issues#971

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3401)
<!-- Reviewable:end -->
