### PR TITLE
pool: fix obj pool layout printing by pmempool create 

### DIFF
--- a/src/test/pmempool_create/TEST14
+++ b/src/test/pmempool_create/TEST14
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_create/TEST14 -- test pmemobj pool creation with default and custom layout
+# using increased verbosity level
+#
+
+. ../unittest/unittest.sh
+
+require_test_type medium
+
+require_fs_type any
+
+setup
+
+LOG=out${UNITTEST_NUM}.log
+ERR_LOG=err${UNITTEST_NUM}.log
+
+# test default layout
+expect_normal_exit "$PMEMPOOL$EXESUFFIX create obj -v $DIR/pool.obj >> $LOG"
+
+# test custom layout
+expect_normal_exit "$PMEMPOOL$EXESUFFIX create obj -v --layout=moose $DIR/pool2.obj >> $LOG"
+
+# test max layout
+
+# MAX_LAYOUT is equal to PMEMOBJ_MAX_LAYOUT (i.e. 1024) macro's value
+# reduced by 1 for terminating null byte
+MAX_LAYOUT=1023
+
+LAYOUT=$(head -c $MAX_LAYOUT < /dev/zero | tr '\0' '\170')
+
+expect_normal_exit "$PMEMPOOL$EXESUFFIX create obj -v --layout=$LAYOUT $DIR/pool3.obj >> $LOG"
+
+# test too long layout
+
+INVALID_LAYOUT=$(head -c $((MAX_LAYOUT+1)) < /dev/zero | tr '\0' '\170')
+
+expect_abnormal_exit "$PMEMPOOL$EXESUFFIX create obj -v --layout=$INVALID_LAYOUT $DIR/pool4.obj 2> $ERR_LOG"
+
+check
+
+pass

--- a/src/test/pmempool_create/TEST14.PS1
+++ b/src/test/pmempool_create/TEST14.PS1
@@ -1,0 +1,72 @@
+#
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_create/TEST14 -- test pmemobj pool creation with default and custom layout
+# using increased verbosity level
+#
+
+. ../unittest/unittest.ps1
+
+require_test_type medium
+
+require_fs_type any
+
+setup
+
+$LOG = "out${Env:UNITTEST_NUM}.log"
+$ERR_LOG = "err${Env:UNITTEST_NUM}.log"
+
+# test default layout
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj -v $DIR\pool.obj >> $LOG
+
+# test custom layout
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj -v --layout=moose $DIR\pool2.obj >> $LOG
+
+# test max layout
+
+# MAX_LAYOUT is equal to PMEMOBJ_MAX_LAYOUT (i.e. 1024) macro's value
+# reduced by 1 for terminating null byte
+$MAX_LAYOUT = 1023
+
+$LAYOUT = "x" * $MAX_LAYOUT
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj -v --layout=$LAYOUT $DIR/pool3.obj >> $LOG
+
+# test too long layout
+
+$INVALID_LAYOUT= "x" * ($MAX_LAYOUT + 1)
+
+expect_abnormal_exit cmd /c $PMEMPOOL$EXESUFFIX create obj -v --layout=$INVALID_LAYOUT $DIR/pool4.obj `>`> $LOG 2`>$ERR_LOG
+
+check
+
+pass

--- a/src/test/pmempool_create/err14.log.match
+++ b/src/test/pmempool_create/err14.log.match
@@ -1,0 +1,1 @@
+$(*)error: Layout name is too long, maximum number of characters (including the terminating null byte) is 1024

--- a/src/test/pmempool_create/out14.log.match
+++ b/src/test/pmempool_create/out14.log.match
@@ -1,0 +1,18 @@
+No size option passed - picking minimum pool size.
+Creating pool: $(nW)pool.obj
+	type  : obj
+	size  : 8.0M [8388608]
+	mode  : 0664
+	layout: ''
+No size option passed - picking minimum pool size.
+Creating pool: $(nW)pool2.obj
+	type  : obj
+	size  : 8.0M [8388608]
+	mode  : 0664
+	layout: 'moose'
+No size option passed - picking minimum pool size.
+Creating pool: $(nW)pool3.obj
+	type  : obj
+	size  : 8.0M [8388608]
+	mode  : 0664
+	layout: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'

--- a/src/tools/pmempool/create.c
+++ b/src/tools/pmempool/create.c
@@ -531,6 +531,14 @@ pmempool_create_func(const char *appname, int argc, char *argv[])
 				return -1;
 			}
 		}
+
+		if (PMEM_POOL_TYPE_OBJ == pc.params.type) {
+			if (pc.layout != NULL) {
+				size_t len = sizeof(pc.params.obj.layout);
+				strncpy(pc.params.obj.layout, pc.layout, len);
+				pc.params.obj.layout[len - 1] = '\0';
+			}
+		}
 	} else if (pc.inherit_fname) {
 		pc.params.type = pc.inherit_params.type;
 	} else {

--- a/src/tools/pmempool/create.c
+++ b/src/tools/pmempool/create.c
@@ -532,12 +532,19 @@ pmempool_create_func(const char *appname, int argc, char *argv[])
 			}
 		}
 
-		if (PMEM_POOL_TYPE_OBJ == pc.params.type) {
-			if (pc.layout != NULL) {
-				size_t len = sizeof(pc.params.obj.layout);
-				strncpy(pc.params.obj.layout, pc.layout, len);
-				pc.params.obj.layout[len - 1] = '\0';
+		if (PMEM_POOL_TYPE_OBJ == pc.params.type && pc.layout != NULL) {
+			size_t max_layout = PMEMOBJ_MAX_LAYOUT;
+
+			if (strlen(pc.layout) >= max_layout) {
+				outv_err(
+						"Layout name is too long, maximum number of characters (including the terminating null byte) is %zu\n",
+						max_layout);
+				return -1;
 			}
+
+			size_t len = sizeof(pc.params.obj.layout);
+			strncpy(pc.params.obj.layout, pc.layout, len);
+			pc.params.obj.layout[len - 1] = '\0';
 		}
 	} else if (pc.inherit_fname) {
 		pc.params.type = pc.inherit_params.type;
@@ -574,15 +581,6 @@ pmempool_create_func(const char *appname, int argc, char *argv[])
 	if (pc.params.size && pc.max_size) {
 		outv_err("-M|--max-size option cannot be used with -s|--size"
 				" option\n");
-		return -1;
-	}
-
-	size_t max_layout = PMEMOBJ_MAX_LAYOUT;
-
-	if (pc.layout && strlen(pc.layout) >= max_layout) {
-		outv_err("Layout name is too long, maximum number of characters"
-			" (including the terminating null byte) is %zu\n",
-			max_layout);
 		return -1;
 	}
 


### PR DESCRIPTION
Pool layout was not set at the moment of printing when pool creation was called with verbose option enabled.
Ref. pmem/issues#1026

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3635)
<!-- Reviewable:end -->
