### PR TITLE
common: unlink remote replicas from poolset when COW is enabled

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -151,7 +151,8 @@ OBJ_REMOTE_DEPS = \
 OBJ_REMOTE_TESTS = \
 	obj_rpmem_basic_integration\
 	obj_rpmem_heap_interrupt\
-	obj_rpmem_heap_state
+	obj_rpmem_heap_state\
+	obj_check_remote
 
 OTHER_TESTS = \
 	arch_flags\

--- a/src/test/obj_check_remote/.gitignore
+++ b/src/test/obj_check_remote/.gitignore
@@ -1,0 +1,1 @@
+obj_check_remote

--- a/src/test/obj_check_remote/Makefile
+++ b/src/test/obj_check_remote/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_check_remote/Makefile -- build obj_check_remote test
+#
+TARGET = obj_check_remote
+OBJS = obj_check_remote.o
+
+LIBPMEMOBJ=y
+SCP_TO_REMOTE_NODES = y
+
+include ../Makefile.inc

--- a/src/test/obj_check_remote/TEST0
+++ b/src/test/obj_check_remote/TEST0
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_check_remote/TEST0 -- unit test which checks if remote
+# replicas were removed from poolset and were not modified by
+# pmemobj_check. (pmemobj_check used to rely on copy on write (MAP_PRIVATE)
+# for all replicas but it have never worked for remote ones)
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_command md5sum
+
+setup
+
+require_nodes 2
+
+require_node_libfabric 0 $RPMEM_PROVIDER
+require_node_libfabric 1 $RPMEM_PROVIDER
+
+init_rpmem_on_node 1 0
+
+# binary for this test
+EXE=obj_check_remote
+
+# define files and directories
+TEST_SET_LOCAL="testset_local"
+TEST_SET_REMOTE="testset_remote"
+
+# remove files created by previous test
+rm_files_from_node 1 ${NODE_DIR[1]}/testfile1
+rm_files_from_node 1 ${NODE_DIR[1]}/testfile2
+rm_files_from_node 1 ${NODE_DIR[1]}/testfile3
+rm_files_from_node 1 ${NODE_DIR[1]}/testfile4
+rm_files_from_node 0 ${NODE_DIR[0]}/testfile5
+rm_files_from_node 0 ${NODE_DIR[0]}/testfile6
+
+create_poolset $DIR/$TEST_SET_LOCAL 32M:${NODE_DIR[1]}/testfile1:z 32M:${NODE_DIR[1]}/testfile2:z  \
+        R 32M:${NODE_DIR[1]}/testfile3:z 32M:${NODE_DIR[1]}/testfile4:z \
+	m ${NODE_ADDR[0]}:$TEST_SET_REMOTE
+
+create_poolset $DIR/$TEST_SET_REMOTE 32M:${NODE_DIR[0]}/testfile5:z 32M:${NODE_DIR[0]}/testfile6:z
+
+copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$TEST_SET_REMOTE
+copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$TEST_SET_LOCAL
+
+expect_normal_exit run_on_node 1 ../pmempool create obj ${NODE_DIR[1]}/$TEST_SET_LOCAL
+
+expect_abnormal_exit run_on_node 1 ./$EXE$EXESUFFIX ${NODE_DIR[1]}/$TEST_SET_LOCAL abort
+
+copy_files_from_node 0 $DIR ${NODE_DIR[0]}/testfile5
+
+REPAB=`md5sum -b $DIR/testfile5`
+
+expect_normal_exit run_on_node 1 ./$EXE$EXESUFFIX ${NODE_DIR[1]}/$TEST_SET_LOCAL check
+
+copy_files_from_node 0 $DIR ${NODE_DIR[0]}/testfile5
+
+REPCHECK=`md5sum -b $DIR/testfile5`
+
+if [ "$REPAB" != "$REPCHECK" ]
+then
+	fatal "$REPAB != $REPCHECK"
+fi
+
+check
+
+pass

--- a/src/test/obj_check_remote/config.sh
+++ b/src/test/obj_check_remote/config.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# obj_check_remote/config.sh -- test configuration
+#
+
+CONF_GLOBAL_FS_TYPE=any
+CONF_GLOBAL_BUILD_TYPE="debug nondebug"
+CONF_GLOBAL_TEST_TYPE=medium
+
+CONF_GLOBAL_RPMEM_PROVIDER=sockets
+CONF_GLOBAL_RPMEM_PMETHOD=all

--- a/src/test/obj_check_remote/obj_check_remote.c
+++ b/src/test/obj_check_remote/obj_check_remote.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * obj_check_remote.c -- unit tests for pmemobj_check_remote
+ */
+
+#include <stddef.h>
+#include "unittest.h"
+#include "libpmemobj.h"
+
+struct vector {
+	int x;
+	int y;
+	int z;
+};
+
+int
+main(int argc, char *argv[])
+{
+	START(argc, argv, "obj_check_remote");
+
+	if (argc < 3)
+		UT_FATAL("insufficient number of arguments");
+
+	const char *path = argv[1];
+	const char *action = argv[2];
+	const char *layout = NULL;
+	PMEMobjpool *pop = NULL;
+
+	if (strcmp(action, "abort") == 0) {
+		pop = pmemobj_open(path, layout);
+		if (pop == NULL)
+			UT_FATAL("usage: %s filename abort|check", argv[0]);
+
+		PMEMoid root = pmemobj_root(pop, sizeof(struct vector));
+		struct vector *vectorp = pmemobj_direct(root);
+
+		TX_BEGIN(pop) {
+			pmemobj_tx_add_range(root, 0, sizeof(struct vector));
+			vectorp->x = 5;
+			vectorp->y = 10;
+			vectorp->z = 15;
+		} TX_ONABORT {
+			UT_ASSERT(0);
+		} TX_END
+
+		int *to_modify = &vectorp->x;
+
+		TX_BEGIN(pop) {
+			pmemobj_tx_add_range_direct(to_modify, sizeof(int));
+			*to_modify = 30;
+			pmemobj_persist(pop, to_modify, sizeof(*to_modify));
+			abort();
+		} TX_END
+	} else if (strcmp(action, "check") == 0) {
+		int ret = pmemobj_check(path, layout);
+		if (ret == 1)
+			return 0;
+		else
+			return ret;
+	} else {
+		UT_FATAL("%s is not a valid action", action);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
pmemobj_check fix for remote replicas

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3585)
<!-- Reviewable:end -->
