### PR TITLE
Requires.private field occurs twice libpmemobj.pc

### DIFF
--- a/utils/libpmemblk.pc.in
+++ b/utils/libpmemblk.pc.in
@@ -4,7 +4,6 @@ Name: libpmemblk
 Description: libpmemblk library from PMDK project
 Version: ${version}
 URL: http://pmem.io/pmdk
-Requires.private: libpmem
-Requires.private: ${rasdeps}
+Requires.private: libpmem, ${rasdeps}
 Libs: -L${libdir} -lpmemblk
 Cflags: -I${includedir}

--- a/utils/libpmemlog.pc.in
+++ b/utils/libpmemlog.pc.in
@@ -4,7 +4,6 @@ Name: libpmemlog
 Description: libpmemlog library from PMDK project
 Version: ${version}
 URL: http://pmem.io/pmdk
-Requires.private: libpmem
-Requires.private: ${rasdeps}
+Requires.private: libpmem, ${rasdeps}
 Libs: -L${libdir} -lpmemlog
 Cflags: -I${includedir}

--- a/utils/libpmemobj.pc.in
+++ b/utils/libpmemobj.pc.in
@@ -4,8 +4,7 @@ Name: libpmemobj
 Description: libpmemobj library from PMDK project
 Version: ${version}
 URL: http://pmem.io/pmdk
-Requires.private: libpmem
-Requires.private: ${rasdeps}
+Requires.private: libpmem, ${rasdeps}
 Libs: -L${libdir} -lpmemobj
 Libs.private: -ldl
 Cflags: -I${includedir}

--- a/utils/libpmempool.pc.in
+++ b/utils/libpmempool.pc.in
@@ -4,8 +4,7 @@ Name: libpmempool
 Description: libpmempool library from PMDK project
 Version: ${version}
 URL: http://pmem.io/pmdk
-Requires.private: libpmem
-Requires.private: ${rasdeps}
+Requires.private: libpmem, ${rasdeps}
 Libs: -L${libdir} -lpmempool
 Libs.private: -ldl
 Cflags: -I${includedir}


### PR DESCRIPTION
When I use latest pmdk, in order to compile pmemkv.
I encountered such kind of error:
Requires.private field occurs twice in '/usr/local/lib64/pkgconfig/libpmemobj.pc'

So I made this change, and it seems to work now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3808)
<!-- Reviewable:end -->
