### PR TITLE
doc: recovery file is created for each part of the pool

### DIFF
--- a/doc/pmempool/pmempool-sync.1.md
+++ b/doc/pmempool/pmempool-sync.1.md
@@ -79,8 +79,8 @@ be opened are recreated.=e=)
 
 : Fix bad blocks - it causes creating or reading special recovery files.
 When bad blocks are detected, special recovery files have to be created
-in order to fix them safely. A separate recovery file is created per each part
-containing bad blocks. The recovery files are created in the same directory
+in order to fix them safely. A separate recovery file is created for each part
+of the pool. The recovery files are created in the same directory
 where the poolset file is located using the following name pattern:
 \<poolset-file-name\> _r \<replica-number\> _p \<part-number\> _badblocks.txt
 These recovery files are automatically removed if the sync operation finishes


### PR DESCRIPTION
A separate recovery file is created for each part of the pool,
not only for parts containing bad blocks. For parts not containing
bad blocks the recovery file contains only the "finish flag" ("0 0").