### PR TITLE
common: detect libunwind on Travis

### DIFF
--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,8 +47,8 @@ export RPMEM_DISABLE_LIBIBVERBS=y
 cd $WORKDIR
 make check-license
 make cstyle
-make -j2 USE_LIBUNWIND=1
-make -j2 test USE_LIBUNWIND=1
+make -j2
+make -j2 test
 make -j2 pcheck TEST_BUILD=$TEST_BUILD
 make DESTDIR=/tmp source
 

--- a/utils/docker/run-coverage.sh
+++ b/utils/docker/run-coverage.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,8 +51,8 @@ export UT_VALGRIND_SKIP_PRINT_MISMATCHED=1
 
 # Build all and run tests
 cd $WORKDIR
-make -j2 USE_LIBUNWIND=1 COVERAGE=1
-make -j2 test USE_LIBUNWIND=1 COVERAGE=1
+make -j2 COVERAGE=1
+make -j2 test COVERAGE=1
 
 # XXX: unfortunately valgrind raports issues in coverage instrumentation
 # which we have to ignore (-k flag), also there is dependency between


### PR DESCRIPTION
"1" is not a valid value for USE_LIBUNWIND. Instead of providing
the correct value, let pmdk build system detect whether it is available
or not. All distros we test on Travis ship with libunwind that
supports pkg-config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3938)
<!-- Reviewable:end -->
