### PR TITLE
common: fix style issues in Python files

### DIFF
--- a/src/tools/pmreorder/operationfactory.py
+++ b/src/tools/pmreorder/operationfactory.py
@@ -1,4 +1,5 @@
-# Copyright 2018, Intel Corporation
+#
+# Copyright 2018-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -106,9 +107,9 @@ class OperationFactory:
             """
             top = stack[-1][0]
             if top.endswith(OperationFactory.__suffix[0]):
-                    top = top[:-len(OperationFactory.__suffix[0])]
+                top = top[:-len(OperationFactory.__suffix[0])]
             if marker.endswith(OperationFactory.__suffix[-1]):
-                    marker = marker[:-len(OperationFactory.__suffix[-1])]
+                marker = marker[:-len(OperationFactory.__suffix[-1])]
 
             if top != marker:
                 raise NotSupportedOperationException(

--- a/src/tools/pmreorder/statemachine.py
+++ b/src/tools/pmreorder/statemachine.py
@@ -147,7 +147,7 @@ class CollectingState(State):
         :rtype: subclass of :class:`State`
         """
         if isinstance(in_op, memops.Fence) and \
-                self._inner_state is "flush":
+                self._inner_state == "flush":
             return ReplayingState(self._ops_list, self._context)
         else:
             return self
@@ -265,16 +265,16 @@ class CollectingState(State):
         :return: None
         """
         if isinstance(in_op, memops.Store) and \
-                self._inner_state is "init":
+                self._inner_state == "init":
             self._inner_state = "dirty"
         elif isinstance(in_op, memops.FlushBase) and \
-                self._inner_state is "dirty":
+                self._inner_state == "dirty":
             self._inner_state = "flush"
         elif isinstance(in_op, memops.Fence) and \
-                self._inner_state is "flush":
+                self._inner_state == "flush":
             self._inner_state = "fence"
         elif isinstance(in_op, memops.Flush) and \
-                self._inner_state is "init":
+                self._inner_state == "init":
             self._inner_state = "flush"
 
 


### PR DESCRIPTION
Fix following style issues:
./statemachine.py:150:17: F632 use ==/!= to compare str, bytes, and int literals
./statemachine.py:268:17: F632 use ==/!= to compare str, bytes, and int literals
./statemachine.py:271:17: F632 use ==/!= to compare str, bytes, and int literals
./statemachine.py:274:17: F632 use ==/!= to compare str, bytes, and int literals
./statemachine.py:277:17: F632 use ==/!= to compare str, bytes, and int literals
./operationfactory.py:109:21: E117 over-indented
./operationfactory.py:111:21: E117 over-indented

Found on Ubuntu-rolling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4092)
<!-- Reviewable:end -->
