### PR TITLE
test: fix another failure from merging of Python tests

### DIFF
--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -467,7 +467,7 @@ endif
 sync-test: all $(SYNC_FILE) $(TESTCONFIG)
 
 TST=$(shell basename `pwd`)
-TSTCHECKS=$(shell ls -1 TEST* 2> /dev/null | grep -v -i -e "\.ps1" | sort -V)
+TSTCHECKS=$(shell ls -1 TEST* 2> /dev/null | grep '^TEST[0-9]\+$$' | sort -V)
 
 $(TSTCHECKS): sync-test
 	@cd .. && ./RUNTESTS ${TST} $(RUNTEST_OPTIONS) -s $@


### PR DESCRIPTION
./RUNTESTS: line 249: S.py: syntax error: invalid arithmetic operator (error token is ".py")

Ref: #3581

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3593)
<!-- Reviewable:end -->
