### PR TITLE
common: check-license warnings

### DIFF
--- a/utils/check_license/check-license.c
+++ b/utils/check_license/check-license.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2019, Intel Corporation
  * Copyright (c) 2016, Microsoft Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -288,8 +288,7 @@ create_pattern(const char *path_license, char *pattern)
 	if (analyze_license(path_license, buffer, &license) == -1)
 		return -1;
 
-	memset(pattern, 0, LICENSE_MAX_LEN);
-	strncpy(pattern, license, strlen(license) + 1);
+	strncpy(pattern, license, LICENSE_MAX_LEN);
 
 	return 0;
 }

--- a/utils/check_license/check-license.c
+++ b/utils/check_license/check-license.c
@@ -184,7 +184,8 @@ format_license(char *license, size_t length)
 	/* is there any comment? */
 	if (comment + 1 != license) {
 		/* separate out a comment */
-		strncpy(comment_str, comment, COMMENT_STR_LEN);
+		strncpy(comment_str, comment, COMMENT_STR_LEN - 1);
+		comment_str[COMMENT_STR_LEN - 1] = 0;
 		comment = comment_str + 1;
 		while (isspace(*comment))
 			comment++;


### PR DESCRIPTION
Cherry-pick a couple of commits applied to vmemcache.  They fix a couple of warnings with new gcc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3502)
<!-- Reviewable:end -->
