### PR TITLE
disable an expected-fail test under valgrind

### DIFF
--- a/src/test/obj_tx_add_range/TEST0
+++ b/src/test/obj_tx_add_range/TEST0
@@ -42,6 +42,7 @@ require_test_type medium
 # Pmemcheck is disabled here. The next test case (TEST1) will run the same test
 # under pmemcheck
 configure_valgrind pmemcheck force-disable
+configure_valgrind memcheck force-disable
 
 setup
 

--- a/src/test/obj_tx_add_range/TESTS.py
+++ b/src/test/obj_tx_add_range/TESTS.py
@@ -41,6 +41,7 @@ import testframework as t
 class TEST0(t.BaseTest):
     test_type = t.Medium
     pmemcheck = t.DISABLE
+    memcheck = t.DISABLE
 
     def run(self, ctx):
         testfile = path.join(ctx.testdir, 'testfile0')


### PR DESCRIPTION
TEST3 already has a match for this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3951)
<!-- Reviewable:end -->
