### PR TITLE
pool: check poolset completness prior to rm

### DIFF
--- a/src/common/set.c
+++ b/src/common/set.c
@@ -1941,6 +1941,27 @@ util_pool_close_remote(RPMEMpool *rpp)
 }
 
 /*
+ * util_poolset_remote_test -- open and close remote replica
+ */
+int util_poolset_remote_test(struct part_file *pf, void *pool_addr,
+		size_t pool_size, unsigned *nlanes,
+		struct rpmem_pool_attr *rpmem_attr)
+{
+	if (!Rpmem_handle_remote) {
+		return -1;
+	}
+
+	RPMEMpool *rpp = Rpmem_open(pf->remote->node_addr,
+			pf->remote->pool_desc, pool_addr, pool_size,
+			nlanes, rpmem_attr);
+	if (rpp == NULL) {
+		ERR("opening remote replica failed");
+		return 1;
+	}
+
+	return Rpmem_close(rpp);
+}
+/*
  * util_poolset_remote_open -- open or create a remote replica
  */
 int

--- a/src/common/set.h
+++ b/src/common/set.h
@@ -406,6 +406,9 @@ void util_remote_destroy_lock(void);
 int util_pool_close_remote(RPMEMpool *rpp);
 void util_remote_unload(void);
 void util_replica_fdclose(struct pool_replica *rep);
+extern int util_poolset_remote_test(struct part_file *pf, void *pool_addr,
+		size_t pool_size, unsigned *nlanes,
+		struct rpmem_pool_attr *rpmem_attr);
 int util_poolset_remote_open(struct pool_replica *rep, unsigned repidx,
 	size_t minsize, int create, void *pool_addr,
 	size_t pool_size, unsigned *nlanes);

--- a/src/test/pmempool_check/TEST14
+++ b/src/test/pmempool_check/TEST14
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,18 +51,18 @@ rm -f $LOG && touch $LOG
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:$DEVICE_DAX_PATH
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $DEVICE_DAX_PATH
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $DEVICE_DAX_PATH
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET >> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET &> /dev/null
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $DEVICE_DAX_PATH
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $DEVICE_DAX_PATH
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET >> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET &> /dev/null
 
 #remove the pools in the poolset while preserving the file itself
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm -s $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -fs $POOLSET
 #verify that the poolset still exists
 check_files $POOLSET
 

--- a/src/test/pmempool_check/TEST23
+++ b/src/test/pmempool_check/TEST23
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2018, Intel Corporation
+# Copyright 2017-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -53,18 +53,18 @@ rm -f $LOG && touch $LOG
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:$DEVICE_DAX_PATH
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $DEVICE_DAX_PATH
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $DEVICE_DAX_PATH
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET >> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET &> /dev/null
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $DEVICE_DAX_PATH
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $DEVICE_DAX_PATH
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET >> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET &> /dev/null
 
 #remove the pools in the poolset while preserving the file itself
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm -s $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -fs $POOLSET
 #verify that the poolset still exists
 check_files $POOLSET
 

--- a/src/test/pmempool_check/TEST25
+++ b/src/test/pmempool_check/TEST25
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2018, Intel Corporation
+# Copyright 2017-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -55,18 +55,18 @@ rm -f $LOG && touch $LOG
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET >> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET &> /dev/null
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET >> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET &> /dev/null
 
 #remove the pools in the poolset while preserving the file itself
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm -s $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -fs $POOLSET
 #verify that the poolset still exists
 check_files $POOLSET
 

--- a/src/test/pmempool_check/TEST27
+++ b/src/test/pmempool_check/TEST27
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2018, Intel Corporation
+# Copyright 2017-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -56,18 +56,18 @@ POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]} \
 	O SINGLEHDR
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET >> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET &> /dev/null
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET >> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET &> /dev/null
 
 #remove the pools in the poolset while preserving the file itself
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm -s $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -fs $POOLSET
 #verify that the poolset still exists
 check_files $POOLSET
 

--- a/src/test/pmempool_check/TEST31
+++ b/src/test/pmempool_check/TEST31
@@ -67,7 +67,7 @@ POOLSET=$DIR/testset1
 create_poolset $POOLSET 10M:$DIR/testfile0:z 10M:$MOUNT_DIR/testfile1:z 10M:$DIR/testfile2:z \
 			R 30M:$DIR/testfile3:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 turn_on_checking_bad_blocks $POOLSET

--- a/src/test/pmempool_check/TEST32
+++ b/src/test/pmempool_check/TEST32
@@ -64,7 +64,7 @@ POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:$FULLDEV:x \
 			R 10M:$DIR/testfile1:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 turn_on_checking_bad_blocks $POOLSET

--- a/src/test/pmempool_create/TEST10
+++ b/src/test/pmempool_create/TEST10
@@ -63,7 +63,7 @@ rm -f $LOG && touch $LOG
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:$FULLDEV:x
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 
 # inject bad block: OFF=11 LEN=1
 ndctl_inject_error $NAMESPACE 11 1

--- a/src/test/pmempool_create/TEST12
+++ b/src/test/pmempool_create/TEST12
@@ -64,7 +64,7 @@ rm -f $LOG && touch $LOG
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:$FULLDEV:x
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 
 # inject bad block: OFF=11 LEN=1
 ndctl_inject_error $NAMESPACE 11 1

--- a/src/test/pmempool_info/TEST18
+++ b/src/test/pmempool_info/TEST18
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -50,7 +50,7 @@ rm -f $LOG && touch $LOG
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:$DEVICE_DAX_PATH
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $DEVICE_DAX_PATH
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $DEVICE_DAX_PATH
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET >> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $DEVICE_DAX_PATH >> $LOG

--- a/src/test/pmempool_info/TEST19
+++ b/src/test/pmempool_info/TEST19
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -52,7 +52,7 @@ rm -f $LOG && touch $LOG
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET >> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX info ${DEVICE_DAX_PATH[0]} >> $LOG

--- a/src/test/pmempool_info/TEST21
+++ b/src/test/pmempool_info/TEST21
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -53,7 +53,7 @@ POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]} \
 	O SINGLEHDR
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET >> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX info ${DEVICE_DAX_PATH[0]} >> $LOG

--- a/src/test/pmempool_info/TEST24
+++ b/src/test/pmempool_info/TEST24
@@ -63,7 +63,7 @@ rm -f $LOG && touch $LOG
 POOLSET=$DIR/testset1
 create_poolset $POOLSET AUTO:$FULLDEV:x
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 # inject bad block: OFF=11 LEN=1

--- a/src/test/pmempool_info/TEST25
+++ b/src/test/pmempool_info/TEST25
@@ -66,7 +66,7 @@ rm -f $LOG && touch $LOG
 POOLSET=$DIR/testset1
 create_poolset $POOLSET 10M:$DIR/testfile0:z 10M:$MOUNT_DIR/testfile1:z 10M:$DIR/testfile2:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 # inject bad block:

--- a/src/test/pmempool_rm/TEST5
+++ b/src/test/pmempool_rm/TEST5
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2015-2018, Intel Corporation
+# Copyright 2015-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -57,9 +57,9 @@ check_no_file $DIR/pool2 $DIR/pool3
 expect_abnormal_exit $PMEMPOOL$EXESUFFIX rm -a\
 	$DIR/pool.1 $DIR/pool.set $DIR/pool.2 2>log$UNITTEST_NUM.log
 
-check_no_files $DIR/pool1 $DIR/pool2 $DIR/pool3 $DIR/pool4\
+check_no_files $DIR/pool2 $DIR/pool3 \
 	$DIR/pool.1 $DIR/pool.2
-check_file $DIR/pool.set
+check_file $DIR/pool.set $DIR/pool1 $DIR/pool4
 
 check
 

--- a/src/test/pmempool_rm/log5.log.match
+++ b/src/test/pmempool_rm/log5.log.match
@@ -1,3 +1,2 @@
-error: cannot remove file '$(nW)pool2': No such file or directory
-error: cannot remove file '$(nW)pool3': No such file or directory
+error: cannot open file '$(nW)pool2': No such file or directory
 error: removing '$(nW)pool.set' failed: No such file or directory

--- a/src/test/pmempool_rm/out2.log.match
+++ b/src/test/pmempool_rm/out2.log.match
@@ -1,7 +1,4 @@
 error: cannot remove '$(*)pool.obj': No such file or directory
-error: cannot remove file '$(*)pool.part1': No such file or directory
-error: cannot remove file '$(*)pool.part2': No such file or directory
-error: cannot remove file '$(*)rep.part1': No such file or directory
-error: cannot remove file '$(*)rep.part2': No such file or directory
+error: cannot open file '$(*)pool.part1': No such file or directory
 error: removing '$(*)pool.set' failed: No such file or directory
 removed '$(*)pool.set'

--- a/src/test/pmempool_rm_remote/TEST1
+++ b/src/test/pmempool_rm_remote/TEST1
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2018, Intel Corporation
+# Copyright 2017-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -80,9 +80,17 @@ check_files_on_node 1 $TEST_SET_LOCAL test_part0 test_part1 test_part2 test_part
 rm_files_from_node 0 ${NODE_DIR[0]}test_part_remote2
 check_no_files_on_node 0 test_part_remote2
 
+# without force should fail
 expect_abnormal_exit run_on_node 1 ../pmempool rm ${NODE_DIR[1]}$TEST_SET_LOCAL 1>> $OUT 2>&1
 
-check_no_files_on_node 0 test_part_remote0 test_part_remote1 test_part_remote2 test_part_remote3
+check_files_on_node 0 $TEST_SET_REMOTE test_part_remote0
+check_files_on_node 1 $TEST_SET_LOCAL test_part0 test_part1
+
+# with force should pass
+expect_normal_exit run_on_node 1 ../pmempool rm -f ${NODE_DIR[1]}$TEST_SET_LOCAL 1>> $OUT 2>&1
+
+check_no_files_on_node 0 test_part_remote0
+check_no_files_on_node 1 test_part0 test_part1
 
 check_local
 

--- a/src/test/pmempool_rm_remote/stdout1.log.match
+++ b/src/test/pmempool_rm_remote/stdout1.log.match
@@ -1,2 +1,1 @@
-error: cannot remove 'testset_remote' on $(nW): $(S)
 error: removing '$(nW)testset_local' failed: $(S)

--- a/src/test/pmempool_sync/TEST25
+++ b/src/test/pmempool_sync/TEST25
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_sync/TEST26
+++ b/src/test/pmempool_sync/TEST26
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -73,7 +73,7 @@ expect_normal_exit $PMEMSPOIL $DIR/testfile1 pool_hdr.uuid=0000000000000000\
 expect_abnormal_exit $PMEMPOOL$EXESUFFIX sync $POOLSET >> $LOG_TEMP 2>&1
 
 # Remove poolset
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 
 # Create pmemlog poolset
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOLSET

--- a/src/test/pmempool_sync/TEST26.PS1
+++ b/src/test/pmempool_sync/TEST26.PS1
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -72,7 +72,7 @@ expect_normal_exit $PMEMSPOIL $DIR\testfile1 "pool_hdr.uuid=0000000000000000" `
 expect_abnormal_exit $PMEMPOOL sync $POOLSET >> $LOG_TEMP 2>&1
 
 # Remove poolset
-expect_normal_exit $PMEMPOOL rm $POOLSET
+expect_normal_exit $PMEMPOOL rm -f $POOLSET
 
 # Create pmemlog poolset
 expect_normal_exit $PMEMPOOL create log $POOLSET

--- a/src/test/pmempool_sync/TEST27
+++ b/src/test/pmempool_sync/TEST27
@@ -72,7 +72,7 @@ create_poolset $POOLSET \
 	R \
 	24M:$DIR/testfile3:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST28
+++ b/src/test/pmempool_sync/TEST28
@@ -66,7 +66,7 @@ create_poolset $POOLSET AUTO:$FULLDEV:x \
 			R \
 			8M:$DIR/testfile1:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST29
+++ b/src/test/pmempool_sync/TEST29
@@ -53,7 +53,7 @@ create_poolset $POOLSET 8M:$DIR/testfile0:z \
 			12M:$DIR/testfile3:z \
 			12M:$DIR/testfile4:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST30
+++ b/src/test/pmempool_sync/TEST30
@@ -72,7 +72,7 @@ create_poolset $POOLSET \
 	R \
 	24M:$DIR/testfile3:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST31
+++ b/src/test/pmempool_sync/TEST31
@@ -66,7 +66,7 @@ create_poolset $POOLSET AUTO:$FULLDEV:x \
 			R \
 			8M:$DIR/testfile1:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST32
+++ b/src/test/pmempool_sync/TEST32
@@ -58,7 +58,7 @@ create_poolset $POOLSET \
 	R \
 	24M:$DIR/testfile3:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST33
+++ b/src/test/pmempool_sync/TEST33
@@ -58,7 +58,7 @@ create_poolset $POOLSET \
 	R \
 	24M:$DIR/testfile3:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST34
+++ b/src/test/pmempool_sync/TEST34
@@ -58,7 +58,7 @@ create_poolset $POOLSET \
 	R \
 	24M:$DIR/testfile3:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST35
+++ b/src/test/pmempool_sync/TEST35
@@ -58,7 +58,7 @@ create_poolset $POOLSET \
 	R \
 	24M:$DIR/testfile3:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST36
+++ b/src/test/pmempool_sync/TEST36
@@ -59,7 +59,7 @@ create_poolset $POOLSET \
 	R \
 	24M:$DIR/testfile3:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST37
+++ b/src/test/pmempool_sync/TEST37
@@ -59,7 +59,7 @@ create_poolset $POOLSET \
 	R \
 	24M:$DIR/testfile3:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST38
+++ b/src/test/pmempool_sync/TEST38
@@ -82,7 +82,7 @@ create_poolset $POOLSET \
 	R \
 	24M:$DIR/testfile3:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST39
+++ b/src/test/pmempool_sync/TEST39
@@ -82,7 +82,7 @@ create_poolset $POOLSET \
 	R \
 	24M:$DIR/testfile3:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST40
+++ b/src/test/pmempool_sync/TEST40
@@ -82,7 +82,7 @@ create_poolset $POOLSET \
 	R \
 	24M:$DIR/testfile3:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST41
+++ b/src/test/pmempool_sync/TEST41
@@ -82,7 +82,7 @@ create_poolset $POOLSET \
 	R \
 	24M:$DIR/testfile3:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST42
+++ b/src/test/pmempool_sync/TEST42
@@ -61,7 +61,7 @@ create_poolset $POOLSET \
 	8M:$DIR/testfile4:z \
 	8M:$DIR/testfile5:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST43
+++ b/src/test/pmempool_sync/TEST43
@@ -61,7 +61,7 @@ create_poolset $POOLSET \
 	8M:$DIR/testfile4:z \
 	8M:$DIR/testfile5:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST44
+++ b/src/test/pmempool_sync/TEST44
@@ -68,7 +68,8 @@ create_poolset $POOLSET \
 	8M:$DIR/testfile7:z \
 	8M:$DIR/testfile8:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
+
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST45
+++ b/src/test/pmempool_sync/TEST45
@@ -68,7 +68,7 @@ create_poolset $POOLSET \
 	8M:$DIR/testfile7:z \
 	8M:$DIR/testfile8:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST46
+++ b/src/test/pmempool_sync/TEST46
@@ -68,7 +68,7 @@ create_poolset $POOLSET \
 	8M:$DIR/testfile7:z \
 	8M:$DIR/testfile8:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST47
+++ b/src/test/pmempool_sync/TEST47
@@ -67,7 +67,7 @@ create_poolset $POOLSET \
 	8M:$DIR/testfile_r2_p1:z \
 	8M:$DIR/testfile_r2_p2:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST48
+++ b/src/test/pmempool_sync/TEST48
@@ -70,7 +70,7 @@ create_poolset $POOLSET \
 	8M:$DIR/testfile_r2_p1:z \
 	8M:$DIR/testfile_r2_p2:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST49
+++ b/src/test/pmempool_sync/TEST49
@@ -71,7 +71,7 @@ create_poolset $POOLSET \
 	8M:$DIR/testfile_r2_p1:z \
 	8M:$DIR/testfile_r2_p2:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST50
+++ b/src/test/pmempool_sync/TEST50
@@ -71,7 +71,7 @@ create_poolset $POOLSET \
 	8M:$DIR/testfile_r2_p1:z \
 	8M:$DIR/testfile_r2_p2:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST51
+++ b/src/test/pmempool_sync/TEST51
@@ -72,7 +72,7 @@ create_poolset $POOLSET \
 	8M:$DIR/testfile_r2_p1:z \
 	8M:$DIR/testfile_r2_p2:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST52
+++ b/src/test/pmempool_sync/TEST52
@@ -67,7 +67,7 @@ create_poolset $POOLSET \
 	8M:$DIR/testfile_r2_p1:z \
 	8M:$DIR/testfile_r2_p2:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/pmempool_sync/TEST53
+++ b/src/test/pmempool_sync/TEST53
@@ -69,7 +69,7 @@ create_poolset $POOLSET \
 	8M:$DIR/testfile_r2_p1:z \
 	8M:$DIR/testfile_r2_p2:z
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"

--- a/src/test/util_poolset/TEST5
+++ b/src/test/util_poolset/TEST5
@@ -108,7 +108,7 @@ expect_normal_exit ./util_poolset$EXESUFFIX o $MIN_POOL\
 
 $GREP "<1>" $TEST_LOG_FILE | sed -e "s/^.*\][ ]*//g" > ./grep$UNITTEST_NUM.log
 
-expect_normal_exit $PMEMPOOL$EXESUFFIX rm $DIR/testset9
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -f $DIR/testset9
 
 check
 


### PR DESCRIPTION
Do not allow to delete poolset without force if it is not complete.

Ref: pmem/issues#832

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3868)
<!-- Reviewable:end -->
