### PR TITLE
common: add BuildRequires:fdupes to spec for opensuse

### DIFF
--- a/utils/pmdk.spec.in
+++ b/utils/pmdk.spec.in
@@ -49,6 +49,11 @@ BuildRequires:	man
 BuildRequires:	pkgconfig
 BuildRequires:	gdb
 
+# fdupes package is available only on 'openSUSE Tumbleweed' and 'openSUSE Leap 15.1'
+%if (0%{?suse_version} > 1500) || (0%{?sles_version} >= 150100 && 0%{?is_opensuse})
+BuildRequires: fdupes
+%endif
+
 %if %{with ndctl}
 %if %{defined suse_version}
 BuildRequires:	libndctl-devel >= %{min_ndctl_ver}


### PR DESCRIPTION
In order to use %fdupes, "BuildRequires: fdupes" has to be included
in the spec file:
https://en.opensuse.org/openSUSE:Packaging_Conventions_RPM_Macros#.25fdupes

Tested on openSuSE Tumbleweed-latest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4057)
<!-- Reviewable:end -->
