### PR TITLE
util: fix util_atomic_load/store_explicit32/64

### DIFF
--- a/src/common/util.h
+++ b/src/common/util.h
@@ -432,14 +432,14 @@ util_mssb_index64(long long value)
 
 /* ISO C11 -- 7.17.7 Operations on atomic types */
 #define util_atomic_load32(object, dest)\
-	util_atomic_load_explicit32(object, dest, memory_order_seqcst)
+	util_atomic_load_explicit32(object, dest, memory_order_seq_cst)
 #define util_atomic_load64(object, dest)\
-	util_atomic_load_explicit64(object, dest, memory_order_seqcst)
+	util_atomic_load_explicit64(object, dest, memory_order_seq_cst)
 
 #define util_atomic_store32(object, desired)\
-	util_atomic_store_explicit32(object, desired, memory_order_seqcst)
+	util_atomic_store_explicit32(object, desired, memory_order_seq_cst)
 #define util_atomic_store64(object, desired)\
-	util_atomic_store_explicit64(object, desired, memory_order_seqcst)
+	util_atomic_store_explicit64(object, desired, memory_order_seq_cst)
 
 /*
  * util_get_printable_ascii -- convert non-printable ascii to dot '.'


### PR DESCRIPTION
Replace wrong 'memory_order_seqcst'
with correct 'memory_order_seq_cst'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3559)
<!-- Reviewable:end -->
