### PR TITLE
common: do not allocate a pseudo-TTY in GitHub Actions

### DIFF
--- a/utils/docker/build-travis.sh
+++ b/utils/docker/build-travis.sh
@@ -95,11 +95,13 @@ fi
 WORKDIR=/pmdk
 SCRIPTSDIR=$WORKDIR/utils/docker
 
+[ ! $GITHUB_ACTIONS ] && TTY='-t' || TTY=''
+
 # Run a container with
 #  - environment variables set (--env)
 #  - host directory containing PMDK source mounted (-v)
 #  - working directory set (-w)
-docker run --rm --privileged=true --name=$containerName -ti \
+docker run --rm --privileged=true --name=$containerName -i $TTY \
 	$DNS_SETTING \
 	$ci_env \
 	--env http_proxy=$http_proxy \


### PR DESCRIPTION
... because it causes the following error:
```
the input device is not a TTY
##[error]Process completed with exit code 1.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4272)
<!-- Reviewable:end -->
