### PR TITLE
allow not building examples

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -37,21 +37,31 @@ include $(TOP)/src/common.inc
 
 TARGETS = libpmem libvmem libpmemblk libpmemlog libpmemobj libpmempool\
 		  libvmmalloc tools
-ALL_TARGETS = $(TARGETS) common librpmem examples benchmarks
+ALL_TARGETS = $(TARGETS) common librpmem
 
 SCOPE_DIRS = $(TARGETS) common librpmem rpmem_common
 
 DEBUG_RELEASE_TARGETS = common libpmem libvmem libpmemblk libpmemlog libpmemobj\
 	libpmempool libvmmalloc librpmem
-RELEASE_TARGETS = tools examples benchmarks
+RELEASE_TARGETS = tools
+
+ifneq ($(BUILD_EXAMPLES),n)
+	ALL_TARGETS += examples
+	RELEASE_TARGETS += examples
+endif
+
+ifneq ($(BUILD_BENCHMARKS),n)
+	ALL_TARGETS += benchmarks
+	RELEASE_TARGETS += benchmarks
+endif
 
 CLEAN_NO_JE_TARGETS = $(ALL_TARGETS) rpmem_common test
-CLEAN_TARGETS = $(CLEAN_NO_JE_TARGETS) jemalloc
+CLEAN_TARGETS = $(CLEAN_NO_JE_TARGETS) jemalloc examples benchmarks
 CLOBBER_NO_JE_TARGETS = $(ALL_TARGETS) rpmem_common test
-CLOBBER_TARGETS = $(CLOBBER_NO_JE_TARGETS) jemalloc
-CSTYLE_TARGETS = $(ALL_TARGETS) test rpmem_common
+CLOBBER_TARGETS = $(CLOBBER_NO_JE_TARGETS) jemalloc examples benchmarks
+CSTYLE_TARGETS = $(ALL_TARGETS) test rpmem_common examples benchmarks
 INSTALL_TARGETS = $(TARGETS)
-SPARSE_TARGETS = $(ALL_TARGETS) test rpmem_common
+SPARSE_TARGETS = $(ALL_TARGETS) test rpmem_common examples benchmarks
 
 HEADERS_DESTDIR = $(DESTDIR)$(includedir)
 HEADERS_INSTALL = include/libpmem.h include/libvmem.h\

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -336,7 +336,6 @@ LOCAL_TESTS = \
 	$(VMEM_TESTS)\
 	$(VMMALLOC_DUMMY_FUNCS_TESTS)\
 	$(VMMALLOC_TESTS)\
-	$(EXAMPLES_TESTS)\
 	$(LIBPMEMPOOL_TESTS)\
 	$(LIBPMEMPOOL_MOD_TESTS)\
 	$(DAXIO_TESTS)\
@@ -345,7 +344,6 @@ LOCAL_TESTS = \
 REMOTE_TESTS = \
 	$(OBJ_REMOTE_TESTS)\
 	$(RPMEM_TESTS)\
-	$(RPMEM_EXAMPLES_TESTS)\
 	libpmempool_rm_remote\
 	remote_basic\
 	remote_obj_basic\
@@ -354,6 +352,11 @@ REMOTE_TESTS = \
 	pmempool_rm_remote\
 	pmempool_sync_remote\
 	pmempool_transform_remote
+
+ifneq ($(BUILD_EXAMPLES),n)
+	LOCAL_TESTS += $(EXAMPLES_TESTS)
+	REMOTE_TESTS += $(RPMEM_EXAMPLES_TESTS)
+endif
 
 TESTS = \
 	$(LOCAL_TESTS)\


### PR DESCRIPTION
While build-testing them is nice, build artifacts littering the to-install dirs make installing examples prohibitively hard.

Debian carries a hard-coded patch that disables compiling them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3922)
<!-- Reviewable:end -->
