### PR TITLE
common: use util variants of locking APIs

### DIFF
--- a/src/libpmemblk/blk.c
+++ b/src/libpmemblk/blk.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -640,13 +640,13 @@ pmemblk_close(PMEMblkpool *pbp)
 	btt_fini(pbp->bttp);
 	if (pbp->locks) {
 		for (unsigned i = 0; i < pbp->nlane; i++)
-			os_mutex_destroy(&pbp->locks[i]);
+			util_mutex_destroy(&pbp->locks[i]);
 		Free((void *)pbp->locks);
 	}
 
 #ifdef DEBUG
 	/* destroy debug lock */
-	os_mutex_destroy(&pbp->write_lock);
+	util_mutex_destroy(&pbp->write_lock);
 #endif
 
 	util_poolset_close(pbp->set, DO_NOT_DELETE_PARTS);

--- a/src/libpmemlog/log.c
+++ b/src/libpmemlog/log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -156,11 +156,7 @@ log_runtime_init(PMEMlogpool *plp, int rdonly)
 		return -1;
 	}
 
-	if ((errno = os_rwlock_init(plp->rwlockp))) {
-		ERR("!os_rwlock_init");
-		Free((void *)plp->rwlockp);
-		return -1;
-	}
+	util_rwlock_init(plp->rwlockp);
 
 	/*
 	 * If possible, turn off all permissions on the pool header page.
@@ -391,8 +387,7 @@ pmemlog_close(PMEMlogpool *plp)
 {
 	LOG(3, "plp %p", plp);
 
-	if ((errno = os_rwlock_destroy(plp->rwlockp)))
-		ERR("!os_rwlock_destroy");
+	util_rwlock_destroy(plp->rwlockp);
 	Free((void *)plp->rwlockp);
 
 	util_poolset_close(plp->set, DO_NOT_DELETE_PARTS);
@@ -406,10 +401,7 @@ pmemlog_nbyte(PMEMlogpool *plp)
 {
 	LOG(3, "plp %p", plp);
 
-	if ((errno = os_rwlock_rdlock(plp->rwlockp))) {
-		ERR("!os_rwlock_rdlock");
-		return (size_t)-1;
-	}
+	util_rwlock_rdlock(plp->rwlockp);
 
 	size_t size = le64toh(plp->end_offset) - le64toh(plp->start_offset);
 	LOG(4, "plp %p nbyte %zu", plp, size);
@@ -476,10 +468,7 @@ pmemlog_append(PMEMlogpool *plp, const void *buf, size_t count)
 		return -1;
 	}
 
-	if ((errno = os_rwlock_wrlock(plp->rwlockp))) {
-		ERR("!os_rwlock_wrlock");
-		return -1;
-	}
+	util_rwlock_wrlock(plp->rwlockp);
 
 	/* get the current values */
 	uint64_t end_offset = le64toh(plp->end_offset);
@@ -551,10 +540,7 @@ pmemlog_appendv(PMEMlogpool *plp, const struct iovec *iov, int iovcnt)
 		return -1;
 	}
 
-	if ((errno = os_rwlock_wrlock(plp->rwlockp))) {
-		ERR("!os_rwlock_wrlock");
-		return -1;
-	}
+	util_rwlock_wrlock(plp->rwlockp);
 
 	/* get the current values */
 	uint64_t end_offset = le64toh(plp->end_offset);
@@ -624,10 +610,7 @@ pmemlog_tell(PMEMlogpool *plp)
 {
 	LOG(3, "plp %p", plp);
 
-	if ((errno = os_rwlock_rdlock(plp->rwlockp))) {
-		ERR("!os_rwlock_rdlock");
-		return (os_off_t)-1;
-	}
+	util_rwlock_rdlock(plp->rwlockp);
 
 	ASSERT(le64toh(plp->write_offset) >= le64toh(plp->start_offset));
 	long long wp = (long long)(le64toh(plp->write_offset) -
@@ -654,10 +637,7 @@ pmemlog_rewind(PMEMlogpool *plp)
 		return;
 	}
 
-	if ((errno = os_rwlock_wrlock(plp->rwlockp))) {
-		ERR("!os_rwlock_wrlock");
-		return;
-	}
+	util_rwlock_wrlock(plp->rwlockp);
 
 	/* unprotect the pool descriptor (debug version only) */
 	RANGE_RW((char *)plp->addr + sizeof(struct pool_hdr),
@@ -693,10 +673,7 @@ pmemlog_walk(PMEMlogpool *plp, size_t chunksize,
 	 * in place. We prevent everyone from changing the data behind our back
 	 * until we are done with processing it.
 	 */
-	if ((errno = os_rwlock_rdlock(plp->rwlockp))) {
-		ERR("!os_rwlock_rdlock");
-		return;
-	}
+	util_rwlock_rdlock(plp->rwlockp);
 
 	char *data = plp->addr;
 	uint64_t write_offset = le64toh(plp->write_offset);

--- a/src/libpmemobj/recycler.c
+++ b/src/libpmemobj/recycler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018, Intel Corporation
+ * Copyright 2016-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -121,7 +121,7 @@ recycler_new(struct palloc_heap *heap, size_t nallocs)
 	VEC_INIT(&r->recalc);
 	VEC_INIT(&r->pending);
 
-	os_mutex_init(&r->lock);
+	util_mutex_init(&r->lock);
 
 	return r;
 
@@ -144,7 +144,7 @@ recycler_delete(struct recycler *r)
 		Free(mr);
 	}
 	VEC_DELETE(&r->pending);
-	os_mutex_destroy(&r->lock);
+	util_mutex_destroy(&r->lock);
 	ravl_delete(r->runs);
 	Free(r);
 }

--- a/src/test/blk_recovery/TEST0
+++ b/src/test/blk_recovery/TEST0
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2014-2018, Intel Corporation
+# Copyright 2014-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,14 +44,7 @@ require_test_type medium
 require_fs_type pmem non-pmem
 require_build_type nondebug static-nondebug
 
-# exits with locked mutexes
-configure_valgrind helgrind force-disable
-configure_valgrind drd force-disable
-
 setup
-
-# this test invokes sigsegvs by design
-export ASAN_OPTIONS=handle_segv=0
 
 # single arena case
 truncate -s 2G $DIR/testfile1
@@ -60,7 +53,11 @@ truncate -s 2G $DIR/testfile1
 # Simple case, one write interrupted.  pmemblk_check() should note
 # that testfile1 is consistent (after recovery steps were taken).
 #
-expect_normal_exit ./blk_recovery$EXESUFFIX 4096 $DIR/testfile1 5 10
+expect_abnormal_exit ./blk_recovery$EXESUFFIX 4096 $DIR/testfile1 5 10 2>/dev/null
+mv out0.log interrupted0.log
+
+expect_normal_exit ./blk_recovery$EXESUFFIX 4096 $DIR/testfile1
+mv out0.log check0.log
 
 check_pool $DIR/testfile1
 

--- a/src/test/blk_recovery/TEST0.PS1
+++ b/src/test/blk_recovery/TEST0.PS1
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018, Intel Corporation
+# Copyright 2014-2019, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -53,7 +53,11 @@ create_holey_file 2G $DIR\testfile1
 # Simple case, one write interrupted.  pmemblk_check() should note
 # that testfile1 is consistent (after recovery steps were taken).
 #
-expect_normal_exit $Env:EXE_DIR\blk_recovery$Env:EXESUFFIX 4096 $DIR\testfile1 5 10
+expect_abnormal_exit $Env:EXE_DIR\blk_recovery$Env:EXESUFFIX 4096 $DIR\testfile1 5 10
+mv out0.log interrupted0.log
+
+expect_normal_exit $Env:EXE_DIR\blk_recovery$Env:EXESUFFIX 4096 $DIR\testfile1
+mv out0.log check0.log
 
 check_pool $DIR\testfile1
 

--- a/src/test/blk_recovery/check0.log.match
+++ b/src/test/blk_recovery/check0.log.match
@@ -1,0 +1,4 @@
+blk_recovery$(nW)TEST0: START: blk_recovery
+ $(nW)blk_recovery$(nW) 4096 $(nW)testfile1
+$(nW)testfile1: consistent
+blk_recovery$(nW)TEST0: DONE

--- a/src/test/blk_recovery/out0.log.match
+++ b/src/test/blk_recovery/out0.log.match
@@ -1,8 +1,0 @@
-blk_recovery$(nW)TEST0: START: blk_recovery
- $(nW)blk_recovery$(nW) 4096 $(nW)testfile1 5 10
-4096 block size 4096 usable blocks 523511
-write     lba 5: {1}
-write-protecting map, length 2097152
-signal: Segmentation fault
-$(nW)testfile1: consistent
-blk_recovery$(nW)TEST0: DONE

--- a/src/test/obj_ctl_arenas/obj_ctl_arenas.c
+++ b/src/test/obj_ctl_arenas/obj_ctl_arenas.c
@@ -39,6 +39,7 @@
  */
 
 #include <sched.h>
+#include "sys_util.h"
 #include "unittest.h"
 #include "util.h"
 
@@ -91,14 +92,14 @@ worker_arenas_size(void *arg)
 	UT_ASSERTeq(ret, 0);
 
 	/* we need to test 2 arenas so 2 threads are needed here */
-	os_mutex_lock(&lock);
+	util_mutex_lock(&lock);
 	nth++;
 	if (nth == NTHREAD)
 		os_cond_broadcast(&cond);
 	else
 		while (nth < NTHREAD)
 			os_cond_wait(&cond, &lock);
-	os_mutex_unlock(&lock);
+	util_mutex_unlock(&lock);
 
 
 	ret = pmemobj_ctl_get(pop, "heap.thread.arena_id", &arena_id);
@@ -143,7 +144,7 @@ main(int argc, char *argv[])
 		UT_ASSERTne(narenas, 0);
 	} else if (t == 's') {
 		os_thread_t threads[NTHREAD];
-		os_mutex_init(&lock);
+		util_mutex_init(&lock);
 		os_cond_init(&cond);
 
 		for (int i = 0; i < NTHREAD; i++)
@@ -157,7 +158,7 @@ main(int argc, char *argv[])
 		POBJ_FOREACH_SAFE(pop, oid, oid2)
 			pmemobj_free(&oid);
 
-		os_mutex_destroy(&lock);
+		util_mutex_destroy(&lock);
 		os_cond_destroy(&cond);
 
 	} else {


### PR DESCRIPTION
os variants should be used only for implementation of user locks (pmemobj_mutex_lock & co).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3532)
<!-- Reviewable:end -->
