### PR TITLE
obj: introduce new statistics useful for defrag

### DIFF
--- a/doc/libpmemobj/pmemobj_ctl_get.3.md
+++ b/doc/libpmemobj/pmemobj_ctl_get.3.md
@@ -7,7 +7,7 @@ header: PMDK
 date: pmemobj API version 2.3
 ...
 
-[comment]: <> (Copyright 2017-2019, Intel Corporation)
+[comment]: <> (Copyright 2017-2020, Intel Corporation)
 
 [comment]: <> (Redistribution and use in source and binary forms, with or without)
 [comment]: <> (modification, are permitted provided that the following conditions)
@@ -337,11 +337,43 @@ re-enabling will not be reflected in subsequent values.
 Statistics are disabled by default. Enabling them may have non-trivial
 performance impact.
 
-stats.heap.curr_allocated | r- | - | int | - | - | -
+stats.heap.curr_allocated | r- | - | uint64_t | - | - | -
 
 Reads the number of bytes currently allocated in the heap. If statistics were
 disabled at any time in the lifetime of the heap, this value may be
 inaccurate.
+
+stats.heap.run_allocated | r- | - | uint64_t | - | - | -
+
+Reads the number of bytes currently allocated using run-based allocation
+classes, i.e., huge allocations are not accounted for in this statistic.
+This is useful for comparison against stats.heap.run_active to estimate the
+ratio between active and allocated memory.
+
+This is a transient statistic and is rebuilt every time the pool is opened.
+
+stats.heap.run_active | r- | - | uint64_t | - | - | -
+
+Reads the number of bytes currently occupied by all memory blocks occupied by
+runs, including both allocated and free space, i.e., all space that's not
+occupied by huge blocks.
+
+This value is a sum of all allocated and free run memory. In systems where
+memory is efficiently used, `run_active` should closely track
+`run_allocated`, and the amount of active, but free, memory should be minimal.
+
+A large relative difference between active memory and allocated memory is
+indicative of heap fragmentation. This information can be used to make
+a decision to call **pmemobj_defrag()**(3) if the fragmentation looks to be high.
+
+However, for small heaps `run_active` might be disproportionately higher than
+`run_allocated` because the allocator typically activates a significantly larger
+amount of memory than is required to satisfy a single request in the
+anticipation of future needs. For example, the first allocation of 100 bytes
+in a heap will trigger activation of 256 kilobytes of space.
+
+This is a transient statistic and is rebuilt lazily every time the pool
+is opened.
 
 heap.size.granularity | rw- | - | uint64_t | uint64_t | - | long long
 

--- a/doc/libpmemobj/pmemobj_ctl_get.3.md
+++ b/doc/libpmemobj/pmemobj_ctl_get.3.md
@@ -328,20 +328,25 @@ naming in the application (e.g. when writing a library that uses libpmemobj).
 The required class identifier will be stored in the `class_id` field of the
 `struct pobj_alloc_class_desc`.
 
-stats.enabled | rw | - | int | int | - | boolean
+stats.enabled | rw | - | enum pobj_stats_enabled | enum pobj_stats_enabled | - |
+string
 
-Enables or disables runtime collection of statistics. Statistics are not
-recalculated after enabling; any operations that occur between disabling and
-re-enabling will not be reflected in subsequent values.
+Enables or disables runtime collection of statistics. There are two types of
+statistics: persistent and transient ones. Persistent statistics survive pool
+restarts, whereas transient ones don't. Statistics are not recalculated after
+enabling; any operations that occur between disabling and re-enabling will not
+be reflected in subsequent values.
 
-Statistics are disabled by default. Enabling them may have non-trivial
-performance impact.
+Only transient statistics are enabled by default. Enabling persistent statistics
+may have non-trivial performance impact.
 
 stats.heap.curr_allocated | r- | - | uint64_t | - | - | -
 
 Reads the number of bytes currently allocated in the heap. If statistics were
 disabled at any time in the lifetime of the heap, this value may be
 inaccurate.
+
+This is a persistent statistic.
 
 stats.heap.run_allocated | r- | - | uint64_t | - | - | -
 
@@ -354,9 +359,9 @@ This is a transient statistic and is rebuilt every time the pool is opened.
 
 stats.heap.run_active | r- | - | uint64_t | - | - | -
 
-Reads the number of bytes currently occupied by all memory blocks occupied by
-runs, including both allocated and free space, i.e., all space that's not
-occupied by huge blocks.
+Reads the number of bytes currently occupied by all run memory blocks, including
+both allocated and free space, i.e., this is all the all space that's not
+occupied by huge allocations.
 
 This value is a sum of all allocated and free run memory. In systems where
 memory is efficiently used, `run_active` should closely track

--- a/src/include/libpmemobj/ctl.h
+++ b/src/include/libpmemobj/ctl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Intel Corporation
+ * Copyright 2017-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -164,6 +164,13 @@ struct pobj_alloc_class_desc {
 	 * The identifier of this allocation class.
 	 */
 	unsigned class_id;
+};
+
+enum pobj_stats_enabled {
+	POBJ_STATS_ENABLED_TRANSIENT,
+	POBJ_STATS_ENABLED_BOTH,
+	POBJ_STATS_ENABLED_PERSISTENT,
+	POBJ_STATS_DISABLED,
 };
 
 #ifndef _WIN32

--- a/src/libpmemobj/stats.c
+++ b/src/libpmemobj/stats.c
@@ -60,9 +60,43 @@ CTL_READ_HANDLER(enabled)(void *ctx,
 {
 	PMEMobjpool *pop = ctx;
 
-	int *arg_out = arg;
+	enum pobj_stats_enabled *arg_out = arg;
 
-	*arg_out = pop->stats->enabled > 0;
+	*arg_out = pop->stats->enabled;
+
+	return 0;
+}
+
+/*
+ * stats_enabled_parser -- parses the stats enabled type
+ */
+static int
+stats_enabled_parser(const void *arg, void *dest, size_t dest_size)
+{
+	const char *vstr = arg;
+	enum pobj_stats_enabled *enabled = dest;
+	ASSERTeq(dest_size, sizeof(enum pobj_stats_enabled));
+
+	int bool_out;
+	if (ctl_arg_boolean(arg, &bool_out, sizeof(bool_out)) == 0) {
+		*enabled = bool_out ?
+			POBJ_STATS_ENABLED_BOTH : POBJ_STATS_DISABLED;
+		return 0;
+	}
+
+	if (strcmp(vstr, "disabled") == 0) {
+		*enabled = POBJ_STATS_DISABLED;
+	} else if (strcmp(vstr, "both") == 0) {
+		*enabled = POBJ_STATS_ENABLED_BOTH;
+	} else if (strcmp(vstr, "persistent") == 0) {
+		*enabled = POBJ_STATS_ENABLED_PERSISTENT;
+	} else if (strcmp(vstr, "transient") == 0) {
+		*enabled = POBJ_STATS_ENABLED_TRANSIENT;
+	} else {
+		ERR("invalid enable type");
+		errno = EINVAL;
+		return -1;
+	}
 
 	return 0;
 }
@@ -77,14 +111,19 @@ CTL_WRITE_HANDLER(enabled)(void *ctx,
 {
 	PMEMobjpool *pop = ctx;
 
-	int arg_in = *(int *)arg;
-
-	pop->stats->enabled = arg_in > 0;
+	pop->stats->enabled = *(enum pobj_stats_enabled *)arg;
 
 	return 0;
 }
 
-static const struct ctl_argument CTL_ARG(enabled) = CTL_ARG_BOOLEAN;
+static const struct ctl_argument CTL_ARG(enabled) = {
+	.dest_size = sizeof(enum pobj_stats_enabled),
+	.parsers = {
+		CTL_ARG_PARSER(sizeof(enum pobj_stats_enabled),
+			stats_enabled_parser),
+		CTL_ARG_PARSER_END
+	}
+};
 
 static const struct ctl_node CTL_NODE(stats)[] = {
 	CTL_CHILD(heap),
@@ -105,7 +144,7 @@ stats_new(PMEMobjpool *pop)
 		return NULL;
 	}
 
-	s->enabled = 0;
+	s->enabled = POBJ_STATS_ENABLED_TRANSIENT;
 	s->persistent = &pop->stats_persistent;
 	VALGRIND_ADD_TO_GLOBAL_TX_IGNORE(s->persistent, sizeof(*s->persistent));
 	s->transient = Zalloc(sizeof(struct stats_transient));

--- a/src/libpmemobj/stats.c
+++ b/src/libpmemobj/stats.c
@@ -39,8 +39,13 @@
 
 STATS_CTL_HANDLER(persistent, curr_allocated, heap_curr_allocated);
 
+STATS_CTL_HANDLER(transient, run_allocated, heap_run_allocated);
+STATS_CTL_HANDLER(transient, run_active, heap_run_active);
+
 static const struct ctl_node CTL_NODE(heap)[] = {
 	STATS_CTL_LEAF(persistent, curr_allocated),
+	STATS_CTL_LEAF(transient, run_allocated),
+	STATS_CTL_LEAF(transient, run_active),
 
 	CTL_NODE_END
 };

--- a/src/libpmemobj/stats.h
+++ b/src/libpmemobj/stats.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Intel Corporation
+ * Copyright 2017-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,7 +44,8 @@ extern "C" {
 #endif
 
 struct stats_transient {
-	int unused;
+	uint64_t heap_run_allocated;
+	uint64_t heap_run_active;
 };
 
 struct stats_persistent {

--- a/src/test/obj_ctl_stats/obj_ctl_stats.c
+++ b/src/test/obj_ctl_stats/obj_ctl_stats.c
@@ -76,11 +76,21 @@ main(int argc, char *argv[])
 	UT_ASSERTeq(ret, 0);
 	UT_ASSERTeq(allocated, oid_size);
 
+	size_t run_allocated = 0;
+	ret = pmemobj_ctl_get(pop, "stats.heap.run_allocated", &run_allocated);
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERTeq(allocated, run_allocated);
+
 	pmemobj_free(&oid);
 
 	ret = pmemobj_ctl_get(pop, "stats.heap.curr_allocated", &allocated);
 	UT_ASSERTeq(ret, 0);
 	UT_ASSERTeq(allocated, 0);
+
+	allocated = 0;
+	ret = pmemobj_ctl_get(pop, "stats.heap.run_allocated", &run_allocated);
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERTeq(allocated, run_allocated);
 
 	TX_BEGIN(pop) {
 		oid = pmemobj_tx_alloc(1, 0);

--- a/src/test/obj_fragmentation2/obj_fragmentation2.c
+++ b/src/test/obj_fragmentation2/obj_fragmentation2.c
@@ -199,6 +199,15 @@ static float workloads_defrag_target[] = {
 	0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.056f, 0.1f, 0.13f, 0.01f
 };
 
+/* last workload operates only on huge chunks, so run stats are useless */
+static float workloads_stat_target[] = {
+	0.01f, 1.1f, 1.1f, 0.86f, 0.76f, 1.01f, 0.23f, 1.24f, 2100.f
+};
+
+static float workloads_defrag_stat_target[] = {
+	0.01f, 0.01f, 0.01f, 0.02f, 0.02f, 0.04f, 0.08f, 0.12f, 2100.f
+};
+
 int
 main(int argc, char *argv[])
 {
@@ -227,7 +236,20 @@ main(int argc, char *argv[])
 	objects = ZALLOC(sizeof(PMEMoid) * MAX_OBJECTS);
 	UT_ASSERTne(objects, NULL);
 
+	int enabled = 1;
+	pmemobj_ctl_set(pop, "stats.enabled", &enabled);
+
 	workloads[w](pop);
+
+	/* this is to trigger global recycling */
+	pmemobj_defrag(pop, NULL, 0, NULL);
+
+	size_t active = 0;
+	size_t allocated = 0;
+	pmemobj_ctl_get(pop, "stats.heap.run_active", &active);
+	pmemobj_ctl_get(pop, "stats.heap.run_allocated", &allocated);
+	float stat_frag = ((float)active / allocated) - 1.f;
+	UT_ASSERT(stat_frag <= workloads_stat_target[w]);
 
 	if (defrag) {
 		PMEMoid **objectsf = ZALLOC(sizeof(PMEMoid) * nobjects);
@@ -237,6 +259,17 @@ main(int argc, char *argv[])
 		pmemobj_defrag(pop, objectsf, nobjects, NULL);
 
 		FREE(objectsf);
+
+		active = 0;
+		allocated = 0;
+
+		/* this is to trigger global recycling */
+		pmemobj_defrag(pop, NULL, 0, NULL);
+
+		pmemobj_ctl_get(pop, "stats.heap.run_active", &active);
+		pmemobj_ctl_get(pop, "stats.heap.run_allocated", &allocated);
+		stat_frag = ((float)active / allocated) - 1.f;
+		UT_ASSERT(stat_frag <= workloads_defrag_stat_target[w]);
 	}
 
 	PMEMoid oid;

--- a/src/test/obj_fragmentation2/obj_fragmentation2.c
+++ b/src/test/obj_fragmentation2/obj_fragmentation2.c
@@ -236,9 +236,6 @@ main(int argc, char *argv[])
 	objects = ZALLOC(sizeof(PMEMoid) * MAX_OBJECTS);
 	UT_ASSERTne(objects, NULL);
 
-	int enabled = 1;
-	pmemobj_ctl_set(pop, "stats.enabled", &enabled);
-
 	workloads[w](pop);
 
 	/* this is to trigger global recycling */


### PR DESCRIPTION
This patch introduces two new statistics: stats.heap.run_active and
stats.heap.run_allocated. Combination of these two can be used to
estimate the total potentially unused space in the heap, indicating
that defrag should be ran.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4332)
<!-- Reviewable:end -->
