### PR TITLE
clarify a comment about benchmark initialization

### DIFF
--- a/src/benchmarks/benchmark.hpp
+++ b/src/benchmarks/benchmark.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018, Intel Corporation
+ * Copyright 2015-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -289,7 +289,7 @@ struct operation_info {
  *                execution time of operation function. If set to false, the
  *                benchmark must report the execution time by itself.
  * init_worker	: Callback for initialization thread specific data. Invoked in
- *                a single thread for every thread worker.
+ *                the worker thread but globally serialized.
  * operation	: Callback function which does the main job of benchmark.
  * rm_file	: Indicates whether the test file should be removed by
  *                framework before the init function will be called.


### PR DESCRIPTION
The init_worker callback is called not from the master thread (as the old comment suggested) but from the worker thread itself.  These callbacks get run for each thread in turn.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3903)
<!-- Reviewable:end -->
