### PR TITLE
common: fix Debian package dependency

### DIFF
--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -219,7 +219,7 @@ cat << EOF >> $CONTROL_FILE
 
 Package: librpmem
 Architecture: any
-Depends: libfabric (>= $LIBFABRIC_MIN_VERSION), \${shlibs:Depends}, \${misc:Depends}
+Depends: \${shlibs:Depends}, \${misc:Depends}
 Description: Persistent Memory remote access support library
  librpmem provides low-level support for remote access to persistent memory
  (pmem) utilizing RDMA-capable RNICs. The library can be used to replicate
@@ -248,7 +248,7 @@ Package: rpmemd
 Section: misc
 Architecture: any
 Priority: optional
-Depends: libfabric (>= $LIBFABRIC_MIN_VERSION), \${shlibs:Depends}, \${misc:Depends}
+Depends: \${shlibs:Depends}, \${misc:Depends}
 Description: rpmem daemon
  Daemon for Remote Persistent Memory support
 EOF


### PR DESCRIPTION
The binary package of libfabric in Debian is called libfabric1 which
has been contained in shlibs:Depends. So remove the explicit dependency.

Signed-off-by: Changcheng Liu <changcheng.liu@aliyun.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4323)
<!-- Reviewable:end -->
