### PR TITLE
[1.4] test: split test obj_tx_lock into two test cases

### DIFF
--- a/src/test/obj_tx_lock/TEST0.PS1
+++ b/src/test/obj_tx_lock/TEST0.PS1
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2019, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -48,6 +48,6 @@ require_test_type medium
 
 setup
 
-expect_normal_exit $Env:EXE_DIR\obj_tx_lock$Env:EXESUFFIX $DIR\testfile1
+expect_normal_exit $Env:EXE_DIR\obj_tx_lock$Env:EXESUFFIX $DIR\testfile1 l n a t
 
 pass

--- a/src/test/obj_tx_lock/TEST1
+++ b/src/test/obj_tx_lock/TEST1
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2019, Intel Corporation
+# Copyright 2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,8 +32,8 @@
 #
 
 #
-# src/test/obj_tx_lock/TEST0 -- unit test for pmemobj_tx_lock()
-#                               with DRD disabled
+# src/test/obj_tx_lock/TEST1 -- unit test for pmemobj_tx_lock() with DRD
+#                               and Helgrind disabled
 #
 
 # standard unit test setup
@@ -42,9 +42,10 @@
 require_test_type medium
 
 configure_valgrind drd force-disable
+configure_valgrind helgrind force-disable
 
 setup
 
-expect_normal_exit ./obj_tx_lock$EXESUFFIX $DIR/testfile1 l n a
+expect_normal_exit ./obj_tx_lock$EXESUFFIX $DIR/testfile1 t
 
 pass


### PR DESCRIPTION
Ref: pmem/issues#1105

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3870)
<!-- Reviewable:end -->
