### PR TITLE
common: do not run remote tests if libfabric is not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,15 @@ clobber:
 	$(RM) -r $(RPM_BUILDDIR) $(DPKG_BUILDDIR) rpm dpkg
 	$(RM) -f $(GIT_VERSION)
 
-test check pcheck check-remote: all
+require-rpmem:
+ifneq ($(BUILD_RPMEM),y)
+	$(error ERROR: cannot run remote tests because $(BUILD_RPMEM_INFO))
+endif
+
+check-remote: require-rpmem all
+	$(MAKE) -C src $@
+
+test check pcheck: all
 	$(MAKE) -C src $@
 
 cstyle:
@@ -143,4 +151,5 @@ install uninstall:
 	$(MAKE) -C doc $@
 
 .PHONY: all clean clobber test check cstyle check-license install uninstall\
-	source rpm dpkg pkg-clean pcheck check-remote format doc $(SUBDIRS)
+	source rpm dpkg pkg-clean pcheck check-remote format doc require-rpmem\
+	$(SUBDIRS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -175,7 +175,12 @@ test: all jemalloc-test
 check pcheck: test jemalloc-check
 	$(MAKE) -C test $@
 
-check-remote: test
+require-rpmem:
+ifneq ($(BUILD_RPMEM),y)
+	$(error ERROR: cannot run remote tests because $(BUILD_RPMEM_INFO))
+endif
+
+check-remote: require-rpmem test
 	$(MAKE) -C test $@
 
 jemalloc jemalloc-clean jemalloc-clobber jemalloc-test jemalloc-check:
@@ -233,4 +238,4 @@ clobber: clean-here
 
 .PHONY: all install uninstall clean clobber cstyle format test check pcheck\
 	jemalloc jemalloc-clean jemalloc-test jemalloc-check cscope $(ALL_TARGETS)\
-	pkg-config check-remote clean-here pkg-cfg-common
+	pkg-config check-remote clean-here pkg-cfg-common require-rpmem

--- a/src/common.inc
+++ b/src/common.inc
@@ -325,7 +325,7 @@ ifeq ($(BUILD_RPMEM),)
 export BUILD_RPMEM := $(call check_package, libfabric --atleast-version=$(LIBFABRIC_MIN_VERSION))
 ifneq ($(BUILD_RPMEM),y)
 export BUILD_RPMEM_INFO := libfabric (version >= $(LIBFABRIC_MIN_VERSION)) is missing -- \
-see src/librpmem/README for details.
+see src/librpmem/README for details
 endif
 endif
 

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -386,6 +386,11 @@ $(VMMALLOC_DUMMY_FUNCS_TESTS): $(VMMALLOC_DUMMY_FUNCS_DEPS)
 $(TESTS_BUILD):
 	$(MAKE) -C $@ $(TARGET)
 
+require-rpmem:
+ifneq ($(BUILD_RPMEM),y)
+	$(error ERROR: cannot run remote tests because $(BUILD_RPMEM_INFO))
+endif
+
 memcheck-summary:
 	grep ERROR */memcheck*.log
 
@@ -400,20 +405,28 @@ $(FILE_MAX_DAX_DEVICES): $(TESTCONFIG) $(CHECK_MAX_MMAP)
 
 global-checks: $(TEST_DEPS) $(FILE_MAX_DAX_DEVICES)
 
-check: sync-remotes global-checks
-	@./RUNTESTS $(RUNTEST_OPTIONS) $(TESTS)
+check: global-checks
+	@./RUNTESTS $(RUNTEST_OPTIONS) $(LOCAL_TESTS)
+	$(MAKE) check-remote-quiet-conditional
 	@echo "No failures."
+
+check-remote-quiet-conditional:
+ifeq ($(BUILD_RPMEM),y)
+	$(MAKE) check-remote-quiet
+else
+	$(info NOTE: Skipping remote tests because $(BUILD_RPMEM_INFO))
+endif
 
 check-remote-quiet: sync-remotes global-checks
 	@MAKEFLAGS="$(MAKEFLAGS)" ./RUNTESTS $(RUNTEST_OPTIONS) $(REMOTE_TESTS)
 
-sync-remotes: test
+sync-remotes: require-rpmem test
 
 check-remote: check-remote-quiet
 	@echo "No failures."
 
 # XXX remote tests do not work in parallel mode
-pcheck: pcheck-local-quiet check-remote-quiet
+pcheck: pcheck-local-quiet check-remote-quiet-conditional
 	@echo "No failures."
 
 pcheck-blk: TARGET = pcheck
@@ -498,4 +511,5 @@ endif
 	 pcheck-other pcheck-pmem pcheck-pmempool pcheck-vmem pcheck-vmmalloc\
 	 test unittest tools check-remote format pcheck-libpmempool\
 	 pcheck-rpmem pcheck-local pcheck-remote sync-remotes $(TESTS_BUILD)\
+	 require-rpmem check-remote-quiet check-remote-quiet-conditional\
 	 global-checks


### PR DESCRIPTION
If libfabric is not installed:
```$ make check-remote```
returns an error and:
```$ make check```
just skips remote tests.

Ref: pmem/issues#976

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3442)
<!-- Reviewable:end -->
