### PR TITLE
 obj: fix pmemobj_check for pools with some sizes

### DIFF
--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1509,8 +1509,9 @@ obj_check_basic_local(PMEMobjpool *pop, size_t mapped_size)
 		consistent = 0;
 	}
 
+	size_t heap_size = pop->set->poolsize - pop->heap_offset;
 	errno = palloc_heap_check((char *)pop + pop->heap_offset,
-		mapped_size);
+		heap_size);
 	if (errno != 0) {
 		LOG(2, "!heap_check");
 		consistent = 0;
@@ -1571,8 +1572,9 @@ obj_check_basic_remote(PMEMobjpool *pop, size_t mapped_size)
 
 	/* XXX add lane_check_remote */
 
+	size_t heap_size = pop->set->poolsize - pop->heap_offset;
 	errno = palloc_heap_check_remote((char *)pop + pop->heap_offset,
-		mapped_size, &pop->p_ops.remote);
+		heap_size, &pop->p_ops.remote);
 	if (errno != 0) {
 		LOG(2, "!heap_check_remote");
 		consistent = 0;

--- a/src/test/obj_pool/TEST34
+++ b/src/test/obj_pool/TEST34
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_pool/TEST34 -- unit test for pmemobj_create
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+
+setup
+umask 0
+
+require_free_space 33G
+
+#
+# TEST0 non-existing file, poolsize > 0
+#
+expect_normal_exit ./obj_pool$EXESUFFIX c $DIR/testfile "test" 32768 0600
+
+check_files $DIR/testfile
+
+check
+
+pass

--- a/src/test/obj_pool/TEST34.PS1
+++ b/src/test/obj_pool/TEST34.PS1
@@ -1,0 +1,55 @@
+#
+# Copyright 2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_pool/TEST34 -- unit test for pmemobj_create
+#
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_test_type medium
+
+setup
+
+require_free_space 33G
+
+#
+# TEST0 non-existing file, poolsize > 0
+#
+expect_normal_exit $Env:EXE_DIR\obj_pool$Env:EXESUFFIX c $DIR\testfile test$Env:SUFFIX 32768 0600
+
+check_files $DIR\testfile
+
+check
+
+pass

--- a/src/test/obj_pool/out34.log.match
+++ b/src/test/obj_pool/out34.log.match
@@ -1,0 +1,4 @@
+obj_pool$(nW)TEST34: START: obj_pool$(nW)
+ $(nW)obj_pool$(nW) c $(nW)testfile test$(nW) 32768 0600
+$(nW)testfile: file size 34359738368 mode 0600
+obj_pool$(nW)TEST34: DONE


### PR DESCRIPTION
If the mapped size of the pool was within 2 megabytes of a multiple
of max zone size, the heap checking function was reading unitialized
data, leading to a segfault. The size passed to heap_check must be
the actual heap size with which the heap was originally initialized.

Ref: pmem/issues#975

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3435)
<!-- Reviewable:end -->
