### PR TITLE
common: fix minor issues related to ndctl linking

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -139,7 +139,7 @@ libpmemblk libpmemlog libpmemobj: libpmem
 benchmarks test tools: common
 
 pkg-cfg-common:
-	@printf "version=%s\nlibdir=%s\nprefix=%s\n" "$(SRCVERSION)" "$(libdir)" "$(prefix)" > $(PKG_CONFIG_COMMON)
+	@printf "version=%s\nlibdir=%s\nprefix=%s\nrasdeps=%s\n" "$(SRCVERSION)" "$(libdir)" "$(prefix)" "$(LIBNDCTL_PKG_CONFIG_DEPS)" > $(PKG_CONFIG_COMMON)
 
 $(PKG_CONFIG_COMMON): pkg-cfg-common
 

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -156,7 +156,7 @@ endif
 LDFLAGS += -Wl,-z,relro -Wl,--fatal-warnings -Wl,--warn-common $(EXTRA_LDFLAGS)
 
 ifneq ($(NORPATH),1)
-LDFLAGS += -Wl,-rpath=$(libdir)$(LIB_SUBDIR)
+LDFLAGS += -Wl,-rpath=$(libdir)$(LIB_SUBDIR):$(LIBNDCTL_LD_LIBRARY_PATHS)
 endif
 
 ifeq ($(LIBRT_NEEDED), y)

--- a/src/common.inc
+++ b/src/common.inc
@@ -389,15 +389,17 @@ ifeq ($(NDCTL_ENABLE),y)
         ifeq ($(HAS_DAXCTL),n)
             $(error libdaxctl(version >= $(NDCTL_MIN_VERSION)) is missing -- see README)
         endif
-        LIBNDCTL_CFLAGS := $(shell $(PKG_CONFIG) --cflags libndctl libdaxctl)
-        LIBNDCTL_LD_LIBRARY_PATHS := $(shell $(PKG_CONFIG) --variable=libdir libndctl libdaxctl | sed "s/ /:/")
-        LIBNDCTL_LIBS := $(shell $(PKG_CONFIG) --libs libndctl libdaxctl)
+        LIBNDCTL_PKG_CONFIG_DEPS := libndctl libdaxctl
+        LIBNDCTL_CFLAGS := $(shell $(PKG_CONFIG) --cflags $(LIBNDCTL_PKG_CONFIG_DEPS))
+        LIBNDCTL_LD_LIBRARY_PATHS := $(shell $(PKG_CONFIG) --variable=libdir $(LIBNDCTL_PKG_CONFIG_DEPS) | sed "s/ /:/")
+        LIBNDCTL_LIBS := $(shell $(PKG_CONFIG) --libs $(LIBNDCTL_PKG_CONFIG_DEPS))
     endif
     OS_DIMM := ndctl
 else
     OS_DIMM := none
 endif
 export OS_DIMM
+export LIBNDCTL_PKG_CONFIG_DEPS
 export LIBNDCTL_CFLAGS
 export LIBNDCTL_LD_LIBRARY_PATHS
 export LIBNDCTL_LIBS

--- a/utils/libpmemblk.pc.in
+++ b/utils/libpmemblk.pc.in
@@ -5,5 +5,6 @@ Description: libpmemblk library from PMDK project
 Version: ${version}
 URL: http://pmem.io/pmdk
 Requires.private: libpmem
+Requires.private: ${rasdeps}
 Libs: -L${libdir} -lpmemblk
 Cflags: -I${includedir}

--- a/utils/libpmemlog.pc.in
+++ b/utils/libpmemlog.pc.in
@@ -5,5 +5,6 @@ Description: libpmemlog library from PMDK project
 Version: ${version}
 URL: http://pmem.io/pmdk
 Requires.private: libpmem
+Requires.private: ${rasdeps}
 Libs: -L${libdir} -lpmemlog
 Cflags: -I${includedir}

--- a/utils/libpmemobj.pc.in
+++ b/utils/libpmemobj.pc.in
@@ -5,6 +5,7 @@ Description: libpmemobj library from PMDK project
 Version: ${version}
 URL: http://pmem.io/pmdk
 Requires.private: libpmem
+Requires.private: ${rasdeps}
 Libs: -L${libdir} -lpmemobj
 Libs.private: -ldl
 Cflags: -I${includedir}

--- a/utils/libpmempool.pc.in
+++ b/utils/libpmempool.pc.in
@@ -5,6 +5,7 @@ Description: libpmempool library from PMDK project
 Version: ${version}
 URL: http://pmem.io/pmdk
 Requires.private: libpmem
+Requires.private: ${rasdeps}
 Libs: -L${libdir} -lpmempool
 Libs.private: -ldl
 Cflags: -I${includedir}


### PR DESCRIPTION
"common: export libndctl and libdaxctl as private dependencies" matters only when linking to pmdk statically

"common: add libndctl directory to rpath" matters only for setups where both pmdk and ndctl are installed in private directories

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3688)
<!-- Reviewable:end -->
