### PR TITLE
[1.4] common: implement correct / robust device_dax_alignment

### DIFF
--- a/src/common/file_posix.c
+++ b/src/common/file_posix.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -209,75 +209,103 @@ util_file_dir_remove(const char *path)
 static size_t
 device_dax_alignment(const char *path)
 {
-	LOG(3, "path \"%s\"", path);
-
+	char spath[PATH_MAX];
+	size_t size = 0;
+	char *daxpath;
 	os_stat_t st;
 	int olderrno;
+
+	LOG(3, "path \"%s\"", path);
 
 	if (os_stat(path, &st) < 0) {
 		ERR("!stat \"%s\"", path);
 		return 0;
 	}
 
-	char spath[PATH_MAX];
-	snprintf(spath, PATH_MAX, "/sys/dev/char/%u:%u/device/align",
+	snprintf(spath, PATH_MAX, "/sys/dev/char/%u:%u",
 		os_major(st.st_rdev), os_minor(st.st_rdev));
 
-	LOG(4, "device align path \"%s\"", spath);
-
-	int fd = os_open(spath, O_RDONLY);
-	if (fd < 0) {
-		ERR("!open \"%s\"", spath);
+	daxpath = realpath(spath, NULL);
+	if (!daxpath) {
+		ERR("!realpath \"%s\"", spath);
 		return 0;
 	}
 
-	size_t size = 0;
-
-	char sizebuf[MAX_SIZE_LENGTH + 1];
-	ssize_t nread;
-	if ((nread = read(fd, sizebuf, MAX_SIZE_LENGTH)) < 0) {
-		ERR("!read");
-		goto out;
+	if (util_safe_strcpy(spath, daxpath, sizeof(spath))) {
+		ERR("util_safe_strcpy failed");
+		free(daxpath);
+		return 0;
 	}
 
-	sizebuf[nread] = 0; /* null termination */
+	free(daxpath);
 
-	char *endptr;
+	while (spath[0] != '\0') {
+		char sizebuf[MAX_SIZE_LENGTH + 1];
+		char *pos = strrchr(spath, '/');
+		char *endptr;
+		size_t len;
+		ssize_t rc;
+		int fd;
 
-	olderrno = errno;
-	errno = 0;
+		if (strcmp(spath, "/sys/devices") == 0)
+			break;
 
-	/* 'align' is in decimal format */
-	size = strtoull(sizebuf, &endptr, 10);
-	if (endptr == sizebuf || *endptr != '\n' ||
-	    (size == ULLONG_MAX && errno == ERANGE)) {
-		ERR("invalid device alignment %s", sizebuf);
-		size = 0;
-		goto out;
-	}
+		if (!pos)
+			break;
 
-	/*
-	 * If the alignment value is not a power of two, try with
-	 * hex format, as this is how it was printed in older kernels.
-	 * Just in case someone is using kernel <4.9.
-	 */
-	if ((size & (size - 1)) != 0) {
-		size = strtoull(sizebuf, &endptr, 16);
+		*pos = '\0';
+		len = strlen(spath);
+
+		snprintf(&spath[len], sizeof(spath) - len, "/dax_region/align");
+		fd = os_open(spath, O_RDONLY);
+		*pos = '\0';
+
+		if (fd < 0)
+			continue;
+
+		LOG(4, "device align path \"%s\"", spath);
+
+		rc = read(fd, sizebuf, MAX_SIZE_LENGTH);
+		os_close(fd);
+
+		if (rc < 0) {
+			ERR("!read");
+			return 0;
+		}
+
+		sizebuf[rc] = 0; /* null termination */
+
+		olderrno = errno;
+		errno = 0;
+
+		/* 'align' is in decimal format */
+		size = strtoull(sizebuf, &endptr, 10);
 		if (endptr == sizebuf || *endptr != '\n' ||
-		    (size == ULLONG_MAX && errno == ERANGE)) {
+				(size == ULLONG_MAX && errno == ERANGE)) {
 			ERR("invalid device alignment %s", sizebuf);
 			size = 0;
-			goto out;
+			errno = olderrno;
+			break;
 		}
+
+		/*
+		 * If the alignment value is not a power of two, try with
+		 * hex format, as this is how it was printed in older kernels.
+		 * Just in case someone is using kernel <4.9.
+		 */
+		if ((size & (size - 1)) != 0) {
+			size = strtoull(sizebuf, &endptr, 16);
+			if (endptr == sizebuf || *endptr != '\n' ||
+					(size == ULLONG_MAX &&
+					errno == ERANGE)) {
+				ERR("invalid device alignment %s", sizebuf);
+				size = 0;
+			}
+		}
+
+		errno = olderrno;
+		break;
 	}
-
-	errno = olderrno;
-
-out:
-	olderrno = errno;
-	(void) os_close(fd);
-	errno = olderrno;
-
 	LOG(4, "device alignment %zu", size);
 	return size;
 }

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -295,3 +295,31 @@ util_localtime(const time_t *timep)
 
 	return tm;
 }
+
+/*
+ * util_safe_strcpy -- copies string from src to dst, returns -1
+ * when length of source string (including null-terminator)
+ * is greater than max_length, 0 otherwise
+ *
+ * For gcc (found in version 8.1.1) calling this function with
+ * max_length equal to dst size produces -Wstringop-truncation warning
+ *
+ * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85902
+ */
+#ifdef STRINGOP_TRUNCATION_SUPPORTED
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
+int
+util_safe_strcpy(char *dst, const char *src, size_t max_length)
+{
+	if (max_length == 0)
+		return -1;
+
+	strncpy(dst, src, max_length);
+
+	return dst[max_length - 1] == '\0' ? 0 : -1;
+}
+#ifdef STRINGOP_TRUNCATION_SUPPORTED
+#pragma GCC diagnostic pop
+#endif

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  * Copyright (c) 2016, Microsoft Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -96,6 +96,7 @@ int util_compare_file_inodes(const char *path1, const char *path2);
 void *util_aligned_malloc(size_t alignment, size_t size);
 void util_aligned_free(void *ptr);
 struct tm *util_localtime(const time_t *timep);
+int util_safe_strcpy(char *dst, const char *src, size_t max_length);
 
 #ifdef _WIN32
 char *util_toUTF8(const wchar_t *wstr);


### PR DESCRIPTION
The original implementation was looking at an NVDIMM specific attribute
that is not generally applicable to all device-dax instances. It was
also fragile in the face of the device-dax instances transitioning
between 'dax-bus' and 'dax-class' device types.

Re-implement device_dax_alignment() to be compatible with either device
model. The implementation walks the sysfs path hierarchy until it
reaches the device hosting the "dax_region".

Link: https://github.com/pmem/issues/issues/1071
Signed-off-by: Dan Williams <dan.j.williams@intel.com>
Signed-off-by: Łukasz Plewa <lukasz.plewa@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3832)
<!-- Reviewable:end -->
