### PR TITLE
common: fix bug in badblock file error handling

### DIFF
--- a/src/common/set.c
+++ b/src/common/set.c
@@ -3796,10 +3796,16 @@ util_pool_open_nocheck(struct pool_set *set, unsigned flags)
 
 	if (flags & POOL_OPEN_CHECK_BAD_BLOCKS) {
 		/* check if any bad block recovery file exists */
-		if (badblocks_recovery_file_exists(set)) {
+		int bfe = badblocks_recovery_file_exists(set);
+		if (bfe > 0) {
 			ERR(
 				"error: a bad block recovery file exists, run 'pmempool sync --bad-blocks' utility to try to recover the pool");
 			errno = EINVAL;
+			return -1;
+		}
+		if (bfe < 0) {
+			LOG(1,
+				"an error occurred when checking whether recovery file exists.");
 			return -1;
 		}
 
@@ -3964,10 +3970,17 @@ util_pool_open(struct pool_set **setp, const char *path, size_t minpartsize,
 
 	if (compat_features & POOL_FEAT_CHECK_BAD_BLOCKS) {
 		/* check if any bad block recovery file exists */
-		if (badblocks_recovery_file_exists(set)) {
+		int bfe = badblocks_recovery_file_exists(set);
+		if (bfe > 0) {
 			ERR(
 				"error: a bad block recovery file exists, run 'pmempool sync --bad-blocks' utility to try to recover the pool");
 			errno = EINVAL;
+			goto err_poolset_free;
+		}
+
+		if (bfe < 0) {
+			LOG(1,
+				"an error occurred when checking whether recovery file exists.");
 			goto err_poolset_free;
 		}
 


### PR DESCRIPTION
Function badblocks_recovery_file_exists now checks for status
-1, 0, 1 instead of !=0
Function returns:
 - 0 when there are no bad block recovery files
 - 1 when there is at least one bad block recovery file and
 - -1 in any other case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3741)
<!-- Reviewable:end -->
