### PR TITLE
common: replace '-j2' with '-j$(nproc)' in make calls

### DIFF
--- a/utils/docker/images/install-libfabric.sh
+++ b/utils/docker/images/install-libfabric.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,8 +49,8 @@ unzip $libfabric_tarball
 cd $libfabric_dir
 ./autogen.sh
 ./configure --prefix=/usr --enable-sockets
-make -j2
-make install
+make -j$(nproc)
+make -j$(nproc) install
 
 cd ..
 rm -f ${libfabric_tarball}

--- a/utils/docker/images/install-libndctl.sh
+++ b/utils/docker/images/install-libndctl.sh
@@ -58,7 +58,7 @@ git archive --format=tar --prefix="ndctl-${VERSION}/" HEAD | gzip > "$RPMDIR/SOU
 echo "==== build ndctl ===="
 ./autogen.sh
 ./configure --disable-docs
-make
+make -j$(nproc)
 
 echo "==== build ndctl packages ===="
 rpmbuild -ba $SPEC
@@ -74,10 +74,10 @@ else
 echo "==== build ndctl ===="
 ./autogen.sh
 ./configure --disable-docs
-make
+make -j$(nproc)
 
 echo "==== install ndctl ===="
-make install
+make -j$(nproc) install
 
 echo "==== cleanup ===="
 

--- a/utils/docker/images/install-valgrind.sh
+++ b/utils/docker/images/install-valgrind.sh
@@ -42,7 +42,7 @@ cd valgrind
 git checkout c27a8a2f973414934e63f1e94bc84c0a580e3840
 ./autogen.sh
 ./configure
-make
-make install
+make -j$(nproc)
+make -j$(nproc) install
 cd ..
 rm -rf valgrind

--- a/utils/docker/run-build-package.sh
+++ b/utils/docker/run-build-package.sh
@@ -48,7 +48,7 @@ git tag -a 1.4.99 -m "1.4" HEAD~1 || true
 # Build all and run tests
 cd $WORKDIR
 export PCHECK_OPTS=-j2
-make -j2 $PACKAGE_MANAGER
+make -j$(nproc) $PACKAGE_MANAGER
 
 # Install packages
 if [[ "$PACKAGE_MANAGER" == "dpkg" ]]; then
@@ -61,5 +61,5 @@ fi
 
 # Compile and run standalone test
 cd $WORKDIR/utils/docker/test_package
-make LIBPMEMOBJ_MIN_VERSION=1.4
+make -j$(nproc) LIBPMEMOBJ_MIN_VERSION=1.4
 ./test_package testfile1

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -42,13 +42,15 @@ set -e
 
 # Build all and run tests
 cd $WORKDIR
-make check-license
-make cstyle
-make -j2
-make -j2 test
+make -j$(nproc) check-license
+make -j$(nproc) cstyle
+make -j$(nproc)
+make -j$(nproc) test
+# do not change -j2 to -j$(nproc) in case of tests (make check/pycheck)
 make -j2 pcheck TEST_BUILD=$TEST_BUILD
+# do not change -j2 to -j$(nproc) in case of tests (make check/pycheck)
 make -j2 pycheck
-make DESTDIR=/tmp source
+make -j$(nproc) DESTDIR=/tmp source
 
 # Create PR with generated docs
 if [[ "$AUTO_DOC_UPDATE" == "1" ]]; then

--- a/utils/docker/run-coverage.sh
+++ b/utils/docker/run-coverage.sh
@@ -48,16 +48,18 @@ export UT_VALGRIND_SKIP_PRINT_MISMATCHED=1
 
 # Build all and run tests
 cd $WORKDIR
-make -j2 COVERAGE=1
-make -j2 test COVERAGE=1
+make -j$(nproc) COVERAGE=1
+make -j$(nproc) test COVERAGE=1
 
 # XXX: unfortunately valgrind raports issues in coverage instrumentation
 # which we have to ignore (-k flag), also there is dependency between
 # local and remote tests (which cannot be easily removed) we have to
 # run local and remote tests separately
 cd src/test
+# do not change -j2 to -j$(nproc) in case of tests (make check/pycheck)
 make -kj2 pcheck-local-quiet TEST_BUILD=debug || true
 make check-remote-quiet TEST_BUILD=debug || true
+# do not change -j2 to -j$(nproc) in case of tests (make check/pycheck)
 make -j2 pycheck TEST_BUILD=debug || true
 cd ../..
 bash <(curl -s https://codecov.io/bash)

--- a/utils/docker/run-coverity.sh
+++ b/utils/docker/run-coverity.sh
@@ -60,7 +60,7 @@ export COVERITY_SCAN_PROJECT_NAME="$TRAVIS_REPO_SLUG"
 [[ "$TRAVIS_EVENT_TYPE" == "cron" ]] \
 	&& export COVERITY_SCAN_BRANCH_PATTERN="master" \
 	|| export COVERITY_SCAN_BRANCH_PATTERN="coverity_scan"
-export COVERITY_SCAN_BUILD_COMMAND="make all"
+export COVERITY_SCAN_BUILD_COMMAND="make -j$(nproc) all"
 
 cd $WORKDIR
 

--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -60,7 +60,7 @@ git config --local user.email "pmem-bot@intel.com"
 git remote update
 git checkout -B ${TARGET_BRANCH} upstream/${TARGET_BRANCH}
 
-make doc
+make -j$(nproc) doc
 
 # Build & PR groff
 git add -A ./doc
@@ -75,7 +75,7 @@ git clean -dfx
 
 # Copy man & PR web md
 cd  ./doc
-make web
+make -j$(nproc) web
 cd ..
 
 mv ./doc/web_linux ../


### PR DESCRIPTION
... and add '-j$(nproc)' where no '-j' option is present,
so that building can be faster when it is run locally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4111)
<!-- Reviewable:end -->
