### PR TITLE
test: fix cmpmap ret val

### DIFF
--- a/src/test/tools/cmpmap/cmpmap.c
+++ b/src/test/tools/cmpmap/cmpmap.c
@@ -266,7 +266,7 @@ out_close2:
 		(void) os_close(fd2);
 out_close1:
 	(void) os_close(fd1);
-	return -1;
+	return ret;
 }
 
 


### PR DESCRIPTION
This issue affects tests on devdax (detected on qb)
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3478)
<!-- Reviewable:end -->
