### PR TITLE
doc: another hyphen update

### DIFF
--- a/doc/pmem_ctl/pmem_ctl.5.md
+++ b/doc/pmem_ctl/pmem_ctl.5.md
@@ -44,7 +44,7 @@ date: pmem_ctl API version 1.4
 
 # NAME #
 
-ctl -- interface for examination and modification of the library's internal state.
+ctl - interface for examination and modification of the library's internal state.
 
 
 # DESCRIPTION #


### PR DESCRIPTION
Turns out that, after a recent fix, all manpages which get installed were correct.  Spot two problems in the preceding sentence. 😏

Because of the way the bot which updates `doc/generated/` works, the test case for man page errors has to go in a separate pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3473)
<!-- Reviewable:end -->
