### PR TITLE
pmreorder: fix handling version's extra argument

### DIFF
--- a/src/tools/pmreorder/pmreorder.py
+++ b/src/tools/pmreorder/pmreorder.py
@@ -81,7 +81,7 @@ def main():
     parser.add_argument("-v", "--version",
                         help="print version of the pmreorder",
                         action="version",
-                        version="%(prog)s (" + pmreorder_version + ")")
+                        version="%(prog)s " + pmreorder_version)
     engines_keys = list(reorderengines.engines.keys())
     parser.add_argument("-r", "--default-engine",
                         help="set default reorder engine " +

--- a/src/tools/pmreorder/pmreorder.py
+++ b/src/tools/pmreorder/pmreorder.py
@@ -44,12 +44,14 @@ def main():
     pmreorder_version = "unknown"
 
     '''
-    Argv[1] should be given in order to use -v or --version flag. Argv[1]
-    is passed from the installed script. We must check whether argv[1]
-    was given since it is always a version of pmreorder.
+    Argv[1] should be given in order to use -v or --version flag. It is passed
+    from the installed script. We check whether argv[1] was given and if it's
+    not any of regular parameters we use it as a version of pmreorder and
+    remove it from the arguments list.
     '''
     if len(sys.argv) > 1 and sys.argv[1][0] != "-":
         pmreorder_version = sys.argv[1]
+        del sys.argv[1]
 
     # TODO unicode support
     # TODO parameterize reorder engine type

--- a/utils/docker/run-build-package.sh
+++ b/utils/docker/run-build-package.sh
@@ -63,3 +63,12 @@ fi
 cd $WORKDIR/utils/docker/test_package
 make LIBPMEMOBJ_MIN_VERSION=1.4
 ./test_package testfile1
+
+# Use pmreorder installed in the system
+pmreorder_version="$(pmreorder -v)"
+pmreorder_pattern="pmreorder\.py .+$"
+(echo "$pmreorder_version" | grep -Ev "$pmreorder_pattern") && echo "pmreorder version failed" && exit 1
+
+touch testfile2
+touch logfile1
+pmreorder -p testfile2 -l logfile1


### PR DESCRIPTION
When pmreorder installed in the system python can't properly parse the extra argument (the one with version), so it's needed to remove it from the argv list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4273)
<!-- Reviewable:end -->
