### PR TITLE
common: disable building ndctl's docs

### DIFF
--- a/utils/docker/images/Dockerfile.ubuntu-18.04
+++ b/utils/docker/images/Dockerfile.ubuntu-18.04
@@ -44,7 +44,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get dist-upgrade -y
 
 # ndctl (optional if libndctl-dev and libdaxctl-dev >= 60.1, 64.1 preferred)
-ENV NDCTL_DEPS "asciidoctor \
+ENV NDCTL_DEPS "\
 	automake \
 	bash-completion \
 	build-essential \

--- a/utils/docker/images/install-libndctl.sh
+++ b/utils/docker/images/install-libndctl.sh
@@ -57,7 +57,7 @@ git archive --format=tar --prefix="ndctl-${VERSION}/" HEAD | gzip > "$RPMDIR/SOU
 
 echo "==== build ndctl ===="
 ./autogen.sh
-./configure
+./configure --disable-docs
 make
 
 echo "==== build ndctl packages ===="
@@ -73,7 +73,7 @@ else
 
 echo "==== build ndctl ===="
 ./autogen.sh
-./configure
+./configure --disable-docs
 make
 
 echo "==== install ndctl ===="


### PR DESCRIPTION
1) Documentation for ndctl is not needed.
2) It will speed up the build.
3) The 'asciidoctor' is not available in some Linux distros.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4091)
<!-- Reviewable:end -->
