### PR TITLE
Spelling fix (depracated -> deprecated)

### DIFF
--- a/doc/libpmemblk/pmemblk_ctl_get.3.md
+++ b/doc/libpmemblk/pmemblk_ctl_get.3.md
@@ -112,7 +112,7 @@ sds.at_create | rw | global | int | int | - | boolean
 
 If set, force-enables or force-disables SDS feature during pool creation.
 Affects only the _UW(pmemblk_create) function. See **pmempool_feature_query**(3)
-for informations about SDS (SHUTDOWN_STATE) feature.
+for information about SDS (SHUTDOWN_STATE) feature.
 
 Always returns 0.
 

--- a/doc/libpmemlog/pmemlog_ctl_get.3.md
+++ b/doc/libpmemlog/pmemlog_ctl_get.3.md
@@ -112,7 +112,7 @@ sds.at_create | rw | global | int | int | - | boolean
 
 If set, force-enables or force-disables SDS feature during pool creation.
 Affects only the _UW(pmemlog_create) function. See **pmempool_feature_query**(3)
-for informations about SDS (SHUTDOWN_STATE) feature.
+for information about SDS (SHUTDOWN_STATE) feature.
 
 Always returns 0.
 

--- a/doc/libpmemobj/pmemobj_ctl_get.3.md
+++ b/doc/libpmemobj/pmemobj_ctl_get.3.md
@@ -108,7 +108,7 @@ sds.at_create | rw | global | int | int | - | boolean
 
 If set, force-enables or force-disables SDS feature during pool creation.
 Affects only the _UW(pmemobj_create) function. See **pmempool_feature_query**(3)
-for informations about SDS (SHUTDOWN_STATE) feature.
+for information about SDS (SHUTDOWN_STATE) feature.
 
 copy_on_write.at_open | rw | global | int | int | - | boolean
 

--- a/doc/librpmem/rpmem_persist.3.md
+++ b/doc/librpmem/rpmem_persist.3.md
@@ -81,7 +81,7 @@ to the *pool_addr* specified in the **rpmem_open**(3) or **rpmem_create**(3)
 call. If the remote pool was created using **rpmem_create**() with non-NULL
 *create_attr* argument, *offset* has to be greater or equal to 4096.
 In that case the first 4096 bytes of the pool is used for storing the pool
-matadata and cannot be overwritten.
+metadata and cannot be overwritten.
 If the pool was created with NULL *create_attr* argument, the pool metadata
 is not stored with the pool and *offset* can be any nonnegative number.
 The *offset* and *length* combined must not exceed the

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -1757,19 +1757,19 @@ static int
 CTL_READ_HANDLER(threshold)(void *ctx,
 	enum ctl_query_source source, void *arg, struct ctl_indexes *indexes)
 {
-	LOG(1, "tx.cache.threshold parameter is depracated");
+	LOG(1, "tx.cache.threshold parameter is deprecated");
 
 	return 0;
 }
 
 /*
- * CTL_WRITE_HANDLER(threshold) -- depracated
+ * CTL_WRITE_HANDLER(threshold) -- deprecated
  */
 static int
 CTL_WRITE_HANDLER(threshold)(void *ctx,
 	enum ctl_query_source source, void *arg, struct ctl_indexes *indexes)
 {
-	LOG(1, "tx.cache.threshold parameter is depracated");
+	LOG(1, "tx.cache.threshold parameter is deprecated");
 
 	return 0;
 }


### PR DESCRIPTION
Debian lintian flagged this simple spelling mistake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3738)
<!-- Reviewable:end -->
