### PR TITLE
test: skip if fi_info is missing

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -2111,7 +2111,10 @@ function require_node_libfabric() {
 	local version=${3:-1.4.2}
 
 	require_pkg libfabric "$version"
+	# fi_info can be found in libfabric-bin
+	require_command fi_info
 	require_node_pkg $N libfabric "$version"
+	require_command_node $N fi_info
 	if [ "$RPMEM_DISABLE_LIBIBVERBS" != "y" ]; then
 		if ! fi_info --list | grep -q verbs; then
 			msg "$UNITTEST_NAME: SKIP libfabric not compiled with verbs provider"


### PR DESCRIPTION
On 1.5 this produces a message without any apparent harm, on 1.6 it makes the tests fail if libfabric-bin is not installed.  At least on Debian and Ubuntu, libfabric-bin (tools) is a separate package than libfabric-dev (headers).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3689)
<!-- Reviewable:end -->
