### PR TITLE
common: build with fault injection in two more configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ env:
     - VALGRIND=1
   matrix:
     - COVERAGE=1 FAULT_INJECTION=1 TEST_BUILD=debug
-    - TEST_BUILD=debug
-    - TEST_BUILD=nondebug
+    - FAULT_INJECTION=1 TEST_BUILD=debug
+    - FAULT_INJECTION=1 TEST_BUILD=nondebug
     - PMDK_CC=clang PMDK_CXX=clang++ TEST_BUILD=debug
     - PMDK_CC=clang PMDK_CXX=clang++ TEST_BUILD=nondebug
     - OS=ubuntu_ndctl_v60 TEST_BUILD=debug

--- a/src/test/scope/out1.log.match
+++ b/src/test/scope/out1.log.match
@@ -5,9 +5,11 @@ pmem_deep_flush
 pmem_deep_persist
 pmem_drain
 pmem_errormsg
+$(OPT)pmem_fault_injection_enabled
 pmem_flush
 pmem_has_auto_flush
 pmem_has_hw_drain
+$(OPT)pmem_inject_fault_at
 pmem_is_pmem
 pmem_map_file
 pmem_memcpy

--- a/src/test/scope/out2.log.match
+++ b/src/test/scope/out2.log.match
@@ -9,6 +9,8 @@ pmemlog_ctl_exec
 pmemlog_ctl_get
 pmemlog_ctl_set
 pmemlog_errormsg
+$(OPT)pmemlog_fault_injection_enabled
+$(OPT)pmemlog_inject_fault_at
 pmemlog_nbyte
 pmemlog_open
 pmemlog_rewind

--- a/src/test/scope/out3.log.match
+++ b/src/test/scope/out3.log.match
@@ -8,6 +8,8 @@ pmemblk_ctl_exec
 pmemblk_ctl_get
 pmemblk_ctl_set
 pmemblk_errormsg
+$(OPT)pmemblk_fault_injection_enabled
+$(OPT)pmemblk_inject_fault_at
 pmemblk_nblock
 pmemblk_open
 pmemblk_read

--- a/src/test/scope/out4.log.match
+++ b/src/test/scope/out4.log.match
@@ -21,9 +21,11 @@ pmemobj_defer_free
 pmemobj_direct
 pmemobj_drain
 pmemobj_errormsg
+$(OPT)pmemobj_fault_injection_enabled
 pmemobj_first
 pmemobj_flush
 pmemobj_free
+$(OPT)pmemobj_inject_fault_at
 pmemobj_list_insert
 pmemobj_list_insert_new
 pmemobj_list_move

--- a/src/test/scope/out6.log.match
+++ b/src/test/scope/out6.log.match
@@ -4,9 +4,11 @@ pmempool_check_end
 pmempool_check_init
 pmempool_check_version
 pmempool_errormsg
+$(OPT)pmempool_fault_injection_enabled
 pmempool_feature_disable
 pmempool_feature_enable
 pmempool_feature_query
+$(OPT)pmempool_inject_fault_at
 pmempool_rm
 pmempool_sync
 pmempool_transform


### PR DESCRIPTION
In COVERAGE=1 job we ignore test failures, because coverage tracking
in gcc/clang is a bit buggy (memcheck complains).
This means that failures from fault injection are not detected.
Solve it by adding fault injection to 2 jobs which do not measure coverage.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3623)
<!-- Reviewable:end -->
