### PR TITLE
fixed debian/ubuntu package build script - change the wrong dependenc…

### DIFF
--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -277,7 +277,7 @@ Package: daxio
 Section: misc
 Architecture: any
 Priority: optional
-Depends: libpmem (=\${binary:Version}), libndctl (>= $NDCTL_MIN_VERSION), libdaxctl (>= $NDCTL_MIN_VERSION), \${shlibs:Depends}, \${misc:Depends}
+Depends: libpmem (=\${binary:Version}), libndctl6 (>= $NDCTL_MIN_VERSION), libdaxctl1 (>= $NDCTL_MIN_VERSION), \${shlibs:Depends}, \${misc:Depends}
 Description: daxio utility
  The daxio utility performs I/O on Device DAX devices or zero
  a Device DAX device.  Since the standard I/O APIs (read/write) cannot be used


### PR DESCRIPTION
…y packages of libndctl and libdaxctl to libndctl6 and libdaxctl1

I want to create an issue on pmem/pmdk of wrong dependency of the daxio package of libndctl and libdaxctl in both Debian and Ubuntu, which this commit can specify to fix, but pmem/pmdk does not allow users to submit new issues.  

Can the administrator of pmem please turn on the issue tracker so that users can file bugs?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3498)
<!-- Reviewable:end -->
