### PR TITLE
test: (win) fix sparsefile error handling

### DIFF
--- a/src/test/tools/sparsefile/sparsefile.c
+++ b/src/test/tools/sparsefile/sparsefile.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -180,8 +180,8 @@ create_sparse_file(const wchar_t *filename, size_t len)
 	LARGE_INTEGER llen;
 	llen.QuadPart = len;
 
-	DWORD ptr = SetFilePointerEx(fh, llen, NULL, FILE_BEGIN);
-	if (ptr == INVALID_SET_FILE_POINTER) {
+	ret = SetFilePointerEx(fh, llen, NULL, FILE_BEGIN);
+	if (ret == FALSE) {
 		out_err(L"SetFilePointerEx");
 		goto err;
 	}


### PR DESCRIPTION
SetFilePointer returns DWORD
SetFilePointerEx returns BOOL

Found by code review, while looking for another bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3693)
<!-- Reviewable:end -->
