### PR TITLE
test: fix libpmempool_bttdev windows test

### DIFF
--- a/src/test/libpmempool_bttdev/TEST11.PS1
+++ b/src/test/libpmempool_bttdev/TEST11.PS1
@@ -41,6 +41,11 @@ require_fs_type any
 # For a large pool, util_map consumes so much memory.
 #
 require_free_physical_memory 3G
+#
+# Automatic page file size management eliminate the risk
+# of exceeding the available resources.
+#
+require_automatic_managed_pagefile
 
 setup
 

--- a/src/test/libpmempool_bttdev/TEST3.PS1
+++ b/src/test/libpmempool_bttdev/TEST3.PS1
@@ -41,6 +41,11 @@ require_fs_type any
 # For a large pool, util_map consumes so much memory.
 #
 require_free_physical_memory 3G
+#
+# Automatic page file size management eliminate the risk
+# of exceeding the available resources.
+#
+require_automatic_managed_pagefile
 
 setup
 

--- a/src/test/libpmempool_bttdev/TEST4.PS1
+++ b/src/test/libpmempool_bttdev/TEST4.PS1
@@ -41,6 +41,11 @@ require_fs_type any
 # For a large pool, util_map consumes so much memory.
 #
 require_free_physical_memory 3G
+#
+# Automatic page file size management eliminate the risk
+# of exceeding the available resources.
+#
+require_automatic_managed_pagefile
 
 setup
 

--- a/src/test/libpmempool_bttdev/TEST5.PS1
+++ b/src/test/libpmempool_bttdev/TEST5.PS1
@@ -41,6 +41,11 @@ require_fs_type any
 # For a large pool, util_map consumes so much memory.
 #
 require_free_physical_memory 3G
+#
+# Automatic page file size management eliminate the risk
+# of exceeding the available resources.
+#
+require_automatic_managed_pagefile
 
 setup
 

--- a/src/test/libpmempool_bttdev/TEST6.PS1
+++ b/src/test/libpmempool_bttdev/TEST6.PS1
@@ -41,6 +41,11 @@ require_fs_type any
 # For a large pool, util_map consumes so much memory.
 #
 require_free_physical_memory 5G
+#
+# Automatic page file size management eliminate the risk
+# of exceeding the available resources.
+#
+require_automatic_managed_pagefile
 
 setup
 

--- a/src/test/unittest/unittest.ps1
+++ b/src/test/unittest/unittest.ps1
@@ -1324,3 +1324,14 @@ function require_free_physical_memory() {
 		exit 0
 	}
 }
+
+#
+# require_automatic_managed_pagefile -- check if system manages the page file size
+#
+function require_automatic_managed_pagefile() {
+	$c = Get-WmiObject Win32_computersystem -EnableAllPrivileges
+	if($c.AutomaticManagedPagefile -eq $false) {
+		msg "${Env:UNITTEST_NAME}: SKIP automatic page file management is disabled"
+		exit 0
+	}
+}


### PR DESCRIPTION
When allocating large pools on the windows we use up a lot of resources,
with automatic page file size management we eliminate the risk
of exceeding the available resources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3687)
<!-- Reviewable:end -->
