### PR TITLE
give examples how to specify multiple /dev/dax devices

### DIFF
--- a/src/test/testconfig.py.example
+++ b/src/test/testconfig.py.example
@@ -107,7 +107,8 @@ config = {
 
     # For tests that require raw dax devices without a file system, add paths to
     # those devices to the list 'device_dax_path'. For most tests one device
-    # is enough, but some might require more
+    # is enough, but some might require more.
+    # Eg. ['/dev/dax0.0', '/dev/dax1.0']
     #
     'device_dax_path' : [],
 }

--- a/src/test/testconfig.sh.example
+++ b/src/test/testconfig.sh.example
@@ -69,7 +69,7 @@
 #
 # Note: some tests require write access to '/sys/bus/nd/devices/region*/deep_flush'.
 #
-#DEVICE_DAX_PATH=(/dev/dax0.0)
+#DEVICE_DAX_PATH=(/dev/dax0.0 /dev/dax1.0)
 
 #
 # Overwrite default test type:


### PR DESCRIPTION
All three test frameworks use their own, different, syntax.

Windows has no devdax, thus here come two of them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3966)
<!-- Reviewable:end -->
