### PR TITLE
test: fix rpmemd_db test

### DIFF
--- a/src/test/rpmemd_db/TEST0
+++ b/src/test/rpmemd_db/TEST0
@@ -71,7 +71,7 @@ expect_normal_exit ./rpmemd_db$EXESUFFIX $LOG_FILE $ROOT_DIR \
 				pool0.set pool1.set
 
 mv rpmem0.log rpmem0_tmp.log
-$GREP -e flock -e Non-empty rpmem0_tmp.log > rpmem0.log || true
+$GREP -e " flock " -e Non-empty rpmem0_tmp.log > rpmem0.log || true
 
 check
 

--- a/src/test/rpmemd_db/TEST1
+++ b/src/test/rpmemd_db/TEST1
@@ -71,7 +71,7 @@ expect_normal_exit ./rpmemd_db$EXESUFFIX $LOG_FILE $ROOT_DIR \
 			pool0.set pool1.set
 
 mv rpmem1.log rpmem1_tmp.log
-$GREP -e flock -e Non-empty rpmem1_tmp.log > rpmem1.log || true
+$GREP -e " flock " -e Non-empty rpmem1_tmp.log > rpmem1.log || true
 
 check
 


### PR DESCRIPTION
Fact 1) rpmemd_db test creates pools with randomly generated headers
filling them using characters from a-z range.

Fact 2) librpmem sometimes prints a pool signature.

Fact 3) After the test binary finishes, test scripts look for some
predefined messages in rpmem log file. One of those messages is about
"flock" system call failure.

If you connect those facts it's clear it's possible that the randomly
generated header can contain the word "flock" in pool signature,
which will mess up log matching.

It seems quite impossible, but this is exactly what happened on
Travis recently.

rpmem0.log contained:
<rpmemd_db>: <3> [set.c:2551 util_header_check_remote] valid header, signature "fnwflock"

Fix this by modifying the grep expression to never hit anything in
the randomly generated header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3408)
<!-- Reviewable:end -->
