### PR TITLE
obj: make obj_pool_init threadsafe

### DIFF
--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -229,22 +229,31 @@ err:
  *
  * This is invoked on a first call to pmemobj_open() or pmemobj_create().
  * Memory is released in library destructor.
+ *
+ * This function needs to be threadsafe.
  */
 static void
 obj_pool_init(void)
 {
 	LOG(3, NULL);
 
-	if (pools_ht)
-		return;
+	struct critnib *c;
 
-	pools_ht = critnib_new();
-	if (pools_ht == NULL)
-		FATAL("!critnib_new for pools_ht");
+	if (pools_ht == NULL) {
+		c = critnib_new();
+		if (c == NULL)
+			FATAL("!critnib_new for pools_ht");
+		if (!util_bool_compare_and_swap64(&pools_ht, NULL, c))
+			critnib_delete(c);
+	}
 
-	pools_tree = critnib_new();
-	if (pools_tree == NULL)
-		FATAL("!critnib_new for pools_tree");
+	if (pools_tree == NULL) {
+		c = critnib_new();
+		if (c == NULL)
+			FATAL("!critnib_new for pools_tree");
+		if (!util_bool_compare_and_swap64(&pools_tree, NULL, c))
+			critnib_delete(c);
+	}
 }
 
 /*


### PR DESCRIPTION
In an effort to make pool management threadsafe, pools_ht and pool_tree
global variables need to be initialized only one time. To accomplish
that, we use CAS to make sure that only one thread initializes these
variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3539)
<!-- Reviewable:end -->
