### PR TITLE
common: use better versioning scheme for git snapshots

### DIFF
--- a/utils/SRCVERSION.ps1
+++ b/utils/SRCVERSION.ps1
@@ -144,6 +144,7 @@ if ($null -ne $ver_array) {
             # <MAJOR>.<MINOR>[.<BUGFIX>]-rc<REVISION>-<BUILD>-<HASH>
             $REVISION += $ver_array[1].Substring("rc".Length)
             $PRERELEASE = $true
+            $version = "$($ver_array[0])-$($ver_array[1])+git$($ver_array[2]).$($ver_array[3])"
         } else {
             # <MAJOR>.<MINOR>[.<BUGFIX>]-<SOMETHING>-<BUILD>-<HASH>
             throw "Unknown version format"
@@ -151,6 +152,7 @@ if ($null -ne $ver_array) {
     } else {
         # <MAJOR>.<MINOR>[.<BUGFIX>]-<BUILD>-<HASH>
         $REVISION += 100
+        $version = "$($ver_array[0])+git$($ver_array[1]).$($ver_array[2])"
     }
 
     if ($BUILD -eq 0) {

--- a/utils/pkg-common.sh
+++ b/utils/pkg-common.sh
@@ -64,50 +64,8 @@ function check_tool() {
 	fi
 }
 
-function format_version () {
-	echo $1 | sed 's|0*\([0-9]\+\)|\1|g'
-}
-
-function get_version_item() {
-	local INPUT=$1
-	local TARGET=$2
-	local REGEX="([^0-9]*)(([0-9]+\.){,2}[0-9]+)([.+-]?.*)"
-	local VERSION="0.0"
-	local RELEASE="-$INPUT"
-
-	if [[ $INPUT =~ $REGEX ]]
-	then
-		VERSION="${BASH_REMATCH[2]}"
-		RELEASE="${BASH_REMATCH[4]}"
-	fi
-
-	case $TARGET in
-		version)
-			echo -n $VERSION
-			;;
-		release)
-			echo -n $RELEASE
-			;;
-		*)
-			error "Wrong target"
-			exit 1
-			;;
-	esac
-}
-
 function get_version() {
-	local VERSION=$(get_version_item $1 version)
-	local RELEASE=$(get_version_item $1 release)
-
-	VERSION=$(format_version $VERSION)
-
-	if [ -z "$RELEASE" ]
-	then
-		echo -n $VERSION
-	else
-		RELEASE=${RELEASE//[-:_.]/"~"}
-		echo -n ${VERSION}${RELEASE}
-	fi
+	echo -n $1
 }
 
 function get_os() {

--- a/utils/version.sh
+++ b/utils/version.sh
@@ -69,7 +69,9 @@ cd "$1"
 
 GIT_DESCRIBE=$(git describe 2>/dev/null) && true
 if [ -n "$GIT_DESCRIBE" ]; then
-	echo "$GIT_DESCRIBE"
+	# 1.5-19-gb8f78a329 -> 1.5+git19.gb8f78a329
+	# 1.5-rc1-19-gb8f78a329 -> 1.5-rc1+git19.gb8f78a329
+	echo "$GIT_DESCRIBE" | sed "s/\([0-9.]*\)-rc\([0-9]*\)-\([0-9]*\)-\([0-9a-g]*\)/\1-rc\2+git\3.\4/" | sed "s/\([0-9.]*\)-\([0-9]*\)-\([0-9a-g]*\)/\1+git\2.\3/"
 	exit 0
 fi
 


### PR DESCRIPTION
Version with two dashes (like 1.5-19-gb8f78a329) confuses rpmbuild in
recent Fedoras, which makes it generate uninstallable -devel packages
(libpmem-devel doesn't have Provides: pkgconfig(libpmem) tag, which
doesn't satisfy Requires: pkgconfig(libpmem) in
libpmem[obj|blk|log]-devel).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3431)
<!-- Reviewable:end -->
