### PR TITLE
common: ignore exit status of find

### DIFF
--- a/utils/docker/configure-tests.sh
+++ b/utils/docker/configure-tests.sh
@@ -103,7 +103,7 @@ else
 	echo "Skipping remote tests"
 	echo
 	echo "Removing all libfabric.pc files in order to simulate that libfabric is not installed:"
-	find /usr -name "libfabric.pc" 2>/dev/null
+	find /usr -name "libfabric.pc" 2>/dev/null || true
 	echo $USERPASS | sudo -S sh -c 'find /usr -name "libfabric.pc" -exec rm -f {} + 2>/dev/null'
 fi
 


### PR DESCRIPTION
'find' can exit with status greater than 0, even if it found the files.
It happens on Arch Linux:
```
$ find /usr -name "libfabric.pc" ; echo RV=$?
find: ‘/usr/share/polkit-1/rules.d’: Permission denied
/usr/lib/pkgconfig/libfabric.pc
RV=1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4260)
<!-- Reviewable:end -->
