### PR TITLE
doc: vmem, vmmalloc: document maintenance state

### DIFF
--- a/doc/libvmem/libvmem.7.md
+++ b/doc/libvmem/libvmem.7.md
@@ -7,7 +7,7 @@ header: PMDK
 date: vmem API version 1.1
 ...
 
-[comment]: <> (Copyright 2016-2018, Intel Corporation)
+[comment]: <> (Copyright 2016-2019, Intel Corporation)
 
 [comment]: <> (Redistribution and use in source and binary forms, with or without)
 [comment]: <> (modification, are permitted provided that the following conditions)
@@ -102,6 +102,11 @@ depending on the file system containing the memory-mapped files.
 In particular, **libvmem** is part of the *Persistent Memory Development Kit*
 because it is sometimes useful to use non-volatile memory as a volatile memory
 pool, leveraging its capacity, cost, or performance characteristics.
+
+It is recommended that new code uses **memkind**(3) instead of **libvmem**, as
+this library is no longer actively developed and lacks certain features of
+**memkind** such as NUMA awareness.  Nevertheless, it is mature, and is
+expected to be maintained for foreseable future.
 
 **libvmem** uses the **mmap**(2) system call to create a pool of volatile
 memory. The library is most useful when used with *Direct Access* storage

--- a/doc/libvmmalloc/libvmmalloc.7.md
+++ b/doc/libvmmalloc/libvmmalloc.7.md
@@ -7,7 +7,7 @@ header: PMDK
 date: vmmalloc API version 1.1
 ...
 
-[comment]: <> (Copyright 2016-2018, Intel Corporation)
+[comment]: <> (Copyright 2016-2019, Intel Corporation)
 
 [comment]: <> (Redistribution and use in source and binary forms, with or without)
 [comment]: <> (modification, are permitted provided that the following conditions)
@@ -105,6 +105,10 @@ attributes, depending on the file system containing the memory-mapped file.
 In particular, **libvmmalloc** is part of the *Persistent Memory Development Kit*
 because it is sometimes useful to use non-volatile memory as a volatile
 memory pool, leveraging its capacity, cost, or performance characteristics.
+
+This library is no longer actively developed, and is in maintenance mode,
+same as its underlying code backend (**libvmem**).  It is mature, and is
+expected to be supported for foreseable future.
 
 **libvmmalloc** may be also linked to the program, by providing the
 **-lvmmalloc* argument to the linker. Then it becomes the default memory


### PR DESCRIPTION
We want folks to use **memkind** instead.

Still, despite deprecation, the cost of keeping a library alive is minimal (fixing bugs and compiler/platform regressions), thus there's no need to force migrations. User code will work a decade in the future just as well as it does today.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3795)
<!-- Reviewable:end -->
