### PR TITLE
add a test for concurrent pool opens

### DIFF
--- a/src/benchmarks/pmembench_obj_gen.cfg
+++ b/src/benchmarks/pmembench_obj_gen.cfg
@@ -19,14 +19,13 @@ data-size = 1024
 objects = 1:*10:100000
 type-number = rand
 
-# pmemobj_open/close are not yet thread-safe
-#[obj_open_threads]
-#bench = obj_open
-#threads = 1:+1:10
-#data-size = 1024
-#min-size = 1
-#objects = 1000
-#type-number = rand
+[obj_open_threads]
+bench = obj_open
+threads = 1:+1:10
+data-size = 1024
+min-size = 1
+objects = 1000
+type-number = rand
 
 [obj_direct_threads_one_pool]
 bench = obj_direct

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -121,6 +121,7 @@ OBJ_TESTS = \
 	obj_pool\
 	obj_pool_lock\
 	obj_pool_lookup\
+	obj_pool_open_mt\
 	obj_ravl\
 	obj_recovery\
 	obj_recreate\

--- a/src/test/obj_pool_open_mt/.gitignore
+++ b/src/test/obj_pool_open_mt/.gitignore
@@ -1,0 +1,1 @@
+obj_pool_open_mt

--- a/src/test/obj_pool_open_mt/Makefile
+++ b/src/test/obj_pool_open_mt/Makefile
@@ -1,0 +1,41 @@
+#
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_obj_pool_mt/Makefile -- build obj_obj_pool_mt unit test
+#
+TARGET = obj_pool_open_mt
+OBJS = obj_pool_open_mt.o
+
+LIBPMEMOBJ=y
+
+include ../Makefile.inc

--- a/src/test/obj_pool_open_mt/TEST0
+++ b/src/test/obj_pool_open_mt/TEST0
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_pool_open_mt/TEST0 -- unit test for concurrent pool opens/closes
+#
+
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+
+setup
+
+expect_normal_exit ./obj_pool_open_mt$EXESUFFIX $DIR 8
+
+pass

--- a/src/test/obj_pool_open_mt/TEST1
+++ b/src/test/obj_pool_open_mt/TEST1
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_pool_open_mt/TEST1 -- multithreaded test for pool_open
+#
+
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+configure_valgrind helgrind force-enable
+
+setup
+
+expect_normal_exit ./obj_pool_open_mt$EXESUFFIX $DIR 2
+
+pass

--- a/src/test/obj_pool_open_mt/TEST2
+++ b/src/test/obj_pool_open_mt/TEST2
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_pool_open_mt/TEST2 -- multithreaded test for pool_open
+#
+
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+configure_valgrind drd force-enable
+
+setup
+
+expect_normal_exit ./obj_pool_open_mt$EXESUFFIX $DIR 2
+
+pass

--- a/src/test/obj_pool_open_mt/obj_pool_open_mt.c
+++ b/src/test/obj_pool_open_mt/obj_pool_open_mt.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * obj_pool_open_mt.c -- multithreaded unit test for pool_open
+ */
+
+#include <errno.h>
+
+#include "unittest.h"
+
+/* more concurrency = good */
+#define NTHREADS 64
+
+#define POOLSIZE (16 * 1048576)
+
+static unsigned long niter;
+static const char *path;
+
+static void *
+thread_oc(void *arg)
+{
+	unsigned tid = (unsigned)(uint64_t)arg;
+
+	char pname[PATH_MAX];
+	snprintf(pname, sizeof(pname), "%s/open_mt_%02u", path, tid);
+
+	PMEMobjpool *p = pmemobj_create(pname, "", POOLSIZE, 0666);
+	UT_ASSERT(p);
+	pmemobj_close(p);
+
+	for (uint64_t count = 0; count < niter; count++) {
+		p = pmemobj_open(pname, "");
+		UT_ASSERT(p);
+		pmemobj_close(p);
+	}
+
+	UNLINK(pname);
+
+	return NULL;
+}
+
+static void
+test()
+{
+	os_thread_t th[NTHREADS];
+
+	for (int i = 0; i < NTHREADS; i++)
+		PTHREAD_CREATE(&th[i], 0, thread_oc, (void *)(uint64_t)i);
+
+	/* The threads work here... */
+
+	for (int i = 0; i < NTHREADS; i++) {
+		void *retval;
+		PTHREAD_JOIN(&th[i], &retval);
+	}
+}
+
+int
+main(int argc, char *argv[])
+{
+	START(argc, argv, "obj_pool_open_mt");
+
+	if (argc != 3)
+		UT_FATAL("usage: %s path niter", argv[0]);
+
+	path = argv[1];
+	niter = ATOUL(argv[2]);
+	if (!niter || niter == ULONG_MAX)
+		UT_FATAL("%s: bad iteration count '%s'", argv[0], argv[2]);
+
+	test();
+
+	DONE(NULL);
+}


### PR DESCRIPTION
https://github.com/pmem/issues/issues/872

The test should also do a token operation on the opened pool, but small steps first.

There's no Windows version yet -- this was written waiting at a laundromat on an arm PDA w/o network, then tested on x86 and submitted over iodine in a mall, thus excuse my reluctance to set up VNC to a Windows VM. :)

Marked as WIP as this test reveals yet-unfixed problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3846)
<!-- Reviewable:end -->
