### PR TITLE
test: (py) fix config granularity filter behaviour

### DIFF
--- a/src/test/pmem2_granularity/TESTS.py
+++ b/src/test/pmem2_granularity/TESTS.py
@@ -57,6 +57,12 @@ class PMEM2_GRANULARITY(t.BaseTest):
             self.cwd,
             "linux_eadr_paths/eadr_available/sys/bus/nd/devices/")
 
+        # Testframework may set this variable to emulate the certain type of
+        # granularity.
+        # This test mocks all granularity checks but they are skipped if
+        # granularity is forced so this test requires unforced granularity.
+        ctx.env['PMEM2_FORCE_GRANULARITY'] = '0'
+
         if self.available_granularity == Granularity.BYTE:
             ctx.env['IS_EADR'] = '1'
             ctx.env['IS_PMEM'] = '1'

--- a/src/test/pmem2_granularity/TESTS.py
+++ b/src/test/pmem2_granularity/TESTS.py
@@ -43,6 +43,7 @@ class Granularity(Enum):
     PAGE = 3
 
 
+@t.require_granularity(t.ANY)
 class PMEM2_GRANULARITY(t.BaseTest):
     test_type = t.Short
     available_granularity = None

--- a/src/test/testconfig.py.example
+++ b/src/test/testconfig.py.example
@@ -31,8 +31,6 @@ config = {
     # Enforce that the library will act in accordance with
     # page granularity, even if the underlying filesystem is not page
     # granular.
-    # XXX: currently, this enforcement does nothing more than omitting
-    # the test directory granularity check.
     #
 
     'force_page': False,
@@ -50,8 +48,6 @@ config = {
     # Enforce that the library will act in accordance with
     # cache line granularity, even if the underlying filesystem is not
     # cache line granular.
-    # XXX: currently, this enforcement does nothing more than omitting
-    # the test directory granularity check.
     #
 
     'force_cacheline': False,
@@ -69,8 +65,6 @@ config = {
     # Enforce that the library will act in accordance with
     # byte granularity, even if the underlying filesystem is not byte
     # granular.
-    # XXX: currently, this enforcement does nothing more than omitting
-    # the test directory granularity check.
     #
 
     'force_byte': False,

--- a/src/test/unittest/context.py
+++ b/src/test/unittest/context.py
@@ -463,5 +463,12 @@ class Any:
             if c.is_preferred:
                 # pick preferred if found
                 return c
-        # if no preferred is found, pick the first one
-        return conf_ctx[0]
+        # if no preferred is found, pick the first non-explicit one
+        ret = [c for c in conf_ctx if not c.explicit]
+        if ret:
+            return ret[0]
+        else:
+            config = configurator.Configurator().config
+            msg = futils.Message(config.unittest_log_level)
+            msg.print_verbose('No valid "Any" context found')
+            return None

--- a/src/test/unittest/granularity.py
+++ b/src/test/unittest/granularity.py
@@ -101,6 +101,8 @@ class Granularity(metaclass=ctx.CtxType):
             tmp_req_gran = [Byte, CacheLine]
         elif req_gran == _PAGE_OR_LESS:
             tmp_req_gran = [Byte, CacheLine, Page]
+        elif req_gran == ctx.Any:
+            tmp_req_gran = [ctx.Any.get(config.granularity), ]
         else:
             tmp_req_gran = req_gran
 
@@ -193,6 +195,7 @@ class _Granularity(Enum):
     BYTE = [Byte, ]
     CL_OR_LESS = _CACHELINE_OR_LESS
     PAGE_OR_LESS = _PAGE_OR_LESS
+    ANY = ctx.Any
 
 
 PAGE = _Granularity.PAGE
@@ -200,6 +203,7 @@ CACHELINE = _Granularity.CACHELINE
 BYTE = _Granularity.BYTE
 CL_OR_LESS = _Granularity.CL_OR_LESS
 PAGE_OR_LESS = _Granularity.PAGE_OR_LESS
+ANY = _Granularity.ANY
 
 
 def require_granularity(granularity, **kwargs):


### PR DESCRIPTION
Take existence of config test dir fields into account
when selecting granularites to be used for execution

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4335)
<!-- Reviewable:end -->
