### PR TITLE
pmem: fix comment in pmem_msync

### DIFF
--- a/src/libpmem/pmem.c
+++ b/src/libpmem/pmem.c
@@ -272,9 +272,9 @@ pmem_msync(const void *addr, size_t len)
 	VALGRIND_DO_CHECK_MEM_IS_ADDRESSABLE(addr, len);
 
 	/*
-	 * msync requires len to be a multiple of pagesize, so
-	 * adjust addr and len to represent the full 4k chunks
-	 * covering the given range.
+	 * msync requires addr to be a multiple of pagesize but there are no
+	 * requirements for len. Align addr down and change len so that
+	 * [addr, addr + len) still contains initial range.
 	 */
 
 	/* increase len by the amount we gain when we round addr down */


### PR DESCRIPTION
The comment wrongly stated that len is changed to cover the whole page.
This is actually not true, len is only increased by the amount of which
addr is decreased.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4006)
<!-- Reviewable:end -->
