### PR TITLE
common: change clang-format req 3.8->6.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ Before contributing please remember to run:
 ```
 
 This will check all C/C++ files in the tree for style issues. To check C++
-files you have to have clang-format version 3.8+, otherwise they will be
+files you have to have clang-format version 6.0, otherwise they will be
 skipped. If you want to run this target automatically at build time, you can
 pass CSTYLEON=1 to make. If you want cstyle to be run, but not fail the build,
 pass CSTYLEON=2 to make.

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -30,6 +30,4 @@ AlwaysBreakTemplateDeclarations: true
 AccessModifierOffset: -8
 AllowShortBlocksOnASingleLine: false
 AllowShortFunctionsOnASingleLine: false
-
-# Uncomment after switching to clang-format >= 3.9
-#BreakStringLiterals: false
+BreakStringLiterals: false

--- a/src/benchmarks/log.cpp
+++ b/src/benchmarks/log.cpp
@@ -509,8 +509,8 @@ log_init(struct benchmark *bench, struct benchmark_args *args)
 
 	if (args->is_poolset || type == TYPE_DEVDAX) {
 		if (lb->args->fileio) {
-			fprintf(stderr, "fileio not supported on device dax "
-					"nor poolset\n");
+			fprintf(stderr,
+				"fileio not supported on device dax nor poolset\n");
 			ret = -1;
 			goto err_free_lb;
 		}

--- a/src/benchmarks/map_bench.cpp
+++ b/src/benchmarks/map_bench.cpp
@@ -521,8 +521,8 @@ map_common_init(struct benchmark *bench, struct benchmark_args *args)
 	}
 
 	if (map_bench->margs->ext_tx && args->n_threads > 1) {
-		fprintf(stderr, "external transaction "
-				"requires single thread\n");
+		fprintf(stderr,
+			"external transaction requires single thread\n");
 		goto err_free_bench;
 	}
 

--- a/src/benchmarks/pmem_flush.cpp
+++ b/src/benchmarks/pmem_flush.cpp
@@ -151,7 +151,9 @@ struct op_mode {
 };
 
 static struct op_mode modes[] = {
-	{"stat", mode_stat}, {"seq", mode_seq}, {"rand", mode_rand},
+	{"stat", mode_stat},
+	{"seq", mode_seq},
+	{"rand", mode_rand},
 };
 
 #define MODES (sizeof(modes) / sizeof(modes[0]))

--- a/src/benchmarks/pmem_memset.cpp
+++ b/src/benchmarks/pmem_memset.cpp
@@ -343,9 +343,8 @@ memset_init(struct benchmark *bench, struct benchmark_args *args)
 
 	if (mb->pargs->memset) {
 		if (mb->pargs->persist && mb->pargs->msync) {
-			fprintf(stderr, "Invalid benchmark parameters: "
-					"persist and msync cannot be specified "
-					"together\n");
+			fprintf(stderr,
+				"Invalid benchmark parameters: persist and msync cannot be specified together\n");
 			ret = -1;
 			goto err_free_offsets;
 		}

--- a/src/benchmarks/pmembench.cpp
+++ b/src/benchmarks/pmembench.cpp
@@ -468,8 +468,9 @@ pmembench_print_results(struct benchmark *bench, struct benchmark_args *args,
 	size_t i;
 	for (i = 0; i < bench->nclos; i++) {
 		if (!bench->clos[i].ignore_in_res)
-			printf(";%s", benchmark_clo_str(&bench->clos[i], args,
-							bench->args_size));
+			printf(";%s",
+			       benchmark_clo_str(&bench->clos[i], args,
+						 bench->args_size));
 	}
 
 	if (bench->info->print_bandwidth)
@@ -679,8 +680,8 @@ compare_doubles(const void *a1, const void *b1)
 }
 
 /*
-* compare_uint64t -- comparing function used for sorting
-*/
+ * compare_uint64t -- comparing function used for sorting
+ */
 static int
 compare_uint64t(const void *a1, const void *b1)
 {
@@ -1392,8 +1393,8 @@ pmembench_run(struct pmembench *pb, struct benchmark *bench)
 			}
 
 			if (!is_absolute_path_to_directory(args->fname)) {
-				fprintf(stderr, "path must be absolute and "
-						"point to a directory\n");
+				fprintf(stderr,
+					"path must be absolute and point to a directory\n");
 				goto out;
 			}
 		} else {
@@ -1401,8 +1402,8 @@ pmembench_run(struct pmembench *pb, struct benchmark *bench)
 				util_is_poolset_file(args->fname) == 1;
 			if (args->is_poolset) {
 				if (!bench->info->allow_poolset) {
-					fprintf(stderr, "poolset files not "
-							"supported\n");
+					fprintf(stderr,
+						"poolset files not supported\n");
 					goto out;
 				}
 				args->fsize = util_poolset_size(args->fname);

--- a/src/benchmarks/pmemobj_atomic_lists.cpp
+++ b/src/benchmarks/pmemobj_atomic_lists.cpp
@@ -167,10 +167,10 @@ struct obj_worker {
 	size_t n_elm;		     /* number of elements in array */
 	fn_position_t *fn_positions; /* element access functions */
 	struct element elm;	  /* pointer to current element */
-				     /*
-				      * list_move is a pointer to structure storing variables used by
-				      * second list (used only for obj_move benchmark).
-				      */
+	/*
+	 * list_move is a pointer to structure storing variables used by
+	 * second list (used only for obj_move benchmark).
+	 */
 	struct obj_worker *list_move;
 };
 

--- a/src/benchmarks/poolset_util.cpp
+++ b/src/benchmarks/poolset_util.cpp
@@ -1,34 +1,34 @@
 /*
-* Copyright 2018, Intel Corporation
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions
-* are met:
-*
-*     * Redistributions of source code must retain the above copyright
-*       notice, this list of conditions and the following disclaimer.
-*
-*     * Redistributions in binary form must reproduce the above copyright
-*       notice, this list of conditions and the following disclaimer in
-*       the documentation and/or other materials provided with the
-*       distribution.
-*
-*     * Neither the name of the copyright holder nor the names of its
-*       contributors may be used to endorse or promote products derived
-*       from this software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-* A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-* OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-* SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <cassert>
 #include <fcntl.h>

--- a/src/benchmarks/rpmem_persist.cpp
+++ b/src/benchmarks/rpmem_persist.cpp
@@ -324,8 +324,8 @@ rpmem_poolset_init(const char *path, struct rpmem_bench *mb,
 	assert(rep);
 	assert(rep->remote == nullptr);
 	if (rep->nparts != 1) {
-		fprintf(stderr, "Multipart master replicas "
-				"are not supported\n");
+		fprintf(stderr,
+			"Multipart master replicas are not supported\n");
 		goto err_poolset_free;
 	}
 
@@ -377,8 +377,8 @@ rpmem_poolset_init(const char *path, struct rpmem_bench *mb,
 		}
 
 		if (mb->nlanes[r] < args->n_threads) {
-			fprintf(stderr, "Number of threads too large for "
-					"replica #%u (max: %u)\n",
+			fprintf(stderr,
+				"Number of threads too large for replica #%u (max: %u)\n",
 				r, mb->nlanes[r]);
 			r++; /* close current replica */
 			goto err_rpmem_close;

--- a/src/benchmarks/vmem.cpp
+++ b/src/benchmarks/vmem.cpp
@@ -494,8 +494,8 @@ vmem_init(struct benchmark *bench, struct benchmark_args *args)
 
 	/* vmem library is enable to create limited number of pools */
 	if (va->pool_per_thread && args->n_threads > MAX_POOLS) {
-		fprintf(stderr, "Maximum number of threads is %d for"
-				"pool-per-thread option\n",
+		fprintf(stderr,
+			"Maximum number of threads is %d for pool-per-thread option\n",
 			MAX_POOLS);
 		goto err;
 	}

--- a/src/common.inc
+++ b/src/common.inc
@@ -65,8 +65,8 @@ $(error Cannot evaluate version)
 endif
 
 ifeq ($(CLANG_FORMAT),)
-ifeq ($(shell command -v clang-format-3.8 > /dev/null && echo y || echo n), y)
-export CLANG_FORMAT ?= clang-format-3.8
+ifeq ($(shell command -v clang-format-6.0 > /dev/null && echo y || echo n), y)
+export CLANG_FORMAT ?= clang-format-6.0
 else
 export CLANG_FORMAT ?= clang-format
 endif

--- a/utils/style_check.sh
+++ b/utils/style_check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,8 +39,8 @@ CSTYLE_ARGS=()
 CLANG_ARGS=()
 CHECK_TYPE=$1
 
-[ -z "$clang_format_bin" ] && which clang-format-3.8 >/dev/null &&
-	clang_format_bin=clang-format-3.8
+[ -z "$clang_format_bin" ] && which clang-format >/dev/null &&
+	clang_format_bin=clang-format
 [ -z "$clang_format_bin" ] && clang_format_bin=clang-format
 
 #
@@ -51,15 +51,15 @@ function usage() {
 }
 
 #
-# require clang-format version 3.8
+# require clang-format version 6.0
 #
 function check_clang_version() {
 	set +e
 	which ${clang_format_bin} &> /dev/null && ${clang_format_bin} --version |\
-	grep "version 3\.8"\
+	grep "version 6\.0"\
 	&> /dev/null
 	if [ $? -ne 0 ]; then
-		echo "SKIP: requires clang-format version 3.8"
+		echo "SKIP: requires clang-format version 6.0"
 		exit 0
 	fi
 	set -e


### PR DESCRIPTION
Since distros are not upgraded clang check should skip.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3422)
<!-- Reviewable:end -->
