### PR TITLE
use the same RNG on Linux/BSD and on Windows

### DIFF
--- a/src/common/pmemcommon.inc
+++ b/src/common/pmemcommon.inc
@@ -52,6 +52,7 @@ SOURCE =\
 	$(COMMON)/os_deep_linux.c\
 	$(COMMON)/out.c\
 	$(COMMON)/pool_hdr.c\
+	$(COMMON)/rand.c\
 	$(COMMON)/set.c\
 	$(COMMON)/shutdown_state.c\
 	$(COMMON)/util.c\

--- a/src/common/rand.c
+++ b/src/common/rand.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * rand.c -- random utils
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <unistd.h>
+
+#include "rand.h"
+
+#ifdef _WIN32
+#include <bcrypt.h>
+#include <process.h>
+#else
+#include <sys/syscall.h>
+#endif
+
+/*
+ * hash64 -- a u64 -> u64 hash
+ */
+uint64_t
+hash64(uint64_t x)
+{
+	x += 0x9e3779b97f4a7c15;
+	x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9;
+	x = (x ^ (x >> 27)) * 0x94d049bb133111eb;
+	return x ^ (x >> 31);
+}
+
+/*
+ * xoshiro256** random generator
+ *
+ * Fastest available good PRNG as of 2018 (sub-nanosecond per entry), produces
+ * much better output than old stuff like rand() or Mersenne's Twister.
+ *
+ * By David Blackman and Sebastiano Vigna; PD/CC0 2018.
+ *
+ * It has a period of 2²⁵⁶-1, excluding all-zero state; it must always get
+ * initialized to avoid that zero.
+ */
+
+static inline uint64_t rotl(const uint64_t x, int k)
+{
+	/* optimized to a single instruction on x86 */
+	return (x << k) | (x >> (64 - k));
+}
+
+/*
+ * rnd64_r -- return 64-bits of randomness
+ */
+uint64_t
+rnd64_r(rng_t *state)
+{
+	uint64_t *s = (void *)state;
+
+	const uint64_t result = rotl(s[1] * 5, 7) * 9;
+	const uint64_t t = s[1] << 17;
+
+	s[2] ^= s[0];
+	s[3] ^= s[1];
+	s[1] ^= s[2];
+	s[0] ^= s[3];
+
+	s[2] ^= t;
+
+	s[3] = rotl(s[3], 45);
+
+	return result;
+}
+
+/*
+ * randomize_r -- initialize random generator
+ *
+ * Seed of 0 means random.
+ */
+void
+randomize_r(rng_t *state, uint64_t seed)
+{
+	if (!seed) {
+#ifdef SYS_getrandom
+		/* We want getentropy() but ancient Red Hat lacks it. */
+		if (!syscall(SYS_getrandom, state, sizeof(rng_t), 0))
+			return; /* nofail, but ENOSYS on kernel < 3.16 */
+#elif _WIN32
+#pragma comment(lib, "Bcrypt.lib")
+		if (BCryptGenRandom(NULL, (PUCHAR)state, sizeof(rng_t),
+			BCRYPT_USE_SYSTEM_PREFERRED_RNG)) {
+			return;
+		}
+#endif
+		seed = (uint64_t)getpid();
+	}
+
+	uint64_t *s = (void *)state;
+	s[0] = hash64(seed);
+	s[1] = hash64(s[0]);
+	s[2] = hash64(s[1]);
+	s[3] = hash64(s[2]);
+}
+
+static rng_t global_rng;
+
+/*
+ * rnd64 -- global state version of rnd64_t
+ */
+uint64_t
+rnd64(void)
+{
+	return rnd64_r(&global_rng);
+}
+
+
+/*
+ * randomize -- initialize global RNG
+ */
+void
+randomize(uint64_t seed)
+{
+	randomize_r(&global_rng, seed);
+}

--- a/src/common/rand.h
+++ b/src/common/rand.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * rand.h -- random utils
+ */
+
+#ifndef RAND_H
+#define RAND_H 1
+
+#include <stdint.h>
+
+typedef uint64_t rng_t[4];
+
+uint64_t hash64(uint64_t x);
+uint64_t rnd64_r(rng_t *rng);
+void randomize_r(rng_t *rng, uint64_t seed);
+uint64_t rnd64(void);
+void randomize(uint64_t seed);
+
+#endif

--- a/src/test/blk_rw_mt/blk_rw_mt.c
+++ b/src/test/blk_rw_mt/blk_rw_mt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  * Copyright (c) 2016, Microsoft Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,6 +39,7 @@
  */
 
 #include "unittest.h"
+#include "rand.h"
 
 static size_t Bsize;
 /* all I/O below this LBA (increases collisions) */
@@ -84,15 +85,17 @@ check(unsigned char *buf)
 static void *
 worker(void *arg)
 {
-	long mytid = (long)(intptr_t)arg;
-	unsigned myseed = Seed + mytid;
+	uintptr_t mytid = (uintptr_t)arg;
 	unsigned char *buf = MALLOC(Bsize);
 	int ord = 1;
+	rng_t rng;
+
+	randomize_r(&rng, Seed + mytid);
 
 	for (unsigned i = 0; i < Nops; i++) {
-		os_off_t lba = os_rand_r(&myseed) % Nblock;
+		os_off_t lba = (os_off_t)(rnd64_r(&rng) % Nblock);
 
-		if (os_rand_r(&myseed) % 2) {
+		if (rnd64_r(&rng) % 2) {
 			/* read */
 			if (pmemblk_read(Handle, buf, lba) < 0)
 				UT_OUT("!read      lba %zu", lba);

--- a/src/test/blk_rw_mt/blk_rw_mt.vcxproj
+++ b/src/test/blk_rw_mt/blk_rw_mt.vcxproj
@@ -77,6 +77,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\common\rand.c" />
     <ClCompile Include="blk_rw_mt.c" />
   </ItemGroup>
   <ItemGroup>

--- a/src/test/obj_critnib_mt/obj_critnib_mt.c
+++ b/src/test/obj_critnib_mt/obj_critnib_mt.c
@@ -54,7 +54,7 @@ static int nrthreads; /* in mixed tests, read threads */
 static int nwthreads; /* ... and write threads */
 
 static uint64_t
-rnd_thid_r64(rng_t *seedp, void *arg)
+rnd_thid_r64(rng_t *seedp, uint16_t thid)
 {
 	/*
 	 * Stick arg (thread index) onto bits 16..31, to make it impossible for
@@ -63,7 +63,7 @@ rnd_thid_r64(rng_t *seedp, void *arg)
 	 */
 	uint64_t r = rnd64_r(seedp);
 	r &= ~0xffff0000ULL;
-	r |= ((uint64_t)arg) << 16;
+	r |= ((uint64_t)thid) << 16;
 	return r;
 }
 
@@ -118,7 +118,7 @@ thread_write1024(void *arg)
 	uint64_t w1024[1024];
 
 	for (int i = 0; i < ARRAY_SIZE(w1024); i++)
-		w1024[i] = rnd_thid_r64(&seed, arg);
+		w1024[i] = rnd_thid_r64(&seed, (uint16_t)(uintptr_t)arg);
 
 	uint64_t niter = helgrind_count(NITER_SLOW);
 
@@ -140,7 +140,7 @@ thread_read_write_remove(void *arg)
 	uint64_t niter = helgrind_count(NITER_SLOW);
 
 	for (uint64_t count = 0; count < niter; count++) {
-		uint64_t r, v = rnd_thid_r64(&seed, arg);
+		uint64_t r, v = rnd_thid_r64(&seed, (uint16_t)(uintptr_t)arg);
 		critnib_insert(c, v, (void *)v);
 		r = (uint64_t)critnib_get(c, v);
 		UT_ASSERTeq(r, v);

--- a/src/test/obj_critnib_mt/obj_critnib_mt.c
+++ b/src/test/obj_critnib_mt/obj_critnib_mt.c
@@ -37,6 +37,7 @@
 #include <errno.h>
 
 #include "critnib.h"
+#include "rand.h"
 #include "os_thread.h"
 #include "unittest.h"
 #include "util.h"
@@ -60,18 +61,6 @@ rnd_thid_r64(unsigned *seedp, void *arg)
 	r = (r & 0xffff) | (r & 0xffff0000) << 32;
 	r |= ((uint64_t)arg) << 16;
 	return r;
-}
-
-static uint64_t
-rnd16()
-{
-	return rand() & 0xffff;
-}
-
-static uint64_t
-rnd64()
-{
-	return rnd16() << 48 | rnd16() << 32 | rnd16() << 16 | rnd16();
 }
 
 static uint64_t
@@ -262,6 +251,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_critnib_mt");
 
 	util_init();
+	randomize(1); /* use a fixed reproducible seed */
 
 	for (int i = 0; i < ARRAY_SIZE(the1024); i++)
 		the1024[i] = rnd64();

--- a/src/test/obj_critnib_mt/obj_critnib_mt.vcxproj
+++ b/src/test/obj_critnib_mt/obj_critnib_mt.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\libpmemobj\critnib.c" />
+    <ClCompile Include="..\..\common\rand.c" />
     <ClCompile Include="obj_critnib_mt.c" />
   </ItemGroup>
   <ItemGroup>

--- a/src/test/obj_fragmentation2/obj_fragmentation2.vcxproj
+++ b/src/test/obj_fragmentation2/obj_fragmentation2.vcxproj
@@ -58,6 +58,7 @@
     <Link />
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\common\rand.c" />
     <ClCompile Include="obj_fragmentation2.c" />
   </ItemGroup>
   <ItemGroup>

--- a/src/test/obj_pmalloc_rand_mt/obj_pmalloc_rand_mt.c
+++ b/src/test/obj_pmalloc_rand_mt/obj_pmalloc_rand_mt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Intel Corporation
+ * Copyright 2017-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,9 +36,10 @@
 #include <stdint.h>
 
 #include "file.h"
+#include "rand.h"
 #include "unittest.h"
 
-#define RRAND(seed, max, min) (os_rand_r(&(seed)) % ((max) - (min)) + (min))
+#define RRAND(seed, max, min) (rnd64_r(&(seed)) % ((max) - (min)) + (min))
 
 static size_t object_size;
 static unsigned nobjects;
@@ -54,7 +55,8 @@ test_worker(void *arg)
 	unsigned fill = 0;
 
 	int ret;
-	unsigned myseed = seed;
+	rng_t myseed;
+	randomize_r(&myseed, seed);
 
 	for (unsigned i = 0; i < iterations; ++i) {
 		unsigned fill_ratio = (fill * 100) / nobjects;
@@ -100,7 +102,7 @@ main(int argc, char *argv[])
 	if (argc > 6)
 		seed = ATOU(argv[6]);
 	else
-		seed = (unsigned)time(NULL);
+		seed = 0;
 
 	PMEMobjpool *pop;
 

--- a/src/test/obj_pmalloc_rand_mt/obj_pmalloc_rand_mt.vcxproj
+++ b/src/test/obj_pmalloc_rand_mt/obj_pmalloc_rand_mt.vcxproj
@@ -58,6 +58,7 @@
     <Link />
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\common\rand.c" />
     <ClCompile Include="obj_pmalloc_rand_mt.c" />
   </ItemGroup>
   <ItemGroup>

--- a/src/test/unittest/Makefile
+++ b/src/test/unittest/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018, Intel Corporation
+# Copyright 2014-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -42,7 +42,7 @@ vpath %.h $(TOP)/src/common
 
 TARGET = libut.a
 OBJS = ut.o ut_alloc.o ut_file.o ut_pthread.o ut_signal.o ut_backtrace.o\
-	os_posix.o os_thread_posix.o
+	os_posix.o os_thread_posix.o rand.o
 CFLAGS = -I$(TOP)/src/include
 CFLAGS += -I$(TOP)/src/common
 CFLAGS += $(OS_INCS)


### PR DESCRIPTION
Windows doesn't support rand_r(), fixed seeds for reproducible tests, and its rand() output is 15-bit only.  And on Linux/BSD, different versions of libc are unstable, too.  Thus, let's use a simple good RNG (such as xoshiro256**) on all platforms.

This copies code that's already in *vmemcache*.

This pull request changes all uses of rand in tests, it doesn't yet touch benchmarks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3894)
<!-- Reviewable:end -->
