### PR TITLE
Pull/freebsd fixes

### DIFF
--- a/src/common/os_posix.c
+++ b/src/common/os_posix.c
@@ -201,8 +201,13 @@ os_posix_fallocate(int fd, os_off_t offset, off_t len)
 			return errno;
 
 		size_t reqd_blocks =
-			(((size_t)len + (fsbuf.f_bsize - 1)) / fsbuf.f_bsize)
-				- (size_t)fbuf.st_blocks;
+			((size_t)len + (fsbuf.f_bsize - 1)) / fsbuf.f_bsize;
+		if (fbuf.st_blocks > 0) {
+			if (reqd_blocks >= (size_t)fbuf.st_blocks)
+				reqd_blocks -= (size_t)fbuf.st_blocks;
+			else
+				reqd_blocks = 0;
+		}
 		if (reqd_blocks > (size_t)fsbuf.f_bavail)
 			return ENOSPC;
 	}

--- a/src/test/vmmalloc_dummy_funcs/libvmmalloc_dummy_funcs.map
+++ b/src/test/vmmalloc_dummy_funcs/libvmmalloc_dummy_funcs.map
@@ -35,7 +35,13 @@
 #
 LIBVMMALLOC_DUMMY_FUNCS_1.0 {
 	global:
+		__free_hook;
+		__malloc_hook;
+		__memalign_hook;
+		__realloc_hook;
 		aligned_alloc;
+		memalign;
+		pvalloc;
 	local:
 		*;
 };

--- a/src/tools/rpmemd/rpmemd_log.c
+++ b/src/tools/rpmemd/rpmemd_log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018, Intel Corporation
+ * Copyright 2016-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,13 +33,6 @@
 /*
  * rpmemd_log.c -- rpmemd logging functions definitions
  */
-/* for GNU version of basename */
-/* XXX Consider changing to Posix basename for consistency */
-#ifdef __FreeBSD__
-#include <libgen.h>
-#else
-#define _GNU_SOURCE
-#endif
 #include <errno.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -78,6 +71,24 @@ static int rpmemd_level2prio[MAX_RPD_LOG] = {
 	[RPD_LOG_INFO]		= LOG_INFO,
 	[_RPD_LOG_DBG]		= LOG_DEBUG,
 };
+
+/*
+ * rpmemd_log_basename -- similar to POSIX basename, but without handling for
+ * trailing slashes.
+ */
+static const char *
+rpmemd_log_basename(const char *fname)
+{
+	const char *s;
+
+	if (fname == NULL)
+		return "(null)";
+	s = strrchr(fname, '/');
+	if (s != NULL)
+		return s + 1;
+	else
+		return fname;
+}
 
 /*
  * rpmemd_log_level_from_str -- converts string to log level value
@@ -196,7 +207,7 @@ rpmemd_log(enum rpmemd_log_level level, const char *fname, int lineno,
 	int ret;
 	if (fname) {
 		ret = snprintf(&buff[cnt], RPMEMD_MAX_MSG - cnt,
-				"[%s:%d] ", basename(fname), lineno);
+				"[%s:%d] ", rpmemd_log_basename(fname), lineno);
 		if (ret < 0)
 			RPMEMD_FATAL("snprintf failed: %d", ret);
 		if ((unsigned)ret >= RPMEMD_MAX_MSG - cnt)


### PR DESCRIPTION
Here are three small fixes that I needed on top of @dawidpaluszkiewicz's work to successfully `make check` on FreeBSD. I'm not familiar with `rpmemd`, so I don't know if the extra memory allocations in `rpmemd_log` are going to be a problem. If so we could probably change it to use strrchr or some such thing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3628)
<!-- Reviewable:end -->
