### PR TITLE
obj: don't use dynamically sized ulog structs

### DIFF
--- a/src/libpmemobj/lane.h
+++ b/src/libpmemobj/lane.h
@@ -87,17 +87,22 @@ struct lane_layout {
 	 * Redo log for self-contained and 'one-shot' allocator operations.
 	 * Cannot be extended.
 	 */
-	struct ULOG(LANE_REDO_INTERNAL_SIZE) internal;
+	struct ulog internal;
+	uint8_t internal_data[LANE_REDO_INTERNAL_SIZE];
+
 	/*
 	 * Redo log for large operations/transactions.
 	 * Can be extended by the use of internal ulog.
 	 */
-	struct ULOG(LANE_REDO_EXTERNAL_SIZE) external;
+	struct ulog external;
+	uint8_t external_data[LANE_REDO_EXTERNAL_SIZE];
+
 	/*
 	 * Undo log for snapshots done in a transaction.
 	 * Can be extended/shrunk by the use of internal ulog.
 	 */
-	struct ULOG(LANE_UNDO_SIZE) undo;
+	struct ulog undo;
+	uint8_t undo_data[LANE_UNDO_SIZE];
 };
 
 struct lane {

--- a/src/libpmemobj/memops.c
+++ b/src/libpmemobj/memops.c
@@ -550,8 +550,8 @@ operation_process(struct operation_context *ctx)
 		ctx->pshadow_ops.offset != 0;
 	if (redo_process &&
 	    ctx->pshadow_ops.offset == sizeof(struct ulog_entry_val)) {
-		struct ulog_entry_base *e = (struct ulog_entry_base *)
-			ctx->pshadow_ops.ulog->data;
+		struct ulog_entry_base *e =
+				(void *)ulog_data(ctx->pshadow_ops.ulog);
 		ulog_operation_type t = ulog_entry_type(e);
 		if (t == ULOG_OPERATION_SET || t == ULOG_OPERATION_AND ||
 		    t == ULOG_OPERATION_OR) {

--- a/src/libpmemobj/ulog.h
+++ b/src/libpmemobj/ulog.h
@@ -69,16 +69,27 @@ struct ulog_entry_buf {
  * This structure *must* be located at a cacheline boundary. To achieve this,
  * the next field is always allocated with extra padding, and then the offset
  * is additionally aligned.
+ *
+ * This structure must be immediately followed by at least `capacity`-sized
+ * buffer.
  */
-#define ULOG(capacity_bytes) {\
-	/* 64 bytes of metadata */\
-	uint64_t checksum; /* checksum of ulog header and its entries */\
-	uint64_t next; /* offset of ulog extension */\
-	uint64_t capacity; /* capacity of this ulog in bytes */\
-	uint64_t gen_num; /* generation counter */\
-	uint64_t unused[4]; /* must be 0 */\
-	uint8_t data[capacity_bytes]; /* N bytes of data */\
-}\
+struct ulog {
+	/* 64 bytes of metadata */
+	uint64_t checksum; /* checksum of ulog header and its entries */
+	uint64_t next; /* offset of ulog extension */
+	uint64_t capacity; /* capacity of this ulog in bytes */
+	uint64_t gen_num; /* generation counter */
+	uint64_t unused[4]; /* must be 0 */
+};
+
+/*
+ * ulog_data - returns data following struct ulog
+ */
+static inline uint8_t *
+ulog_data(struct ulog *u)
+{
+	return ((uint8_t *)u) + sizeof(struct ulog);
+}
 
 #define SIZEOF_ULOG(base_capacity)\
 (sizeof(struct ulog) + base_capacity)
@@ -86,8 +97,6 @@ struct ulog_entry_buf {
 /* use this for allocations of aligned ulog extensions */
 #define SIZEOF_ALIGNED_ULOG(base_capacity)\
 (SIZEOF_ULOG(base_capacity) + CACHELINE_SIZE)
-
-struct ulog ULOG(0);
 
 VEC(ulog_next, uint64_t);
 

--- a/src/test/obj_layout/obj_layout.c
+++ b/src/test/obj_layout/obj_layout.c
@@ -225,8 +225,11 @@ main(int argc, char *argv[])
 
 	ASSERT_ALIGNED_BEGIN(struct lane_layout);
 	ASSERT_ALIGNED_FIELD(struct lane_layout, internal);
+	ASSERT_ALIGNED_FIELD(struct lane_layout, internal_data);
 	ASSERT_ALIGNED_FIELD(struct lane_layout, external);
+	ASSERT_ALIGNED_FIELD(struct lane_layout, external_data);
 	ASSERT_ALIGNED_FIELD(struct lane_layout, undo);
+	ASSERT_ALIGNED_FIELD(struct lane_layout, undo_data);
 	ASSERT_ALIGNED_CHECK(struct lane_layout);
 	UT_COMPILE_ERROR_ON(sizeof(struct lane_layout) !=
 		SIZEOF_LANE_V3);

--- a/src/test/tools/pmemspoil/spoil.c
+++ b/src/test/tools/pmemspoil/spoil.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1197,11 +1197,11 @@ pmemspoil_process_lane(struct pmemspoil *psp, struct pmemspoil_list *pfp,
 		struct lane_layout *lane)
 {
 	PROCESS_BEGIN(psp, pfp) {
-		PROCESS_FIELD_ARRAY(lane, undo.data,
+		PROCESS_FIELD_ARRAY(lane, undo_data,
 			uint8_t, LANE_UNDO_SIZE);
-		PROCESS_FIELD_ARRAY(lane, internal.data,
+		PROCESS_FIELD_ARRAY(lane, internal_data,
 			uint8_t, LANE_REDO_INTERNAL_SIZE);
-		PROCESS_FIELD_ARRAY(lane, external.data,
+		PROCESS_FIELD_ARRAY(lane, external_data,
 			uint8_t, LANE_REDO_EXTERNAL_SIZE);
 	} PROCESS_END
 


### PR DESCRIPTION
It quiets down gcc strict-aliasing warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3804)
<!-- Reviewable:end -->
