### PR TITLE
test: fix a match failure with Clang 8

### DIFF
--- a/src/test/obj_action/memcheck1.log.match
+++ b/src/test/obj_action/memcheck1.log.match
@@ -22,7 +22,7 @@
 ==$(N)==  Address 0x$(X) is 0 bytes inside a block of size 112 free'd
 ==$(N)==    at 0x$(X): palloc_heap_action_on_process (palloc.c:$(N))
 ==$(N)==    by 0x$(X): palloc_exec_actions (palloc.c:$(N))
-==$(N)==    by 0x$(X): palloc_publish (palloc.c:$(N))
+$(OPT)==$(N)==    by 0x$(X): palloc_publish (palloc.c:$(N))
 ==$(N)==    by 0x$(X): pmemobj_publish (obj.c:$(N))
 ==$(N)==    by 0x$(X): test_defer_free (obj_action.c:$(N))
 ==$(N)==    by 0x$(X): main (obj_action.c:$(N))


### PR DESCRIPTION
With new Clang, the stack frame for this function can get elided.  Let's make it optional in the match file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3788)
<!-- Reviewable:end -->
