### PR TITLE
common: dpkg: drop bogus hardcoded library dependencies

### DIFF
--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2014-2018, Intel Corporation
+# Copyright 2014-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -277,7 +277,7 @@ Package: daxio
 Section: misc
 Architecture: any
 Priority: optional
-Depends: libpmem (=\${binary:Version}), libndctl (>= $NDCTL_MIN_VERSION), libdaxctl (>= $NDCTL_MIN_VERSION), \${shlibs:Depends}, \${misc:Depends}
+Depends: libpmem (=\${binary:Version}), \${shlibs:Depends}, \${misc:Depends}
 Description: daxio utility
  The daxio utility performs I/O on Device DAX devices or zero
  a Device DAX device.  Since the standard I/O APIs (read/write) cannot be used


### PR DESCRIPTION
The dependencies on generated daxio package use non-existent "libndctl" and "libdaxctl"; the real packages have soversion numbers attached.  There's no need to write explicit deps: packaged shared libraries already do the right thing.

This is a fixed version of #3498 by kcleung.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3518)
<!-- Reviewable:end -->
