### PR TITLE
[1.4] test: remove invalid expect_normal_exit

### DIFF
--- a/src/test/rpmem_basic/TEST15
+++ b/src/test/rpmem_basic/TEST15
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -61,7 +61,7 @@ create_poolset $DIR/pool2.set AUTO:$(get_node_devdax_path 0 0) O NOHDRS
 expect_normal_exit run_on_node 0 rm -rf $PART_DIR
 expect_normal_exit run_on_node 0 mkdir -p ${RPMEM_POOLSET_DIR[0]}
 expect_normal_exit run_on_node 0 mkdir -p $PART_DIR
-expect_normal_exit copy_files_to_node 0 ${RPMEM_POOLSET_DIR[0]} $DIR/{pool0.set,pool1.set,pool2.set}
+copy_files_to_node 0 ${RPMEM_POOLSET_DIR[0]} $DIR/{pool0.set,pool1.set,pool2.set}
 
 expect_normal_exit run_on_node 0 ../pmempool rm -sf ${RPMEM_POOLSET_DIR[0]}/{pool0.set,pool1.set,pool2.set}
 expect_normal_exit run_on_node 1 ../pmempool rm -sf $(get_node_devdax_path 0 0)

--- a/src/test/rpmem_basic/TEST5
+++ b/src/test/rpmem_basic/TEST5
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -59,7 +59,7 @@ create_poolset $DIR/pool2.set 8M:$PART_DIR/pool2.part0 8M:$PART_DIR/pool2.part1 
 expect_normal_exit run_on_node 0 rm -rf $PART_DIR
 expect_normal_exit run_on_node 0 mkdir -p ${RPMEM_POOLSET_DIR[0]}
 expect_normal_exit run_on_node 0 mkdir -p $PART_DIR
-expect_normal_exit copy_files_to_node 0 ${RPMEM_POOLSET_DIR[0]} $DIR/{pool0.set,pool1.set,pool2.set}
+copy_files_to_node 0 ${RPMEM_POOLSET_DIR[0]} $DIR/{pool0.set,pool1.set,pool2.set}
 
 expect_abnormal_exit run_on_node 1 ssh ${NODE_ADDR[0]} "\$RPMEM_CMD --remove pool0.set"
 expect_abnormal_exit run_on_node 1 ssh ${NODE_ADDR[0]} "\$RPMEM_CMD --remove pool1.set"

--- a/src/test/rpmem_basic/TEST6
+++ b/src/test/rpmem_basic/TEST6
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -59,7 +59,7 @@ create_poolset $DIR/pool2.set 8M:$PART_DIR/pool2.part0 8M:$PART_DIR/pool2.part1 
 expect_normal_exit run_on_node 0 rm -rf $PART_DIR
 expect_normal_exit run_on_node 0 mkdir -p ${RPMEM_POOLSET_DIR[0]}
 expect_normal_exit run_on_node 0 mkdir -p $PART_DIR
-expect_normal_exit copy_files_to_node 0 ${RPMEM_POOLSET_DIR[0]} $DIR/{pool0.set,pool1.set,pool2.set}
+copy_files_to_node 0 ${RPMEM_POOLSET_DIR[0]} $DIR/{pool0.set,pool1.set,pool2.set}
 
 expect_abnormal_exit run_on_node 1 ssh ${NODE_ADDR[0]} "\$RPMEM_CMD --remove pool0.set"
 expect_abnormal_exit run_on_node 1 ssh ${NODE_ADDR[0]} "\$RPMEM_CMD --remove pool1.set"

--- a/src/test/rpmem_basic/TEST7
+++ b/src/test/rpmem_basic/TEST7
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -60,7 +60,7 @@ create_poolset $DIR/pool2.set AUTO:$(get_node_devdax_path 0 0) O NOHDRS
 expect_normal_exit run_on_node 0 rm -rf $PART_DIR
 expect_normal_exit run_on_node 0 mkdir -p ${RPMEM_POOLSET_DIR[0]}
 expect_normal_exit run_on_node 0 mkdir -p $PART_DIR
-expect_normal_exit copy_files_to_node 0 ${RPMEM_POOLSET_DIR[0]} $DIR/{pool0.set,pool1.set,pool2.set}
+copy_files_to_node 0 ${RPMEM_POOLSET_DIR[0]} $DIR/{pool0.set,pool1.set,pool2.set}
 
 expect_normal_exit run_on_node 0 ../pmempool rm -sf ${RPMEM_POOLSET_DIR[0]}/{pool0.set,pool1.set,pool2.set}
 expect_normal_exit run_on_node 1 ../pmempool rm -sf $(get_node_devdax_path 0 0)


### PR DESCRIPTION
expect_normal_exit is incompatible with copy_file_to_node and is
causing trouble when used with valgrind.

Ref: pmem/issues#1092

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3881)
<!-- Reviewable:end -->
