### PR TITLE
test: avoid obj_critnib_mt taking very long on many-core machines

### DIFF
--- a/src/test/obj_critnib_mt/obj_critnib_mt.c
+++ b/src/test/obj_critnib_mt/obj_critnib_mt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Intel Corporation
+ * Copyright 2018-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,9 +42,9 @@
 #include "util.h"
 #include "valgrind_internal.h"
 
-#define NITER_FAST 20000000
-#define NITER_MID   2000000
-#define NITER_SLOW   200000
+#define NITER_FAST 200000000
+#define NITER_MID   20000000
+#define NITER_SLOW   2000000
 
 #define MAXTHREADS 4096
 
@@ -77,6 +77,8 @@ rnd64()
 static uint64_t
 helgrind_count(uint64_t x)
 {
+	/* Convert total number of ops to per-thread. */
+	x /= (unsigned)nthreads;
 	/*
 	 * Reduce iteration count when running on foogrind, by a factor of 64.
 	 * Multiple instances of foogrind cause exponential slowdown, so handle


### PR DESCRIPTION
The structure is optimized for get speed, with little heed for puts and removes, which contend on a single lock.  Thus, MT write tests can take a long time on a machine with many cores.  Let's specify the # of ops as a total rather than per-thread number.

New values: same on a 10-thread machine, 1.25× longer on 8-threaded, 9.6× shorter on 96-threaded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3706)
<!-- Reviewable:end -->
