### PR TITLE
obj: fix use after free in heap_cleanup

### DIFF
--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -1258,6 +1258,7 @@ heap_cleanup(struct palloc_heap *heap)
 
 	alloc_class_collection_delete(rt->alloc_classes);
 
+	os_tls_key_delete(rt->thread_arena);
 	bucket_delete(rt->default_bucket);
 
 	for (unsigned i = 0; i < rt->narenas; ++i)
@@ -1268,7 +1269,6 @@ heap_cleanup(struct palloc_heap *heap)
 
 	util_mutex_destroy(&rt->arenas_lock);
 
-	os_tls_key_delete(rt->thread_arena);
 
 	Free(rt->arenas);
 


### PR DESCRIPTION
By the time tls_destructor was called arena was already destroyed

fixes: d2fc16caed3c7fe2f188ab1bf44687c939b7c7e1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3603)
<!-- Reviewable:end -->
