### PR TITLE
obj: fix pool_hdr endianess conversions

### DIFF
--- a/src/common/pool_hdr.h
+++ b/src/common/pool_hdr.h
@@ -265,12 +265,13 @@ static const features_t features_zero =
  * POOL_FEAT_CKSUM_2K incompat feature is set.
  */
 #define POOL_HDR_CSUM_END_OFF(hdrp) \
-	((hdrp)->features.incompat & POOL_FEAT_CKSUM_2K) \
+	(le32toh((hdrp)->features.incompat) & POOL_FEAT_CKSUM_2K) \
 		? POOL_HDR_CSUM_2K_END_OFF : POOL_HDR_CSUM_4K_END_OFF
 
 /* ignore shutdown state if incompat feature is disabled */
 #define IGNORE_SDS(hdrp) \
-	(((hdrp) != NULL) && (((hdrp)->features.incompat & POOL_FEAT_SDS) == 0))
+	(((hdrp) != NULL) && \
+	((le32toh((hdrp)->features.incompat) & POOL_FEAT_SDS) == 0))
 
 #ifdef __cplusplus
 }

--- a/src/common/set.c
+++ b/src/common/set.c
@@ -2303,8 +2303,6 @@ util_header_create(struct pool_set *set, unsigned repidx, unsigned partidx,
 	if (arch_is_zeroed)
 		util_get_arch_flags(&hdrp->arch_flags);
 
-	util_convert2le_hdr(hdrp);
-
 	if (!arch_is_zeroed) {
 		memcpy(&hdrp->arch_flags, attr->arch_flags, POOL_HDR_ARCH_LEN);
 	}
@@ -2321,6 +2319,8 @@ util_header_create(struct pool_set *set, unsigned repidx, unsigned partidx,
 
 	util_checksum(hdrp, sizeof(*hdrp), &hdrp->checksum,
 		1, POOL_HDR_CSUM_END_OFF(hdrp));
+
+	util_convert2le_hdr(hdrp);
 
 	/* store pool's header */
 	util_persist_auto(rep->is_pmem, hdrp, sizeof(*hdrp));
@@ -2348,9 +2348,7 @@ util_header_check(struct pool_set *set, unsigned repidx, unsigned partidx,
 
 	memcpy(&hdr, hdrp, sizeof(hdr));
 
-	/* local copy of a remote header does not need to be converted */
-	if (rep->remote == NULL)
-		util_convert2h_hdr_nocheck(&hdr);
+	util_convert2h_hdr_nocheck(&hdr);
 
 	/* to be valid, a header must have a major version of at least 1 */
 	if (hdr.major == 0) {


### PR DESCRIPTION
The pool_hdr was being prematurely converter to LE which invalidate the
posterior tests. The structure is now being converted only exactly
before writing. And is restored always after reading.

This ensures BE systems have a consistent and coherent pool.

Signed-off-by: Lucas A. M. Magalhaes <lamm@linux.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3939)
<!-- Reviewable:end -->
