### PR TITLE
pmem: initial PPC64 port

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -180,7 +180,9 @@ endif
 
 ifneq ($(ARCH), x86_64)
 ifneq ($(ARCH), aarch64)
+ifneq ($(ARCH), ppc64)
 $(error unsupported architecture: $(ARCH))
+endif
 endif
 endif
 

--- a/src/common.inc
+++ b/src/common.inc
@@ -95,6 +95,12 @@ endif
 ifeq ($(ARCH),arm64)
 override ARCH := aarch64
 endif
+ifeq ($(ARCH),ppc64el)
+override ARCH := ppc64
+endif
+ifeq ($(ARCH),powerpc64le)
+override ARCH := ppc64
+endif
 
 ifeq ($(PKG_CONFIG_CHECKED),)
 ifeq ($(shell command -v $(PKG_CONFIG) && echo y || echo n), n)

--- a/src/common/pool_hdr.c
+++ b/src/common/pool_hdr.c
@@ -53,6 +53,10 @@
 #define PMDK_MACHINE PMDK_MACHINE_AARCH64
 #define PMDK_MACHINE_CLASS PMDK_MACHINE_CLASS_64
 
+#elif defined(__powerpc64__)
+#define PMDK_MACHINE PMDK_MACHINE_PPC64
+#define PMDK_MACHINE_CLASS PMDK_MACHINE_CLASS_64
+
 #else
 /* add appropriate definitions here when porting PMDK to another ISA */
 #error unable to recognize ISA at compile time

--- a/src/common/pool_hdr.h
+++ b/src/common/pool_hdr.h
@@ -103,6 +103,7 @@ struct arch_flags {
 /* possible values of the machine field in the above struct */
 #define PMDK_MACHINE_X86_64 62
 #define PMDK_MACHINE_AARCH64 183
+#define PMDK_MACHINE_PPC64 20
 
 /* possible values of the data field in the above struct */
 #define PMDK_DATA_LE 1 /* 2's complement, little endian */

--- a/src/libpmem/ppc64/flags.inc
+++ b/src/libpmem/ppc64/flags.inc
@@ -1,0 +1,38 @@
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# src/libpmem/ppc64/flags.inc -- flags for libpmem/ppc64el
+#
+
+vpath %.c $(TOP)/src/libpmem/ppc64
+vpath %.h $(TOP)/src/libpmem/ppc64
+
+CFLAGS += -Ippc64

--- a/src/libpmem/ppc64/flush.h
+++ b/src/libpmem/ppc64/flush.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PPC64_FLUSH_H
+#define PPC64_FLUSH_H
+
+#include <stdint.h>
+#include "ppc_cacheops.h"
+#include "util.h"
+
+#define FLUSH_ALIGN ((uintptr_t)128)
+
+/*
+ * flush_dcache_nolog -- flush the CPU cache, using DCBST
+ */
+static force_inline void
+flush_dcache_nolog(const void *addr, size_t len)
+{
+	uintptr_t uptr;
+
+	/*
+	 * Loop through cache-line-size (typically 128B) aligned chunks
+	 * covering the given range.
+	 */
+	for (uptr = (uintptr_t)addr & ~(FLUSH_ALIGN - 1);
+		uptr < (uintptr_t)addr + len; uptr += FLUSH_ALIGN) {
+		ppc_clean_va_to_poc((char *)uptr);
+	}
+}
+
+#endif

--- a/src/libpmem/ppc64/init.c
+++ b/src/libpmem/ppc64/init.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2014-2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <string.h>
+#include "libpmem.h"
+
+#include "flush.h"
+#include "os.h"
+#include "out.h"
+#include "pmem.h"
+#include "valgrind_internal.h"
+
+/*
+ * memmove_nodrain_libc -- (internal) memmove to pmem without hw drain
+ */
+static void *
+memmove_nodrain_libc(void *pmemdest, const void *src, size_t len,
+		unsigned flags)
+{
+	LOG(15, "pmemdest %p src %p len %zu flags 0x%x", pmemdest, src, len,
+			flags);
+
+	memmove(pmemdest, src, len);
+	pmem_flush_flags(pmemdest, len, flags);
+	return pmemdest;
+}
+
+/*
+ * memset_nodrain_libc -- (internal) memset to pmem without hw drain
+ */
+static void *
+memset_nodrain_libc(void *pmemdest, int c, size_t len, unsigned flags)
+{
+	LOG(15, "pmemdest %p c 0x%x len %zu flags 0x%x", pmemdest, c, len,
+			flags);
+
+	memset(pmemdest, c, len);
+	pmem_flush_flags(pmemdest, len, flags);
+	return pmemdest;
+}
+
+/*
+ * predrain_memory_barrier -- (internal) issue the pre-drain fence instruction
+ */
+static void
+predrain_memory_barrier(void)
+{
+	LOG(15, NULL);
+	ppc_data_memory_barrier();
+}
+
+/*
+ * flush_dcache -- (internal) flush the CPU cache, using clwb
+ */
+static void
+flush_dcache(const void *addr, size_t len)
+{
+	LOG(15, "addr %p len %zu", addr, len);
+
+	flush_dcache_nolog(addr, len);
+}
+
+/*
+ * flush_empty -- (internal) do not flush the CPU cache
+ */
+static void
+flush_empty(const void *addr, size_t len)
+{
+	LOG(15, "addr %p len %zu", addr, len);
+
+	flush_empty_nolog(addr, len);
+}
+
+/*
+ * pmem_init_funcs -- initialize architecture-specific list of pmem operations
+ */
+void
+pmem_init_funcs(struct pmem_funcs *funcs)
+{
+	LOG(3, NULL);
+
+	funcs->predrain_fence = predrain_memory_barrier;
+	funcs->deep_flush = flush_dcache;
+	funcs->is_pmem = is_pmem_detect;
+	funcs->memmove_nodrain = memmove_nodrain_generic;
+	funcs->memset_nodrain = memset_nodrain_generic;
+
+	char *ptr = os_getenv("PMEM_NO_GENERIC_MEMCPY");
+	if (ptr) {
+		long long val = atoll(ptr);
+
+		if (val) {
+			funcs->memmove_nodrain = memmove_nodrain_libc;
+			funcs->memset_nodrain = memset_nodrain_libc;
+		}
+	}
+
+	int flush;
+	char *e = os_getenv("PMEM_NO_FLUSH");
+	if (e && (strcmp(e, "1") == 0)) {
+		flush = 0;
+		LOG(3, "Forced not flushing CPU_cache");
+	} else if (e && (strcmp(e, "0") == 0)) {
+		flush = 1;
+		LOG(3, "Forced flushing CPU_cache");
+	} else if (pmem_has_auto_flush() == 1) {
+		flush = 0;
+		LOG(3, "Not flushing CPU_cache, eADR detected");
+	} else {
+		flush = 1;
+		LOG(3, "Flushing CPU cache");
+	}
+
+	if (flush)
+		funcs->flush = funcs->deep_flush;
+	else
+		funcs->flush = flush_empty;
+
+	if (funcs->deep_flush == flush_dcache)
+		LOG(3, "Using PPC cache block store");
+	else
+		FATAL("invalid deep flush function address");
+
+	if (funcs->flush == flush_empty)
+		LOG(3, "not flushing CPU cache");
+	else if (funcs->flush != funcs->deep_flush)
+		FATAL("invalid flush function address");
+
+	if (funcs->memmove_nodrain == memmove_nodrain_generic)
+		LOG(3, "using generic memmove");
+	else if (funcs->memmove_nodrain == memmove_nodrain_libc)
+		LOG(3, "using libc memmove");
+	else
+		FATAL("invalid memove_nodrain function address");
+}

--- a/src/libpmem/ppc64/ppc_cacheops.h
+++ b/src/libpmem/ppc64/ppc_cacheops.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*
+ * PPC inline assembly to flush and invalidate caches
+ * clwb => dcbst
+ * fence => eieio
+ */
+
+#ifndef PPC64_CACHEOPS_H
+#define PPC64_CACHEOPS_H
+
+#include <stdlib.h>
+
+static inline void
+ppc_clean_va_to_poc(void const *p __attribute__((unused)))
+{
+	asm volatile("dcbst 0, %0" : : "r"(p) : "memory");
+}
+
+static inline void
+ppc_data_memory_barrier(void)
+{
+	asm volatile("sync" : : : "memory");
+}
+#endif

--- a/src/libpmem/ppc64/sources.inc
+++ b/src/libpmem/ppc64/sources.inc
@@ -1,0 +1,35 @@
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# src/libpmem/ppc64/sources.inc -- list of files for libpmem/ppc64el
+#
+
+LIBPMEM_ARCH_SOURCE = init.c

--- a/src/tools/pmempool/output.c
+++ b/src/tools/pmempool/output.c
@@ -749,6 +749,8 @@ out_get_arch_machine_str(uint16_t machine)
 		return "AMD X86-64";
 	case PMDK_MACHINE_AARCH64:
 		return "Aarch64";
+	case PMDK_MACHINE_PPC64:
+		return "PPC64";
 	default:
 		break;
 	}


### PR DESCRIPTION
Just basic flushes for now, this should make libpmem functional.

Thanks to Breno Leitao.

v2: EIEIO replaced by SYNC, it's said to be enough yet more lightweight.

Aneesh Kumar suggested copying code from https://github.com/torvalds/linux/blob/master/arch/powerpc/lib/pmem.c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3786)
<!-- Reviewable:end -->
