### PR TITLE
obj: helgrind annotations for critnib

### DIFF
--- a/src/common/valgrind_internal.h
+++ b/src/common/valgrind_internal.h
@@ -110,6 +110,12 @@ extern unsigned _On_valgrind;
 	ANNOTATE_IGNORE_WRITES_END();\
 } while (0)
 
+/* Supported by both helgrind and drd. */
+#define VALGRIND_HG_DRD_DISABLE_CHECKING(addr, size) do {\
+	if (On_valgrind) \
+		VALGRIND_HG_DISABLE_CHECKING((addr), (size));\
+} while (0)
+
 #else
 
 #define VALGRIND_ANNOTATE_HAPPENS_BEFORE(obj) do { (void)(obj); } while (0)
@@ -128,6 +134,11 @@ extern unsigned _On_valgrind;
 #define VALGRIND_ANNOTATE_IGNORE_WRITES_BEGIN() do {} while (0)
 
 #define VALGRIND_ANNOTATE_IGNORE_WRITES_END() do {} while (0)
+
+#define VALGRIND_HG_DRD_DISABLE_CHECKING(addr, size) do {\
+	(void) (addr);\
+	(void) (size);\
+} while (0)
 
 #endif
 

--- a/src/libpmemobj/critnib.c
+++ b/src/libpmemobj/critnib.c
@@ -222,6 +222,10 @@ critnib_new(void)
 
 	util_mutex_init(&c->mutex);
 
+	VALGRIND_HG_DRD_DISABLE_CHECKING(&c->root, sizeof(c->root));
+	VALGRIND_HG_DRD_DISABLE_CHECKING(&c->remove_count,
+					sizeof(c->remove_count));
+
 	return c;
 }
 
@@ -541,8 +545,10 @@ critnib_get(struct critnib *c, uint64_t key)
 		 * each node's critical bit^H^H^Hnibble.  This means we risk
 		 * going wrong way if our path is missing, but that's ok...
 		 */
-		while (n && !is_leaf(n))
+		while (n && !is_leaf(n)) {
+			VALGRIND_HG_DRD_DISABLE_CHECKING(n, sizeof(*n));
 			load(&n->child[slice_index(key, n->shift)], &n);
+		}
 
 		/* ... as we check it at the end. */
 		struct critnib_leaf *k = to_leaf(n);

--- a/src/test/obj_critnib_mt/TEST2
+++ b/src/test/obj_critnib_mt/TEST2
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Copyright 2015-2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_critnib/TEST2 -- multithreaded test for critnib
+#
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type long
+configure_valgrind drd force-enable
+
+setup
+
+expect_normal_exit ./obj_critnib_mt$EXESUFFIX
+
+pass


### PR DESCRIPTION
The helgrind warnings are correct: there are races; they just have clearly defined semantics that don't affect correctness — that's common for lock-free algorithms.  The rule is: a read can return any value that was current at any time between the read call started and finished.

So we need annotations.  Alas, I can't seem to find a way to set up ignoring races at allocation time — which should work according to my understanding of helgrind — reported errors don't disappear unless I repeat the annotation just prior to accessing the data.

But, with 1.6 release coming, there's no time.  Thus, here's a version that makes helgrind happy, at the cost of performance.  We can revisit this later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3644)
<!-- Reviewable:end -->
