### PR TITLE
common: support older versions of pkg-config

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -139,7 +139,7 @@ libpmemblk libpmemlog libpmemobj: libpmem
 benchmarks test tools: common
 
 pkg-cfg-common:
-	@printf "version=%s\nlibdir=%s\nprefix=%s\nrasdeps=%s\n" "$(SRCVERSION)" "$(libdir)" "$(prefix)" "$(LIBNDCTL_PKG_CONFIG_DEPS)" > $(PKG_CONFIG_COMMON)
+	@printf "version=%s\nlibdir=%s\nprefix=%s\nrasdeps=%s\n" "$(SRCVERSION)" "$(libdir)" "$(prefix)" "$(LIBNDCTL_PKG_CONFIG_DEPS_VAR)" > $(PKG_CONFIG_COMMON)
 
 $(PKG_CONFIG_COMMON): pkg-cfg-common
 

--- a/src/common.inc
+++ b/src/common.inc
@@ -390,6 +390,7 @@ ifeq ($(NDCTL_ENABLE),y)
             $(error libdaxctl(version >= $(NDCTL_MIN_VERSION)) is missing -- see README)
         endif
         LIBNDCTL_PKG_CONFIG_DEPS := libndctl libdaxctl
+        LIBNDCTL_PKG_CONFIG_DEPS_VAR := ,libndctl,libdaxctl
         LIBNDCTL_CFLAGS := $(shell $(PKG_CONFIG) --cflags $(LIBNDCTL_PKG_CONFIG_DEPS))
         LIBNDCTL_LD_LIBRARY_PATHS := $(shell $(PKG_CONFIG) --variable=libdir $(LIBNDCTL_PKG_CONFIG_DEPS) | sed "s/ /:/")
         LIBNDCTL_LIBS := $(shell $(PKG_CONFIG) --libs $(LIBNDCTL_PKG_CONFIG_DEPS))
@@ -400,6 +401,7 @@ else
 endif
 export OS_DIMM
 export LIBNDCTL_PKG_CONFIG_DEPS
+export LIBNDCTL_PKG_CONFIG_DEPS_VAR
 export LIBNDCTL_CFLAGS
 export LIBNDCTL_LD_LIBRARY_PATHS
 export LIBNDCTL_LIBS

--- a/utils/libpmemblk.pc.in
+++ b/utils/libpmemblk.pc.in
@@ -4,7 +4,6 @@ Name: libpmemblk
 Description: libpmemblk library from PMDK project
 Version: ${version}
 URL: http://pmem.io/pmdk
-Requires.private: libpmem
-Requires.private: ${rasdeps}
+Requires.private: libpmem${rasdeps}
 Libs: -L${libdir} -lpmemblk
 Cflags: -I${includedir}

--- a/utils/libpmemlog.pc.in
+++ b/utils/libpmemlog.pc.in
@@ -4,7 +4,6 @@ Name: libpmemlog
 Description: libpmemlog library from PMDK project
 Version: ${version}
 URL: http://pmem.io/pmdk
-Requires.private: libpmem
-Requires.private: ${rasdeps}
+Requires.private: libpmem${rasdeps}
 Libs: -L${libdir} -lpmemlog
 Cflags: -I${includedir}

--- a/utils/libpmemobj.pc.in
+++ b/utils/libpmemobj.pc.in
@@ -4,8 +4,7 @@ Name: libpmemobj
 Description: libpmemobj library from PMDK project
 Version: ${version}
 URL: http://pmem.io/pmdk
-Requires.private: libpmem
-Requires.private: ${rasdeps}
+Requires.private: libpmem${rasdeps}
 Libs: -L${libdir} -lpmemobj
 Libs.private: -ldl
 Cflags: -I${includedir}

--- a/utils/libpmempool.pc.in
+++ b/utils/libpmempool.pc.in
@@ -4,8 +4,7 @@ Name: libpmempool
 Description: libpmempool library from PMDK project
 Version: ${version}
 URL: http://pmem.io/pmdk
-Requires.private: libpmem
-Requires.private: ${rasdeps}
+Requires.private: libpmem${rasdeps}
 Libs: -L${libdir} -lpmempool
 Libs.private: -ldl
 Cflags: -I${includedir}


### PR DESCRIPTION
Older pkg-config (at least 0.27.1) doesn't support multiple
Requires.private's in a single file.

Ref: #3808

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3819)
<!-- Reviewable:end -->
