### PR TITLE
rpmem: enable logs from common/out module in rpmemd

### DIFF
--- a/src/common/out.h
+++ b/src/common/out.h
@@ -222,9 +222,15 @@ out_fatal_abort(const char *file, int line, const char *func,
 #define ERR(...)\
 	out_err(__FILE__, __LINE__, __func__, __VA_ARGS__)
 
+#define LOG_PREFIX_LEVEL_COMPLETE	(0)
+#define LOG_PREFIX_LEVEL_FUNC		(1)
+#define LOG_PREFIX_LEVEL_NO		(2)
+
 void out_init(const char *log_prefix, const char *log_level_var,
 		const char *log_file_var, int major_version,
 		int minor_version);
+void out_init_attach(const char *log_prefix, int log_prefix_level,
+		int log_level, FILE *log_file);
 void out_fini(void);
 void out(const char *fmt, ...) FORMAT_PRINTF(1, 2);
 void out_nonl(int level, const char *fmt, ...) FORMAT_PRINTF(2, 3);

--- a/src/test/arch_flags/log0.log.match
+++ b/src/test/arch_flags/log0.log.match
@@ -1,12 +1,12 @@
-<arch_flags>: <1> [$(nW) out_init]$(W)pid $(nW): program: $(nW)
-<arch_flags>: <1> [$(nW) out_init]$(W)arch_flags version 0.0
-<arch_flags>: <1> [$(nW) out_init]$(W)src version: $(nW)
-$(OPT)<arch_flags>: <1> [$(nW) out_init]$(W)compiled with support for Valgrind pmemcheck
-$(OPT)<arch_flags>: <1> [$(nW) out_init]$(W)compiled with support for Valgrind helgrind
-$(OPT)<arch_flags>: <1> [$(nW) out_init]$(W)compiled with support for Valgrind memcheck
-$(OPT)<arch_flags>: <1> [$(nW) out_init]$(W)compiled with support for Valgrind drd
-$(OPT)<arch_flags>: <1> [$(nW) out_init]$(W)compiled with support for shutdown state
-$(OPT)<arch_flags>: <1> [$(nW) out_init]$(W)compiled with libndctl 63+
+<arch_flags>: <1> [$(nW) out_init_preamble]$(W)pid $(nW): program: $(nW)
+<arch_flags>: <1> [$(nW) out_init_preamble]$(W)arch_flags version 0.0
+<arch_flags>: <1> [$(nW) out_init_preamble]$(W)src version: $(nW)
+$(OPT)<arch_flags>: <1> [$(nW) out_init_preamble]$(W)compiled with support for Valgrind pmemcheck
+$(OPT)<arch_flags>: <1> [$(nW) out_init_preamble]$(W)compiled with support for Valgrind helgrind
+$(OPT)<arch_flags>: <1> [$(nW) out_init_preamble]$(W)compiled with support for Valgrind memcheck
+$(OPT)<arch_flags>: <1> [$(nW) out_init_preamble]$(W)compiled with support for Valgrind drd
+$(OPT)<arch_flags>: <1> [$(nW) out_init_preamble]$(W)compiled with support for shutdown state
+$(OPT)<arch_flags>: <1> [$(nW) out_init_preamble]$(W)compiled with libndctl 63+
 <arch_flags>: <3> [$(nW) util_mmap_init] 
 <arch_flags>: <1> [$(nW) util_check_arch_flags]$(W)invalid machine value
 <arch_flags>: <1> [$(nW) util_check_arch_flags]$(W)invalid machine_class value

--- a/src/test/obj_rpmem_basic_integration/TEST20
+++ b/src/test/obj_rpmem_basic_integration/TEST20
@@ -46,6 +46,8 @@ require_nodes 2
 require_node_libfabric 0 $RPMEM_PROVIDER
 require_node_libfabric 1 $RPMEM_PROVIDER
 
+export RPMEMD_LOG_LEVEL=info
+
 init_rpmem_on_node 1 0
 
 # binary for this test

--- a/src/test/obj_rpmem_basic_integration/node_0_rpmemd20.log.match
+++ b/src/test/obj_rpmem_basic_integration/node_0_rpmemd20.log.match
@@ -21,4 +21,6 @@ pool attributes:
     uuid: $(nW)
     next_uuid: $(nW)
     prev_uuid: $(nW)
+size 2093056 smaller than 2097152
+failed to create file: $(*)
 cannot create pool set -- '$(nW)/testset_remote': Invalid argument

--- a/src/test/out_err/traces0.log.match
+++ b/src/test/out_err/traces0.log.match
@@ -1,12 +1,12 @@
-<trace>: <1> [out.c:$(N) out_init]$(W)pid $(N): program: $(nW)
-<trace>: <1> [out.c:$(N) out_init]$(W)trace version 1.0
-<trace>: <1> [out.c:$(N) out_init]$(W)src version: $(nW)
-$(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind pmemcheck
-$(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind helgrind
-$(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind memcheck
-$(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind drd
-$(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for shutdown state
-$(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with libndctl 63+
+<trace>: <1> [out.c:$(N) out_init_preamble]$(W)pid $(N): program: $(nW)
+<trace>: <1> [out.c:$(N) out_init_preamble]$(W)trace version 1.0
+<trace>: <1> [out.c:$(N) out_init_preamble]$(W)src version: $(nW)
+$(OPT)<trace>: <1> [out.c:$(N) out_init_preamble]$(W)compiled with support for Valgrind pmemcheck
+$(OPT)<trace>: <1> [out.c:$(N) out_init_preamble]$(W)compiled with support for Valgrind helgrind
+$(OPT)<trace>: <1> [out.c:$(N) out_init_preamble]$(W)compiled with support for Valgrind memcheck
+$(OPT)<trace>: <1> [out.c:$(N) out_init_preamble]$(W)compiled with support for Valgrind drd
+$(OPT)<trace>: <1> [out.c:$(N) out_init_preamble]$(W)compiled with support for shutdown state
+$(OPT)<trace>: <1> [out.c:$(N) out_init_preamble]$(W)compiled with libndctl 63+
 <trace>: <1> [out_err$(nW).c:$(N) $(nW)main]$(W)ERR #1
 $(OPT)<trace>: <1> [out_err$(nW).c:$(N) $(nW)main]$(W)ERR #2: Success
 $(OPX)<trace>: <1> [out_err$(nW).c:$(N) $(nW)main]$(W)ERR #2: No error: 0

--- a/src/test/out_err_win/traces0.log.match
+++ b/src/test/out_err_win/traces0.log.match
@@ -1,12 +1,12 @@
-<trace>: <1> [out.c:$(N) out_init]$(W)pid $(N): program: $(nW)
-<trace>: <1> [out.c:$(N) out_init]$(W)trace version 1.0
-<trace>: <1> [out.c:$(N) out_init]$(W)src version: $(nW)
-$(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind pmemcheck
-$(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind helgrind
-$(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind memcheck
-$(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind drd
-$(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for shutdown state
-$(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with libndctl 63+
+<trace>: <1> [out.c:$(N) out_init_preamble]$(W)pid $(N): program: $(nW)
+<trace>: <1> [out.c:$(N) out_init_preamble]$(W)trace version 1.0
+<trace>: <1> [out.c:$(N) out_init_preamble]$(W)src version: $(nW)
+$(OPT)<trace>: <1> [out.c:$(N) out_init_preamble]$(W)compiled with support for Valgrind pmemcheck
+$(OPT)<trace>: <1> [out.c:$(N) out_init_preamble]$(W)compiled with support for Valgrind helgrind
+$(OPT)<trace>: <1> [out.c:$(N) out_init_preamble]$(W)compiled with support for Valgrind memcheck
+$(OPT)<trace>: <1> [out.c:$(N) out_init_preamble]$(W)compiled with support for Valgrind drd
+$(OPT)<trace>: <1> [out.c:$(N) out_init_preamble]$(W)compiled with support for shutdown state
+$(OPT)<trace>: <1> [out.c:$(N) out_init_preamble]$(W)compiled with libndctl 63+
 <trace>: <1> [out_err$(nW).c:$(N) $(nW)main]$(W)ERR #1
 <trace>: <1> [out_err$(nW).c:$(N) $(nW)main]$(W)ERR #2: Success
 <trace>: <1> [out_err$(nW).c:$(N) $(nW)main]$(W)ERR #3: Invalid argument

--- a/src/test/rpmem_fip/rpmem_fip_test.c
+++ b/src/test/rpmem_fip/rpmem_fip_test.c
@@ -999,7 +999,8 @@ main(int argc, char *argv[])
 		"RPMEM_LOG_LEVEL",
 		"RPMEM_LOG_FILE", 0, 0);
 	rpmem_util_cmds_init();
-	rpmemd_log_init("rpmemd", os_getenv("RPMEMD_LOG_FILE"), 0);
+	rpmemd_log_init("rpmemd", os_getenv("RPMEMD_LOG_FILE"), 0,
+				1 /* init_out */);
 	rpmemd_log_level = rpmemd_log_level_from_str(
 			os_getenv("RPMEMD_LOG_LEVEL"));
 	TEST_CASE_PROCESS(argc, argv, test_cases, NTESTS);

--- a/src/test/rpmem_obc_int/rpmem_obc_int.c
+++ b/src/test/rpmem_obc_int/rpmem_obc_int.c
@@ -408,7 +408,8 @@ main(int argc, char *argv[])
 	common_init("rpmem_fip",
 		"RPMEM_LOG_LEVEL",
 		"RPMEM_LOG_FILE", 0, 0);
-	rpmemd_log_init("rpmemd", os_getenv("RPMEMD_LOG_FILE"), 0);
+	rpmemd_log_init("rpmemd", os_getenv("RPMEMD_LOG_FILE"), 0,
+				1 /* init_out */);
 	rpmemd_log_level = rpmemd_log_level_from_str(
 			os_getenv("RPMEMD_LOG_LEVEL"));
 	rpmem_util_cmds_init();

--- a/src/test/rpmemd_config/rpmemd_config_test.c
+++ b/src/test/rpmemd_config/rpmemd_config_test.c
@@ -118,7 +118,7 @@ main(int argc, char *argv[])
 
 	START(argc, argv, "rpmemd_config");
 
-	int ret = rpmemd_log_init("rpmemd_log", NULL, 0);
+	int ret = rpmemd_log_init("rpmemd_log", NULL, 0, 1 /* init_out */);
 	UT_ASSERTeq(ret, 0);
 
 	parse_test_params(&argc, argv);

--- a/src/test/rpmemd_config/stdout0.log.match
+++ b/src/test/rpmemd_config/stdout0.log.match
@@ -1,9 +1,5 @@
-$(OPT)rpmemd_config/TEST0: START: rpmemd_config
-$(OPT)rpmemd_config/TEST0: START: rpmemd_config
 rpmemd version $(*)
-$(OPT)rpmemd_config/TEST0: START: rpmemd_config
 rpmemd version $(*)
-$(OPT)rpmemd_config/TEST0: START: rpmemd_config
 usage: $(*) [--version] [--help] [<args>]
 rpmemd version $(*)
 
@@ -27,7 +23,6 @@ Options:
                                         debug   debug-level message
 
 For complete documentation see rpmemd(1) manual page.
-$(OPT)rpmemd_config/TEST0: START: rpmemd_config
 usage: $(*) [--version] [--help] [<args>]
 rpmemd version $(*)
 
@@ -51,9 +46,5 @@ Options:
                                         debug   debug-level message
 
 For complete documentation see rpmemd(1) manual page.
-$(OPT)rpmemd_config/TEST0: START: rpmemd_config
-$(OPT)rpmemd_config/TEST0: START: rpmemd_config
-$(OPT)rpmemd_config/TEST0: START: rpmemd_config
 $(*): No such file or directory
-$(OPT)rpmemd_config/TEST0: START: rpmemd_config
 $(*): No such file or directory

--- a/src/test/rpmemd_db/rpmemd_db_test.c
+++ b/src/test/rpmemd_db/rpmemd_db_test.c
@@ -657,7 +657,7 @@ main(int argc, char *argv[])
 	pool_desc[0] = argv[3];
 	pool_desc[1] = argv[4];
 
-	if (rpmemd_log_init("rpmemd error: ", log_file, 0))
+	if (rpmemd_log_init("rpmemd error: ", log_file, 0, 1 /* init_out */))
 		FAILED_FUNC("rpmemd_log_init");
 
 	test_init(root_dir);

--- a/src/test/rpmemd_log/rpmemd_log_test.c
+++ b/src/test/rpmemd_log/rpmemd_log_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -218,15 +218,15 @@ main(int argc, char *argv[])
 
 	switch (type) {
 	case TEST_STDERR:
-		ret = rpmemd_log_init("rpmemd_log", NULL, 0);
+		ret = rpmemd_log_init("rpmemd_log", NULL, 0, 1 /* init_out */);
 		UT_ASSERTeq(ret, 0);
 		break;
 	case TEST_SYSLOG:
-		ret = rpmemd_log_init("rpmemd_log", NULL, 1);
+		ret = rpmemd_log_init("rpmemd_log", NULL, 1, 1 /* init_out */);
 		UT_ASSERTeq(ret, 0);
 		break;
 	case TEST_FILE:
-		ret = rpmemd_log_init("rpmemd_log", file, 0);
+		ret = rpmemd_log_init("rpmemd_log", file, 0, 1 /* init_out */);
 		UT_ASSERTeq(ret, 0);
 		break;
 	}

--- a/src/test/rpmemd_obc/rpmemd_obc_test.c
+++ b/src/test/rpmemd_obc/rpmemd_obc_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017, Intel Corporation
+ * Copyright 2016-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -68,7 +68,8 @@ main(int argc, char *argv[])
 	out_init("rpmemd_obc",
 		"RPMEM_LOG_LEVEL",
 		"RPMEM_LOG_FILE", 0, 0);
-	rpmemd_log_init("rpmemd", os_getenv("RPMEMD_LOG_FILE"), 0);
+	rpmemd_log_init("rpmemd", os_getenv("RPMEMD_LOG_FILE"), 0,
+				1 /* init_out */);
 	rpmemd_log_level = rpmemd_log_level_from_str(
 			os_getenv("RPMEMD_LOG_LEVEL"));
 	rpmem_util_cmds_init();

--- a/src/test/rpmemd_util/rpmemd_util_test.c
+++ b/src/test/rpmemd_util/rpmemd_util_test.c
@@ -113,7 +113,7 @@ static void
 test(const int pm_range[2], const int is_pmem_range[2])
 {
 	rpmemd_log_level = RPD_LOG_NOTICE;
-	int ret = rpmemd_log_init("rpmemd_log", NULL, 0);
+	int ret = rpmemd_log_init("rpmemd_log", NULL, 0, 1 /* init_out */);
 	UT_ASSERTeq(ret, 0);
 
 	struct result result;

--- a/src/test/rpmemd_util/stdout0.log.match
+++ b/src/test/rpmemd_util/stdout0.log.match
@@ -1,4 +1,3 @@
-$(OPT)rpmemd_util/TEST0: START: rpmemd_util
 persistency policy:
     persist method: General Purpose Server Persistency Method
     persist flush: pmem_msync

--- a/src/test/rpmemd_util/stdout1.log.match
+++ b/src/test/rpmemd_util/stdout1.log.match
@@ -1,2 +1,1 @@
-$(OPT)rpmemd_util/TEST1: START: rpmemd_util
 invalid persist method: 3

--- a/src/test/traces_custom_function/out0.log.match
+++ b/src/test/traces_custom_function/out0.log.match
@@ -1,22 +1,22 @@
 traces_custom_function$(nW)TEST0: START: traces_custom_function
  $(nW)traces_custom_function$(nW) p
-CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)pid $(N): program: $(nW)
+CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init_preamble]$(W)pid $(N): program: $(nW)
 
-CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)trace_func version $(S)
+CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init_preamble]$(W)trace_func version $(S)
 
-CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)src version: $(nW)
+CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init_preamble]$(W)src version: $(nW)
 
-$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with support for Valgrind pmemcheck
+$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init_preamble]$(W)compiled with support for Valgrind pmemcheck
 $(OPT)
-$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with support for Valgrind helgrind
+$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init_preamble]$(W)compiled with support for Valgrind helgrind
 $(OPT)
-$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with support for Valgrind memcheck
+$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init_preamble]$(W)compiled with support for Valgrind memcheck
 $(OPT)
-$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with support for Valgrind drd
+$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init_preamble]$(W)compiled with support for Valgrind drd
 $(OPT)
-$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with support for shutdown state
+$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init_preamble]$(W)compiled with support for shutdown state
 $(OPT)
-$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with libndctl 63+
+$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init_preamble]$(W)compiled with libndctl 63+
 $(OPT)
 CUSTOM_PRINT: <trace_func>: <3> [$(nW):$(N) util_mmap_init]$(W)
 

--- a/src/test/traces_custom_function/out1.log.match
+++ b/src/test/traces_custom_function/out1.log.match
@@ -1,22 +1,22 @@
 traces_custom_function$(nW)TEST1: START: traces_custom_function
  $(nW)traces_custom_function$(nW) v
-CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)pid $(N): program: $(nW)
+CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init_preamble]$(W)pid $(N): program: $(nW)
 
-CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)trace_func version $(S)
+CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init_preamble]$(W)trace_func version $(S)
 
-CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)src version: $(nW)
+CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init_preamble]$(W)src version: $(nW)
 
-$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with support for Valgrind pmemcheck
+$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init_preamble]$(W)compiled with support for Valgrind pmemcheck
 $(OPT)
-$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with support for Valgrind helgrind
+$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init_preamble]$(W)compiled with support for Valgrind helgrind
 $(OPT)
-$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with support for Valgrind memcheck
+$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init_preamble]$(W)compiled with support for Valgrind memcheck
 $(OPT)
-$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with support for Valgrind drd
+$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init_preamble]$(W)compiled with support for Valgrind drd
 $(OPT)
-$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with support for shutdown state
+$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init_preamble]$(W)compiled with support for shutdown state
 $(OPT)
-$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with libndctl 63+
+$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init_preamble]$(W)compiled with libndctl 63+
 $(OPT)
 CUSTOM_PRINT: <trace_func>: <3> [$(nW):$(N) util_mmap_init]$(W)
 

--- a/src/tools/rpmemd/rpmemd.c
+++ b/src/tools/rpmemd/rpmemd.c
@@ -734,7 +734,7 @@ main(int argc, char *argv[])
 		goto err_obc;
 	}
 
-	if (rpmemd_log_init(DAEMON_NAME, NULL, 0)) {
+	if (rpmemd_log_init(DAEMON_NAME, NULL, 0, 0 /* init_out */)) {
 		RPMEMD_LOG(ERR, "logging subsystem initialization failed");
 		goto err_log_init;
 	}
@@ -747,7 +747,7 @@ main(int argc, char *argv[])
 	rpmemd_log_close();
 	rpmemd_log_level = rpmemd->config.log_level;
 	if (rpmemd_log_init(DAEMON_NAME, rpmemd->config.log_file,
-				rpmemd->config.use_syslog)) {
+				rpmemd->config.use_syslog, 1 /* init_out */)) {
 		RPMEMD_LOG(ERR, "logging subsystem initialization"
 			" failed (%s, %d)", rpmemd->config.log_file,
 			rpmemd->config.use_syslog);

--- a/src/tools/rpmemd/rpmemd_log.h
+++ b/src/tools/rpmemd/rpmemd_log.h
@@ -97,7 +97,8 @@ enum rpmemd_log_level rpmemd_log_level_from_str(const char *str);
 const char *rpmemd_log_level_to_str(enum rpmemd_log_level level);
 
 extern enum rpmemd_log_level rpmemd_log_level;
-int rpmemd_log_init(const char *ident, const char *fname, int use_syslog);
+int rpmemd_log_init(const char *ident, const char *fname, int use_syslog,
+			int init_out);
 void rpmemd_log_close(void);
 int rpmemd_prefix(const char *fmt, ...) FORMAT_PRINTF(1, 2);
 void rpmemd_log(enum rpmemd_log_level level, const char *fname,


### PR DESCRIPTION
Ref: [ldorau/rpmem-enable-logs-from-common-out-module-in-rpmemd](https://github.com/ldorau/pmdk/tree/rpmem-enable-logs-from-common-out-module-in-rpmemd)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3615)
<!-- Reviewable:end -->
