### PR TITLE
benchmark: assert name and brief are defined

### DIFF
--- a/src/benchmarks/pmembench.cpp
+++ b/src/benchmarks/pmembench.cpp
@@ -320,6 +320,8 @@ pmembench_set_priv(struct benchmark *bench, void *priv)
 int
 pmembench_register(struct benchmark_info *bench_info)
 {
+	assert(bench_info->name && bench_info->brief);
+
 	struct benchmark *bench = (struct benchmark *)calloc(1, sizeof(*bench));
 	assert(bench != nullptr);
 


### PR DESCRIPTION
Benchmark name and brief are used unconditionally in the pmembench
codebase. It is better to assert they are not null during benchmark
registration to avoid tracking unclear SIGSEGV later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3551)
<!-- Reviewable:end -->
