### PR TITLE
test: fix memcheck.log.match in obj_tx_add_range(_direct) tests

### DIFF
--- a/src/test/obj_tx_add_range/memcheck3.log.match
+++ b/src/test/obj_tx_add_range/memcheck3.log.match
@@ -24,11 +24,17 @@
 ==$(*)== 
 ==$(*)== 
 ==$(*)== HEAP SUMMARY:
-==$(*)==     in use at exit: 0 bytes in 0 blocks
+==$(*)==     in use at exit: $(*) bytes in $(*) blocks
 ==$(*)==   total heap usage: $(*) allocs, $(*) frees, $(*) bytes allocated
 ==$(*)== 
-==$(*)== All heap blocks were freed -- no leaks are possible
+$(OPT)==$(*)== All heap blocks were freed -- no leaks are possible
+$(OPX)==$(*)== LEAK SUMMARY:
+$(OPT)==$(*)==    definitely lost: 0 bytes in 0 blocks
+$(OPT)==$(*)==    indirectly lost: 0 bytes in 0 blocks
+$(OPT)==$(*)==      possibly lost: 0 bytes in 0 blocks
+$(OPT)==$(*)==    still reachable: 0 bytes in 0 blocks
+$(OPT)==$(*)==         suppressed: $(*) bytes in $(*) blocks
 ==$(*)== 
 ==$(*)== Use --track-origins=yes to see where uninitialised values come from
 $(OPT)==$(*)== For lists of detected and suppressed errors, rerun with: -s
-==$(*)== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
+==$(*)== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: $(*) from $(*))

--- a/src/test/obj_tx_add_range_direct/memcheck2.log.match
+++ b/src/test/obj_tx_add_range_direct/memcheck2.log.match
@@ -24,11 +24,17 @@
 ==$(*)== 
 ==$(*)== 
 ==$(*)== HEAP SUMMARY:
-==$(*)==     in use at exit: 0 bytes in 0 blocks
+==$(*)==     in use at exit: $(*) bytes in $(*) blocks
 ==$(*)==   total heap usage: $(*) allocs, $(*) frees, $(*) bytes allocated
 ==$(*)== 
-==$(*)== All heap blocks were freed -- no leaks are possible
+$(OPT)==$(*)== All heap blocks were freed -- no leaks are possible
+$(OPX)==$(*)== LEAK SUMMARY:
+$(OPT)==$(*)==    definitely lost: 0 bytes in 0 blocks
+$(OPT)==$(*)==    indirectly lost: 0 bytes in 0 blocks
+$(OPT)==$(*)==      possibly lost: 0 bytes in 0 blocks
+$(OPT)==$(*)==    still reachable: 0 bytes in 0 blocks
+$(OPT)==$(*)==         suppressed: $(*) bytes in $(*) blocks
 ==$(*)== 
 ==$(*)== Use --track-origins=yes to see where uninitialised values come from
 $(OPT)==$(*)== For lists of detected and suppressed errors, rerun with: -s
-==$(*)== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
+==$(*)== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: $(*) from $(*))


### PR DESCRIPTION
On some systems (for example OpenSUSE) memcheck generates errors
which we are suppressing. This patch adds optional lines to
memcheck.log.match to match those suppressed errors.

Fixes test introduced in: #3921

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3935)
<!-- Reviewable:end -->
