### PR TITLE
drop whitespace after a few manpage links

### DIFF
--- a/doc/generated/pmemobj_cancel.3
+++ b/doc/generated/pmemobj_cancel.3
@@ -1,2 +1,1 @@
 .so pmemobj_action.3
-

--- a/doc/generated/pmemobj_publish.3
+++ b/doc/generated/pmemobj_publish.3
@@ -1,2 +1,1 @@
 .so pmemobj_action.3
-

--- a/doc/generated/pmemobj_reserve.3
+++ b/doc/generated/pmemobj_reserve.3
@@ -1,2 +1,1 @@
 .so pmemobj_action.3
-

--- a/doc/generated/pmemobj_set_value.3
+++ b/doc/generated/pmemobj_set_value.3
@@ -1,2 +1,1 @@
 .so pmemobj_action.3
-

--- a/doc/generated/pmemobj_tx_publish.3
+++ b/doc/generated/pmemobj_tx_publish.3
@@ -1,2 +1,1 @@
 .so pmemobj_action.3
-

--- a/doc/generated/pmemobj_xreserve.3
+++ b/doc/generated/pmemobj_xreserve.3
@@ -1,2 +1,1 @@
 .so pmemobj_action.3
-

--- a/doc/generated/pobj_reserve_alloc.3
+++ b/doc/generated/pobj_reserve_alloc.3
@@ -1,2 +1,1 @@
 .so pmemobj_action.3
-

--- a/doc/generated/pobj_reserve_new.3
+++ b/doc/generated/pobj_reserve_new.3
@@ -1,2 +1,1 @@
 .so pmemobj_action.3
-


### PR DESCRIPTION
These files are blacklisted from the usual whitespace check, thus the newlines haven't been found before.  Axing them simplifies my work elsewhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4275)
<!-- Reviewable:end -->
