### PR TITLE
test: fix failing pmemdetect on windows

### DIFF
--- a/src/test/RUNTESTLIB.PS1
+++ b/src/test/RUNTESTLIB.PS1
@@ -365,32 +365,49 @@ if ($Env:NON_PMEM_FS_DIR -And (-Not (isDir($Env:NON_PMEM_FS_DIR)))) {
     throw "error: NON_PMEM_FS_DIR=$Env:NON_PMEM_FS_DIR doesn't exist"
 }
 
-$PMEMDETECT="..\x64\Debug\tests\pmemdetect.exe"
+# run this code in the separate thread to not pollute PATH variable in user shell.
+Start-Job -Name $name -Args $PSScriptRoot -ScriptBlock {
+    param ([string]$dir)
+    cd $dir
 
-if (-Not (Test-Path $PMEMDETECT)) {
-    $PMEMDETECT="..\x64\Release\tests\pmemdetect.exe"
-}
+    # in script block there is no access to other functions
+    function isDir {
+        if (-Not $args[0]) {
+            return $false
+        }
+        return Test-Path $args[0] -PathType Container
+    }
 
-if (isDir($Env:PMEM_FS_DIR)) {
-    if ($Env:PMEM_FS_DIR_FORCE_PMEM -eq "1") {
-        # "0" means there is PMEM
-        $Local:PMEM_IS_PMEM = "0"
+    $PMEMDETECT="..\x64\Debug\tests\pmemdetect.exe"
+
+    if (-Not (Test-Path $PMEMDETECT)) {
+        $PMEMDETECT="..\x64\Release\tests\pmemdetect.exe"
+        $Env:Path =  "..\x64\Release\libs;" + $Env:Path
     } else {
-        &$PMEMDETECT $Env:PMEM_FS_DIR
-        $Local:PMEM_IS_PMEM = $Global:LASTEXITCODE
+        $Env:Path =  "..\x64\Debug\libs;" + $Env:Path
     }
 
-    if ($Local:PMEM_IS_PMEM -ne "0") {
-        throw "error: PMEM_FS_DIR=$Env:PMEM_FS_DIR does not point to a PMEM device"
+
+    if (isDir($Env:PMEM_FS_DIR)) {
+        if ($Env:PMEM_FS_DIR_FORCE_PMEM -eq "1") {
+            # "0" means there is PMEM
+            $Local:PMEM_IS_PMEM = "0"
+        } else {
+            &$PMEMDETECT $Env:PMEM_FS_DIR
+            $Local:PMEM_IS_PMEM = $Global:LASTEXITCODE
+        }
+
+        if ($Local:PMEM_IS_PMEM -ne "0") {
+            throw "error: PMEM_FS_DIR=$Env:PMEM_FS_DIR does not point to a PMEM device"
+        }
     }
-}
 
-if (isDir($Env:NON_PMEM_FS_DIR)) {
-    &$PMEMDETECT $Env:NON_PMEM_FS_DIR
-    $Local:NON_PMEM_IS_PMEM = $Global:LASTEXITCODE
+    if (isDir($Env:NON_PMEM_FS_DIR)) {
+        &$PMEMDETECT $Env:NON_PMEM_FS_DIR
+        $Local:NON_PMEM_IS_PMEM = $Global:LASTEXITCODE
 
-    if ($Local:NON_PMEM_IS_PMEM -eq "0") {
-        throw "error: NON_PMEM_FS_DIR=$Env:NON_PMEM_FS_DIR does not point to a non-PMEM device"
+        if ($Local:NON_PMEM_IS_PMEM -eq "0") {
+            throw "error: NON_PMEM_FS_DIR=$Env:NON_PMEM_FS_DIR does not point to a non-PMEM device"
+        }
     }
-}
-
+} | Receive-Job -Wait -AutoRemoveJob


### PR DESCRIPTION
After #3099 pmemdetect on windows was silently failing due to
missing access to libpmem which was moved to a different directory.
To fix this issue we have to append lib directory to the PATH variable.

This change moves pmemdetect related code to a separate
thread (separate shell), as we should not modify PATH
variable in the user shell.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3444)
<!-- Reviewable:end -->
