### PR TITLE
common: fix vecq resize for not front-append scenarios

### DIFF
--- a/src/common/vecq.h
+++ b/src/common/vecq.h
@@ -99,8 +99,13 @@ vecq_grow(void *vec, size_t s)
 		ERR("!Realloc");
 		return -1;
 	}
-	vecp->buffer = tbuf;
+	memcpy((char *)tbuf + (s * vecp->capacity), (char *)tbuf,
+		(s * VECQ_FRONT_POS(vecp)));
+
+	vecp->front = VECQ_FRONT_POS(vecp);
+	vecp->back = vecp->front + vecp->capacity;
 	vecp->capacity = ncapacity;
+	vecp->buffer = tbuf;
 
 	return 0;
 }

--- a/src/test/util_vecq/util_vecq.c
+++ b/src/test/util_vecq/util_vecq.c
@@ -81,14 +81,17 @@ vecq_test_grow()
 	VECQ(testvec, int) v;
 	VECQ_INIT(&v);
 
-	for (int i = 1; i < 1000; ++i) {
-		int ret = VECQ_ENQUEUE(&v, i);
-		UT_ASSERTeq(ret, 0);
-	}
+	for (int j = 0; j < 100; ++j) {
+		int n = j * 100;
+		for (int i = 1; i < n; ++i) {
+			int ret = VECQ_ENQUEUE(&v, i);
+			UT_ASSERTeq(ret, 0);
+		}
 
-	for (int i = 1; i < 1000; ++i) {
-		int res = VECQ_DEQUEUE(&v);
-		UT_ASSERTeq(res, i);
+		for (int i = 1; i < n; ++i) {
+			int res = VECQ_DEQUEUE(&v);
+			UT_ASSERTeq(res, i);
+		}
 	}
 
 	VECQ_DELETE(&v);


### PR DESCRIPTION
The vector based queue didn't properly dequeue elements whenever the
underlying buffer was resized in a way that resulted in the logical
queue being split into two halves.
To address this problem, these two halves need to be merged back together
after a realloc, and the front/back variables need to be adjusted to match.

This thankfully didn't affect the allocator, because the seglists container
doesn't grow past the initial size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3492)
<!-- Reviewable:end -->
