### PR TITLE
doc: ctl man pages cleanup

### DIFF
--- a/doc/libpmemblk/pmemblk_ctl_get.3.md
+++ b/doc/libpmemblk/pmemblk_ctl_get.3.md
@@ -7,7 +7,7 @@ header: PMDK
 date: pmemblk API version 1.1
 ...
 
-[comment]: <> (Copyright 2018, Intel Corporation)
+[comment]: <> (Copyright 2018-2019, Intel Corporation)
 
 [comment]: <> (Redistribution and use in source and binary forms, with or without)
 [comment]: <> (modification, are permitted provided that the following conditions)
@@ -73,6 +73,19 @@ _UNICODE()
 The _UW(pmemblk_ctl_get), _UW(pmemblk_ctl_set) and _UW(pmemblk_ctl_exec)
 functions provide a uniform interface for querying and modifying the internal
 behavior of **libpmemblk**(7) through the control (CTL) namespace.
+
+The *name* argument specifies an entry point as defined in the CTL namespace
+specification. The entry point description specifies whether the extra *arg* is
+required. Those two parameters together create a CTL query. The functions and
+the entry points are thread-safe unless
+indicated otherwise below. If there are special conditions for calling an entry
+point, they are explicitly stated in its description. The functions propagate
+the return value of the entry point. If either *name* or *arg* is invalid, -1
+is returned.
+
+If the provided ctl query is valid, the CTL functions will always return 0
+on success and -1 on failure, unless otherwise specified in the entry point
+description.
 
 See more in **pmem_ctl**(5) man page.
 

--- a/doc/libpmemlog/pmemlog_ctl_get.3.md
+++ b/doc/libpmemlog/pmemlog_ctl_get.3.md
@@ -7,7 +7,7 @@ header: PMDK
 date: pmemlog API version 1.1
 ...
 
-[comment]: <> (Copyright 2018, Intel Corporation)
+[comment]: <> (Copyright 2018-2019, Intel Corporation)
 
 [comment]: <> (Redistribution and use in source and binary forms, with or without)
 [comment]: <> (modification, are permitted provided that the following conditions)
@@ -73,6 +73,19 @@ _UNICODE()
 The _UW(pmemlog_ctl_get), _UW(pmemlog_ctl_set) and _UW(pmemlog_ctl_exec)
 functions provide a uniform interface for querying and modifying the internal
 behavior of **libpmemlog**(7) through the control (CTL) namespace.
+
+The *name* argument specifies an entry point as defined in the CTL namespace
+specification. The entry point description specifies whether the extra *arg* is
+required. Those two parameters together create a CTL query. The functions and
+the entry points are thread-safe unless
+indicated otherwise below. If there are special conditions for calling an entry
+point, they are explicitly stated in its description. The functions propagate
+the return value of the entry point. If either *name* or *arg* is invalid, -1
+is returned.
+
+If the provided ctl query is valid, the CTL functions will always return 0
+on success and -1 on failure, unless otherwise specified in the entry point
+description.
 
 See more in **pmem_ctl**(5) man page.
 

--- a/doc/pmem_ctl/pmem_ctl.5.md
+++ b/doc/pmem_ctl/pmem_ctl.5.md
@@ -7,7 +7,7 @@ header: PMDK
 date: pmem_ctl API version 1.4
 ...
 
-[comment]: <> (Copyright 2018, Intel Corporation)
+[comment]: <> (Copyright 2018-2019, Intel Corporation)
 
 [comment]: <> (Redistribution and use in source and binary forms, with or without)
 [comment]: <> (modification, are permitted provided that the following conditions)
@@ -57,14 +57,6 @@ have string identifiers. Indexed nodes represent an abstract array index and
 have an associated string identifier. The index itself is provided by the user.
 A collection of indexes present on the path of an entry point is provided to
 the handler functions as name and index pairs.
-
-The *name* argument specifies an entry point as defined in the CTL namespace
-specification. The entry point description specifies whether the extra *arg* is
-required. Those two parameters together create a CTL query. The functions and the entry points are thread-safe unless
-indicated otherwise below. If there are special conditions for calling an entry
-point, they are explicitly stated in its description. The functions propagate
-the return value of the entry point. If either *name* or *arg* is invalid, -1
-is returned.
 
 Entry points are the leaves of the CTL namespace structure. Each entry point
 can read from the internal state, write to the internal state,


### PR DESCRIPTION
This patch mostly clarifies the behavior of ctl functions in presence
of error conditions, but also removes outdated entry points
descriptions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3526)
<!-- Reviewable:end -->
