### PR TITLE
pool: get rid of a helper function

### DIFF
--- a/src/tools/pmempool/common.c
+++ b/src/tools/pmempool/common.c
@@ -802,18 +802,11 @@ ask(char op, char *answers, char def_ans, const char *fmt, va_list ap)
 }
 
 char
-ask_yn(char op, char def_ans, const char *fmt, va_list ap)
-{
-	char ret = ask(op, "yn", def_ans, fmt, ap);
-	return ret;
-}
-
-char
 ask_Yn(char op, const char *fmt, ...)
 {
 	va_list ap;
 	va_start(ap, fmt);
-	char ret = ask_yn(op, 'y', fmt, ap);
+	char ret = ask(op, "yn", 'y', fmt, ap);
 	va_end(ap);
 	return ret;
 }
@@ -823,7 +816,7 @@ ask_yN(char op, const char *fmt, ...)
 {
 	va_list ap;
 	va_start(ap, fmt);
-	char ret = ask_yn(op, 'n', fmt, ap);
+	char ret = ask(op, "yn", 'n', fmt, ap);
 	va_end(ap);
 	return ret;
 }

--- a/src/tools/pmempool/common.h
+++ b/src/tools/pmempool/common.h
@@ -220,7 +220,6 @@ int util_check_memory(const uint8_t *buff, size_t len, uint8_t val);
 int util_parse_chunk_types(const char *str, uint64_t *types);
 int util_parse_lane_sections(const char *str, uint64_t *types);
 char ask(char op, char *answers, char def_ans, const char *fmt, va_list ap);
-char ask_yn(char op, char def_ans, const char *fmt, va_list ap);
 char ask_Yn(char op, const char *fmt, ...) FORMAT_PRINTF(2, 3);
 char ask_yN(char op, const char *fmt, ...) FORMAT_PRINTF(2, 3);
 unsigned util_heap_max_zone(size_t size);


### PR DESCRIPTION
Just a simplification for one too many levels of indirection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3496)
<!-- Reviewable:end -->
