### PR TITLE
pmem2: split errormsg.c out of libpmem2.c

### DIFF
--- a/src/libpmem2/Makefile
+++ b/src/libpmem2/Makefile
@@ -48,6 +48,7 @@ SOURCE =\
 	libpmem2.c\
 	config.c\
 	config_posix.c\
+	errormsg.c\
 	memops_generic.c\
 	pmem2.c\
 	map.c\

--- a/src/libpmem2/errormsg.c
+++ b/src/libpmem2/errormsg.c
@@ -31,41 +31,40 @@
  */
 
 /*
- * libpmem2.c -- pmem2 library constructor & destructor
+ * errormsg.c -- pmem2_errormsg* implementation
  */
 
 #include "libpmem2.h"
-
-#include "pmem2.h"
 #include "out.h"
-#include "util.h"
 
 /*
- * libpmem2_init -- load-time initialization for libpmem2
- *
- * Called automatically by the run-time loader.
+ * pmem2_errormsgU -- return last error message
  */
-ATTR_CONSTRUCTOR
-void
-libpmem2_init(void)
+#ifndef _WIN32
+static inline
+#endif
+const char *
+pmem2_errormsgU(void)
 {
-	util_init();
-	out_init(PMEM2_LOG_PREFIX, PMEM2_LOG_LEVEL_VAR, PMEM2_LOG_FILE_VAR,
-			PMEM2_MAJOR_VERSION, PMEM2_MINOR_VERSION);
-
-	LOG(3, NULL);
+	return out_get_errormsg();
 }
 
+#ifndef _WIN32
 /*
- * libpmem2_fini -- libpmem2 cleanup routine
- *
- * Called automatically when the process terminates.
+ * pmem2_errormsg -- return last error message
  */
-ATTR_DESTRUCTOR
-void
-libpmem2_fini(void)
+const char *
+pmem2_errormsg(void)
 {
-	LOG(3, NULL);
-
-	out_fini();
+	return pmem2_errormsgU();
 }
+#else
+/*
+ * pmem2_errormsgW -- return last error message as wchar_t
+ */
+const wchar_t *
+pmem2_errormsgW(void)
+{
+	return out_get_errormsgW();
+}
+#endif

--- a/src/libpmem2/libpmem2.vcxproj
+++ b/src/libpmem2/libpmem2.vcxproj
@@ -23,6 +23,7 @@
     <ClCompile Include="auto_flush_windows.c" />
     <ClCompile Include="config.c" />
     <ClCompile Include="config_windows.c" />
+    <ClCompile Include="errormsg.c" />
     <ClCompile Include="pmem2_utils.c" />
 	<ClCompile Include="map.c" />
     <ClCompile Include="map_windows.c" />

--- a/src/libpmem2/libpmem2.vcxproj.filters
+++ b/src/libpmem2/libpmem2.vcxproj.filters
@@ -53,6 +53,12 @@
     <ClCompile Include="config.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="config_windows.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="errormsg.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="auto_flush_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -281,10 +281,11 @@ OBJS +=\
 	$(TOP)/src/debug/libpmem2/libpmem2.o\
 	$(TOP)/src/debug/libpmem2/config.o\
 	$(TOP)/src/debug/libpmem2/config_posix.o\
-	$(TOP)/src/debug/libpmem2/pmem2.o\
+	$(TOP)/src/debug/libpmem2/errormsg.o\
 	$(TOP)/src/debug/libpmem2/map.o\
 	$(TOP)/src/debug/libpmem2/memops_generic.o\
 	$(TOP)/src/debug/libpmem2/map_posix.o\
+	$(TOP)/src/debug/libpmem2/pmem2.o\
 	$(TOP)/src/debug/libpmem2/pmem2_utils.o\
 	$(TOP)/src/debug/common/alloc.o\
 	$(TOP)/src/debug/common/fs_posix.o\
@@ -318,10 +319,11 @@ OBJS +=\
 	$(TOP)/src/nondebug/libpmem2/libpmem2.o\
 	$(TOP)/src/nondebug/libpmem2/config.o\
 	$(TOP)/src/nondebug/libpmem2/config_posix.o\
-	$(TOP)/src/nondebug/libpmem2/pmem2.o\
+	$(TOP)/src/nondebug/libpmem2/errormsg.o\
 	$(TOP)/src/nondebug/libpmem2/map.o\
 	$(TOP)/src/nondebug/libpmem2/map_posix.o\
 	$(TOP)/src/nondebug/libpmem2/memops_generic.o\
+	$(TOP)/src/nondebug/libpmem2/pmem2.o\
 	$(TOP)/src/nondebug/libpmem2/pmem2_utils.o\
 	$(TOP)/src/nondebug/common/alloc.o\
 	$(TOP)/src/nondebug/common/fs_posix.o\

--- a/src/test/pmem2_config/Makefile
+++ b/src/test/pmem2_config/Makefile
@@ -40,7 +40,7 @@ vpath %.c $(TOP)/src/libpmem2
 
 INCS += -I$(TOP)/src/libpmem2
 TARGET = pmem2_config
-OBJS += libpmem2.o\
+OBJS += errormsg.o\
 	pmem2_config.o\
 	ut_pmem2_config.o\
 	ut_pmem2_utils.o

--- a/src/test/pmem2_config/pmem2_config.vcxproj
+++ b/src/test/pmem2_config/pmem2_config.vcxproj
@@ -78,7 +78,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\libpmem2\config.c" />
     <ClCompile Include="..\..\libpmem2\config_windows.c" />
-    <ClCompile Include="..\..\libpmem2\libpmem2.c" />
+    <ClCompile Include="..\..\libpmem2\errormsg.c" />
     <ClCompile Include="..\..\libpmem2\pmem2_utils.c" />
     <ClCompile Include="..\unittest\ut_pmem2_config.c" />
     <ClCompile Include="..\unittest\ut_pmem2_utils.c" />

--- a/src/test/pmem2_config/pmem2_config.vcxproj.filters
+++ b/src/test/pmem2_config/pmem2_config.vcxproj.filters
@@ -14,7 +14,7 @@
     <ClCompile Include="pmem2_config.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\libpmem2\libpmem2.c">
+    <ClCompile Include="..\..\libpmem2\errormsg.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\libpmem2\config.c">

--- a/src/test/pmem2_config_get_alignment/Makefile
+++ b/src/test/pmem2_config_get_alignment/Makefile
@@ -41,7 +41,7 @@ vpath %.c $(TOP)/src/libpmem2
 
 INCS += -I$(TOP)/src/libpmem2
 TARGET = pmem2_config_get_alignment
-OBJS += libpmem2.o\
+OBJS += errormsg.o\
 	pmem2_config_get_alignment.o\
 	ut_pmem2_config.o\
 	ut_pmem2_utils.o

--- a/src/test/pmem2_config_get_alignment/pmem2_config_get_alignment.vcxproj
+++ b/src/test/pmem2_config_get_alignment/pmem2_config_get_alignment.vcxproj
@@ -78,7 +78,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\libpmem2\config.c" />
     <ClCompile Include="..\..\libpmem2\config_windows.c" />
-    <ClCompile Include="..\..\libpmem2\libpmem2.c" />
+    <ClCompile Include="..\..\libpmem2\errormsg.c" />
     <ClCompile Include="..\..\libpmem2\pmem2_utils.c" />
     <ClCompile Include="..\unittest\ut_pmem2_config.c" />
     <ClCompile Include="..\unittest\ut_pmem2_utils.c" />

--- a/src/test/pmem2_config_get_alignment/pmem2_config_get_alignment.vcxproj.filters
+++ b/src/test/pmem2_config_get_alignment/pmem2_config_get_alignment.vcxproj.filters
@@ -14,7 +14,7 @@
     <ClCompile Include="pmem2_config_get_alignment.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\libpmem2\libpmem2.c">
+    <ClCompile Include="..\..\libpmem2\errormsg.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\libpmem2\config.c">

--- a/src/test/pmem2_config_get_file_size/Makefile
+++ b/src/test/pmem2_config_get_file_size/Makefile
@@ -41,7 +41,7 @@ vpath %.c $(TOP)/src/libpmem2
 
 INCS += -I$(TOP)/src/libpmem2
 TARGET = pmem2_config_get_file_size
-OBJS += libpmem2.o\
+OBJS += errormsg.o\
 	pmem2_config_get_file_size.o\
 	ut_pmem2_config.o\
 	ut_pmem2_utils.o

--- a/src/test/pmem2_config_get_file_size/pmem2_config_get_file_size.vcxproj
+++ b/src/test/pmem2_config_get_file_size/pmem2_config_get_file_size.vcxproj
@@ -78,7 +78,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\libpmem2\config.c" />
     <ClCompile Include="..\..\libpmem2\config_windows.c" />
-    <ClCompile Include="..\..\libpmem2\libpmem2.c" />
+    <ClCompile Include="..\..\libpmem2\errormsg.c" />
     <ClCompile Include="..\..\libpmem2\pmem2_utils.c" />
     <ClCompile Include="..\unittest\ut_pmem2_config.c" />
     <ClCompile Include="..\unittest\ut_pmem2_utils.c" />

--- a/src/test/pmem2_config_get_file_size/pmem2_config_get_file_size.vcxproj.filters
+++ b/src/test/pmem2_config_get_file_size/pmem2_config_get_file_size.vcxproj.filters
@@ -14,7 +14,7 @@
     <ClCompile Include="pmem2_config_get_file_size.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\libpmem2\libpmem2.c">
+    <ClCompile Include="..\..\libpmem2\errormsg.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\libpmem2\config.c">

--- a/src/test/pmem2_granularity/pmem2_granularity.vcxproj
+++ b/src/test/pmem2_granularity/pmem2_granularity.vcxproj
@@ -76,6 +76,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\libpmem2\auto_flush_windows.c" />
+    <ClCompile Include="..\..\libpmem2\errormsg.c" />
     <ClCompile Include="..\..\libpmem2\libpmem2.c" />
     <ClCompile Include="..\..\libpmem2\map.c" />
     <ClCompile Include="..\..\libpmem2\map_windows.c" />

--- a/src/test/pmem2_granularity/pmem2_granularity.vcxproj.filters
+++ b/src/test/pmem2_granularity/pmem2_granularity.vcxproj.filters
@@ -41,6 +41,9 @@
     <ClCompile Include="..\pmem_has_auto_flush_win\mocks_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\libpmem2\errormsg.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\unittest\ut_pmem2_utils.h">

--- a/src/test/pmem2_map/Makefile
+++ b/src/test/pmem2_map/Makefile
@@ -40,7 +40,7 @@ vpath %.c $(TOP)/src/libpmem2
 
 INCS += -I$(TOP)/src/libpmem2
 TARGET = pmem2_map
-OBJS += libpmem2.o\
+OBJS += errormsg.o\
 	map_posix.o\
 	map.o\
 	pmem2_map.o\

--- a/src/test/pmem2_map/pmem2_map.c
+++ b/src/test/pmem2_map/pmem2_map.c
@@ -626,6 +626,7 @@ int
 main(int argc, char *argv[])
 {
 	START(argc, argv, "pmem2_map");
+	util_init();
 	out_init("pmem2_map", "TEST_LOG_LEVEL", "TEST_LOG_FILE", 0, 0);
 	TEST_CASE_PROCESS(argc, argv, test_cases, NTESTS);
 	out_fini();

--- a/src/test/pmem2_map/pmem2_map.vcxproj
+++ b/src/test/pmem2_map/pmem2_map.vcxproj
@@ -77,7 +77,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\libpmem2\config.c" />
-    <ClCompile Include="..\..\libpmem2\libpmem2.c" />
+    <ClCompile Include="..\..\libpmem2\errormsg.c" />
 	<ClCompile Include="..\..\libpmem2\map.c" />
     <ClCompile Include="..\..\libpmem2\map_windows.c" />
     <ClCompile Include="..\..\libpmem2\pmem2_utils.c" />

--- a/src/test/pmem2_map/pmem2_map.vcxproj.filters
+++ b/src/test/pmem2_map/pmem2_map.vcxproj.filters
@@ -20,7 +20,7 @@
     <ClCompile Include="..\..\libpmem2\pmem2_utils.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\libpmem2\libpmem2.c">
+    <ClCompile Include="..\..\libpmem2\errormsg.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\libpmem2\config.c">


### PR DESCRIPTION
libpmem2_init will soon call other modules init functions.
libpmem2.c is linked into some unit tests because of pmem2_errormsg.

When I'll extend libpmem2_init to call other module initialization
functions the above tests would have to link to those other modules...

Avoid that by splitting libpmem2.c and linking the tests that need
pmem2_errormsg with errormsg.c.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4351)
<!-- Reviewable:end -->
