### PR TITLE
fix missing Makefile dependencies for some targets

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018, Intel Corporation
+# Copyright 2014-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -134,8 +134,9 @@ sparse: $(SPARSE_TARGETS:=-sparse)
 custom_build = $(DEBUG)$(OBJDIR)
 
 libvmmalloc libvmem: jemalloc
-tools: libpmem libpmemblk libpmemlog libpmemobj
+tools: libpmem libpmemblk libpmemlog libpmemobj libpmempool
 libpmemblk libpmemlog libpmemobj: libpmem
+libpmempool: libpmemblk
 benchmarks test tools: common
 
 pkg-cfg-common:


### PR DESCRIPTION
To reproduce the fails:
`make tools`
or
`make libpmempool`
or
remove `.NOTPARALLEL`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3920)
<!-- Reviewable:end -->
