### PR TITLE
bench: re-enable multithreaded opens

### DIFF
--- a/src/benchmarks/pmembench_obj_gen.cfg
+++ b/src/benchmarks/pmembench_obj_gen.cfg
@@ -19,14 +19,13 @@ data-size = 1024
 objects = 1:*10:100000
 type-number = rand
 
-# pmemobj_open/close are not yet thread-safe
-#[obj_open_threads]
-#bench = obj_open
-#threads = 1:+1:10
-#data-size = 1024
-#min-size = 1
-#objects = 1000
-#type-number = rand
+[obj_open_threads]
+bench = obj_open
+threads = 1:+1:10
+data-size = 1024
+min-size = 1
+objects = 1000
+type-number = rand
 
 [obj_direct_threads_one_pool]
 bench = obj_direct


### PR DESCRIPTION
This benchmark had been included in the tree despite testing a known-broken scenario; for this reason it got disabled.  We do support concurrent opens and closes now...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3812)
<!-- Reviewable:end -->
