### PR TITLE
doc: add missing aliases to pmemobj_f_mem macros

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -98,6 +98,7 @@ MANPAGES_3_DUMMY = pmem_drain.3 pmem_has_hw_drain.3 pmem_has_auto_flush.3 \
 		   tx_begin_param.3 tx_begin_cb.3 tx_begin.3 tx_onabort.3 tx_oncommit.3 tx_finally.3 tx_end.3 \
 		   tx_add.3 tx_add_field.3 tx_add_direct.3 tx_add_field_direct.3 tx_xadd.3 tx_xadd_field.3 tx_xadd_direct.3 tx_xadd_field_direct.3 \
 		   tx_new.3 tx_alloc.3 tx_znew.3 tx_zalloc.3 tx_xalloc.3 tx_realloc.3 tx_zrealloc.3 tx_strdup.3 tx_wcsdup.3 tx_free.3 tx_set.3 tx_set_direct.3 tx_memcpy.3 tx_memset.3 \
+		   pmemobj_f_mem_nodrain.3 pmemobj_f_mem_nontemporal.3 pmemobj_f_mem_temporal.3 pmemobj_f_mem_wc.3 pmemobj_f_mem_wb.3 pmemobj_f_mem_noflush.3 pmemobj_f_relaxed.3 \
 		   pmemobj_mutex_lock.3 pmemobj_mutex_timedlock.3 pmemobj_mutex_trylock.3 pmemobj_mutex_unlock.3 \
 		   pmemobj_rwlock_zero.3 pmemobj_rwlock_rdlock.3 pmemobj_rwlock_wrlock.3 pmemobj_rwlock_timedrdlock.3 pmemobj_rwlock_timedwrlock.3 pmemobj_rwlock_tryrdlock.3 pmemobj_rwlock_trywrlock.3 pmemobj_rwlock_unlock.3 \
 		   pmemobj_cond_zero.3 pmemobj_cond_broadcast.3 pmemobj_cond_signal.3 pmemobj_cond_timedwait.3 pmemobj_cond_wait.3 \

--- a/doc/generated/pmemobj_f_mem_nodrain.3
+++ b/doc/generated/pmemobj_f_mem_nodrain.3
@@ -1,0 +1,1 @@
+.so pmemobj_memcpy_persist.3

--- a/doc/generated/pmemobj_f_mem_noflush.3
+++ b/doc/generated/pmemobj_f_mem_noflush.3
@@ -1,0 +1,1 @@
+.so pmemobj_memcpy_persist.3

--- a/doc/generated/pmemobj_f_mem_nontemporal.3
+++ b/doc/generated/pmemobj_f_mem_nontemporal.3
@@ -1,0 +1,1 @@
+.so pmemobj_memcpy_persist.3

--- a/doc/generated/pmemobj_f_mem_temporal.3
+++ b/doc/generated/pmemobj_f_mem_temporal.3
@@ -1,0 +1,1 @@
+.so pmemobj_memcpy_persist.3

--- a/doc/generated/pmemobj_f_mem_wb.3
+++ b/doc/generated/pmemobj_f_mem_wb.3
@@ -1,0 +1,1 @@
+.so pmemobj_memcpy_persist.3

--- a/doc/generated/pmemobj_f_mem_wc.3
+++ b/doc/generated/pmemobj_f_mem_wc.3
@@ -1,0 +1,1 @@
+.so pmemobj_memcpy_persist.3

--- a/doc/generated/pmemobj_f_relaxed.3
+++ b/doc/generated/pmemobj_f_relaxed.3
@@ -1,0 +1,1 @@
+.so pmemobj_memcpy_persist.3


### PR DESCRIPTION
Ref: pmem/issues#992

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3489)
<!-- Reviewable:end -->
