### PR TITLE
obj: fix pmemobj_check for pools with some sizes (1.4)

### DIFF
--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1400,8 +1400,10 @@ obj_check_basic_local(PMEMobjpool *pop, size_t mapped_size)
 		consistent = 0;
 	}
 
+	/* pop->heap_size can still be 0 at this point */
+	size_t heap_size = mapped_size - pop->heap_offset;
 	errno = palloc_heap_check((char *)pop + pop->heap_offset,
-		mapped_size);
+		heap_size);
 	if (errno != 0) {
 		LOG(2, "!heap_check");
 		consistent = 0;
@@ -1462,8 +1464,10 @@ obj_check_basic_remote(PMEMobjpool *pop, size_t mapped_size)
 
 	/* XXX add lane_check_remote */
 
+	/* pop->heap_size can still be 0 at this point */
+	size_t heap_size = mapped_size - pop->heap_offset;
 	errno = palloc_heap_check_remote((char *)pop + pop->heap_offset,
-		mapped_size, &pop->p_ops.remote);
+		heap_size, &pop->p_ops.remote);
 	if (errno != 0) {
 		LOG(2, "!heap_check_remote");
 		consistent = 0;


### PR DESCRIPTION
If the mapped size of the pool was within 2 megabytes of a multiple
of max zone size, the heap checking function was reading unitialized
data, leading to a segfault. The size passed to heap_check must be
the actual heap size with which the heap was originally initialized.

Ref: pmem/issues#975

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3433)
<!-- Reviewable:end -->
