### PR TITLE
pmem2: fix doc, libpmem2.h variable names and missing brackets

### DIFF
--- a/doc/libpmem2/pmem2_config.3.md
+++ b/doc/libpmem2/pmem2_config.3.md
@@ -34,7 +34,7 @@ date: pmem2 API version 1.0
 [comment]: <> ((INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE)
 [comment]: <> (OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.)
 
-[comment]: <> (pmem2_config.3 -- man page for libpmem2 config API
+[comment]: <> (pmem2_config.3 -- man page for libpmem2 config API)
 
 [NAME](#name)<br />
 [SYNOPSIS](#synopsis)<br />

--- a/doc/libpmem2/pmem2_config_new.3.md
+++ b/doc/libpmem2/pmem2_config_new.3.md
@@ -34,7 +34,7 @@ date: pmem2 API version 1.0
 [comment]: <> ((INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE)
 [comment]: <> (OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.)
 
-[comment]: <> (pmem2_config_new.3 -- man page for pmem2_config_new and pmem2_config_delete
+[comment]: <> (pmem2_config_new.3 -- man page for pmem2_config_new and pmem2_config_delete)
 
 [NAME](#name)<br />
 [SYNOPSIS](#synopsis)<br />

--- a/doc/libpmem2/pmem2_errormsg.3.md
+++ b/doc/libpmem2/pmem2_errormsg.3.md
@@ -34,7 +34,7 @@ date: pmem2 API version 1.0
 [comment]: <> ((INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE)
 [comment]: <> (OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.)
 
-[comment]: <> (pmem2_errormsg.3 -- man page for error handling in libpmem2
+[comment]: <> (pmem2_errormsg.3 -- man page for error handling in libpmem2)
 
 [NAME](#name)<br />
 [SYNOPSIS](#synopsis)<br />

--- a/doc/libpmem2/pmem2_map.3.md
+++ b/doc/libpmem2/pmem2_map.3.md
@@ -34,7 +34,7 @@ date: pmem2 API version 1.0
 [comment]: <> ((INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE)
 [comment]: <> (OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.)
 
-[comment]: <> (pmem2_map.3 -- man page for libpmem2 mapping operation
+[comment]: <> (pmem2_map.3 -- man page for libpmem2 mapping operation)
 
 [NAME](#name)<br />
 [SYNOPSIS](#synopsis)<br />

--- a/doc/libpmem2/pmem2_map_get_address.3.md
+++ b/doc/libpmem2/pmem2_map_get_address.3.md
@@ -34,7 +34,7 @@ date: pmem2 API version 1.0
 [comment]: <> ((INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE)
 [comment]: <> (OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.)
 
-[comment]: <> (pmem2_map_get_address.3 -- man page for libpmem2 mapping operations
+[comment]: <> (pmem2_map_get_address.3 -- man page for libpmem2 mapping operations)
 
 [NAME](#name)<br />
 [SYNOPSIS](#synopsis)<br />
@@ -51,13 +51,13 @@ date: pmem2 API version 1.0
 ```c
 #include <libpmem2.h>
 
-void *pmem2_map_get_address(struct pmem2_map **map_ptr);
+void *pmem2_map_get_address(struct pmem2_map *map);
 ```
 
 # DESCRIPTION #
 
 The **pmem2_map_get_address**() function reads address of the created mapping.
-The *map_ptr* parameter points to the structure describing mapping created using
+The *map* parameter points to the structure describing mapping created using
 the **pmem2_map**(3) function.
 
 # RETURN VALUE #

--- a/doc/libpmem2/pmem2_map_get_size.3.md
+++ b/doc/libpmem2/pmem2_map_get_size.3.md
@@ -34,7 +34,7 @@ date: pmem2 API version 1.0
 [comment]: <> ((INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE)
 [comment]: <> (OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.)
 
-[comment]: <> (pmem2_map_get_size.3 -- man page for libpmem2 mapping operations
+[comment]: <> (pmem2_map_get_size.3 -- man page for libpmem2 mapping operations)
 
 [NAME](#name)<br />
 [SYNOPSIS](#synopsis)<br />
@@ -51,13 +51,13 @@ date: pmem2 API version 1.0
 ```c
 #include <libpmem2.h>
 
-size_t *pmem2_map_get_size(struct pmem2_map **map_ptr);
+size_t pmem2_map_get_size(struct pmem2_map *map);
 ```
 
 # DESCRIPTION #
 
 The **pmem2_map_get_size**() function reads size of the created mapping.
-The *map_ptr* parameter points to the structure describing mapping created using
+The *map* parameter points to the structure describing mapping created using
 the **pmem2_map**(3) function.
 
 # RETURN VALUE #

--- a/src/include/libpmem2.h
+++ b/src/include/libpmem2.h
@@ -127,9 +127,9 @@ int pmem2_config_get_file_size(const struct pmem2_config *cfg, size_t *size);
 
 struct pmem2_map;
 
-int pmem2_map(const struct pmem2_config *cfg, struct pmem2_map **map);
+int pmem2_map(const struct pmem2_config *cfg, struct pmem2_map **map_ptr);
 
-int pmem2_unmap(struct pmem2_map **map);
+int pmem2_unmap(struct pmem2_map **map_ptr);
 
 void *pmem2_map_get_address(struct pmem2_map *map);
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4244)
<!-- Reviewable:end -->
