### PR TITLE
doc: obey $SOURCE_DATE_EPOCH

### DIFF
--- a/utils/md2man.sh
+++ b/utils/md2man.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -81,12 +81,16 @@ if [ "$WEB" == 1 ]; then
 	mkdir -p "$(dirname $outfile)"
 	m4 $OPTS macros.man $filename | sed -n -e '/---/,$p' > $outfile
 else
-	dt=$(date +"%F")
+	SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}"
+	YEAR=$(date -u -d "@$SOURCE_DATE_EPOCH" +%Y 2>/dev/null ||
+		date -u -r "$SOURCE_DATE_EPOCH" +%Y 2>/dev/null || date -u +%Y)
+	dt=$(date -u -d "@$SOURCE_DATE_EPOCH" +%F 2>/dev/null ||
+		date -u -r "$SOURCE_DATE_EPOCH" +%F 2>/dev/null || date -u +%F)
 	m4 $OPTS macros.man $filename | sed -n -e '/# NAME #/,$p' |\
 		pandoc -s -t man -o $outfile.tmp --template=$template \
 		-V title=$title -V section=$section \
 		-V date="$dt" -V version="$version" \
-		-V year=$(date +"%Y") |
+		-V year="$YEAR" |
 sed '/^\.IP/{
 N
 /\n\.nf/{


### PR DESCRIPTION
It's a cross-distro effort to make the same package with same toolchain versions compile to bit-by-bit identical code; various distros follow it to various degrees, with at least Debian [nearly complete](https://isdebianreproducibleyet.com/), and if your package doesn't build reproducibly, you get shouted at.  I don't like being shouted at.

For PMDK, the only problem was date in generated man pages.

As a packaging fix, I'm submitting this for 1.5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3504)
<!-- Reviewable:end -->
