### PR TITLE
common: bump the ndctl requirement to 64 for bad blocks

### DIFF
--- a/src/common.inc
+++ b/src/common.inc
@@ -331,7 +331,7 @@ endif
 endif
 
 # unsafe shutdown count and badblock access without root (depends on kernel 4.20)
-NDCTL_MIN_VERSION_FIXED := 63
+NDCTL_MIN_VERSION_FIXED := 64
 
 NDCTL_MIN_VERSION := 60.1
 
@@ -376,7 +376,7 @@ ifeq ($(NDCTL_ENABLE),y)
     ifeq ($(LIBNDCTL),)
         HAS_NDCTL :=  $(call check_package, libndctl --atleast-version $(NDCTL_MIN_VERSION_FIXED))
         ifeq ($(HAS_NDCTL),y)
-            OS_DIMM_CFLAG=-DNDCTL_GE_63
+            OS_DIMM_CFLAG=-DNDCTL_GE_64
         else
             HAS_NDCTL :=  $(call check_package, libndctl --atleast-version $(NDCTL_MIN_VERSION))
             ifeq ($(HAS_NDCTL),n)

--- a/src/common/os_dimm_ndctl.c
+++ b/src/common/os_dimm_ndctl.c
@@ -252,7 +252,7 @@ end:
 	return ret;
 }
 
-#ifdef NDCTL_GE_63
+#ifdef NDCTL_GE_64
 static long long
 os_dimm_usc_dimm(struct ndctl_dimm *dimm)
 {
@@ -505,7 +505,7 @@ os_dimm_namespace_get_badblocks_by_region(struct ndctl_region *region,
 	return 0;
 }
 
-#ifdef NDCTL_GE_63
+#ifdef NDCTL_GE_64
 /*
  * os_dimm_namespace_get_badblocks_by_namespace -- (internal) returns bad blocks
  *                                    in the given namespace using the
@@ -551,7 +551,7 @@ os_dimm_namespace_get_badblocks(struct ndctl_region *region,
 				struct ndctl_namespace *ndns,
 				struct badblocks *bbs)
 {
-#ifdef NDCTL_GE_63
+#ifdef NDCTL_GE_64
 	/*
 	 * Only the new NDCTL versions have the namespace badblock iterator,
 	 * when compiled with older versions, the library needs to rely on the

--- a/src/common/out.c
+++ b/src/common/out.c
@@ -269,10 +269,10 @@ out_init(const char *log_prefix, const char *log_level_var,
 			"compiled with support for shutdown state";
 	LOG(1, "%s", shutdown_state_msg);
 #endif
-#if NDCTL_GE_63
-	static __attribute__((used)) const char *ndctl_ge_63_msg =
-		"compiled with libndctl 63+";
-	LOG(1, "%s", ndctl_ge_63_msg);
+#if NDCTL_GE_64
+	static __attribute__((used)) const char *ndctl_ge_64_msg =
+		"compiled with libndctl 64+";
+	LOG(1, "%s", ndctl_ge_64_msg);
 #endif
 
 	Last_errormsg_key_alloc();

--- a/src/common/pool_hdr.h
+++ b/src/common/pool_hdr.h
@@ -227,19 +227,19 @@ static const features_t features_zero =
 #define POOL_FEAT_INCOMPAT_VALID \
 	(POOL_FEAT_SINGLEHDR | POOL_FEAT_CKSUM_2K | POOL_E_FEAT_SDS)
 
-#if defined(_WIN32) || defined(NDCTL_GE_63)
+#if defined(_WIN32) || defined(NDCTL_GE_64)
 #define POOL_FEAT_INCOMPAT_DEFAULT \
 	(POOL_FEAT_CKSUM_2K | POOL_E_FEAT_SDS)
 #else
 /*
  * shutdown state support on Linux requires root access on kernel < 4.20 with
- * ndctl < 63 so it is disabled by default
+ * ndctl < 64 so it is disabled by default
  */
 #define POOL_FEAT_INCOMPAT_DEFAULT \
 	(POOL_FEAT_CKSUM_2K)
 #endif
 
-#if defined(NDCTL_GE_63)
+#if defined(NDCTL_GE_64)
 #define POOL_FEAT_COMPAT_DEFAULT \
 	(POOL_FEAT_CHECK_BAD_BLOCKS)
 #else

--- a/src/test/arch_flags/log0.log.match
+++ b/src/test/arch_flags/log0.log.match
@@ -6,7 +6,7 @@ $(OPT)<arch_flags>: <1> [$(nW) out_init]$(W)compiled with support for Valgrind h
 $(OPT)<arch_flags>: <1> [$(nW) out_init]$(W)compiled with support for Valgrind memcheck
 $(OPT)<arch_flags>: <1> [$(nW) out_init]$(W)compiled with support for Valgrind drd
 $(OPT)<arch_flags>: <1> [$(nW) out_init]$(W)compiled with support for shutdown state
-$(OPT)<arch_flags>: <1> [$(nW) out_init]$(W)compiled with libndctl 63+
+$(OPT)<arch_flags>: <1> [$(nW) out_init]$(W)compiled with libndctl 64+
 <arch_flags>: <3> [$(nW) util_mmap_init] 
 <arch_flags>: <1> [$(nW) util_check_arch_flags]$(W)invalid machine value
 <arch_flags>: <1> [$(nW) util_check_arch_flags]$(W)invalid machine_class value

--- a/src/test/common_badblock.sh
+++ b/src/test/common_badblock.sh
@@ -264,8 +264,8 @@ function ndctl_nfit_test_grant_access_node() {
 function ndctl_requires_extra_access()
 {
 	# Tests require additional permissions for badblock iteration if they
-	# are ran on device dax or with ndctl version prior to v63.
-	if [ "$1" != "fsdax" ] || ! is_ndctl_ge_63 $PMEMPOOL$EXESUFFIX ; then
+	# are ran on device dax or with ndctl version prior to v64.
+	if [ "$1" != "fsdax" ] || ! is_ndctl_ge_64 $PMEMPOOL$EXESUFFIX ; then
 		return 0
 	fi
 	return 1

--- a/src/test/libpmempool_feature/common.sh
+++ b/src/test/libpmempool_feature/common.sh
@@ -44,7 +44,7 @@ QUERY_PATTERN="query"
 ERROR_PATTERN="<1> \\[feature.c:.*\\]"
 
 exit_func=expect_normal_exit
-sds_enabled=$(is_ndctl_ge_63 ./libpmempool_feature$EXESUFFIX; echo $?)
+sds_enabled=$(is_ndctl_ge_64 ./libpmempool_feature$EXESUFFIX; echo $?)
 
 # libpmempool_feature_query_abnormal -- query feature with expected
 #	abnormal result

--- a/src/test/obj_sds/obj_sds.c
+++ b/src/test/obj_sds/obj_sds.c
@@ -76,7 +76,7 @@ main(int argc, char *argv[])
 		if ((pop = pmemobj_create(path, "LAYOUT", 0, 0600)) == NULL) {
 			UT_FATAL("!%s: pmemobj_create", path);
 		}
-#if !defined(_WIN32) && !defined(NDCTL_GE_63)
+#if !defined(_WIN32) && !defined(NDCTL_GE_64)
 		pmemobj_close(pop);
 		pmempool_feature_enable(path, PMEMPOOL_FEAT_SHUTDOWN_STATE, 0);
 		if ((pop = pmemobj_open(path, "LAYOUT")) == NULL) {

--- a/src/test/out_err/traces0.log.match
+++ b/src/test/out_err/traces0.log.match
@@ -6,7 +6,7 @@ $(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind h
 $(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind memcheck
 $(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind drd
 $(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for shutdown state
-$(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with libndctl 63+
+$(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with libndctl 64+
 <trace>: <1> [out_err$(nW).c:$(N) $(nW)main]$(W)ERR #1
 $(OPT)<trace>: <1> [out_err$(nW).c:$(N) $(nW)main]$(W)ERR #2: Success
 $(OPX)<trace>: <1> [out_err$(nW).c:$(N) $(nW)main]$(W)ERR #2: No error: 0

--- a/src/test/out_err_win/traces0.log.match
+++ b/src/test/out_err_win/traces0.log.match
@@ -6,7 +6,7 @@ $(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind h
 $(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind memcheck
 $(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind drd
 $(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for shutdown state
-$(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with libndctl 63+
+$(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with libndctl 64+
 <trace>: <1> [out_err$(nW).c:$(N) $(nW)main]$(W)ERR #1
 <trace>: <1> [out_err$(nW).c:$(N) $(nW)main]$(W)ERR #2: Success
 <trace>: <1> [out_err$(nW).c:$(N) $(nW)main]$(W)ERR #3: Invalid argument

--- a/src/test/pmempool_feature/common.sh
+++ b/src/test/pmempool_feature/common.sh
@@ -48,7 +48,7 @@ LOG=grep${UNITTEST_NUM}.log
 
 pmempool_exe=$PMEMPOOL$EXESUFFIX
 exit_func=expect_normal_exit
-sds_enabled=$(is_ndctl_ge_63 $pmempool_exe; echo $?)
+sds_enabled=$(is_ndctl_ge_64 $pmempool_exe; echo $?)
 
 # pmempool_feature_query -- query feature
 #

--- a/src/test/rpmem_addr_ext/node_1_rpmem0.log.match
+++ b/src/test/rpmem_addr_ext/node_1_rpmem0.log.match
@@ -6,7 +6,7 @@ $(OPT)<librpmem>: <1> [$(*)] compiled with support for Valgrind helgrind
 $(OPT)<librpmem>: <1> [$(*)] compiled with support for Valgrind memcheck
 $(OPT)<librpmem>: <1> [$(*)] compiled with support for Valgrind drd
 $(OPT)<librpmem>: <1> [$(*)] compiled with support for shutdown state
-$(OPT)<librpmem>: <1> [$(*)] compiled with libndctl 63+
+$(OPT)<librpmem>: <1> [$(*)] compiled with libndctl 64+
 <librpmem>: <3> [$(*)] 
 <librpmem>: <3> [$(*)] Libfabric is fork safe
 $(OPT)<librpmem>: <3> [$(*)] $(*)

--- a/src/test/traces/custom_file0.log.match
+++ b/src/test/traces/custom_file0.log.match
@@ -6,7 +6,7 @@ $(OPT)$(*) compiled with support for Valgrind helgrind
 $(OPT)$(*) compiled with support for Valgrind memcheck
 $(OPT)$(*) compiled with support for Valgrind drd
 $(OPT)$(*) compiled with support for shutdown state
-$(OPT)$(*) compiled with libndctl 63+
+$(OPT)$(*) compiled with libndctl 64+
 $(*)
 $(*)Log level NONE
 $(*)Log level ERROR

--- a/src/test/traces/redir_stderr2.log.match
+++ b/src/test/traces/redir_stderr2.log.match
@@ -6,6 +6,6 @@ $(OPT)$(*) compiled with support for Valgrind helgrind
 $(OPT)$(*) compiled with support for Valgrind memcheck
 $(OPT)$(*) compiled with support for Valgrind drd
 $(OPT)$(*) compiled with support for shutdown state
-$(OPT)$(*) compiled with libndctl 63+
+$(OPT)$(*) compiled with libndctl 64+
 $(*)Log level NONE
 $(*)Log level ERROR

--- a/src/test/traces/redir_stderr3.log.match
+++ b/src/test/traces/redir_stderr3.log.match
@@ -6,7 +6,7 @@ $(OPT)$(*) compiled with support for Valgrind helgrind
 $(OPT)$(*) compiled with support for Valgrind memcheck
 $(OPT)$(*) compiled with support for Valgrind drd
 $(OPT)$(*) compiled with support for shutdown state
-$(OPT)$(*) compiled with libndctl 63+
+$(OPT)$(*) compiled with libndctl 64+
 $(*)Log level NONE
 $(*)Log level ERROR
 $(*)Log level WARNING

--- a/src/test/traces/redir_stderr4.log.match
+++ b/src/test/traces/redir_stderr4.log.match
@@ -6,7 +6,7 @@ $(OPT)$(*) compiled with support for Valgrind helgrind
 $(OPT)$(*) compiled with support for Valgrind memcheck
 $(OPT)$(*) compiled with support for Valgrind drd
 $(OPT)$(*) compiled with support for shutdown state
-$(OPT)$(*) compiled with libndctl 63+
+$(OPT)$(*) compiled with libndctl 64+
 $(*)
 $(*)Log level NONE
 $(*)Log level ERROR

--- a/src/test/traces/redir_stderr5.log.match
+++ b/src/test/traces/redir_stderr5.log.match
@@ -6,7 +6,7 @@ $(OPT)$(*) compiled with support for Valgrind helgrind
 $(OPT)$(*) compiled with support for Valgrind memcheck
 $(OPT)$(*) compiled with support for Valgrind drd
 $(OPT)$(*) compiled with support for shutdown state
-$(OPT)$(*) compiled with libndctl 63+
+$(OPT)$(*) compiled with libndctl 64+
 $(*)
 $(*)Log level NONE
 $(*)Log level ERROR

--- a/src/test/traces/redir_stderr6.log.match
+++ b/src/test/traces/redir_stderr6.log.match
@@ -6,7 +6,7 @@ $(OPT)$(*) compiled with support for Valgrind helgrind
 $(OPT)$(*) compiled with support for Valgrind memcheck
 $(OPT)$(*) compiled with support for Valgrind drd
 $(OPT)$(*) compiled with support for shutdown state
-$(OPT)$(*) compiled with libndctl 63+
+$(OPT)$(*) compiled with libndctl 64+
 $(*)
 <ut>: <0> [traces.c:$(*) main]$(W)Log level NONE
 <ut>: <1> [traces.c:$(*) main]$(W)Log level ERROR

--- a/src/test/traces_custom_function/out0.log.match
+++ b/src/test/traces_custom_function/out0.log.match
@@ -16,7 +16,7 @@ $(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with sup
 $(OPT)
 $(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with support for shutdown state
 $(OPT)
-$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with libndctl 63+
+$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with libndctl 64+
 $(OPT)
 CUSTOM_PRINT: <trace_func>: <3> [$(nW):$(N) util_mmap_init]$(W)
 

--- a/src/test/traces_custom_function/out1.log.match
+++ b/src/test/traces_custom_function/out1.log.match
@@ -16,7 +16,7 @@ $(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with sup
 $(OPT)
 $(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with support for shutdown state
 $(OPT)
-$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with libndctl 63+
+$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with libndctl 64+
 $(OPT)
 CUSTOM_PRINT: <trace_func>: <3> [$(nW):$(N) util_mmap_init]$(W)
 

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1985,19 +1985,19 @@ function require_no_sds() {
 }
 
 #
-# is_ndctl_ge_63 -- check if binary is compiled with libndctl 63+
+# is_ndctl_ge_64 -- check if binary is compiled with libndctl 64+
 #
-#	usage: is_ndctl_ge_63 <binary>
+#	usage: is_ndctl_ge_64 <binary>
 #
-function is_ndctl_ge_63() {
+function is_ndctl_ge_64() {
 	local binary=$1
 	local dir=.
 	if [ -z "$binary" ]; then
-		fatal "is_ndctl_ge_63: error: no binary found"
+		fatal "is_ndctl_ge_64: error: no binary found"
 	fi
 
 	strings ${binary} 2>&1 | \
-		grep -q "compiled with libndctl 63+" && true
+		grep -q "compiled with libndctl 64+" && true
 
 	return $?
 }
@@ -2009,7 +2009,7 @@ function is_ndctl_ge_63() {
 #	usage: require_user_bb <binary>
 #
 function require_user_bb() {
-	if ! is_ndctl_ge_63 $1 &> /dev/null ; then
+	if ! is_ndctl_ge_64 $1 &> /dev/null ; then
 		msg "$UNITTEST_NAME: SKIP unprivileged bad block iteration not supported"
 		exit 0
 	fi
@@ -2024,7 +2024,7 @@ function require_user_bb() {
 #	usage: require_su_bb <binary>
 #
 function require_su_bb() {
-	if is_ndctl_ge_63 $1 &> /dev/null ; then
+	if is_ndctl_ge_64 $1 &> /dev/null ; then
 		msg "$UNITTEST_NAME: SKIP unprivileged bad block iteration supported"
 		exit 0
 	fi

--- a/src/test/util_pool_hdr/util_pool_hdr.c
+++ b/src/test/util_pool_hdr/util_pool_hdr.c
@@ -118,7 +118,7 @@ test_layout()
 #define POOL_FEAT_SDS_FINAL		0x0004U
 
 /* incompat features effective values */
-#if defined(_WIN32) || defined(NDCTL_GE_63)
+#if defined(_WIN32) || defined(NDCTL_GE_64)
 #ifdef SDS_ENABLED
 #define POOL_E_FEAT_SDS_FINAL		POOL_FEAT_SDS_FINAL
 #else
@@ -127,7 +127,7 @@ test_layout()
 #else
 /*
  * shutdown state support on Linux requires root access on kernel < 4.20 with
- * ndctl < 63 so it is disabled by default
+ * ndctl < 64 so it is disabled by default
  */
 #define POOL_E_FEAT_SDS_FINAL		0x0000U	/* empty */
 #endif

--- a/src/test/util_poolset/grep0.log.match
+++ b/src/test/util_poolset/grep0.log.match
@@ -6,7 +6,7 @@ $(OPT)compiled with support for Valgrind helgrind
 $(OPT)compiled with support for Valgrind memcheck
 $(OPT)compiled with support for Valgrind drd
 $(OPT)compiled with support for shutdown state
-$(OPT)compiled with libndctl 63+
+$(OPT)compiled with libndctl 64+
 open "$(nW)/testset0": No such file or directory
 size 1000000 smaller than 2097152
 size 1000000 smaller than 2097152

--- a/src/test/util_poolset/grep1.log.match
+++ b/src/test/util_poolset/grep1.log.match
@@ -6,7 +6,7 @@ $(OPT)compiled with support for Valgrind helgrind
 $(OPT)compiled with support for Valgrind memcheck
 $(OPT)compiled with support for Valgrind drd
 $(OPT)compiled with support for shutdown state
-$(OPT)compiled with libndctl 63+
+$(OPT)compiled with libndctl 64+
 open "$(nW)/testset0": No such file or directory
 invalid major version (0)
 open "$(nW)/testset2": Permission denied

--- a/src/test/util_poolset/grep2.log.match
+++ b/src/test/util_poolset/grep2.log.match
@@ -6,7 +6,7 @@ $(OPT)compiled with support for Valgrind helgrind
 $(OPT)compiled with support for Valgrind memcheck
 $(OPT)compiled with support for Valgrind drd
 $(OPT)compiled with support for shutdown state
-$(OPT)compiled with libndctl 63+
+$(OPT)compiled with libndctl 64+
 invalid checksum of pool header
 wrong pool type: "ERRORXX"
 pool version 99 (library expects 1)

--- a/src/test/util_poolset/grep3.log.match
+++ b/src/test/util_poolset/grep3.log.match
@@ -6,4 +6,4 @@ $(OPT)compiled with support for Valgrind helgrind
 $(OPT)compiled with support for Valgrind memcheck
 $(OPT)compiled with support for Valgrind drd
 $(OPT)compiled with support for shutdown state
-$(OPT)compiled with libndctl 63+
+$(OPT)compiled with libndctl 64+

--- a/src/test/util_poolset/grep4.log.match
+++ b/src/test/util_poolset/grep4.log.match
@@ -6,4 +6,4 @@ $(OPT)compiled with support for Valgrind helgrind
 $(OPT)compiled with support for Valgrind memcheck
 $(OPT)compiled with support for Valgrind drd
 $(OPT)compiled with support for shutdown state
-$(OPT)compiled with libndctl 63+
+$(OPT)compiled with libndctl 64+

--- a/src/test/util_poolset/grep5.log.match
+++ b/src/test/util_poolset/grep5.log.match
@@ -6,4 +6,4 @@ $(OPT)compiled with support for Valgrind helgrind
 $(OPT)compiled with support for Valgrind memcheck
 $(OPT)compiled with support for Valgrind drd
 $(OPT)compiled with support for shutdown state
-$(OPT)compiled with libndctl 63+
+$(OPT)compiled with libndctl 64+

--- a/src/test/util_poolset/grep6.log.match
+++ b/src/test/util_poolset/grep6.log.match
@@ -6,7 +6,7 @@ $(OPT)compiled with support for Valgrind helgrind
 $(OPT)compiled with support for Valgrind memcheck
 $(OPT)compiled with support for Valgrind drd
 $(OPT)compiled with support for shutdown state
-$(OPT)compiled with libndctl 63+
+$(OPT)compiled with libndctl 64+
 cannot mix directories and files in a set
 cannot mix directories and files in a set
 cannot mix directories and files in a set

--- a/src/test/util_poolset/grep7.log.match
+++ b/src/test/util_poolset/grep7.log.match
@@ -2,7 +2,7 @@ pid $(N): program: $(nW)util_poolset$(nW)
 ut version 1.0
 src version: $(nW)
 $(OPT)compiled with support for shutdown state
-$(OPT)compiled with libndctl 63+
+$(OPT)compiled with libndctl 64+
 the NOHDRS poolset option is not supported for local poolsets
 the NOHDRS poolset option is not supported for local poolsets
 the NOHDRS poolset option is not supported for local poolsets


### PR DESCRIPTION
All relevant distributions with kernel >- 4.20 have ndctl >= 64, thus it's no big loss — and the file leak bug breaks the test suite pretty badly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3618)
<!-- Reviewable:end -->
