### PR TITLE
common: fix windows installation steps in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ In brief:
 	> git clone https://github.com/Microsoft/vcpkg
 	> cd vcpkg
 	> .\bootstrap-vcpkg.bat
-	> .\vcpkg integrate install
 	> .\vcpkg install pmdk:x64-windows
+	> .\vcpkg integrate install
 ```
 
 The last command can take a while - it is PMDK building and installation time.


### PR DESCRIPTION
"integrate install" should be called after installing pmdk, not before.

See: https://github.com/microsoft/vcpkg/blob/master/docs/examples/installing-and-using-packages.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4030)
<!-- Reviewable:end -->
