### PR TITLE
common: add rsync to Fedora28 docker file

### DIFF
--- a/utils/docker/images/Dockerfile.fedora-28
+++ b/utils/docker/images/Dockerfile.fedora-28
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2018, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -74,6 +74,7 @@ RUN dnf update -y \
 	rpm-build \
 	rpm-build-libs \
 	rpmdevtools \
+	rsync \
 	sudo \
 	tar \
 	wget \


### PR DESCRIPTION
I would like to use rsync in auto doc file to have cp with more options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3487)
<!-- Reviewable:end -->
