### PR TITLE
[1.4] Fix obj_tx_add_range_direct test

### DIFF
--- a/src/test/obj_tx_add_range_direct/obj_tx_add_range_direct.c
+++ b/src/test/obj_tx_add_range_direct/obj_tx_add_range_direct.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018, Intel Corporation
+ * Copyright 2015-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -569,8 +569,6 @@ do_tx_add_range_lots_of_small_snapshots(PMEMobjpool *pop)
 	} TX_ONABORT {
 		UT_ASSERT(0);
 	} TX_END
-
-	UT_ASSERTeq(errno, 0);
 }
 
 static void


### PR DESCRIPTION
remove checking errno in obj_tx_add_range_direct.
Malloc sets errno, despite function succeed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3889)
<!-- Reviewable:end -->
