### PR TITLE
test: fix lock initialization in obj_pmalloc_mt

### DIFF
--- a/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
+++ b/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
@@ -317,7 +317,14 @@ action_mix_worker(void *arg)
 static void
 actions_clear(struct root *r)
 {
-	memset(r->actions, 0, sizeof(r->actions));
+	for (unsigned i = 0; i < Threads; ++i) {
+		for (unsigned j = 0; j < Ops_per_thread; ++j) {
+			struct action *a = &r->actions[i][j];
+			os_mutex_init(&a->lock);
+			os_cond_init(&a->cond);
+			memset(&a->pact, 0, sizeof(a->pact));
+		}
+	}
 }
 
 static void


### PR DESCRIPTION
Ref: pmem/issues#1076

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3864)
<!-- Reviewable:end -->
