### PR TITLE
test: fix match file in rpmem_addr_ext test

### DIFF
--- a/src/test/rpmem_addr_ext/node_1_rpmem0.log.match
+++ b/src/test/rpmem_addr_ext/node_1_rpmem0.log.match
@@ -8,7 +8,6 @@ $(OPT)<librpmem>: <1> [$(*)] compiled with support for Valgrind drd
 $(OPT)<librpmem>: <1> [$(*)] compiled with support for shutdown state
 $(OPT)<librpmem>: <1> [$(*)] compiled with libndctl 63+
 <librpmem>: <3> [$(*)] 
-<librpmem>: <3> [$(*)] Libfabric is fork safe
 $(OPT)<librpmem>: <3> [$(*)] $(*)
 $(OPT)<librpmem>: <3> [$(*)] $(*)
 <librpmem>: <3> [$(*)] create request:


### PR DESCRIPTION
Information about libfabric fork safety is no longer printed

---
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3862)
<!-- Reviewable:end -->
