### PR TITLE
test: fix util_badblock/TEST7

### DIFF
--- a/src/test/util_badblock/TEST7
+++ b/src/test/util_badblock/TEST7
@@ -74,7 +74,17 @@ ndctl_inject_error $NAMESPACE $FIRST_SECTOR 1
 
 expect_bad_blocks
 
-expect_normal_exit ./util_badblock$EXESUFFIX $FILE l c l
+enable_log_append
+
+expect_normal_exit ./util_badblock$EXESUFFIX $FILE l c
+
+#
+# This is a workaround for a Linux kernel bug (at least v4.16):
+# fixed blocks have to be written to get bad blocks cleared.
+#
+dd if=/dev/zero of=$FILE count=1 status=none
+
+expect_normal_exit ./util_badblock$EXESUFFIX $FILE l
 
 ndctl_nfit_test_fini $MOUNT_DIR
 

--- a/src/test/util_badblock/out7.log.match
+++ b/src/test/util_badblock/out7.log.match
@@ -1,6 +1,9 @@
 util_badblock$(nW)TEST7: START: util_badblock
- $(nW)util_badblock$(nW) $(nW)/mnt-pmem/file l c l
+ $(nW)util_badblock$(nW) $(nW)/mnt-pmem/file l c
 Found 1 bad block(s):
 0 2
+util_badblock$(nW)TEST7: DONE
+util_badblock$(nW)TEST7: START: util_badblock
+ $(nW)util_badblock$(nW) $(nW)/mnt-pmem/file l
 No bad blocks found.
 util_badblock$(nW)TEST7: DONE


### PR DESCRIPTION
This is a workaround for a Linux kernel bug (at least v4.16):
fixed blocks have to be written to get bad blocks cleared.

This patch fixes util_badblock/TEST7 failing sporadically on Jenkins.

Ref: pmem/issues#980

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3449)
<!-- Reviewable:end -->
