### PR TITLE
pmem2: fix map_reserve

### DIFF
--- a/src/libpmem2/map.c
+++ b/src/libpmem2/map.c
@@ -88,7 +88,7 @@ pmem2_map_get_size(struct pmem2_map *map)
 {
 	LOG(3, "map %p", map);
 
-	return map->length;
+	return map->content_length;
 }
 
 /*

--- a/src/libpmem2/map.h
+++ b/src/libpmem2/map.h
@@ -46,7 +46,8 @@ extern "C" {
 
 struct pmem2_map {
 	void *addr; /* base address */
-	size_t length; /* effective length of the mapping */
+	size_t reserved_length; /* length of the mapping reservation */
+	size_t content_length; /* length of the mapped content */
 	/* effective persistence granularity */
 	enum pmem2_granularity effective_granularity;
 };

--- a/src/libpmem2/map_windows.c
+++ b/src/libpmem2/map_windows.c
@@ -228,7 +228,12 @@ pmem2_map(const struct pmem2_config *cfg, struct pmem2_map **map_ptr)
 		goto err_unmap_base;
 
 	map->addr = base;
-	map->length = length;
+	/*
+	 * XXX probably in some cases the reserved length > the content length.
+	 * Maybe it is worth to do the research.
+	 */
+	map->reserved_length = length;
+	map->content_length = length;
 	map->effective_granularity = available_min_granularity;
 
 	/* return a pointer to the pmem2_map structure */

--- a/src/test/pmem2_map/TESTS.py
+++ b/src/test/pmem2_map/TESTS.py
@@ -122,3 +122,12 @@ class TEST13(PMEM2_MAP):
 class TEST14(PMEM2_MAP):
     """simply get the previously stored value of granularity"""
     test_case = "test_get_granularity_simple"
+
+
+class TEST15(PMEM2_MAP):
+    """map a file of length which is not page-aligned"""
+    test_case = "test_map_unaligned_length"
+
+    def run(self, ctx):
+        filepath = ctx.create_holey_file(3 * t.KiB, 'testfile',)
+        ctx.exec('pmem2_map', self.test_case, filepath)


### PR DESCRIPTION
Fix unmapping the not needed part of the reservation.

Ref: pmem/pmdk#4013

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4282)
<!-- Reviewable:end -->
