### PR TITLE
obj: replace EOVERFLOW with ERANGE

### DIFF
--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -1863,7 +1863,7 @@ pmemobj_tx_log_snapshot_max_size(size_t *sizes, size_t nsizes)
 	return result;
 
 err_overflow:
-	errno = EOVERFLOW;
+	errno = ERANGE;
 	return SIZE_MAX;
 }
 
@@ -1914,7 +1914,7 @@ pmemobj_tx_log_intent_max_size(size_t nintents)
 	return result;
 
 err_overflow:
-	errno = EOVERFLOW;
+	errno = ERANGE;
 	return SIZE_MAX;
 }
 


### PR DESCRIPTION
Rationale:
1. ERANGE is C99 standard defined error code.
2. EOVERFLOW is used when destination buffer is too small and data
transfer will overflow it. When ERANGE is used for values that do not
fit in the destination type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3957)
<!-- Reviewable:end -->
