### PR TITLE
common: fix using TRAVIS_REPO_SLUG in if's

### DIFF
--- a/utils/check-commit.sh
+++ b/utils/check-commit.sh
@@ -38,7 +38,7 @@
 # usage: ./check-commit.sh
 #
 
-if [[ $TRAVIS_REPO_SLUG != "$GITHUB_REPO" \
+if [[ "$TRAVIS_REPO_SLUG" != "$GITHUB_REPO" \
 	|| $TRAVIS_EVENT_TYPE != "pull_request" ]];
 then
 	echo "SKIP: $0 can only be executed for pull requests to $GITHUB_REPO"

--- a/utils/check-doc.sh
+++ b/utils/check-doc.sh
@@ -46,7 +46,7 @@ if [[ -z "$TRAVIS" ]]; then
 	exit 1
 fi
 
-if [[ $TRAVIS_REPO_SLUG != "$GITHUB_REPO" \
+if [[ "$TRAVIS_REPO_SLUG" != "$GITHUB_REPO" \
 	|| $TRAVIS_EVENT_TYPE != "pull_request" ]];
 then
 	echo "SKIP: $0 can only be executed for pull requests to ${GITHUB_REPO}"

--- a/utils/docker/pull-or-rebuild-image.sh
+++ b/utils/docker/pull-or-rebuild-image.sh
@@ -77,7 +77,7 @@ fi
 
 # TRAVIS_COMMIT_RANGE is usually invalid for force pushes - ignore such values
 # when used with non-upstream repository
-if [ -n "$TRAVIS_COMMIT_RANGE" -a $TRAVIS_REPO_SLUG != "$GITHUB_REPO" ]; then
+if [ -n "$TRAVIS_COMMIT_RANGE" -a "$TRAVIS_REPO_SLUG" != "$GITHUB_REPO" ]; then
 	if ! git rev-list $TRAVIS_COMMIT_RANGE; then
 		TRAVIS_COMMIT_RANGE=
 	fi
@@ -123,7 +123,7 @@ for file in $files; do
 		# repository's stable-1.5 branch, and the Travis build is not
 		# of the "pull_request" type). In that case, create the empty
 		# file.
-		if [[ $TRAVIS_REPO_SLUG == "$GITHUB_REPO" \
+		if [[ "$TRAVIS_REPO_SLUG" == "$GITHUB_REPO" \
 			&& $TRAVIS_BRANCH == "stable-1.5" \
 			&& $TRAVIS_EVENT_TYPE != "pull_request"
 			&& $PUSH_IMAGE == "1" ]]


### PR DESCRIPTION
TRAVIS_REPO_SLUG should be always placed in double quotes
when used in the 'if' instruction, because it can be empty
(for example when the Travis build is run locally)
what causes syntax error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3699)
<!-- Reviewable:end -->
