### PR TITLE
doc: fix lexgrog parsing (man-db index)

### DIFF
--- a/doc/libpmemlog/pmemlog_ctl_get.3.md
+++ b/doc/libpmemlog/pmemlog_ctl_get.3.md
@@ -49,7 +49,7 @@ date: pmemlog API version 1.1
 _UW(pmemlog_ctl_get),
 _UW(pmemlog_ctl_set),
 _UW(pmemlog_ctl_exec)
--- Query and modify libpmemlog internal behavior (EXPERIMENTAL)
+- Query and modify libpmemlog internal behavior (EXPERIMENTAL)
 
 
 # SYNOPSIS #


### PR DESCRIPTION
Turns out, `-` vs `--` does make a difference, in this case it's a syntax error for man page indexer which breaks references from _UW aliases.

For reference, the common three kinds of dashes are:
 * `-` (hyphen)
 * `–` (en dash)
 * `—` (em dash)

Unicode has a few tens more...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3470)
<!-- Reviewable:end -->
