### PR TITLE
obj: fix a crash in critnib

### DIFF
--- a/src/libpmemobj/critnib.c
+++ b/src/libpmemobj/critnib.c
@@ -485,6 +485,12 @@ critnib_remove(struct critnib *c, uint64_t key)
 		n = kn;
 		k_parent = &kn->child[slice_index(key, kn->shift)];
 		kn = *k_parent;
+
+		if (!kn) {
+			os_mutex_unlock(&c->mutex);
+
+			return NULL;
+		}
 	}
 
 	struct critnib_leaf *k = to_leaf(kn);

--- a/src/test/obj_critnib/obj_critnib.c
+++ b/src/test/obj_critnib/obj_critnib.c
@@ -360,6 +360,25 @@ test_same_two()
 	critnib_delete(c);
 }
 
+static void
+test_remove_nonexist()
+{
+	struct critnib *c = critnib_new();
+
+	/* root */
+	UT_ASSERTeq(critnib_remove(c, 1), NULL);
+
+	/* in a leaf node */
+	critnib_insert(c, 2, (void *)2);
+	UT_ASSERTeq(critnib_remove(c, 1), NULL);
+
+	/* in a non-leaf node */
+	critnib_insert(c, 3, (void *)3);
+	UT_ASSERTeq(critnib_remove(c, 1), NULL);
+
+	critnib_delete(c);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -381,6 +400,7 @@ main(int argc, char *argv[])
 	test_le_brute();
 	test_same_only();
 	test_same_two();
+	test_remove_nonexist();
 
 	DONE(NULL);
 }


### PR DESCRIPTION
Removing a non-existent key is supposed to work, and do nothing.  A segfault is no nothing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3572)
<!-- Reviewable:end -->
