### PR TITLE
blk,log: Reverse the RANGE_RO and RANGE_NONE order in {log,blk}_runtime_init()

### DIFF
--- a/src/libpmemblk/blk.c
+++ b/src/libpmemblk/blk.c
@@ -366,6 +366,9 @@ blk_runtime_init(PMEMblkpool *pbp, size_t bsize, int rdonly)
 	util_mutex_init(&pbp->write_lock);
 #endif
 
+	/* the data area should be kept read-only for debug version */
+	RANGE_RO(pbp->data, pbp->datasize, pbp->is_dev_dax);
+
 	/*
 	 * If possible, turn off all permissions on the pool header page.
 	 *
@@ -374,8 +377,6 @@ blk_runtime_init(PMEMblkpool *pbp, size_t bsize, int rdonly)
 	 */
 	RANGE_NONE(pbp->addr, sizeof(struct pool_hdr), pbp->is_dev_dax);
 
-	/* the data area should be kept read-only for debug version */
-	RANGE_RO(pbp->data, pbp->datasize, pbp->is_dev_dax);
 
 	return 0;
 

--- a/src/libpmemlog/log.c
+++ b/src/libpmemlog/log.c
@@ -146,6 +146,10 @@ log_runtime_init(PMEMlogpool *plp, int rdonly)
 		return -1;
 	}
 
+	/* the rest should be kept read-only (debug version only) */
+	RANGE_RO((char *)plp->addr + sizeof(struct pool_hdr),
+		plp->size - sizeof(struct pool_hdr), plp->is_dev_dax);
+
 	/*
 	 * If possible, turn off all permissions on the pool header page.
 	 *
@@ -153,10 +157,6 @@ log_runtime_init(PMEMlogpool *plp, int rdonly)
 	 * use. It is not considered an error if this fails.
 	 */
 	RANGE_NONE(plp->addr, sizeof(struct pool_hdr), plp->is_dev_dax);
-
-	/* the rest should be kept read-only (debug version only) */
-	RANGE_RO((char *)plp->addr + sizeof(struct pool_hdr),
-			plp->size - sizeof(struct pool_hdr), plp->is_dev_dax);
 
 	return 0;
 }


### PR DESCRIPTION
This PR has two commits that fix the order of calling RANGE_NONE and RANGE_RO macros inside the logpool and blkpool run-time initialization functions. Without these commits I see a SIGSEGV reported when the run-time initialization tries to mark the pool data region as read only in debug builds as the page containing the corresponding pool header struct is already marked as PROT_NONE hence cannot be further accessed.

The patches fixes this issue by reversing the order of RANGE_{NONE,RO} macros in these initialization functions so that pages containing blk/log-pool headers are only marked PROT_NONE once the pools data area is marked read-only via RANGE_RO macro.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3765)
<!-- Reviewable:end -->
