### PR TITLE
Revert "common: check if input is not null"

### DIFF
--- a/src/tools/pmempool/common.c
+++ b/src/tools/pmempool/common.c
@@ -740,12 +740,6 @@ pmempool_ask_yes_no(char def_ans, const char *answers, const char *qbuff)
 	printf("] ");
 
 	char *line_of_answer = util_readline(stdin);
-
-	if (line_of_answer == NULL) {
-		outv_err("input is empty");
-		return '?';
-	}
-
 	char first_letter = line_of_answer[0];
 	line_of_answer[0] = (char)tolower(first_letter);
 


### PR DESCRIPTION
Reverts pmem/pmdk#3494

It should go to pmem:stable-1.5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3499)
<!-- Reviewable:end -->
