### PR TITLE
test: (win) fix timeouts from abort window popups

### DIFF
--- a/src/test/unittest/unittest.ps1
+++ b/src/test/unittest/unittest.ps1
@@ -472,8 +472,8 @@ function expect_abnormal_exit {
     }
 
     # Suppress abort window
-    $prev_abort = $Env:UNITTEST_NO_ABORT_MSG
-    $Env:UNITTEST_NO_ABORT_MSG = 1
+    $prev_abort = $Env:PMDK_NO_ABORT_MSG
+    $Env:PMDK_NO_ABORT_MSG = 1
 
     # Set $LASTEXITCODE to the value indicating success. It should be
     # overwritten with the exit status of the invoked command.
@@ -482,7 +482,7 @@ function expect_abnormal_exit {
     # status of some other command executed before.
     $Global:LASTEXITCODE = 0
     Invoke-Expression "$command $params"
-    $Env:UNITTEST_NO_ABORT_MSG = $prev_abort
+    $Env:PMDK_NO_ABORT_MSG = $prev_abort
     if ($Global:LASTEXITCODE -eq 0) {
         fail "${Env:UNITTEST_NAME}: command succeeded unexpectedly."
     }


### PR DESCRIPTION
In b09db041cbc38c31ae897084136673d73c0d0bfb UNITTEST_NO_ABORT_MSG
was renamed, but not all uses were updated.

Ref: pmem/issues#983
Ref: pmem/issues#1001

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3576)
<!-- Reviewable:end -->
