### PR TITLE
Remove unnecessary file entries in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -37,13 +37,3 @@ with the following exceptions:
 
 * js/jquery.min.js released under the MIT license
   (see: http://jquery.org/license)
-
-* cpp_obj/cpp_html/jquery.js dual licensed under the MIT
-  or GPL Version 2 license (see: http://jquery.org/license)
-
-* sizzle.js (included in cpp_obj/cpp_html/jquery.js) released under
-  the MIT, BSD and GPL licenses (see: http://sizzle.com)
-
-* cpp_obj/cpp_html/search/search.js licensed under the GPL
-
-* cpp_obj/cpp_html/dynsections.js licensed under the GPL


### PR DESCRIPTION
cpp_obj is not including any of these files anymore, since the content
is moved to the libpmemobj-cpp repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3891)
<!-- Reviewable:end -->
