### PR TITLE
[1.3] common: implement correct / robust device_dax_alignment

### DIFF
--- a/src/common/util.c
+++ b/src/common/util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -288,3 +288,31 @@ util_localtime(const time_t *timep)
 
 	return tm;
 }
+
+/*
+ * util_safe_strcpy -- copies string from src to dst, returns -1
+ * when length of source string (including null-terminator)
+ * is greater than max_length, 0 otherwise
+ *
+ * For gcc (found in version 8.1.1) calling this function with
+ * max_length equal to dst size produces -Wstringop-truncation warning
+ *
+ * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85902
+ */
+#ifdef STRINGOP_TRUNCATION_SUPPORTED
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
+int
+util_safe_strcpy(char *dst, const char *src, size_t max_length)
+{
+	if (max_length == 0)
+		return -1;
+
+	strncpy(dst, src, max_length);
+
+	return dst[max_length - 1] == '\0' ? 0 : -1;
+}
+#ifdef STRINGOP_TRUNCATION_SUPPORTED
+#pragma GCC diagnostic pop
+#endif

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  * Copyright (c) 2016, Microsoft Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -94,6 +94,7 @@ int util_compare_file_inodes(const char *path1, const char *path2);
 void *util_aligned_malloc(size_t alignment, size_t size);
 void util_aligned_free(void *ptr);
 struct tm *util_localtime(const time_t *timep);
+int util_safe_strcpy(char *dst, const char *src, size_t max_length);
 
 #ifdef _WIN32
 char *util_toUTF8(const wchar_t *wstr);


### PR DESCRIPTION
The original implementation was looking at an NVDIMM specific attribute
that is not generally applicable to all device-dax instances. It was
also fragile in the face of the device-dax instances transitioning
between 'dax-bus' and 'dax-class' device types.

Re-implement device_dax_alignment() to be compatible with either device
model. The implementation walks the sysfs path hierarchy until it
reaches the device hosting the "dax_region".

Link: https://github.com/pmem/issues/issues/1071
Signed-off-by: Dan Williams <dan.j.williams@intel.com>
Signed-off-by: Łukasz Plewa <lukasz.plewa@intel.com>
[ Marcin: backported to pre-os-major tree ]
Signed-off-by: Marcin Ślusarz <marcin.slusarz@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3833)
<!-- Reviewable:end -->
