### PR TITLE
obj: fix user buffer range check for overlaps

### DIFF
--- a/src/libpmemobj/memops.c
+++ b/src/libpmemobj/memops.c
@@ -533,7 +533,7 @@ operation_user_buffer_try_insert(PMEMobjpool *pop, void *addr, size_t size)
 		struct user_buffer_def *r = ravl_data(n);
 		void *r_end = (char *)r->addr + r->size;
 
-		if (r_end >= addr && r->addr <= addr_end) {
+		if (r_end > userbuf->addr && r->addr < addr_end) {
 			/* what was found overlaps with what is being added */
 			ret = -1;
 			goto out;

--- a/src/test/obj_ulog_size/obj_ulog_size.c
+++ b/src/test/obj_ulog_size/obj_ulog_size.c
@@ -493,6 +493,85 @@ do_tx_max_alloc_tx_publish(PMEMobjpool *pop)
 	}
 }
 
+/*
+ * do_tx_buffer_overlapping -- checks if user buffer overlap detection works
+ */
+static void
+do_tx_buffer_overlapping(PMEMobjpool *pop)
+{
+	UT_OUT("do_tx_buffer_overlapping");
+
+	/* changes verify_user_buffers value */
+	int verify_user_buffers = 1;
+	int ret = pmemobj_ctl_set(pop, "tx.debug.verify_user_buffers",
+			&verify_user_buffers);
+	UT_ASSERTeq(ret, 0);
+
+	PMEMoid oid = OID_NULL;
+	pmemobj_alloc(pop, &oid, MAX_ALLOC, 0, NULL, NULL);
+	UT_ASSERT(!OID_IS_NULL(oid));
+
+	char *ptr = pmemobj_direct(oid);
+	ptr = (char *)ALIGN_UP((size_t)ptr, CACHELINE_SIZE);
+
+	TX_BEGIN(pop) {
+		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
+			ptr + 256, 256);
+		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
+			ptr, 256);
+	} TX_ONABORT {
+		UT_ASSERT(0);
+	} TX_ONCOMMIT {
+		UT_OUT("Overlap not detected");
+	} TX_END
+
+	TX_BEGIN(pop) {
+		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
+			ptr, 256);
+		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
+			ptr + 256, 256);
+	} TX_ONABORT {
+		UT_ASSERT(0);
+	} TX_ONCOMMIT {
+		UT_OUT("Overlap not detected");
+	} TX_END
+
+	TX_BEGIN(pop) {
+		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
+			ptr, 256);
+		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
+			ptr, 256);
+	} TX_ONABORT {
+		UT_OUT("Overlap detected");
+	} TX_ONCOMMIT {
+		UT_ASSERT(0);
+	} TX_END
+
+	TX_BEGIN(pop) {
+		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
+			ptr, 256);
+		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
+			ptr + 128, 256);
+	} TX_ONABORT {
+		UT_OUT("Overlap detected");
+	} TX_ONCOMMIT {
+		UT_ASSERT(0);
+	} TX_END
+
+	TX_BEGIN(pop) {
+		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
+			ptr + 128, 256);
+		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
+			ptr, 256);
+	} TX_ONABORT {
+		UT_OUT("Overlap detected");
+	} TX_ONCOMMIT {
+		UT_ASSERT(0);
+	} TX_END
+
+	pmemobj_free(&oid);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -522,6 +601,7 @@ main(int argc, char *argv[])
 	do_tx_max_alloc_tx_publish_abort(pop);
 	do_tx_buffer_currently_used(pop);
 	do_tx_max_alloc_tx_publish(pop);
+	do_tx_buffer_overlapping(pop);
 
 	pmemobj_close(pop);
 	pmemobj_close(pop2);

--- a/src/test/obj_ulog_size/out0.log.match
+++ b/src/test/obj_ulog_size/out0.log.match
@@ -19,4 +19,10 @@ do_tx_buffer_currently_used
 User cannot append the same undo log buffer twice: Invalid argument
 do_tx_max_alloc_tx_publish
 Can extend redo log with appended buffer
+do_tx_buffer_overlapping
+Overlap not detected
+Overlap not detected
+Overlap detected
+Overlap detected
+Overlap detected
 obj_ulog_size$(nW)TEST0: DONE

--- a/src/test/obj_ulog_size/out1.log.match
+++ b/src/test/obj_ulog_size/out1.log.match
@@ -19,4 +19,10 @@ do_tx_buffer_currently_used
 User cannot append the same undo log buffer twice: Invalid argument
 do_tx_max_alloc_tx_publish
 Can extend redo log with appended buffer
+do_tx_buffer_overlapping
+Overlap not detected
+Overlap not detected
+Overlap detected
+Overlap detected
+Overlap detected
 obj_ulog_size$(nW)TEST1: DONE

--- a/src/test/obj_ulog_size/out2.log.match
+++ b/src/test/obj_ulog_size/out2.log.match
@@ -19,4 +19,10 @@ do_tx_buffer_currently_used
 User cannot append the same undo log buffer twice: Invalid argument
 do_tx_max_alloc_tx_publish
 Can extend redo log with appended buffer
+do_tx_buffer_overlapping
+Overlap not detected
+Overlap not detected
+Overlap detected
+Overlap detected
+Overlap detected
 obj_ulog_size$(nW)TEST2: DONE


### PR DESCRIPTION
Test fails because of the redo intent bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3958)
<!-- Reviewable:end -->
