### PR TITLE
os_posix: Use __FreeBSD__ to control secure_getenv definition

### DIFF
--- a/src/common/os_posix.c
+++ b/src/common/os_posix.c
@@ -346,7 +346,7 @@ os_setenv(const char *name, const char *value, int overwrite)
 /*
  * secure_getenv -- provide GNU secure_getenv for FreeBSD
  */
-#ifndef __USE_GNU
+#if defined(__FreeBSD__)
 static char *
 secure_getenv(const char *name)
 {


### PR DESCRIPTION
__USE_GNU does not cover all Linux platforms, e.g. when using musl as C
library, __USE_GNU may not be defined but it does provide secure_getenv
so instead of narrowing the else condition, lets speicifically check for
FreeBSD being the platform, since that seems to be the intention here
anyway

Signed-off-by: Khem Raj <raj.khem@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4000)
<!-- Reviewable:end -->
