### PR TITLE
test: add tests for pmem_map_file

### DIFF
--- a/src/test/pmem_map_file/README
+++ b/src/test/pmem_map_file/README
@@ -5,7 +5,7 @@ This is src/test/pmem_map_file/README.
 This directory contains a unit test for pmem_map_file().
 
 The program in pmem_map_file.c takes a path, file length, flags, mode,
-use_mapped_len and use_is_pmem flags.
+use_mapped_len, use_is_pmem flags and err_code.
 
 The accepted flags in 'flags' string are:
 'C' - PMEM_FILE_CREATE
@@ -18,7 +18,7 @@ The accepted flags in 'flags' string are:
 'mode' - an an octal number that specifies the file mode
 
 Example:
-$ pmem_map_file /mnt/pmem/testfile 4096 CTS 0644 1 1 ...
+$ pmem_map_file /mnt/pmem/testfile 4096 CTS 0644 1 1 0 ...
 
 If the file is successfully mapped to memory, and it is not a temporary file,
 then initially the first 4k of the file is populated with some pattern

--- a/src/test/pmem_map_file/TEST0
+++ b/src/test/pmem_map_file/TEST0
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2014-2018, Intel Corporation
+# Copyright 2014-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,23 +51,23 @@ export ASAN_OPTIONS=handle_segv=0
 
 truncate -s 2G $DIR/testfile1
 
-# <path> <size> <flags> <mode> <use_mlen> <use_is_pmem>
+# <path> <size> <flags> <mode> <use_mlen> <use_is_pmem> <err_code>
 
 expect_normal_exit ./pmem_map_file$EXESUFFIX \
-    $DIR/testfile1 0 - 0 1 1 \
-    $DIR/testfile1 -1 - 0 1 1 \
-    $DIR/testfile1 0 - 0 0 0 \
-    $DIR/testfile1 0 X 0 0 0 \
-    $DIR/testfile1 0 - 0644 1 1 \
-    $DIR/testfile1 1024 - 0 1 1 \
-    $DIR/testfile1 0 C 0 1 1 \
-    $DIR/testfile1 0 E 0 1 1 \
-    $DIR/testfile1 4096 T 0644 1 1 \
-    $DIR/testfile1 4096 E 0644 1 1 \
-    $DIR/testfile1 0 - 0644 1 1 \
-    $DIR/testfile1 4096 C 0644 1 1 \
-    $DIR/testfile1 8192 C 0644 1 1 \
-    $DIR/testfile1 4096 CS 0644 1 1
+    $DIR/testfile1 0 - 0 1 1 0 \
+    $DIR/testfile1 -1 - 0 1 1 0 \
+    $DIR/testfile1 0 - 0 0 0 0 \
+    $DIR/testfile1 0 X 0 0 0 0 \
+    $DIR/testfile1 0 - 0644 1 1 0 \
+    $DIR/testfile1 1024 - 0 1 1 0 \
+    $DIR/testfile1 0 C 0 1 1 0 \
+    $DIR/testfile1 0 E 0 1 1 0 \
+    $DIR/testfile1 4096 T 0644 1 1 0 \
+    $DIR/testfile1 4096 E 0644 1 1 0 \
+    $DIR/testfile1 0 - 0644 1 1 0 \
+    $DIR/testfile1 4096 C 0644 1 1 0 \
+    $DIR/testfile1 8192 C 0644 1 1 0 \
+    $DIR/testfile1 4096 CS 0644 1 1 0
 
 check_files $DIR/testfile1
 

--- a/src/test/pmem_map_file/TEST0.PS1
+++ b/src/test/pmem_map_file/TEST0.PS1
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018, Intel Corporation
+# Copyright 2014-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,23 +44,23 @@ setup
 
 create_holey_file 2G $DIR\testfile1
 
-# <path> <size> <flags> <mode> <use_mlen> <use_is_pmem>
+# <path> <size> <flags> <mode> <use_mlen> <use_is_pmem> <err_code>
 
 expect_normal_exit $Env:EXE_DIR\pmem_map_file$Env:EXESUFFIX `
-    $DIR\testfile1 0 - 0 1 1 `
-    $DIR\testfile1 -1 - 0 1 1 `
-    $DIR\testfile1 0 - 0 0 0 `
-    $DIR\testfile1 0 X 0 0 0 `
-    $DIR\testfile1 0 - 0644 1 1 `
-    $DIR\testfile1 1024 - 0 1 1 `
-    $DIR\testfile1 0 C 0 1 1 `
-    $DIR\testfile1 0 E 0 1 1 `
-    $DIR\testfile1 4096 T 0644 1 1 `
-    $DIR\testfile1 4096 E 0644 1 1 `
-    $DIR\testfile1 0 - 0644 1 1 `
-    $DIR\testfile1 4096 C 0644 1 1 `
-    $DIR\testfile1 8192 C 0644 1 1 `
-    $DIR\testfile1 4096 CS 0644 1 1
+    $DIR\testfile1 0 - 0 1 1 0 `
+    $DIR\testfile1 -1 - 0 1 1 0 `
+    $DIR\testfile1 0 - 0 0 0 0 `
+    $DIR\testfile1 0 X 0 0 0 0 `
+    $DIR\testfile1 0 - 0644 1 1 0 `
+    $DIR\testfile1 1024 - 0 1 1 0 `
+    $DIR\testfile1 0 C 0 1 1 0 `
+    $DIR\testfile1 0 E 0 1 1 0 `
+    $DIR\testfile1 4096 T 0644 1 1 0 `
+    $DIR\testfile1 4096 E 0644 1 1 0 `
+    $DIR\testfile1 0 - 0644 1 1 0 `
+    $DIR\testfile1 4096 C 0644 1 1 0 `
+    $DIR\testfile1 8192 C 0644 1 1 0 `
+    $DIR\testfile1 4096 CS 0644 1 1 0
 
 check_files $DIR\testfile1
 

--- a/src/test/pmem_map_file/TEST1
+++ b/src/test/pmem_map_file/TEST1
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2014-2018, Intel Corporation
+# Copyright 2014-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,31 +49,31 @@ setup
 # this test invokes sigsegvs by design
 export ASAN_OPTIONS=handle_segv=0
 
-# <path> <size> <flags> <mode> <use_mlen> <use_is_pmem>
+# <path> <size> <flags> <mode> <use_mlen> <use_is_pmem> <err_code>
 
 # pass the file of zero length
 expect_normal_exit ./pmem_map_file$EXESUFFIX \
-    $DIR/testfile1 0 - 0666 1 1 \
-    $DIR/testfile2 0 C 0666 0 0 \
-    $DIR/testfile3 4096 C 0666 1 1 \
-    $DIR/testfile4 0 E 0666 1 1 \
-    $DIR/testfile5 4096 E 0666 1 1 \
-    $DIR/testfile6 4096 CE 0666 1 1 \
-    $DIR/testfile7 4096 CES 0666 1 1 \
-    $DIR/testfile8 4096 CS 0666 1 1 \
-    $DIR/testfile9 -1 C 0666 1 1 \
-    $DIR/testfile10 4096 X 0666 1 1 \
-    $DIR/testfile11 4096 CX 0666 1 1 \
-    $DIR/testfile12 0x1FFFFFFFFFFFFFFF CE 0666 1 1 \
-    $DIR 0 T 0666 1 1 \
-    $DIR 4096 T 0666 1 1 \
-    $DIR 4096 TC 0666 1 1 \
-    $DIR 4096 TE 0666 1 1 \
-    $DIR 4096 TS 0666 1 1 \
-    $DIR 4096 TSE 0666 1 1 \
-    $DIR 4096 TCE 0666 1 1 \
-    $DIR 4096 TSEC 0666 1 1 \
-    /proc/nonexistingdir 4096 T 0666 1 1
+    $DIR/testfile1 0 - 0666 1 1 0 \
+    $DIR/testfile2 0 C 0666 0 0 0 \
+    $DIR/testfile3 4096 C 0666 1 1 0 \
+    $DIR/testfile4 0 E 0666 1 1 0 \
+    $DIR/testfile5 4096 E 0666 1 1 0 \
+    $DIR/testfile6 4096 CE 0666 1 1 0 \
+    $DIR/testfile7 4096 CES 0666 1 1 0 \
+    $DIR/testfile8 4096 CS 0666 1 1 0 \
+    $DIR/testfile9 -1 C 0666 1 1 0 \
+    $DIR/testfile10 4096 X 0666 1 1 0 \
+    $DIR/testfile11 4096 CX 0666 1 1 0 \
+    $DIR/testfile12 0x1FFFFFFFFFFFFFFF CE 0666 1 1 0 \
+    $DIR 0 T 0666 1 1 0 \
+    $DIR 4096 T 0666 1 1 0 \
+    $DIR 4096 TC 0666 1 1 0 \
+    $DIR 4096 TE 0666 1 1 0 \
+    $DIR 4096 TS 0666 1 1 0 \
+    $DIR 4096 TSE 0666 1 1 0 \
+    $DIR 4096 TCE 0666 1 1 0 \
+    $DIR 4096 TSEC 0666 1 1 0 \
+    /proc/nonexistingdir 4096 T 0666 1 1 0
 
 check_files $DIR/testfile3 \
 	$DIR/testfile6 \

--- a/src/test/pmem_map_file/TEST2
+++ b/src/test/pmem_map_file/TEST2
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2014-2018, Intel Corporation
+# Copyright 2014-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,16 +49,16 @@ setup
 # this test invokes sigsegvs by design
 export ASAN_OPTIONS=handle_segv=0
 
-# <path> <size> <flags> <mode> <use_mlen> <use_is_pmem>
+# <path> <size> <flags> <mode> <use_mlen> <use_is_pmem> <err_code>
 
 # pass the file of zero length
 expect_normal_exit ./pmem_map_file$EXESUFFIX\
-    $DEVICE_DAX_PATH 0 D 0666 1 1\
-    $DEVICE_DAX_PATH 0 DSC 0666 1 1\
-    $DEVICE_DAX_PATH 0 DT 0666 1 1\
-    $DEVICE_DAX_PATH 0 DCE 0666 1 1\
-    $DEVICE_DAX_PATH 0 DC 0666 1 1\
-    $DEVICE_DAX_PATH 2097152 DC 0666 1 1\ # len != 0
+    $DEVICE_DAX_PATH 0 D 0666 1 1 0\
+    $DEVICE_DAX_PATH 0 DSC 0666 1 1 0\
+    $DEVICE_DAX_PATH 0 DT 0666 1 1 0\
+    $DEVICE_DAX_PATH 0 DCE 0666 1 1 0\
+    $DEVICE_DAX_PATH 0 DC 0666 1 1 0\
+    $DEVICE_DAX_PATH 2097152 DC 0666 1 1 0\ # len != 0
 
 check
 

--- a/src/test/pmem_map_file/TEST3
+++ b/src/test/pmem_map_file/TEST3
@@ -1,5 +1,6 @@
+#!/usr/bin/env bash
 #
-# Copyright 2014-2019, Intel Corporation
+# Copyright 2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,56 +32,41 @@
 #
 
 #
-# src/test/pmem_map_file/TEST1 -- unit test for pmem_map_file
+# src/test/pmem_map_file/TEST3 -- unit test for pmem_map_file
 #
 
-# standard unit test setup
-. ..\unittest\unittest.ps1
+. ../unittest/unittest.sh
 
 require_test_type medium
 require_fs_type any
 
 setup
 
+is_sparse(){
+	file_name=$1
+	apparent_size=`du --apparent-size $file_name | awk '{print $1}'`
+	actual_size=`du $file_name | awk '{print $1}'`
+
+	if [ $apparent_size -le $actual_size ]; then
+		msg "error: file is not sparse"
+		exit 1
+	fi
+}
+
+create_file 4K $DIR/testfile2
+create_file 4K $DIR/testfile3
+create_holey_file 4K $DIR/sparsefile1
+
 # <path> <size> <flags> <mode> <use_mlen> <use_is_pmem> <err_code>
+expect_normal_exit ./pmem_map_file$EXESUFFIX \
+	$DIR/testfile1 0 0 0666 nullptr nullptr 0 \
+	$DIR/testfile2 4096 CE 0666 1 1 EEXIST \
+	$DIR/testfile3 4096 CES 0666 1 1 EEXIST \
+	$DIR/sparsefile1 0 CS 0666 1 1 0 \
+	/nul/nonexistingdir 0 0 0666 1 1 ENOENT \
+	/nul/nonexistingdir 4096 CET 0666 1 1 ENOENT
 
-# pass the file of zero length
-expect_normal_exit $Env:EXE_DIR\pmem_map_file$Env:EXESUFFIX `
-    $DIR\testfile1 0 - 0666 1 1 0 `
-    $DIR\testfile2 0 C 0666 0 0 0 `
-    $DIR\testfile3 4096 C 0666 1 1 0 `
-    $DIR\testfile4 0 E 0666 1 1 0 `
-    $DIR\testfile5 4096 E 0666 1 1 0 `
-    $DIR\testfile6 4096 CE 0666 1 1 0 `
-    $DIR\testfile7 4096 CES 0666 1 1 0 `
-    $DIR\testfile8 4096 CS 0666 1 1 0 `
-    $DIR\testfile9 -1 C 0666 1 1 0 `
-    $DIR\testfile10 4096 X 0666 1 1 0 `
-    $DIR\testfile11 4096 CX 0666 1 1 0 `
-    $DIR\testfile12 0x1FFFFFFFFFFFFFFF CE 0666 1 1 0 `
-    $DIR 0 T 0666 1 1 0 `
-    $DIR 4096 T 0666 1 1 0 `
-    $DIR 4096 TC 0666 1 1 0 `
-    $DIR 4096 TE 0666 1 1 0 `
-    $DIR 4096 TS 0666 1 1 0 `
-    $DIR 4096 TSE 0666 1 1 0 `
-    $DIR 4096 TCE 0666 1 1 0 `
-    $DIR 4096 TSEC 0666 1 1 0 `
-    \nul\nonexistingdir 4096 T 0666 1 1 0
-
-check_files $DIR\testfile3 `
-    $DIR\testfile6 `
-    $DIR\testfile7 `
-    $DIR\testfile8
-
-check_no_files $DIR\testfile1 `
-    $DIR\testfile2 `
-    $DIR\testfile4 `
-    $DIR\testfile5 `
-    $DIR\testfile9 `
-    $DIR\testfile10 `
-    $DIR\testfile11 `
-    $DIR\testfile12
+is_sparse $DIR/sparsefile1
 
 check
 

--- a/src/test/pmem_map_file/TEST3.PS1
+++ b/src/test/pmem_map_file/TEST3.PS1
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2019, Intel Corporation
+# Copyright 2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,10 +31,9 @@
 #
 
 #
-# src/test/pmem_map_file/TEST1 -- unit test for pmem_map_file
+# src/test/pmem_map_file/TEST3 -- unit test for pmem_map_file
 #
 
-# standard unit test setup
 . ..\unittest\unittest.ps1
 
 require_test_type medium
@@ -42,45 +41,30 @@ require_fs_type any
 
 setup
 
+function is_sparse(){
+	$file = $args[0]
+	$res = fsutil sparse queryflag $file
+
+	if ($res -match "This file is NOT set as sparse"){
+		fail "error: file is not sparse"
+	}
+}
+
+create_file 4K $DIR/testfile2
+create_file 4K $DIR/testfile3
+
+create_holey_file 4K $DIR/sparsefile1
+
 # <path> <size> <flags> <mode> <use_mlen> <use_is_pmem> <err_code>
-
-# pass the file of zero length
 expect_normal_exit $Env:EXE_DIR\pmem_map_file$Env:EXESUFFIX `
-    $DIR\testfile1 0 - 0666 1 1 0 `
-    $DIR\testfile2 0 C 0666 0 0 0 `
-    $DIR\testfile3 4096 C 0666 1 1 0 `
-    $DIR\testfile4 0 E 0666 1 1 0 `
-    $DIR\testfile5 4096 E 0666 1 1 0 `
-    $DIR\testfile6 4096 CE 0666 1 1 0 `
-    $DIR\testfile7 4096 CES 0666 1 1 0 `
-    $DIR\testfile8 4096 CS 0666 1 1 0 `
-    $DIR\testfile9 -1 C 0666 1 1 0 `
-    $DIR\testfile10 4096 X 0666 1 1 0 `
-    $DIR\testfile11 4096 CX 0666 1 1 0 `
-    $DIR\testfile12 0x1FFFFFFFFFFFFFFF CE 0666 1 1 0 `
-    $DIR 0 T 0666 1 1 0 `
-    $DIR 4096 T 0666 1 1 0 `
-    $DIR 4096 TC 0666 1 1 0 `
-    $DIR 4096 TE 0666 1 1 0 `
-    $DIR 4096 TS 0666 1 1 0 `
-    $DIR 4096 TSE 0666 1 1 0 `
-    $DIR 4096 TCE 0666 1 1 0 `
-    $DIR 4096 TSEC 0666 1 1 0 `
-    \nul\nonexistingdir 4096 T 0666 1 1 0
+	$DIR/testfile1 0 0 0666 nullptr nullptr 0 `
+	$DIR/testfile2 4096 CE 0666 1 1 EEXIST `
+	$DIR/testfile3 4096 CES 0666 1 1 EEXIST `
+	$DIR/sparsefile1 0 CS 0666 1 1 0 `
+	\nul\nonexistingdir 0 0 0666 1 1 ENOENT `
+	\nul\nonexistingdir 4096 CET 0666 1 1 ENOENT
 
-check_files $DIR\testfile3 `
-    $DIR\testfile6 `
-    $DIR\testfile7 `
-    $DIR\testfile8
-
-check_no_files $DIR\testfile1 `
-    $DIR\testfile2 `
-    $DIR\testfile4 `
-    $DIR\testfile5 `
-    $DIR\testfile9 `
-    $DIR\testfile10 `
-    $DIR\testfile11 `
-    $DIR\testfile12
+is_sparse $DIR/sparsefile1
 
 check
 

--- a/src/test/pmem_map_file/out0.log.match
+++ b/src/test/pmem_map_file/out0.log.match
@@ -1,42 +1,42 @@
 pmem_map_file$(nW)TEST0: START: pmem_map_file$(nW)
  $(nW)pmem_map_file$(nW) $(*)
-$(nW)testfile1 0 - 0 1 1
+$(nW)testfile1 0 - 0 1 1 0
 mapped_len 2147483648
 unmap successful
-$(nW)testfile1 -1 - 0 1 1
+$(nW)testfile1 -1 - 0 1 1 0
 pmem_map_file: Invalid argument
-$(nW)testfile1 0 - 0 0 0
+$(nW)testfile1 0 - 0 0 0 0
 unmap successful
-$(nW)testfile1 0 X 0 0 0
+$(nW)testfile1 0 X 0 0 0 0
 pmem_map_file: Invalid argument
-$(nW)testfile1 0 - 644 1 1
+$(nW)testfile1 0 - 644 1 1 0
 mapped_len 2147483648
 unmap successful
-$(nW)testfile1 1024 - 0 1 1
+$(nW)testfile1 1024 - 0 1 1 0
 pmem_map_file: Invalid argument
-$(nW)testfile1 0 C 0 1 1
+$(nW)testfile1 0 C 0 1 1 0
 pmem_map_file: Invalid argument
-$(nW)testfile1 0 E 0 1 1
+$(nW)testfile1 0 E 0 1 1 0
 mapped_len 2147483648
 unmap successful
-$(nW)testfile1 4096 T 644 1 1
+$(nW)testfile1 4096 T 644 1 1 0
 pmem_map_file: Invalid argument
-$(nW)testfile1 4096 E 644 1 1
+$(nW)testfile1 4096 E 644 1 1 0
 pmem_map_file: Invalid argument
-$(nW)testfile1 0 - 644 1 1
+$(nW)testfile1 0 - 644 1 1 0
 mapped_len 2147483648
 unmap successful
-$(nW)testfile1 4096 C 644 1 1
+$(nW)testfile1 4096 C 644 1 1 0
 ftruncate: len 4096
 posix_fallocate: off 0 len 4096
 mapped_len 4096
 unmap successful
-$(nW)testfile1 8192 C 644 1 1
+$(nW)testfile1 8192 C 644 1 1 0
 ftruncate: len 8192
 posix_fallocate: off 0 len 8192
 mapped_len 8192
 unmap successful
-$(nW)testfile1 4096 CS 644 1 1
+$(nW)testfile1 4096 CS 644 1 1 0
 ftruncate: len 4096
 mapped_len 4096
 unmap successful

--- a/src/test/pmem_map_file/out1.log.match
+++ b/src/test/pmem_map_file/out1.log.match
@@ -1,61 +1,61 @@
 pmem_map_file$(nW)TEST1: START: pmem_map_file$(nW)
  $(nW)pmem_map_file$(nW) $(*)
-$(nW)testfile1 0 - 666 1 1
+$(nW)testfile1 0 - 666 1 1 0
 pmem_map_file: No such file or directory
-$(nW)testfile2 0 C 666 0 0
+$(nW)testfile2 0 C 666 0 0 0
 pmem_map_file: Invalid argument
-$(nW)testfile3 4096 C 666 1 1
+$(nW)testfile3 4096 C 666 1 1 0
 ftruncate: len 4096
 posix_fallocate: off 0 len 4096
 mapped_len 4096
 unmap successful
-$(nW)testfile4 0 E 666 1 1
+$(nW)testfile4 0 E 666 1 1 0
 pmem_map_file: No such file or directory
-$(nW)testfile5 4096 E 666 1 1
+$(nW)testfile5 4096 E 666 1 1 0
 pmem_map_file: Invalid argument
-$(nW)testfile6 4096 CE 666 1 1
+$(nW)testfile6 4096 CE 666 1 1 0
 ftruncate: len 4096
 posix_fallocate: off 0 len 4096
 mapped_len 4096
 unmap successful
-$(nW)testfile7 4096 CES 666 1 1
+$(nW)testfile7 4096 CES 666 1 1 0
 ftruncate: len 4096
 mapped_len 4096
 unmap successful
-$(nW)testfile8 4096 CS 666 1 1
+$(nW)testfile8 4096 CS 666 1 1 0
 ftruncate: len 4096
 mapped_len 4096
 unmap successful
-$(nW)testfile9 -1 C 666 1 1
+$(nW)testfile9 -1 C 666 1 1 0
 pmem_map_file: Invalid argument
-$(nW)testfile10 4096 X 666 1 1
+$(nW)testfile10 4096 X 666 1 1 0
 pmem_map_file: Invalid argument
-$(nW)testfile11 4096 CX 666 1 1
+$(nW)testfile11 4096 CX 666 1 1 0
 pmem_map_file: Invalid argument
-$(nW)testfile12 2305843009213693951 CE 666 1 1
+$(nW)testfile12 2305843009213693951 CE 666 1 1 0
 ftruncate: len 2305843009213693951
 pmem_map_file: $(*)
-$(nW) 0 T 666 1 1
+$(nW) 0 T 666 1 1 0
 pmem_map_file: Invalid argument
-$(nW) 4096 T 666 1 1
+$(nW) 4096 T 666 1 1 0
 pmem_map_file: Invalid argument
-$(nW) 4096 TC 666 1 1
+$(nW) 4096 TC 666 1 1 0
 ftruncate: len 4096
 posix_fallocate: off 0 len 4096
 mapped_len 4096
-$(nW) 4096 TE 666 1 1
+$(nW) 4096 TE 666 1 1 0
 pmem_map_file: Invalid argument
-$(nW) 4096 TS 666 1 1
+$(nW) 4096 TS 666 1 1 0
 pmem_map_file: Invalid argument
-$(nW) 4096 TSE 666 1 1
+$(nW) 4096 TSE 666 1 1 0
 pmem_map_file: Invalid argument
-$(nW) 4096 TCE 666 1 1
+$(nW) 4096 TCE 666 1 1 0
 ftruncate: len 4096
 posix_fallocate: off 0 len 4096
 mapped_len 4096
-$(nW) 4096 TSEC 666 1 1
+$(nW) 4096 TSEC 666 1 1 0
 ftruncate: len 4096
 mapped_len 4096
-$(nW)nonexistingdir 4096 T 666 1 1
+$(nW)nonexistingdir 4096 T 666 1 1 0
 pmem_map_file: Invalid argument
 pmem_map_file$(nW)TEST1: DONE

--- a/src/test/pmem_map_file/out2.log.match
+++ b/src/test/pmem_map_file/out2.log.match
@@ -1,15 +1,15 @@
 pmem_map_file$(nW)TEST2: START: pmem_map_file$(nW)
- $(nW)pmem_map_file$(nW) $(nW) 0 D 0666 1 1 $(nW) 0 DSC 0666 1 1 $(nW) 0 DT 0666 1 1 $(nW) 0 DCE 0666 1 1 $(nW) 0 DC 0666 1 1 $(nW) 2097152 DC 0666 1 1
-$(nW) 0 D 666 1 1
+ $(nW)pmem_map_file$(nW) $(nW) 0 D 0666 1 1 0 $(nW) 0 DSC 0666 1 1 0 $(nW) 0 DT 0666 1 1 0 $(nW) 0 DCE 0666 1 1 0 $(nW) 0 DC 0666 1 1 0 $(nW) 2097152 DC 0666 1 1 0
+$(nW) 0 D 666 1 1 0
 mapped_len $(N)
-$(nW) 0 DSC 666 1 1
+$(nW) 0 DSC 666 1 1 0
 mapped_len $(N)
-$(nW) 0 DT 666 1 1
+$(nW) 0 DT 666 1 1 0
 pmem_map_file: Invalid argument
-$(nW) 0 DCE 666 1 1
+$(nW) 0 DCE 666 1 1 0
 pmem_map_file: Invalid argument
-$(nW) 0 DC 666 1 1
+$(nW) 0 DC 666 1 1 0
 mapped_len $(N)
-$(nW) 2097152 DC 666 1 1
+$(nW) 2097152 DC 666 1 1 0
 pmem_map_file: Invalid argument
 pmem_map_file$(nW)TEST2: DONE

--- a/src/test/pmem_map_file/out3.log.match
+++ b/src/test/pmem_map_file/out3.log.match
@@ -1,0 +1,15 @@
+pmem_map_file$(nW)TEST3: START: pmem_map_file$(nW)
+ $(nW)pmem_map_file$(nW) $(*)
+$(nW)testfile1 0 0 666 0 0 0
+pmem_map_file: No such file or directory
+$(nW)testfile2 4096 CE 666 1 1 17
+pmem_map_file: File exists
+$(nW)testfile3 4096 CES 666 1 1 17
+pmem_map_file: File exists
+$(nW)sparsefile1 0 CS 666 1 1 0
+pmem_map_file: Invalid argument
+$(nW)nonexistingdir 0 0 666 1 1 2
+pmem_map_file: No such file or directory
+$(nW)nonexistingdir 4096 CET 666 1 1 2
+pmem_map_file: No such file or directory
+pmem_map_file$(nW)TEST3: DONE

--- a/src/test/pmem_map_file/pmem_map_file.c
+++ b/src/test/pmem_map_file/pmem_map_file.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -57,6 +57,26 @@ signal_handler(int sig)
 	(PMEM_FILE_CREATE|PMEM_FILE_EXCL|PMEM_FILE_SPARSE|PMEM_FILE_TMPFILE)
 
 static int is_dev_dax = 0;
+
+/*
+ * parse_err_code -- parse 'err_code' string
+ */
+static int
+parse_err_code(const char *err_str)
+{
+	int ret = 0;
+	if (strcmp(err_str, "ENOENT") == 0) {
+		ret = ENOENT;
+	} else if (strcmp(err_str, "EEXIST") == 0) {
+		ret = EEXIST;
+	} else if (strcmp(err_str, "0") == 0) {
+		ret = 0;
+	} else {
+		UT_FATAL("unknown err_code: %c", *err_str);
+	}
+
+	return ret;
+}
 
 /*
  * parse_flags -- parse 'flags' string
@@ -160,18 +180,20 @@ main(int argc, char *argv[])
 	int *is_pmemp;
 	int use_mlen;
 	int use_is_pmem;
+	int err_code;
 
-	if (argc < 7)
+	if (argc < 8)
 		UT_FATAL("usage: %s path len flags mode use_mlen "
-				"use_is_pmem ...", argv[0]);
+				"use_is_pmem err_code...", argv[0]);
 
-	for (int i = 1; i + 5 < argc; i += 6) {
+	for (int i = 1; i + 6 < argc; i += 7) {
 		path = argv[i];
 		len = strtoull(argv[i + 1], NULL, 0);
 		flags = parse_flags(argv[i + 2]);
 		mode = STRTOU(argv[i + 3], NULL, 8);
 		use_mlen = atoi(argv[i + 4]);
 		use_is_pmem = atoi(argv[i + 5]);
+		err_code = parse_err_code(argv[i + 6]);
 
 		mlen = SIZE_MAX;
 		if (use_mlen)
@@ -184,10 +206,16 @@ main(int argc, char *argv[])
 		else
 			is_pmemp = NULL;
 
-		UT_OUT("%s %lld %s %o %d %d",
-			path, len, argv[i + 2], mode, use_mlen, use_is_pmem);
+		UT_OUT("%s %lld %s %o %d %d %d",
+			path, len, argv[i + 2], mode, use_mlen,
+			use_is_pmem, err_code);
 
 		addr = pmem_map_file(path, len, flags, mode, mlenp, is_pmemp);
+
+		if (err_code != 0) {
+			UT_ASSERTeq(errno, err_code);
+		}
+
 		if (addr == NULL) {
 			UT_OUT("!pmem_map_file");
 			continue;


### PR DESCRIPTION
Added 6 test cases for pmem_map_file.

Scope of new test cases:
-Create mapping for an non-existing file
-Create mapping for an existing file passing nullptr as address for both mapped_lenp and is_pmem
-Create mapping for an existing file with an unnecesary creation flag
-Create mapping, forcing a sparse map file to be created
-Create mapping, forcing the map file to be created as a temporary file in a non-existent directory
-Create mapping for an existing file, forcing the map file to be created as a sparse file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3537)
<!-- Reviewable:end -->
