### PR TITLE
common: extend suppression for memcheck leak

### DIFF
--- a/src/test/ld.supp
+++ b/src/test/ld.supp
@@ -35,7 +35,5 @@
    Memcheck:Leak
    ...
    fun:_dl_init
-   fun:dl_open_worker
-   fun:_dl_catch_error
    ...
 }


### PR DESCRIPTION
This patch extends suppression for memcheck leak in ld.so,
because of differences between libc 2.26 and 2.27 stack traces.
General issue is described here: pmem/issues#858

**2.27**
==7758== HEAP SUMMARY:
==7758==     in use at exit: 155 bytes in 5 blocks
==7758==   total heap usage: 938 allocs, 933 frees, 797,593 bytes allocated
==7758== 
==7758== 18 bytes in 1 blocks are definitely lost in loss record 1 of 5
==7758==    at 0x4C2EDA7: malloc (vg_replace_malloc.c:299)
==7758==    by 0x6306C49: strdup (in /usr/lib64/libc-2.27.so)
==7758==    by 0x9532528: ???
==7758==    by 0x400F519: call_init.part.0 (in /usr/lib64/ld-2.27.so)
==7758==    by 0x400F615: _dl_init (in /usr/lib64/ld-2.27.so)
==7758==    by 0x401379E: dl_open_worker (in /usr/lib64/ld-2.27.so)
==7758==    by 0x63B49CE: _dl_catch_exception (in /usr/lib64/libc-2.27.so)
==7758==    by 0x4013016: _dl_open (in /usr/lib64/ld-2.27.so)
==7758==    by 0x5E5D005: dlopen_doit (in /usr/lib64/libdl-2.27.so)
==7758==    by 0x63B49CE: _dl_catch_exception (in /usr/lib64/libc-2.27.so)
==7758==    by 0x63B4A5E: _dl_catch_error (in /usr/lib64/libc-2.27.so)
==7758==    by 0x5E5D724: _dlerror_run (in /usr/lib64/libdl-2.27.so)
==7758== 
==7758== 18 bytes in 1 blocks are definitely lost in loss record 2 of 5
==7758==    at 0x4C2EDA7: malloc (vg_replace_malloc.c:299)
==7758==    by 0x6306C49: strdup (in /usr/lib64/libc-2.27.so)
==7758==    by 0x92CE100: ???
==7758==    by 0x400F519: call_init.part.0 (in /usr/lib64/ld-2.27.so)
==7758==    by 0x400F615: _dl_init (in /usr/lib64/ld-2.27.so)
==7758==    by 0x401379E: dl_open_worker (in /usr/lib64/ld-2.27.so)
==7758==    by 0x63B49CE: _dl_catch_exception (in /usr/lib64/libc-2.27.so)
==7758==    by 0x4013016: _dl_open (in /usr/lib64/ld-2.27.so)
==7758==    by 0x5E5D005: dlopen_doit (in /usr/lib64/libdl-2.27.so)
==7758==    by 0x63B49CE: _dl_catch_exception (in /usr/lib64/libc-2.27.so)
==7758==    by 0x63B4A5E: _dl_catch_error (in /usr/lib64/libc-2.27.so)
==7758==    by 0x5E5D724: _dlerror_run (in /usr/lib64/libdl-2.27.so)
==7758== 
==7758== 31 bytes in 1 blocks are definitely lost in loss record 3 of 5
==7758==    at 0x4C2EDA7: malloc (vg_replace_malloc.c:299)
==7758==    by 0x92CE6BD: ???
==7758==    by 0x400F519: call_init.part.0 (in /usr/lib64/ld-2.27.so)
==7758==    by 0x400F615: _dl_init (in /usr/lib64/ld-2.27.so)
==7758==    by 0x401379E: dl_open_worker (in /usr/lib64/ld-2.27.so)
==7758==    by 0x63B49CE: _dl_catch_exception (in /usr/lib64/libc-2.27.so)
==7758==    by 0x4013016: _dl_open (in /usr/lib64/ld-2.27.so)
==7758==    by 0x5E5D005: dlopen_doit (in /usr/lib64/libdl-2.27.so)
==7758==    by 0x63B49CE: _dl_catch_exception (in /usr/lib64/libc-2.27.so)
==7758==    by 0x63B4A5E: _dl_catch_error (in /usr/lib64/libc-2.27.so)
==7758==    by 0x5E5D724: _dlerror_run (in /usr/lib64/libdl-2.27.so)
==7758==    by 0x5E5D095: dlopen@@GLIBC_2.2.5 (in /usr/lib64/libdl-2.27.so)
==7758== 
==7758== 56 bytes in 1 blocks are definitely lost in loss record 5 of 5
==7758==    at 0x4C2EDA7: malloc (vg_replace_malloc.c:299)
==7758==    by 0x89CEEF7: ???
==7758==    by 0x84B0F5B: ???
==7758==    by 0x84A8E28: ???
==7758==    by 0x846E203: ???
==7758==    by 0x8471F34: ???
==7758==    by 0x82477A2: ???
==7758==    by 0x8247778: ???
==7758==    by 0x823EBFE: ???
==7758==    by 0x400F519: call_init.part.0 (in /usr/lib64/ld-2.27.so)
==7758==    by 0x400F615: _dl_init (in /usr/lib64/ld-2.27.so)
==7758==    by 0x401379E: dl_open_worker (in /usr/lib64/ld-2.27.so)
==7758== 
==7758== LEAK SUMMARY:
==7758==    definitely lost: 123 bytes in 4 blocks
==7758==    indirectly lost: 0 bytes in 0 blocks
==7758==      possibly lost: 0 bytes in 0 blocks
==7758==    still reachable: 32 bytes in 1 blocks
==7758==         suppressed: 0 bytes in 0 blocks

**2.26**
==10930== HEAP SUMMARY:
==10930==     in use at exit: 1,693 bytes in 8 blocks
==10930==   total heap usage: 633 allocs, 625 frees, 700,830 bytes allocated
==10930==
==10930== 27 bytes in 1 blocks are definitely lost in loss record 3 of 8
==10930==    at 0x4C2FB1B: malloc (vg_replace_malloc.c:299)
==10930==    by 0x6126639: strdup (in /usr/lib64/libc-2.26.so)
==10930==    by 0x7F06501: ???
==10930==    by 0x4010C12: _dl_init (in /usr/lib64/ld-2.26.so)
==10930==    by 0x4015B69: dl_open_worker (in /usr/lib64/ld-2.26.so)
==10930==    by 0x61EBFFE: _dl_catch_error (in /usr/lib64/libc-2.26.so)
==10930==    by 0x4015078: _dl_open (in /usr/lib64/ld-2.26.so)
==10930==    by 0x5C6DF95: dlopen_doit (in /usr/lib64/libdl-2.26.so)
==10930==    by 0x61EBFFE: _dl_catch_error (in /usr/lib64/libc-2.26.so)
==10930==    by 0x5C6E714: _dlerror_run (in /usr/lib64/libdl-2.26.so)
==10930==    by 0x5C6E020: dlopen@@GLIBC_2.2.5 (in /usr/lib64/libdl-2.26.so)
==10930==    by 0x44930E: util_dlopen (dlsym.h:54)
==10930==
==10930== 27 bytes in 1 blocks are definitely lost in loss record 4 of 8
==10930==    at 0x4C2FB1B: malloc (vg_replace_malloc.c:299)
==10930==    by 0x6126639: strdup (in /usr/lib64/libc-2.26.so)
==10930==    by 0x7887B80: ???
==10930==    by 0x4010C12: _dl_init (in /usr/lib64/ld-2.26.so)
==10930==    by 0x4015B69: dl_open_worker (in /usr/lib64/ld-2.26.so)
==10930==    by 0x61EBFFE: _dl_catch_error (in /usr/lib64/libc-2.26.so)
==10930==    by 0x4015078: _dl_open (in /usr/lib64/ld-2.26.so)
==10930==    by 0x5C6DF95: dlopen_doit (in /usr/lib64/libdl-2.26.so)
==10930==    by 0x61EBFFE: _dl_catch_error (in /usr/lib64/libc-2.26.so)
==10930==    by 0x5C6E714: _dlerror_run (in /usr/lib64/libdl-2.26.so)
==10930==    by 0x5C6E020: dlopen@@GLIBC_2.2.5 (in /usr/lib64/libdl-2.26.so)
==10930==    by 0x44930E: util_dlopen (dlsym.h:54)
==10930==
==10930== LEAK SUMMARY:
==10930==    definitely lost: 54 bytes in 2 blocks
==10930==    indirectly lost: 0 bytes in 0 blocks
==10930==      possibly lost: 0 bytes in 0 blocks
==10930==    still reachable: 1,639 bytes in 6 blocks
==10930==         suppressed: 0 bytes in 0 blocks

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3480)
<!-- Reviewable:end -->
