### PR TITLE
test: make two pmempool_sync tests more precise

### DIFF
--- a/src/test/pmempool_sync/TEST27
+++ b/src/test/pmempool_sync/TEST27
@@ -32,8 +32,11 @@
 #
 #
 # pmempool_sync/TEST27 -- test for sync command with badblocks
-#                         - bad blocks in the regular file
-#                           blocks: offset: 0 length: 8
+#                         - bad blocks in a regular file
+#                         - blocks: offset: 0 length: 16
+#
+# This test verifies whether pmempool-sync is able to fix bad blocks
+# in the first 8kB of the pool (in the pool header) located in a regular file.
 #
 
 . ../unittest/unittest.sh
@@ -69,9 +72,10 @@ expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
 turn_on_checking_bad_blocks $POOLSET
 
-# inject bad block:
+# inject bad block at offset 0 (the pool header)
+# DO NOT CHANGE THIS OFFSET! IT HAS TO BE EQUAL 0!
 FIRST_SECTOR=$(expect_normal_exit $EXTENTS $MOUNT_DIR/testfile1 -l 0)
-ndctl_inject_error $NAMESPACE $FIRST_SECTOR 8
+ndctl_inject_error $NAMESPACE $FIRST_SECTOR 16
 
 expect_bad_blocks $NAMESPACE
 
@@ -85,7 +89,7 @@ expect_normal_exit "$PMEMPOOL$EXESUFFIX info --bad-blocks=yes $POOLSET >> $LOG"
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG"
 
-ndctl_uninject_error $FULLDEV $NAMESPACE $FIRST_SECTOR 8
+ndctl_uninject_error $FULLDEV $NAMESPACE $FIRST_SECTOR 16
 badblock_test_fini $MOUNT_DIR
 
 check

--- a/src/test/pmempool_sync/TEST28
+++ b/src/test/pmempool_sync/TEST28
@@ -32,9 +32,13 @@
 #
 #
 # pmempool_sync/TEST28 -- test for sync command with badblocks
-#                         - bad blocks in the dax device
-#                           blocks: offset: 0 length: 8
+#                         - bad blocks in a DAX device
+#                         - blocks: offset: 0 length: 16
 #
+# This test verifies whether pmempool-sync is able to fix bad blocks
+# in the first 8kB of the pool (in the pool header) located in a DAX device.
+#
+
 
 . ../unittest/unittest.sh
 
@@ -65,8 +69,9 @@ expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
 turn_on_checking_bad_blocks $POOLSET
 
-# inject bad block: OFF=0 LEN=8
-ndctl_inject_error $NAMESPACE 0 8
+# inject bad block at offset 0 (the pool header)
+# DO NOT CHANGE THIS OFFSET! IT HAS TO BE EQUAL 0!
+ndctl_inject_error $NAMESPACE 0 16
 
 expect_bad_blocks $NAMESPACE
 
@@ -88,7 +93,7 @@ print_bad_blocks $NAMESPACE
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG"
 
-ndctl_uninject_error $FULLDEV $NAMESPACE 0 8
+ndctl_uninject_error $FULLDEV $NAMESPACE 0 16
 badblock_test_fini
 
 check

--- a/src/test/pmempool_sync/out27.log.match
+++ b/src/test/pmempool_sync/out27.log.match
@@ -1,12 +1,12 @@
 create($(nW)/testset1): allocating records in the pool ...
 create($(nW)/testset1): allocated $(N) records (of size $(N))
 verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))
-    "badblock_count":8,
+    "badblock_count":16,
         "offset":$(N),
-        "length":8,
-    "badblock_count":8,
+        "length":16,
+    "badblock_count":16,
         "offset":$(N),
-        "length":8,
+        "length":16,
 $(nW)/testset1: synchronized
 replica 0: checking shutdown state
 replica 0: shutdown state correct

--- a/src/test/pmempool_sync/out28.log.match
+++ b/src/test/pmempool_sync/out28.log.match
@@ -1,12 +1,12 @@
 create($(nW)/testset1): allocating records in the pool ...
 create($(nW)/testset1): allocated $(N) records (of size $(N))
 verify($(nW)/testset1): pool file successfully verified ($(N) records of size $(N))
-    "badblock_count":8,
+    "badblock_count":16,
         "offset":0,
-        "length":8,
-    "badblock_count":8,
+        "length":16,
+    "badblock_count":16,
         "offset":0,
-        "length":8,
+        "length":16,
 $(nW)/testset1: synchronized
 No bad blocks found
 replica 0: checking shutdown state


### PR DESCRIPTION
Make two pmempool_sync tests fixing bad blocks
in the pool header more precise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/3980)
<!-- Reviewable:end -->
