### PR TITLE
common: incomplete arm64 fixes

### DIFF
--- a/src/common/os_dimm_ndctl.c
+++ b/src/common/os_dimm_ndctl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Intel Corporation
+ * Copyright 2017-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,6 +45,9 @@
 #include <ndctl/libdaxctl.h>
 /* XXX: workaround for missing PAGE_SIZE - should be fixed in linux/ndctl.h */
 #include <sys/user.h>
+#ifndef PAGE_SIZE
+#define PAGE_SIZE 4096
+#endif
 #include <linux/ndctl.h>
 
 #include "out.h"

--- a/src/libpmem/aarch64/init.c
+++ b/src/libpmem/aarch64/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -179,7 +179,7 @@ pmem_init_funcs(struct pmem_funcs *funcs)
 	else
 		FATAL("invalid deep flush function address");
 
-	if (funcs->deep_flush == flush_empty)
+	if (funcs->flush == flush_empty)
 		LOG(3, "not flushing CPU cache");
 	else if (funcs->flush != funcs->deep_flush)
 		FATAL("invalid flush function address");


### PR DESCRIPTION
A couple of arm64 fixes; they're not enough to pass the testsuite, but it's still good to have them in case someone bothers to look at this again.

The PAGE_SIZE commit fixes compilation with kernel uapi headers 4.16..4.19 (Debian buster will probably release with linux-libc-dev 4.19).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3525)
<!-- Reviewable:end -->
