### PR TITLE
common: update FreeBSD version in Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-12-0-release-amd64
+  image: freebsd-12-1-release-amd64
 
 task:
   install_script: pkg install -y


### PR DESCRIPTION
- to FreeBSD 12.1 version (released 4 November 2019)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4318)
<!-- Reviewable:end -->
