### PR TITLE
common: dpkg: purge old debian/ dir if it exists

### DIFF
--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -339,6 +339,7 @@ tar zcf $PACKAGE_TARBALL_ORIG $PACKAGE_SOURCE
 
 cd $PACKAGE_SOURCE
 
+rm -rf debian
 mkdir debian
 
 # Generate compat file


### PR DESCRIPTION
In particular, it causes a Travis failure on downstream distributions that
have a non-volatile packaging directory there.  This causes noise that can
spook external contributors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3742)
<!-- Reviewable:end -->
