### PR TITLE
common: Fix build failure due to unused macro PAGE_SIZE

### DIFF
--- a/src/common/os_dimm_ndctl.c
+++ b/src/common/os_dimm_ndctl.c
@@ -45,12 +45,6 @@
 #include <fcntl.h>
 #include <ndctl/libndctl.h>
 #include <ndctl/libdaxctl.h>
-/* XXX: workaround for missing PAGE_SIZE - should be fixed in linux/ndctl.h */
-#include <sys/user.h>
-#ifndef PAGE_SIZE
-#define PAGE_SIZE 4096
-#endif
-#include <linux/ndctl.h>
 
 #include "file.h"
 #include "out.h"


### PR DESCRIPTION
common: Fix build failure due to unused macro PAGE_SIZE

Commit b1251de66742("common: work around missing PAGE_SIZE") provided
a default value for PAGE_SIZE as a workaround for older kernels that
doesn't have the kernel fix f366d322ae("UAPI: ndctl: Remove use of
PAGE_SIZE").

However this causes a build failure when trying to build pmdk with
GCC-7.3.0 and a kernel that already has this above fix. GCC reports
following error indicating unused macro PAGE_SIZE:

$ gcc --version
gcc (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0
< snip >

$ make
< snip >
../../src/../src/common/os_dimm_ndctl.c:51:0: error: macro "PAGE_SIZE"
 is not used [-Werror=unused-macros]
 #define PAGE_SIZE 4096
< snip >

However since commit 10983411cc25 ("common: do not start ARS before
clearing bad blocks on DAX device") 'src/common/os_dimm_ndctl.c'
doesn't need inclusion of 'ndctl.h' anymore. Hence this patch fixes
the above issue by updating include headers in
'src/common/os_dimm_ndctl.c' to remove include of header
'linux/ndctl.h' 'sys/user.h' and corresponding fallback defines for
PAGE_SIZE.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3748)
<!-- Reviewable:end -->
