### PR TITLE
pmem2: trim the list list of linked files

### DIFF
--- a/src/libpmem2/Makefile
+++ b/src/libpmem2/Makefile
@@ -39,16 +39,12 @@ LIBRARY_SO_VERSION = 1
 LIBRARY_VERSION = 0.0
 SOURCE =\
 	$(COMMON)/alloc.c\
-	$(COMMON)/file.c\
-	$(COMMON)/file_posix.c\
-	$(COMMON)/out.c\
+	$(COMMON)/fs_posix.c\
 	$(COMMON)/os_posix.c\
 	$(COMMON)/os_thread_posix.c\
-	$(COMMON)/mmap.c\
-	$(COMMON)/mmap_posix.c\
+	$(COMMON)/out.c\
 	$(COMMON)/util.c\
 	$(COMMON)/util_posix.c\
-	$(COMMON)/fs_posix.c\
 	libpmem2.c\
 	config.c\
 	config_posix.c\

--- a/src/libpmem2/libpmem2.vcxproj
+++ b/src/libpmem2/libpmem2.vcxproj
@@ -14,7 +14,6 @@
     <ClCompile Include="..\libpmem2\libpmem2.c" />
     <ClCompile Include="..\libpmem2\pmem2.c" />
     <ClCompile Include="..\common\alloc.c" />
-    <ClCompile Include="..\common\file_windows.c" />
     <ClCompile Include="..\common\os_thread_windows.c" />
     <ClCompile Include="..\common\os_windows.c" />
     <ClCompile Include="..\common\out.c" />

--- a/src/libpmem2/libpmem2.vcxproj.filters
+++ b/src/libpmem2/libpmem2.vcxproj.filters
@@ -29,9 +29,6 @@
     <ClCompile Include="..\common\alloc.c">
       <Filter>Source Files\common</Filter>
     </ClCompile>
-    <ClCompile Include="..\common\file_windows.c">
-      <Filter>Source Files\common</Filter>
-    </ClCompile>
     <ClCompile Include="..\common\util.c">
       <Filter>Source Files\common</Filter>
     </ClCompile>

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -287,16 +287,12 @@ OBJS +=\
 	$(TOP)/src/debug/libpmem2/map_posix.o\
 	$(TOP)/src/debug/libpmem2/pmem2_utils.o\
 	$(TOP)/src/debug/common/alloc.o\
-	$(TOP)/src/debug/common/file.o\
-	$(TOP)/src/debug/common/file_posix.o\
+	$(TOP)/src/debug/common/fs_posix.o\
 	$(TOP)/src/debug/common/os_posix.o\
 	$(TOP)/src/debug/common/os_thread_posix.o\
+	$(TOP)/src/debug/common/out.o\
 	$(TOP)/src/debug/common/util.o\
-	$(TOP)/src/debug/common/mmap.o\
-	$(TOP)/src/debug/common/mmap_posix.o\
-	$(TOP)/src/debug/common/util_posix.o\
-	$(TOP)/src/debug/common/fs_posix.o\
-	$(TOP)/src/debug/common/out.o
+	$(TOP)/src/debug/common/util_posix.o
 
 ifeq ($(OS_KERNEL_NAME),Linux)
 OBJS +=\
@@ -328,16 +324,12 @@ OBJS +=\
 	$(TOP)/src/nondebug/libpmem2/memops_generic.o\
 	$(TOP)/src/nondebug/libpmem2/pmem2_utils.o\
 	$(TOP)/src/nondebug/common/alloc.o\
-	$(TOP)/src/nondebug/common/file.o\
-	$(TOP)/src/nondebug/common/file_posix.o\
+	$(TOP)/src/nondebug/common/fs_posix.o\
 	$(TOP)/src/nondebug/common/os_posix.o\
 	$(TOP)/src/nondebug/common/os_thread_posix.o\
+	$(TOP)/src/nondebug/common/out.o\
 	$(TOP)/src/nondebug/common/util.o\
-	$(TOP)/src/nondebug/common/mmap.o\
-	$(TOP)/src/nondebug/common/mmap_posix.o\
-	$(TOP)/src/nondebug/common/util_posix.o\
-	$(TOP)/src/nondebug/common/fs_posix.o\
-	$(TOP)/src/nondebug/common/out.o
+	$(TOP)/src/nondebug/common/util_posix.o
 
 ifeq ($(OS_KERNEL_NAME),Linux)
 OBJS +=\


### PR DESCRIPTION
These files are no longer needed:
- common/file.c
- common/file_posix.c
- common/file_windows.c
- common/mmap.c
- common/mmap_posix.c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4344)
<!-- Reviewable:end -->
