### PR TITLE
test: fix convert_to_bytes to actually return a number

### DIFF
--- a/src/test/unittest/unittest.ps1
+++ b/src/test/unittest/unittest.ps1
@@ -135,7 +135,7 @@ function convert_to_bytes() {
         fatal "Error suspicious byte value to convert_to_bytes"
     }
 
-    return $size
+    return [Int64]$size
 }
 
 #


### PR DESCRIPTION
Fixes require_free_space failure:

obj_root/TEST0: SETUP (check\pmem\debug)
Cannot convert value "19327352832966367641.6" to type "System.Int64".
Error: "Input string was not in a correct format."
    + CategoryInfo          : InvalidArgument: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvalidCastFromStringToInteger
    + PSComputerName        : localhost

obj_root/TEST0: PASS			[00.957 s]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3450)
<!-- Reviewable:end -->
