### PR TITLE
test: unbreak the testsuite after TESTS.py

### DIFF
--- a/src/test/RUNTESTS
+++ b/src/test/RUNTESTS
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2014-2018, Intel Corporation
+# Copyright 2014-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -306,7 +306,7 @@ runtest() {
 	runscripts=$testfile
 	if [ "$runscripts" = all ]; then
 		if [ "$testseq" = all ]; then
-			runscripts=`ls -1 TEST* | grep -v -i -e "\.ps1" | sort -V`
+			runscripts=`ls -1 TEST* | grep '^TEST[0-9]\+$' | sort -V`
 		else
 			# generate test sequence
 			seqs=(${testseq//,/ })


### PR DESCRIPTION
The testsuite currently gets to:
```
./RUNTESTS: line 247: S.py: syntax error: invalid arithmetic operator (error token is ".py")
```
then aborts, returning a **successful** result.

The false success is another issue, but restricting names to numbers only will do the trick for now.

Obsoletes  #3570.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3581)
<!-- Reviewable:end -->
