### PR TITLE
pmem: improve flushes on arm64

### DIFF
--- a/src/libpmem/aarch64/arm_cacheops.h
+++ b/src/libpmem/aarch64/arm_cacheops.h
@@ -82,9 +82,9 @@ arm_clean_va_to_poc(void const *p __attribute__((unused)))
 }
 
 static inline void
-arm_data_memory_barrier(void)
+arm_store_memory_barrier(void)
 {
-	asm volatile("dmb ish" : : : "memory");
+	asm volatile("dmb ishst" : : : "memory");
 }
 
 static inline void

--- a/src/libpmem/aarch64/arm_cacheops.h
+++ b/src/libpmem/aarch64/arm_cacheops.h
@@ -86,10 +86,4 @@ arm_store_memory_barrier(void)
 {
 	asm volatile("dmb ishst" : : : "memory");
 }
-
-static inline void
-arm_clean_and_invalidate_va_to_poc(const void *addr)
-{
-	asm volatile("dc civac, %0" : : "r" (addr) : "memory");
-}
 #endif

--- a/src/libpmem/aarch64/arm_cacheops.h
+++ b/src/libpmem/aarch64/arm_cacheops.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +34,40 @@
  * clwb => dc cvac
  * clflush | clflushopt => dc civac
  * fence => dmb ish
+ */
+
+/*
+ * Cache instructions on ARM:
+ * ARMv8.0-a    DC CVAC  - cache clean to Point of Coherency
+ *                         Meant for thread synchronization, usually implies
+ *                         real memory flush but may mean less.
+ * ARMv8.2-a    DC CVAP  - cache clean to Point of Persistency
+ *                         Meant exactly for our use.
+ * ARMv8.5-a    DC CVADP - cache clean to Point of Deep Persistency
+ *                         As of mid-2019 not on any commercially available CPU.
+ * Any of the above may be disabled for EL0, but it's probably safe to consider
+ * that a system configuration error.
+ * Other flags include I (like "DC CIVAC") that invalidates the cache line, but
+ * we don't want that.
+ *
+ * Memory fences:
+ * * DMB [ISH]    MFENCE
+ * * DMB [ISH]ST  SFENCE
+ * * DMB [ISH]LD  LFENCE
+ * We care about persistence not synchronization thus ISH should be enough?
+ *
+ * Memory domains:
+ * * non-shareable - local to a single core
+ * * inner shareable (ISH) - usu. one or multiple processor sockets
+ * * outer shareable (OSH) - usu. including GPU
+ * * full system (SY) - anything that can possibly access memory
+ * ??? What about RDMA?  No libfabric on ARM thus not a concern for now.
+ *
+ * Exception (privilege) levels:
+ * * EL0 - userspace (ring 3)
+ * * EL1 - kernel (ring 0)
+ * * EL2 - hypervisor (ring -1)
+ * * EL3 - "secure world" (ring -3)
  */
 
 #ifndef AARCH64_CACHEOPS_H

--- a/src/libpmem/aarch64/flush.h
+++ b/src/libpmem/aarch64/flush.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,12 +48,11 @@ flush_dcache_invalidate_opt_nolog(const void *addr, size_t len)
 {
 	uintptr_t uptr;
 
-	arm_data_memory_barrier();
 	for (uptr = (uintptr_t)addr & ~(FLUSH_ALIGN - 1);
 		uptr < (uintptr_t)addr + len; uptr += FLUSH_ALIGN) {
 		arm_clean_and_invalidate_va_to_poc((char *)uptr);
 	}
-	arm_data_memory_barrier();
+	arm_store_memory_barrier();
 }
 
 /*

--- a/src/libpmem/aarch64/flush.h
+++ b/src/libpmem/aarch64/flush.h
@@ -40,22 +40,6 @@
 #define FLUSH_ALIGN ((uintptr_t)64)
 
 /*
- * flush_clflushopt_nolog -- flush the CPU cache, using
- * arm_clean_and_invalidate_va_to_poc (see arm_cacheops.h) {DC CIVAC}
- */
-static force_inline void
-flush_dcache_invalidate_opt_nolog(const void *addr, size_t len)
-{
-	uintptr_t uptr;
-
-	for (uptr = (uintptr_t)addr & ~(FLUSH_ALIGN - 1);
-		uptr < (uintptr_t)addr + len; uptr += FLUSH_ALIGN) {
-		arm_clean_and_invalidate_va_to_poc((char *)uptr);
-	}
-	arm_store_memory_barrier();
-}
-
-/*
  * flush_dcache_nolog -- flush the CPU cache, using DC CVAC
  */
 static force_inline void

--- a/src/libpmem/aarch64/init.c
+++ b/src/libpmem/aarch64/init.c
@@ -87,7 +87,7 @@ static void
 predrain_memory_barrier(void)
 {
 	LOG(15, NULL);
-	arm_data_memory_barrier();
+	arm_store_memory_barrier();
 }
 
 /*

--- a/src/libpmem/aarch64/init.c
+++ b/src/libpmem/aarch64/init.c
@@ -69,18 +69,6 @@ memset_nodrain_libc(void *pmemdest, int c, size_t len, unsigned flags)
 }
 
 /*
- * predrain_fence_empty -- (internal) issue the pre-drain fence instruction
- */
-static void
-predrain_fence_empty(void)
-{
-	LOG(15, NULL);
-
-	VALGRIND_DO_FENCE;
-	/* nothing to do (because CLFLUSH did it for us) */
-}
-
-/*
  * predrain_memory_barrier -- (internal) issue the pre-drain fence instruction
  */
 static void
@@ -120,7 +108,7 @@ pmem_init_funcs(struct pmem_funcs *funcs)
 {
 	LOG(3, NULL);
 
-	funcs->predrain_fence = predrain_fence_empty;
+	funcs->predrain_fence = predrain_memory_barrier;
 	funcs->deep_flush = flush_dcache;
 	funcs->is_pmem = is_pmem_detect;
 	funcs->memmove_nodrain = memmove_nodrain_generic;
@@ -156,7 +144,6 @@ pmem_init_funcs(struct pmem_funcs *funcs)
 		funcs->flush = funcs->deep_flush;
 	else
 		funcs->flush = flush_empty;
-	funcs->predrain_fence = predrain_memory_barrier;
 
 	if (funcs->deep_flush == flush_dcache)
 		LOG(3, "Synchronize VA to poc for ARM");


### PR DESCRIPTION
It was pointed out that we use CVAC instead of CVAP.  While this PR doesn't fix that yet, it does at least document my understanding so far, and fixes two other inefficiencies:
 * a store fence is enough
 * we shouldn't emulate CLFLUSH as even arm64 baseline has the equivalent of CLWB

The last part is especially egregious: our code effectively did:
```
MFENCE
CLFLUSH
MFENCE
```
for every cacheline.  Let's instead do the same thing we do on x86: a CLWB per cacheline, then a single SFENCE.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3785)
<!-- Reviewable:end -->
