### PR TITLE
tools: fix dynamic link line in Makefile.inc

### DIFF
--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -144,7 +144,7 @@ LIBPMEMCOMMON=y
 endif
 
 ifeq ($(LIBPMEMCOMMON), y)
-DYNAMIC_LIBS += $(LIBSDIR_DEBUG)/libpmemcommon.a
+DYNAMIC_LIBS += -lpmemcommon
 STATIC_DEBUG_LIBS += $(LIBSDIR_DEBUG)/libpmemcommon.a
 STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libpmemcommon.a
 CFLAGS += -I$(TOP)/src/common


### PR DESCRIPTION
This is an obvious thinko.  The result is that debug objects are
linked into the production build of the library.  Fix it.

Signed-off-by: Jeff Moyer <jmoyer@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3792)
<!-- Reviewable:end -->
