### PR TITLE
obj: don't overwrite errno when palloc_heap_check_remote fails

### DIFF
--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1575,9 +1575,8 @@ obj_check_basic_remote(PMEMobjpool *pop, size_t mapped_size)
 
 	/* pop->heap_size can still be 0 at this point */
 	size_t heap_size = mapped_size - pop->heap_offset;
-	errno = palloc_heap_check_remote((char *)pop + pop->heap_offset,
-		heap_size, &pop->p_ops.remote);
-	if (errno != 0) {
+	if (palloc_heap_check_remote((char *)pop + pop->heap_offset,
+			heap_size, &pop->p_ops.remote)) {
 		LOG(2, "!heap_check_remote");
 		consistent = 0;
 	}


### PR DESCRIPTION
Found using fault injection.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3780)
<!-- Reviewable:end -->
