### PR TITLE
pmem2: remove pmem2_get_config

### DIFF
--- a/src/include/libpmem2.h
+++ b/src/include/libpmem2.h
@@ -128,8 +128,6 @@ struct pmem2_map;
 
 int pmem2_map(const struct pmem2_config *cfg, struct pmem2_map **map);
 
-struct pmem2_config *pmem2_get_config(struct pmem2_map *map);
-
 int pmem2_unmap(struct pmem2_map **map);
 
 void *pmem2_map_get_address(struct pmem2_map *map);

--- a/src/libpmem2/libpmem2.def
+++ b/src/libpmem2/libpmem2.def
@@ -49,7 +49,6 @@ EXPORTS
 	pmem2_config_set_address
 	pmem2_config_set_required_store_granularity
 	pmem2_map
-	pmem2_get_config
 	pmem2_unmap
 	pmem2_map_get_address
 	pmem2_map_get_size

--- a/src/libpmem2/libpmem2.link.in
+++ b/src/libpmem2/libpmem2.link.in
@@ -45,7 +45,6 @@ LIBPMEM2_1.0 {
 		pmem2_config_set_address;
 		pmem2_config_set_required_store_granularity;
 		pmem2_map;
-		pmem2_get_config;
 		pmem2_unmap;
 		pmem2_map_get_address;
 		pmem2_map_get_size;

--- a/src/libpmem2/pmem2.c
+++ b/src/libpmem2/pmem2.c
@@ -86,12 +86,6 @@ pmem2_map(const struct pmem2_config *cfg, struct pmem2_map **map)
 	return PMEM2_E_NOSUPP;
 }
 
-struct pmem2_config *
-pmem2_get_config(struct pmem2_map *map)
-{
-	return NULL;
-}
-
 int
 pmem2_unmap(struct pmem2_map **map)
 {

--- a/src/test/scope/out13.log.match
+++ b/src/test/scope/out13.log.match
@@ -13,7 +13,6 @@ pmem2_config_set_required_store_granularity
 pmem2_config_set_sharing
 pmem2_config_use_anonymous_mapping
 pmem2_errormsg
-pmem2_get_config
 pmem2_get_device_id
 pmem2_get_device_usc
 pmem2_get_drain_fn


### PR DESCRIPTION
We have realized it is not a useful functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4069)
<!-- Reviewable:end -->
