### PR TITLE
test: modify suppression for ndctl memleaks

### DIFF
--- a/src/test/memcheck-ndctl.supp
+++ b/src/test/memcheck-ndctl.supp
@@ -15,7 +15,6 @@
    fun:realloc
    ...
    fun:ndctl_dax_get_first
-   fun:ndctl_namespace_get_dax
    ...
 }
 {


### PR DESCRIPTION
This patch suppresses the following memory leak in ndctl 64.1:
```
[line 14166] daxio/TEST0: SETUP (all/pmem/debug/memcheck)
[line 14167] daxio/TEST0 failed with Valgrind. See memcheck0.log. Last 20 lines below.
[line 14168] daxio/TEST0 memcheck0.log ==62745== 156 bytes in 13 blocks are definitely lost in loss record 2 of 3
[line 14169] daxio/TEST0 memcheck0.log ==62745==    at 0x4C30701: realloc (vg_replace_malloc.c:836)
[line 14170] daxio/TEST0 memcheck0.log ==62745==    by 0x50F0A94: ??? (in /usr/lib64/libndctl.so.6.13.0)
[line 14171] daxio/TEST0 memcheck0.log ==62745==    by 0x50F2487: ??? (in /usr/lib64/libndctl.so.6.13.0)
[line 14172] daxio/TEST0 memcheck0.log ==62745==    by 0x50F970C: ??? (in /usr/lib64/libndctl.so.6.13.0)
[line 14173] daxio/TEST0 memcheck0.log ==62745==    by 0x50EB479: ??? (in /usr/lib64/libndctl.so.6.13.0)
[line 14174] daxio/TEST0 memcheck0.log ==62745==    by 0x50F21A3: ??? (in /usr/lib64/libndctl.so.6.13.0)
[line 14175] daxio/TEST0 memcheck0.log ==62745==    by 0x50F968F: ndctl_dax_get_first (in /usr/lib64/libndctl.so.6.13.0)
[line 14176] daxio/TEST0 memcheck0.log ==62745==    by 0x405A14: setup_device (in /home/jenkins-slave/workspace/PMDK-unittests-complex-linux/src/tools/daxio/daxio)
[line 14177] daxio/TEST0 memcheck0.log ==62745==    by 0x4052A2: main (in /home/jenkins-slave/workspace/PMDK-unittests-complex-linux/src/tools/daxio/daxio)
[line 14178] daxio/TEST0 memcheck0.log ==62745== 
[line 14179] daxio/TEST0 memcheck0.log ==62745== LEAK SUMMARY:
[line 14180] daxio/TEST0 memcheck0.log ==62745==    definitely lost: 156 bytes in 13 blocks
[line 14181] daxio/TEST0 memcheck0.log ==62745==    indirectly lost: 0 bytes in 0 blocks
[line 14182] daxio/TEST0 memcheck0.log ==62745==      possibly lost: 0 bytes in 0 blocks
[line 14183] daxio/TEST0 memcheck0.log ==62745==    still reachable: 0 bytes in 0 blocks
[line 14184] daxio/TEST0 memcheck0.log ==62745==         suppressed: 168 bytes in 14 blocks
[line 14185] daxio/TEST0 memcheck0.log ==62745== 
[line 14186] daxio/TEST0 memcheck0.log ==62745== For lists of detected and suppressed errors, rerun with: -s
[line 14187] daxio/TEST0 memcheck0.log ==62745== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 2 from 2)
[==line 14188==] RUNTESTS: stopping: daxio//TEST0 failed, TEST=all FS=any BUILD=debug
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4052)
<!-- Reviewable:end -->
