### PR TITLE
common: use versioned name for clang-format-6.0

### DIFF
--- a/utils/docker/build-local.sh
+++ b/utils/docker/build-local.sh
@@ -115,7 +115,7 @@ docker run --privileged=true --name=$containerName -ti \
 	--env WORKDIR=$WORKDIR \
 	--env EXPERIMENTAL=$EXPERIMENTAL \
 	--env SCRIPTSDIR=$SCRIPTSDIR \
-	--env CLANG_FORMAT=clang-format \
+	--env CLANG_FORMAT=clang-format-6.0 \
 	--env KEEP_TEST_CONFIG=$KEEP_TEST_CONFIG \
 	$ndctl_enable \
 	-v $HOST_WORKDIR:$WORKDIR \

--- a/utils/docker/build-travis.sh
+++ b/utils/docker/build-travis.sh
@@ -108,7 +108,7 @@ docker run --rm --privileged=true --name=$containerName -ti \
 	--env EXPERIMENTAL=$EXPERIMENTAL \
 	--env BUILD_PACKAGE_CHECK=$BUILD_PACKAGE_CHECK \
 	--env SCRIPTSDIR=$SCRIPTSDIR \
-	--env CLANG_FORMAT=clang-format \
+	--env CLANG_FORMAT=clang-format-6.0 \
 	--env TRAVIS=$TRAVIS \
 	--env TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE \
 	--env TRAVIS_COMMIT=$TRAVIS_COMMIT \

--- a/utils/style_check.sh
+++ b/utils/style_check.sh
@@ -39,6 +39,8 @@ CSTYLE_ARGS=()
 CLANG_ARGS=()
 CHECK_TYPE=$1
 
+[ -z "$clang_format_bin" ] && which clang-format-6.0 >/dev/null &&
+	clang_format_bin=clang-format-6.0
 [ -z "$clang_format_bin" ] && which clang-format >/dev/null &&
 	clang_format_bin=clang-format
 [ -z "$clang_format_bin" ] && clang_format_bin=clang-format


### PR DESCRIPTION
While on Travis we use distributions that default to 6.0, this no longer works on newer ones.

Ref: b8f57befef902826870b57e419ba18ae6bc822bc, 3df7731e24e139433e1052f995b46bb6ac33b171.