### PR TITLE
common: (win) fix possible pool file coruption

### DIFF
--- a/src/common/file.c
+++ b/src/common/file.c
@@ -329,8 +329,12 @@ util_file_zero(const char *path, os_off_t off, size_t len)
 	int fd;
 	int olderrno;
 	int ret = 0;
+	int flags = O_RDWR;
+#ifdef _WIN32
+	flags |= O_BINARY;
+#endif
 
-	if ((fd = os_open(path, O_RDWR)) < 0) {
+	if ((fd = os_open(path, flags)) < 0) {
 		ERR("!open \"%s\"", path);
 		return -1;
 	}

--- a/src/common/file.c
+++ b/src/common/file.c
@@ -288,8 +288,12 @@ util_file_map_whole(const char *path)
 	int fd;
 	int olderrno;
 	void *addr = NULL;
+	int flags = O_RDWR;
+#ifdef _WIN32
+	flags |= O_BINARY;
+#endif
 
-	if ((fd = os_open(path, O_RDWR)) < 0) {
+	if ((fd = os_open(path, flags)) < 0) {
 		ERR("!open \"%s\"", path);
 		return NULL;
 	}

--- a/src/libpmem/pmem.c
+++ b/src/libpmem/pmem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -423,6 +423,9 @@ pmem_map_fileU(const char *path, size_t len, int flags,
 	int open_flags = O_RDWR;
 	int delete_on_err = 0;
 	int file_type = util_file_get_type(path);
+#ifdef _WIN32
+	open_flags |= O_BINARY;
+#endif
 
 	if (file_type == OTHER_ERROR)
 		return NULL;


### PR DESCRIPTION
It turns out that _wopen on Windows can truncate a file by 1 byte when O_BINARY flag is not used and the last byte has a value of 0x1a. It doesn't always happen, but it does happen frequently enough. Currently this behavior is not mentioned in _wopen documentation (https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/open-wopen?view=vs-2019), but is in fopen documentation: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=vs-2019. Specifically it says:

> In text mode, CTRL+Z is interpreted as an EOF character on input. In files that are opened for reading/writing by using "a+", fopen checks for a CTRL+Z at the end of the file and removes it, if it is possible. This is done because using fseek and ftell to move within a file that ends with CTRL+Z may cause fseek to behave incorrectly near the end of the file.

Opening files without O_BINARY was never an immediate problem for us, because we are not reading anything from the opened files using "read", just mapping them.

This bug affects:
- pmem_map_file
- pmempool_create
- pmempool_dump
- pmempool_info
- pmempool_transform

libpmemobj, libpmemblk, libpmemlog, librpmem, libvmem and libvmmalloc are **not** affected.

Ref: pmem/issues#972
Ref: pmem/issues#715
Ref: pmem/issues#603

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3728)
<!-- Reviewable:end -->
