### PR TITLE
obj: fix helgrind false positive with memblock refcount

### DIFF
--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -814,8 +814,10 @@ heap_ensure_run_bucket_filled(struct palloc_heap *heap, struct bucket *b,
 		b->c_ops->rm_all(b->container);
 		struct memory_block_reserved **active = &b->active_memory_block;
 		if (util_fetch_and_sub64(&(*active)->nresv, 1) == 1) {
+			VALGRIND_ANNOTATE_HAPPENS_AFTER(&(*active)->nresv);
 			heap_discard_run(heap, &(*active)->m);
 		} else {
+			VALGRIND_ANNOTATE_HAPPENS_BEFORE(&(*active)->nresv);
 			*active = Zalloc(sizeof(struct memory_block_reserved));
 		}
 		b->is_active = 0;

--- a/src/libpmemobj/palloc.c
+++ b/src/libpmemobj/palloc.c
@@ -344,8 +344,8 @@ palloc_reservation_clear(struct palloc_heap *heap,
 	if (act->mresv == NULL)
 		return;
 
-	struct bucket *b = act->mresv->bucket;
 	struct memory_block_reserved *mresv = act->mresv;
+	struct bucket *b = mresv->bucket;
 
 	if (!publish) {
 		util_mutex_lock(&b->lock);
@@ -360,8 +360,11 @@ palloc_reservation_clear(struct palloc_heap *heap,
 	}
 
 	if (util_fetch_and_sub64(&mresv->nresv, 1) == 1) {
+		VALGRIND_ANNOTATE_HAPPENS_AFTER(&mresv->nresv);
 		heap_discard_run(heap, &mresv->m);
 		Free(mresv);
+	} else {
+		VALGRIND_ANNOTATE_HAPPENS_BEFORE(&mresv->nresv);
 	}
 }
 


### PR DESCRIPTION
Ref: pmem/issues#1077 pmem/issues#1078

@Greg091 Can you check if this patch fixes this on Travis? I ran the test a couple of times and it worked fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3821)
<!-- Reviewable:end -->
