### PR TITLE
obj: move pools ht/tree init to library constructor

### DIFF
--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -227,7 +227,7 @@ err:
 /*
  * obj_pool_init -- (internal) allocate global structs holding all opened pools
  *
- * This is invoked on a first call to pmemobj_open() or pmemobj_create().
+ * This is called by library's constructor.
  * Memory is released in library destructor.
  */
 static void
@@ -312,6 +312,8 @@ obj_init(void)
 		FATAL("error: %s", pmemobj_errormsg());
 
 	lane_info_boot();
+
+	obj_pool_init();
 
 	util_remote_init();
 }
@@ -1243,8 +1245,6 @@ obj_runtime_init(PMEMobjpool *pop, int rdonly, int boot, unsigned nlanes)
 				(char *)pop + pop->set->poolsize - (char *)end);
 		}
 #endif
-
-		obj_pool_init();
 
 		if ((errno = critnib_insert(pools_ht, pop->uuid_lo, pop))) {
 			ERR("!critnib_insert to pools_ht");

--- a/src/test/obj_lane/obj_lane.c
+++ b/src/test/obj_lane/obj_lane.c
@@ -306,8 +306,6 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_lane");
 
-	obj_init();
-
 	if (argc != 2)
 		usage(argv[0]);
 
@@ -327,7 +325,6 @@ main(int argc, char *argv[])
 		usage(argv[0]);
 	}
 
-	obj_fini();
 	DONE(NULL);
 }
 


### PR DESCRIPTION
In an effort to make pool management threadsafe, pools_ht and pool_tree
global variables need to be initialized only one time. To accomplish
that, this patch moves the functions responsible for assigning those
variables to the library's constructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3535)
<!-- Reviewable:end -->
