### PR TITLE
test: do not use '&>' in require_command(_node)

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1520,7 +1520,7 @@ function require_build_type() {
 # require_command -- only allow script to continue if specified command exists
 #
 function require_command() {
-	if ! which $1 &>/dev/null; then
+	if ! which $1 >/dev/null 2>&1; then
 		msg "$UNITTEST_NAME: SKIP: '$1' command required"
 		exit 0
 	fi
@@ -1532,7 +1532,7 @@ function require_command() {
 # usage: require_command_node <node-number>
 #
 function require_command_node() {
-	if ! run_on_node $1 "which $2 &>/dev/null"; then
+	if ! run_on_node $1 "which $2 >/dev/null 2>&1"; then
 		msg "$UNITTEST_NAME: SKIP: node $1: '$2' command required"
 		exit 0
 	fi


### PR DESCRIPTION
I'm aware the complete solution is to remove all ```&>``` and ```&>>```. But the simple replace causes tests to fail. This PR aims to solve the issue with littering log with multiple ```/usr/bin/fi_info``` entries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3734)
<!-- Reviewable:end -->
