### PR TITLE
obj: fix runtime state corruption after undo recovery

### DIFF
--- a/src/libpmemobj/lane.c
+++ b/src/libpmemobj/lane.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018, Intel Corporation
+ * Copyright 2015-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -402,24 +402,10 @@ lane_recover_and_section_boot(PMEMobjpool *pop)
 	 * a undo recovery might require deallocation of the next ulogs.
 	 */
 	for (i = 0; i < pop->nlanes; ++i) {
-		layout = lane_get_layout(pop, i);
-
-		struct ulog *undo = (struct ulog *)&layout->undo;
-
-		struct operation_context *ctx = operation_new(
-			undo,
-			LANE_UNDO_SIZE,
-			lane_undo_extend, (ulog_free_fn)pfree, &pop->p_ops,
-			LOG_TYPE_UNDO);
-		if (ctx == NULL) {
-			LOG(2, "undo recovery failed %" PRIu64 " %d",
-				i, err);
-			return err;
-		}
+		struct operation_context *ctx = pop->lanes_desc.lane[i].undo;
 		operation_resume(ctx);
 		operation_process(ctx);
 		operation_finish(ctx);
-		operation_delete(ctx);
 	}
 
 	return 0;

--- a/src/test/obj_recovery/TEST9
+++ b/src/test/obj_recovery/TEST9
@@ -1,5 +1,6 @@
+#!/usr/bin/env bash
 #
-# Copyright 2015-2019, Intel Corporation
+# Copyright 2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,14 +32,25 @@
 #
 
 #
-# src/test/obj_recovery/Makefile -- build obj_recovery unit test
+# src/test/obj_recovery/TEST9 -- unit test for pool recovery
 #
 
-TARGET = obj_recovery
-OBJS = obj_recovery.o
+# standard unit test setup
+. ../unittest/unittest.sh
 
-LIBPMEM=y
-LIBPMEMOBJ=y
-LIBPMEMCOMMON=y
+require_test_type medium
+require_no_asan
 
-include ../Makefile.inc
+setup
+
+# exits in the middle of transaction, so pool cannot be closed
+export MEMCHECK_DONT_CHECK_LEAKS=1
+
+create_holey_file 16M $DIR/testfile
+
+expect_normal_exit ./obj_recovery$EXESUFFIX $DIR/testfile n c l
+expect_normal_exit ./obj_recovery$EXESUFFIX $DIR/testfile n o l
+
+check
+
+pass


### PR DESCRIPTION
The 'operation_context' structure was being created twice, once as part
of lane initialization, and once as part of the recovery operation.
The first context is used for all operations, whereas the second context
lives only for the duration of the undo log recovery.

The problem was that the recovery process can change the persistent
state in such a way that the context runtime information becomes stale.
This is perfectly fine, and it's handled for the operation that
does the recovery - but at the same time, this makes the data of the
lane context invalid.

This bug was triggering ASSERTs in debug builds and might have led to
NULL dereference on release builds. Fortunately the crash happens
after recovery has been finished and simply restarting the application
gets rid of the problem.

The fix is quite simple: instead of duplicating the runtime state for
the purpose of recovery, simply use the one that already exists in the
lane.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3663)
<!-- Reviewable:end -->
