### PR TITLE
rpmem: remove kill command

### DIFF
--- a/src/librpmem/rpmem_cmd.c
+++ b/src/librpmem/rpmem_cmd.c
@@ -255,9 +255,9 @@ rpmem_cmd_wait(struct rpmem_cmd *cmd, int *status)
 }
 
 /*
- * rpmem_cmd_term -- terminate process by sending SIGINT signal
+ * rpmem_cmd_term -- close child process's unix sockets
  */
-int
+void
 rpmem_cmd_term(struct rpmem_cmd *cmd)
 {
 	os_close(cmd->fd_in);
@@ -265,8 +265,4 @@ rpmem_cmd_term(struct rpmem_cmd *cmd)
 	os_close(cmd->fd_err);
 
 	RPMEM_ASSERT(cmd->pid > 0);
-	int rv = kill(cmd->pid, SIGINT);
-	if (rv)
-		RPMEM_LOG(ERR, "!kill failed");
-	return rv;
 }

--- a/src/librpmem/rpmem_cmd.h
+++ b/src/librpmem/rpmem_cmd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018, Intel Corporation
+ * Copyright 2016-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -57,7 +57,7 @@ struct rpmem_cmd {
 struct rpmem_cmd *rpmem_cmd_init(void);
 int rpmem_cmd_push(struct rpmem_cmd *cmd, const char *arg);
 int rpmem_cmd_run(struct rpmem_cmd *cmd);
-int rpmem_cmd_term(struct rpmem_cmd *cmd);
+void rpmem_cmd_term(struct rpmem_cmd *cmd);
 int rpmem_cmd_wait(struct rpmem_cmd *cmd, int *status);
 void rpmem_cmd_fini(struct rpmem_cmd *cmd);
 

--- a/src/librpmem/rpmem_ssh.c
+++ b/src/librpmem/rpmem_ssh.c
@@ -334,10 +334,7 @@ rpmem_ssh_close(struct rpmem_ssh *rps)
 {
 	int ret, rv;
 
-	rv = rpmem_cmd_term(rps->cmd);
-	if (rv)
-		return rv;
-
+	rpmem_cmd_term(rps->cmd);
 	rv = rpmem_cmd_wait(rps->cmd, &ret);
 	if (rv)
 		return rv;


### PR DESCRIPTION
Killing daemon before starting waiting
for it to close is unnecessary and causes issues.
Ref: /pmem/issues#995
Ref: /pmem/issues#1060

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3872)
<!-- Reviewable:end -->
