### PR TITLE
obj: fix pmemobj_tx_lock error handling

### DIFF
--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -511,7 +511,8 @@ add_to_tx_and_lock(struct tx *tx, enum pobj_tx_param type, void *lock)
 			break;
 	}
 
-	SLIST_INSERT_HEAD(&tx->tx_locks, txl, tx_lock);
+	if (retval == 0)
+		SLIST_INSERT_HEAD(&tx->tx_locks, txl, tx_lock);
 
 	return retval;
 }

--- a/src/test/obj_tx_lock/obj_tx_lock.c
+++ b/src/test/obj_tx_lock/obj_tx_lock.c
@@ -141,6 +141,29 @@ do_tx_add_locks_nested_all(struct transaction_data *data)
 	return NULL;
 }
 
+/*
+ * do_tx_add_taken_lock -- (internal) verify that failed tx_lock doesn't add
+ * the lock to transaction
+ */
+static void *
+do_tx_add_taken_lock(struct transaction_data *data)
+{
+	/* wrlocks on Windows don't detect self-deadlocks */
+#ifdef _WIN32
+	(void) data;
+#else
+	UT_ASSERTeq(pmemobj_rwlock_wrlock(Pop, &data->rwlocks[0]), 0);
+
+	TX_BEGIN(Pop) {
+		UT_ASSERTne(pmemobj_tx_lock(TX_PARAM_RWLOCK, &data->rwlocks[0]),
+				0);
+	} TX_END
+
+	UT_ASSERTne(pmemobj_rwlock_trywrlock(Pop, &data->rwlocks[0]), 0);
+	UT_ASSERTeq(pmemobj_rwlock_unlock(Pop, &data->rwlocks[0]), 0);
+#endif
+	return NULL;
+}
 
 int
 main(int argc, char *argv[])
@@ -162,6 +185,7 @@ main(int argc, char *argv[])
 	do_tx_add_locks(test_obj);
 	do_tx_add_locks_nested(test_obj);
 	do_tx_add_locks_nested_all(test_obj);
+	do_tx_add_taken_lock(test_obj);
 
 	pmemobj_close(Pop);
 


### PR DESCRIPTION
Locking failure should NOT result in adding the lock to transaction!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3536)
<!-- Reviewable:end -->
