### PR TITLE
obj: fix transient redo log of more than 64 entries

### DIFF
--- a/src/libpmemobj/memops.c
+++ b/src/libpmemobj/memops.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018, Intel Corporation
+ * Copyright 2016-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -330,6 +330,7 @@ operation_add_typed_entry(struct operation_context *ctx,
 			return -1;
 		oplog->capacity += ULOG_BASE_SIZE;
 		oplog->ulog = ulog;
+		oplog->ulog->capacity = oplog->capacity;
 
 		/*
 		 * Realloc invalidated the ulog entries that are inside of this
@@ -573,7 +574,8 @@ operation_finish(struct operation_context *ctx)
 	ASSERTeq(ctx->in_progress, 1);
 	ctx->in_progress = 0;
 
-	if (ctx->type == LOG_TYPE_REDO && ctx->pshadow_ops.offset != 0) {
+	if (ctx->type == LOG_TYPE_REDO && (ctx->pshadow_ops.offset != 0 ||
+	    ctx->transient_ops.offset != 0)) {
 		operation_process(ctx);
 	} else if (ctx->type == LOG_TYPE_UNDO && ctx->total_logged != 0) {
 		ulog_clobber_data(ctx->ulog,

--- a/src/libpmemobj/ulog.c
+++ b/src/libpmemobj/ulog.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018, Intel Corporation
+ * Copyright 2015-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -349,12 +349,16 @@ ulog_store(struct ulog *dest, struct ulog *src, size_t nbytes,
 	 * Then, calculate the checksum and store the first part of the
 	 * ulog.
 	 */
+	size_t old_capacity = src->capacity;
+	src->capacity = base_nbytes;
 	src->next = VEC_SIZE(next) == 0 ? 0 : VEC_FRONT(next);
 	ulog_checksum(src, checksum_nbytes, 1);
 
 	pmemops_memcpy(p_ops, dest, src,
 		SIZEOF_ULOG(base_nbytes),
 		PMEMOBJ_F_MEM_WC);
+
+	src->capacity = old_capacity;
 }
 
 /*


### PR DESCRIPTION
All transient actions in a single memory operation after 64th weren't
being applied correctly because the non-cached capacity of a transient ulog
wasn't being updated alongside the cached capacity - this caused a problem
where the vast majority of code used the cached version, but the actual
applying method used the uncached one.

The only public API that could conceivably trigger this is
pmemobj_set_value when used on volatile variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4266)
<!-- Reviewable:end -->
