### PR TITLE
obj: remove 64 byte alignment in favor of cl alignment

### DIFF
--- a/src/libpmemobj/memblock.c
+++ b/src/libpmemobj/memblock.c
@@ -449,7 +449,8 @@ memblock_run_bitmap(uint32_t *size_idx, uint16_t flags,
 		 * Then, align the number of values up, so that the cacheline
 		 * alignment is preserved.
 		 */
-		b->nvalues = ALIGN_UP(b->nvalues + RUN_BASE_METADATA_VALUES, 8U)
+		b->nvalues = ALIGN_UP(b->nvalues + RUN_BASE_METADATA_VALUES,
+			(unsigned)(CACHELINE_SIZE / sizeof(*b->values)))
 			- RUN_BASE_METADATA_VALUES;
 
 		/*


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4240)
<!-- Reviewable:end -->
