### PR TITLE
test: pmreorder VALGRIND_EMIT_LOG cleanup

### DIFF
--- a/src/test/obj_reorder_basic/Makefile
+++ b/src/test/obj_reorder_basic/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,6 +39,8 @@ TARGET = obj_reorder_basic
 OBJS = obj_reorder_basic.o
 
 LIBPMEMOBJ=y
+
+# included for VALGRIND_EMIT_LOG
 LIBPMEMCOMMON=y
 
 include ../Makefile.inc

--- a/src/test/pmreorder_flushes/Makefile
+++ b/src/test/pmreorder_flushes/Makefile
@@ -38,6 +38,8 @@ TARGET = pmreorder_flushes
 OBJS = pmreorder_flushes.o
 
 LIBPMEM=y
+
+# included for VALGRIND_EMIT_LOG
 LIBPMEMCOMMON=y
 
 include ../Makefile.inc

--- a/src/test/pmreorder_simple/Makefile
+++ b/src/test/pmreorder_simple/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,6 +39,8 @@ TARGET = pmreorder_simple
 OBJS = pmreorder_simple.o
 
 LIBPMEM=y
+
+# included for VALGRIND_EMIT_LOG
 LIBPMEMCOMMON=y
 
 include ../Makefile.inc

--- a/src/test/pmreorder_stack/Makefile
+++ b/src/test/pmreorder_stack/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -38,6 +38,8 @@ TARGET = pmreorder_stack
 OBJS = pmreorder_stack.o
 
 LIBPMEM=y
+
+# included for VALGRIND_EMIT_LOG
 LIBPMEMCOMMON=y
 
 include ../Makefile.inc

--- a/src/test/pmreorder_stack/pmreorder_stack.c
+++ b/src/test/pmreorder_stack/pmreorder_stack.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Intel Corporation
+ * Copyright 2018-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -114,7 +114,6 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "pmreorder_stack");
 
-	VALGRIND_EMIT_LOG("NOT_DEFINED_BY_USER.END");
 	util_init();
 
 	if ((argc != 3) || (strchr("wc", argv[1][0]) == NULL) ||


### PR DESCRIPTION
1. add comments clarifying linking LIBPMEMCOMMON
2. remove unnecessary macro call

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3803)
<!-- Reviewable:end -->
