### PR TITLE
obj: optimize reservation handling

### DIFF
--- a/src/libpmemobj/heap.h
+++ b/src/libpmemobj/heap.h
@@ -92,6 +92,9 @@ os_mutex_t *heap_get_run_lock(struct palloc_heap *heap,
 		uint32_t chunk_id);
 
 void
+heap_discard_run(struct palloc_heap *heap, struct memory_block *m);
+
+void
 heap_memblock_on_free(struct palloc_heap *heap, const struct memory_block *m);
 
 int

--- a/src/libpmemobj/memblock.h
+++ b/src/libpmemobj/memblock.h
@@ -289,6 +289,7 @@ struct memory_block {
 struct memory_block_reserved {
 	struct memory_block m;
 
+	struct bucket *bucket;
 	/*
 	 * Number of reservations made from this run, the pointer to this value
 	 * is stored in a user facing pobj_action structure. Decremented once

--- a/src/libpmemobj/palloc.c
+++ b/src/libpmemobj/palloc.c
@@ -85,7 +85,7 @@ struct pobj_action_internal {
 			uint64_t offset;
 			enum memblock_state new_state;
 			struct memory_block m;
-			int *resvp;
+			struct memory_block_reserved *mresv;
 		};
 
 		/* valid only when type == POBJ_ACTION_TYPE_MEM */
@@ -258,8 +258,8 @@ palloc_reservation_create(struct palloc_heap *heap, size_t size,
 	 * The memory block cannot be put back into the global state unless
 	 * there are no active reservations.
 	 */
-	if ((out->resvp = bucket_current_resvp(b)) != NULL)
-		util_fetch_and_add64(out->resvp, 1);
+	if ((out->mresv = b->active_memory_block) != NULL)
+		util_fetch_and_add64(&out->mresv->nresv, 1);
 
 	out->lock = new_block->m_ops->get_lock(new_block);
 	out->new_state = MEMBLOCK_ALLOCATED;
@@ -334,22 +334,52 @@ palloc_mem_action_noop(struct palloc_heap *heap,
 }
 
 /*
+ * palloc_reservation_clear -- clears the reservation state of the block,
+ *	discards the associated memory block if possible
+ */
+static void
+palloc_reservation_clear(struct palloc_heap *heap,
+	struct pobj_action_internal *act, int publish)
+{
+	if (act->mresv == NULL)
+		return;
+
+	struct bucket *b = act->mresv->bucket;
+
+	os_mutex_lock(&b->lock);
+
+	int cleared = util_fetch_and_sub64(&act->mresv->nresv, 1) == 1;
+
+	if (b->active_memory_block == act->mresv) {
+		if (!publish)
+			bucket_insert_block(b, &act->m);
+		os_mutex_unlock(&b->lock);
+	} else {
+		os_mutex_unlock(&b->lock);
+		if (cleared) {
+			heap_discard_run(heap, &act->mresv->m);
+			Free(act->mresv);
+		}
+	}
+}
+
+/*
  * palloc_heap_action_on_cancel -- restores the state of the heap
  */
 static void
 palloc_heap_action_on_cancel(struct palloc_heap *heap,
 	struct pobj_action_internal *act)
 {
-	if (act->new_state == MEMBLOCK_ALLOCATED) {
-		VALGRIND_DO_MEMPOOL_FREE(heap->layout,
-			act->m.m_ops->get_user_data(&act->m));
+	if (act->new_state == MEMBLOCK_FREE)
+		return;
 
-		act->m.m_ops->invalidate(&act->m);
-		palloc_restore_free_chunk_state(heap, &act->m);
-	}
+	VALGRIND_DO_MEMPOOL_FREE(heap->layout,
+		act->m.m_ops->get_user_data(&act->m));
 
-	if (act->resvp)
-		util_fetch_and_sub64(act->resvp, 1);
+	act->m.m_ops->invalidate(&act->m);
+	palloc_restore_free_chunk_state(heap, &act->m);
+
+	palloc_reservation_clear(heap, act, 0 /* publish */);
 }
 
 /*
@@ -363,8 +393,6 @@ palloc_heap_action_on_process(struct palloc_heap *heap,
 	if (act->new_state == MEMBLOCK_ALLOCATED) {
 		STATS_INC(heap->stats, persistent, heap_curr_allocated,
 			act->m.m_ops->get_real_size(&act->m));
-		if (act->resvp)
-			util_fetch_and_sub64(act->resvp, 1);
 	} else if (act->new_state == MEMBLOCK_FREE) {
 		if (On_valgrind) {
 			void *ptr = act->m.m_ops->get_user_data(&act->m);
@@ -401,7 +429,9 @@ static void
 palloc_heap_action_on_unlock(struct palloc_heap *heap,
 	struct pobj_action_internal *act)
 {
-	if (act->new_state == MEMBLOCK_FREE) {
+	if (act->new_state == MEMBLOCK_ALLOCATED) {
+		palloc_reservation_clear(heap, act, 1 /* publish */);
+	} else if (act->new_state == MEMBLOCK_FREE) {
 		palloc_restore_free_chunk_state(heap, &act->m);
 	}
 }
@@ -576,7 +606,7 @@ palloc_defer_free_create(struct palloc_heap *heap, uint64_t off,
 	 * metadata from being modified.
 	 */
 	out->lock = out->m.m_ops->get_lock(&out->m);
-	out->resvp = NULL;
+	out->mresv = NULL;
 	out->new_state = MEMBLOCK_FREE;
 }
 

--- a/src/libpmemobj/recycler.h
+++ b/src/libpmemobj/recycler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018, Intel Corporation
+ * Copyright 2016-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -59,7 +59,7 @@ struct recycler_element {
 };
 
 struct recycler *recycler_new(struct palloc_heap *layout,
-	size_t nallocs);
+	size_t nallocs, size_t *peak_arenas);
 void recycler_delete(struct recycler *r);
 struct recycler_element recycler_element_new(struct palloc_heap *heap,
 	const struct memory_block *m);

--- a/src/libpmemobj/recycler.h
+++ b/src/libpmemobj/recycler.h
@@ -69,10 +69,6 @@ int recycler_put(struct recycler *r, const struct memory_block *m,
 
 int recycler_get(struct recycler *r, struct memory_block *m);
 
-void
-recycler_pending_put(struct recycler *r,
-	struct memory_block_reserved *m);
-
 struct empty_runs recycler_recalc(struct recycler *r, int force);
 
 void recycler_inc_unaccounted(struct recycler *r,

--- a/src/test/obj_action/pmemcheck2.log.match
+++ b/src/test/obj_action/pmemcheck2.log.match
@@ -10,10 +10,10 @@
 ==$(N)== [0]    at 0x$(X): test_defer_free (obj_action.c:$(N))
 ==$(N)==    by 0x$(X): main (obj_action.c:$(N))
 ==$(N)== 	Address: 0x$(X)	size: 4	state: DIRTY
-==$(N)== [1]    at 0x$(X): main (obj_action.c:$(N))
-==$(N)== 	Address: 0x$(X)	size: 4	state: DIRTY
-==$(N)== [2]    at 0x$(X): test_defer_free (obj_action.c:$(N))
+==$(N)== [1]    at 0x$(X): test_defer_free (obj_action.c:$(N))
 ==$(N)==    by 0x$(X): main (obj_action.c:$(N))
+==$(N)== 	Address: 0x$(X)	size: 4	state: DIRTY
+==$(N)== [2]    at 0x$(X): main (obj_action.c:$(N))
 ==$(N)== 	Address: 0x$(X)	size: 4	state: DIRTY
 ==$(N)== [3]    at 0x$(X): main (obj_action.c:$(N))
 ==$(N)== 	Address: 0x$(X)	size: 4	state: DIRTY

--- a/src/test/obj_heap/obj_heap.c
+++ b/src/test/obj_heap/obj_heap.c
@@ -269,7 +269,8 @@ do_fault_injection_recycler()
 
 	pmemobj_inject_fault_at(PMEM_MALLOC, 1, "recycler_new");
 
-	struct recycler *r = recycler_new(NULL, 0);
+	size_t active_arenas = 1;
+	struct recycler *r = recycler_new(NULL, 0, &active_arenas);
 	UT_ASSERTeq(r, NULL);
 	UT_ASSERTeq(errno, ENOMEM);
 }

--- a/src/test/obj_heap/obj_heap.c
+++ b/src/test/obj_heap/obj_heap.c
@@ -455,7 +455,10 @@ test_recycler(void)
 
 	int ret;
 
-	struct recycler *r = recycler_new(&pop->heap, 10000 /* never recalc */);
+	size_t active_arenas = 1;
+	struct recycler *r = recycler_new(&pop->heap, 10000 /* never recalc */,
+		&active_arenas);
+
 	UT_ASSERTne(r, NULL);
 
 	init_run_with_score(pop->heap.layout, 0, 64);


### PR DESCRIPTION
This patch removes the linear algorithm for reservation tracking
in favor of a simpler approach where reservations are immediately
resolved. This new approach has potentially lower scalability
(publish and cancel can contend on the bucket), but doesn't
exhibit prohibitive performance drops in cases with many
reservations.

Ref: pmem/issues#1034

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3642)
<!-- Reviewable:end -->
