### PR TITLE
test: add require_free_space to obj_pmalloc_rand_mt/TEST1

### DIFF
--- a/src/test/obj_pmalloc_rand_mt/TEST1
+++ b/src/test/obj_pmalloc_rand_mt/TEST1
@@ -40,7 +40,10 @@
 
 require_fs_type pmem
 require_test_type medium
+
 setup
+
+require_free_space 2064M
 
 PMEM_IS_PMEM_FORCE=1 expect_normal_exit\
 	./obj_pmalloc_rand_mt$EXESUFFIX $DIR/testfile 8 1000 260000 1234


### PR DESCRIPTION
Otherwise obj_pmalloc_rand_mt/TEST1 can fail with the error:
obj_pmalloc_rand_mt/TEST1 pmemobj1.log <libpmemobj>: <1> \
[file.c:522 util_file_create] \
posix_fallocate "testfile", 2163886080: No space left on device

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3429)
<!-- Reviewable:end -->
