### PR TITLE
pmem2: remove PMEM2_E_OK

### DIFF
--- a/doc/libpmem2/pmem2_map.3.md
+++ b/doc/libpmem2/pmem2_map.3.md
@@ -91,7 +91,7 @@ be destroyed using the **pmem2_unmap**() function. For details please see
 
 # RETURN VALUE #
 
-When **pmem2_map**() succeeds it returns **PMEM2_E_OK**. Otherwise, it returns
+When **pmem2_map**() succeeds it returns 0. Otherwise, it returns
 one of the following error values:
 
 * **PMEM2_E_INVALID_FILE_HANDLE** - invalid *file descriptor* value in *config*

--- a/doc/libpmem2/pmem2_unmap.3.md
+++ b/doc/libpmem2/pmem2_unmap.3.md
@@ -67,7 +67,7 @@ return values please see [RETURN VALUE](#return-value).
 
 # RETURN VALUE #
 
-When **pmem2_map**() succeeds it returns **PMEM2_E_OK**. Otherwise, it returns
+When **pmem2_map**() succeeds it returns 0. Otherwise, it returns
 one of the following error values:
 
 * **-EINVAL** - if the mapping object was already unmapped (Windows only)

--- a/src/include/libpmem2.h
+++ b/src/include/libpmem2.h
@@ -63,7 +63,6 @@
 extern "C" {
 #endif
 
-#define PMEM2_E_OK			(0)
 #define PMEM2_E_UNKNOWN			(-100000)
 #define PMEM2_E_NOSUPP			(-100001)
 #define PMEM2_E_INVALID_ARG		(-100002)

--- a/src/libpmem2/map.c
+++ b/src/libpmem2/map.c
@@ -66,7 +66,7 @@ pmem2_get_length(const struct pmem2_config *cfg, size_t file_len,
 	if (!(*length))
 		*length = file_len - cfg->offset;
 
-	return PMEM2_E_OK;
+	return 0;
 }
 
 /*

--- a/src/libpmem2/map_posix.c
+++ b/src/libpmem2/map_posix.c
@@ -144,7 +144,7 @@ map_reserve(size_t len, size_t alignment, void **reserv)
 			return PMEM2_E_ERRNO;
 		}
 
-	return PMEM2_E_OK;
+	return 0;
 }
 
 /*
@@ -171,7 +171,7 @@ file_map(void *reserv, size_t len, int proto, int flags,
 	if (*base != MAP_FAILED) {
 		LOG(4, "mmap with MAP_SYNC succeeded");
 		*map_sync = true;
-		return PMEM2_E_OK;
+		return 0;
 	}
 
 	/* try to mmap with MAP_SHARED flag (without MAP_SYNC) */
@@ -181,7 +181,7 @@ file_map(void *reserv, size_t len, int proto, int flags,
 				offset);
 		if (*base != MAP_FAILED) {
 			*map_sync = false;
-			return PMEM2_E_OK;
+			return 0;
 		}
 	}
 
@@ -210,7 +210,7 @@ unmap(void *addr, size_t len)
 		return PMEM2_E_ERRNO;
 	}
 
-	return PMEM2_E_OK;
+	return 0;
 }
 
 /*
@@ -221,7 +221,7 @@ pmem2_map(const struct pmem2_config *cfg, struct pmem2_map **map_ptr)
 {
 	LOG(3, "cfg %p map_ptr %p", cfg, map_ptr);
 
-	int ret = PMEM2_E_OK;
+	int ret = 0;
 	struct pmem2_map *map;
 	size_t file_len;
 	*map_ptr = NULL;
@@ -277,7 +277,7 @@ pmem2_map(const struct pmem2_config *cfg, struct pmem2_map **map_ptr)
 	/* find a hint for the mapping */
 	void *reserv = NULL;
 	ret = map_reserve(length, alignment, &reserv);
-	if (ret != PMEM2_E_OK) {
+	if (ret != 0) {
 		LOG(1, "cannot find a contiguous region of given size");
 		return ret;
 	}
@@ -327,7 +327,7 @@ pmem2_unmap(struct pmem2_map **map_ptr)
 {
 	LOG(3, "map_ptr %p", map_ptr);
 
-	int ret = PMEM2_E_OK;
+	int ret = 0;
 	struct pmem2_map *map = *map_ptr;
 
 	ret = unmap(map->addr, map->length);

--- a/src/libpmem2/map_windows.c
+++ b/src/libpmem2/map_windows.c
@@ -88,7 +88,7 @@ pmem2_map(const struct pmem2_config *cfg, struct pmem2_map **map_ptr)
 {
 	LOG(3, "cfg %p map_ptr %p", cfg, map_ptr);
 
-	int ret = PMEM2_E_OK;
+	int ret = 0;
 	unsigned long err = 0;
 	size_t file_size;
 	*map_ptr = NULL;
@@ -186,5 +186,5 @@ pmem2_unmap(struct pmem2_map **map_ptr)
 	Free(map);
 	*map_ptr = NULL;
 
-	return PMEM2_E_OK;
+	return 0;
 }

--- a/src/test/pmem2_integration/pmem2_integration.c
+++ b/src/test/pmem2_integration/pmem2_integration.c
@@ -44,11 +44,11 @@ static void
 prepare_config(struct pmem2_config **cfg, int fd)
 {
 	int ret = pmem2_config_new(cfg);
-	UT_PMEM2_EXPECT_RETURN(ret, PMEM2_E_OK);
+	UT_PMEM2_EXPECT_RETURN(ret, 0);
 
 	if (fd != -1) {
 		ret = pmem2_config_set_fd(*cfg, fd);
-		UT_PMEM2_EXPECT_RETURN(ret, PMEM2_E_OK);
+		UT_PMEM2_EXPECT_RETURN(ret, 0);
 	}
 }
 
@@ -72,7 +72,7 @@ map_valid(struct pmem2_config *cfg, size_t size)
 {
 	struct pmem2_map *map = NULL;
 	int ret = pmem2_map(cfg, &map);
-	UT_PMEM2_EXPECT_RETURN(ret, PMEM2_E_OK);
+	UT_PMEM2_EXPECT_RETURN(ret, 0);
 	UT_ASSERTne(map, NULL);
 	UT_ASSERTeq(pmem2_map_get_size(map), size);
 
@@ -135,7 +135,7 @@ test_reuse_cfg_with_diff_fd(const struct test_case *tc, int argc, char *argv[])
 
 	/* set another valid file descriptor in config */
 	int ret = pmem2_config_set_fd(cfg, fd2);
-	UT_PMEM2_EXPECT_RETURN(ret, PMEM2_E_OK);
+	UT_PMEM2_EXPECT_RETURN(ret, 0);
 
 	size_t size2;
 	UT_ASSERTeq(pmem2_config_get_file_size(cfg, &size2), 0);

--- a/src/test/pmem2_map/pmem2_map.c
+++ b/src/test/pmem2_map/pmem2_map.c
@@ -181,7 +181,7 @@ test_map_rdrw_file(const struct test_case *tc, int argc, char *argv[])
 
 	struct pmem2_map *map;
 	int ret = pmem2_map(&cfg, &map);
-	UT_PMEM2_EXPECT_RETURN(ret, PMEM2_E_OK);
+	UT_PMEM2_EXPECT_RETURN(ret, 0);
 
 	unmap_map(map);
 	FREE(map);
@@ -206,7 +206,7 @@ test_map_rdonly_file(const struct test_case *tc, int argc, char *argv[])
 
 	struct pmem2_map *map;
 	int ret = pmem2_map(&cfg, &map);
-	UT_PMEM2_EXPECT_RETURN(ret, PMEM2_E_OK);
+	UT_PMEM2_EXPECT_RETURN(ret, 0);
 
 	unmap_map(map);
 	FREE(map);
@@ -253,7 +253,7 @@ map_valid_ranges_common(const char *file, size_t offset, size_t length,
 
 	prepare_config(&cfg, &fd, file, length, offset, O_RDWR);
 	ret = pmem2_map(&cfg, &map);
-	UT_PMEM2_EXPECT_RETURN(ret, PMEM2_E_OK);
+	UT_PMEM2_EXPECT_RETURN(ret, 0);
 	UT_ASSERTeq(map->length, val_length);
 
 	unmap_map(map);
@@ -416,7 +416,7 @@ test_unmap_valid(const struct test_case *tc, int argc, char *argv[])
 
 	/* unmap the valid mapping */
 	int ret = pmem2_unmap(&map);
-	UT_PMEM2_EXPECT_RETURN(ret, PMEM2_E_OK);
+	UT_PMEM2_EXPECT_RETURN(ret, 0);
 	UT_ASSERTeq(map, NULL);
 	CLOSE(fd);
 


### PR DESCRIPTION
We have to document that our functions return 0 on success
so the user knows that he is allowed to do:

if (pmem2_xxxx()) {
   /* error handling */
}

otherwise he must do:

if (pmem2_xxxx() != PMEM2_E_OK) {
   /* error handling */
}

Also, this commit is replacing PMEM2_E_OK with 0
to make code aligned with documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4255)
<!-- Reviewable:end -->
