### PR TITLE
don't inline vecq_grow

### DIFF
--- a/src/common/vecq.h
+++ b/src/common/vecq.h
@@ -89,7 +89,7 @@ struct name {\
 #define VECQ_SIZE(vec)\
 ((vec)->back - (vec)->front)
 
-static inline int
+static int __attribute((noinline))
 vecq_grow(void *vec, size_t s)
 {
 	VECQ(vvec, void) *vecp = (struct vvec *)vec;


### PR DESCRIPTION
So far this causes a crash only on arm64 (for nearly any uses of pmemobj) with gcc if `-fstrict-aliasing` is on (enabled by default for `-O2` and `-O3`), but working ok on our platforms is only due to luck: any future compiler may use this optimization, it might be triggered by something like LTO, etc.

Disabling inlining of this function is just a hack, but should work for now until we have a better fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3798)
<!-- Reviewable:end -->
