### PR TITLE
pmem2: fix naming of arch flush callback

### DIFF
--- a/src/libpmem/pmem.c
+++ b/src/libpmem/pmem.c
@@ -858,9 +858,9 @@ pmem_init(void)
 	struct pmem2_arch_info info;
 	info.memmove_nodrain = NULL;
 	info.memset_nodrain = NULL;
-	info.deep_flush = NULL;
+	info.flush = NULL;
 	info.fence = NULL;
-	info.deep_flush_has_builtin_fence = 0;
+	info.flush_has_builtin_fence = 0;
 
 	pmem2_arch_init(&info);
 
@@ -909,10 +909,10 @@ pmem_init(void)
 		LOG(3, "Flushing CPU cache");
 	}
 
-	Funcs.deep_flush = info.deep_flush;
+	Funcs.deep_flush = info.flush;
 	if (flush) {
-		Funcs.flush = info.deep_flush;
-		if (info.deep_flush_has_builtin_fence)
+		Funcs.flush = info.flush;
+		if (info.flush_has_builtin_fence)
 			Funcs.fence = fence_empty;
 		else
 			Funcs.fence = info.fence;

--- a/src/libpmem2/aarch64/init.c
+++ b/src/libpmem2/aarch64/init.c
@@ -67,9 +67,9 @@ pmem2_arch_init(struct pmem2_arch_info *info)
 	LOG(3, NULL);
 
 	info->fence = memory_barrier;
-	info->deep_flush = flush_dcache;
+	info->flush = flush_dcache;
 
-	if (info->deep_flush == flush_dcache)
+	if (info->flush == flush_dcache)
 		LOG(3, "Synchronize VA to poc for ARM");
 	else
 		FATAL("invalid deep flush function address");

--- a/src/libpmem2/pmem2_arch.h
+++ b/src/libpmem2/pmem2_arch.h
@@ -56,9 +56,9 @@ typedef void *(*memset_nodrain_func)(void *pmemdest, int c, size_t len,
 struct pmem2_arch_info {
 	memmove_nodrain_func memmove_nodrain;
 	memset_nodrain_func memset_nodrain;
-	flush_func deep_flush;
+	flush_func flush;
 	fence_func fence;
-	int deep_flush_has_builtin_fence;
+	int flush_has_builtin_fence;
 };
 
 void pmem2_arch_init(struct pmem2_arch_info *info);

--- a/src/libpmem2/ppc64/platform_generic.c
+++ b/src/libpmem2/ppc64/platform_generic.c
@@ -75,7 +75,7 @@ platform_init(struct pmem2_arch_info *info)
 	LOG(3, "Initializing Platform");
 
 	info->fence = ppc_fence;
-	info->deep_flush = ppc_flush;
+	info->flush = ppc_flush;
 
 	return 0;
 }

--- a/src/libpmem2/x86_64/init.c
+++ b/src/libpmem2/x86_64/init.c
@@ -183,20 +183,20 @@ use_sse2_memcpy_memset(struct pmem2_arch_info *info, enum memcpy_impl *impl)
 {
 #if SSE2_AVAILABLE
 	*impl = MEMCPY_SSE2;
-	if (info->deep_flush == flush_clflush)
+	if (info->flush == flush_clflush)
 		info->memmove_nodrain = memmove_nodrain_sse2_clflush;
-	else if (info->deep_flush == flush_clflushopt)
+	else if (info->flush == flush_clflushopt)
 		info->memmove_nodrain = memmove_nodrain_sse2_clflushopt;
-	else if (info->deep_flush == flush_clwb)
+	else if (info->flush == flush_clwb)
 		info->memmove_nodrain = memmove_nodrain_sse2_clwb;
 	else
 		ASSERT(0);
 
-	if (info->deep_flush == flush_clflush)
+	if (info->flush == flush_clflush)
 		info->memset_nodrain = memset_nodrain_sse2_clflush;
-	else if (info->deep_flush == flush_clflushopt)
+	else if (info->flush == flush_clflushopt)
 		info->memset_nodrain = memset_nodrain_sse2_clflushopt;
-	else if (info->deep_flush == flush_clwb)
+	else if (info->flush == flush_clwb)
 		info->memset_nodrain = memset_nodrain_sse2_clwb;
 	else
 		ASSERT(0);
@@ -224,20 +224,20 @@ use_avx_memcpy_memset(struct pmem2_arch_info *info, enum memcpy_impl *impl)
 	LOG(3, "PMEM_AVX enabled");
 	*impl = MEMCPY_AVX;
 
-	if (info->deep_flush == flush_clflush)
+	if (info->flush == flush_clflush)
 		info->memmove_nodrain = memmove_nodrain_avx_clflush;
-	else if (info->deep_flush == flush_clflushopt)
+	else if (info->flush == flush_clflushopt)
 		info->memmove_nodrain = memmove_nodrain_avx_clflushopt;
-	else if (info->deep_flush == flush_clwb)
+	else if (info->flush == flush_clwb)
 		info->memmove_nodrain = memmove_nodrain_avx_clwb;
 	else
 		ASSERT(0);
 
-	if (info->deep_flush == flush_clflush)
+	if (info->flush == flush_clflush)
 		info->memset_nodrain = memset_nodrain_avx_clflush;
-	else if (info->deep_flush == flush_clflushopt)
+	else if (info->flush == flush_clflushopt)
 		info->memset_nodrain = memset_nodrain_avx_clflushopt;
-	else if (info->deep_flush == flush_clwb)
+	else if (info->flush == flush_clwb)
 		info->memset_nodrain = memset_nodrain_avx_clwb;
 	else
 		ASSERT(0);
@@ -265,20 +265,20 @@ use_avx512f_memcpy_memset(struct pmem2_arch_info *info,
 	LOG(3, "PMEM_AVX512F enabled");
 	*impl = MEMCPY_AVX512F;
 
-	if (info->deep_flush == flush_clflush)
+	if (info->flush == flush_clflush)
 		info->memmove_nodrain = memmove_nodrain_avx512f_clflush;
-	else if (info->deep_flush == flush_clflushopt)
+	else if (info->flush == flush_clflushopt)
 		info->memmove_nodrain = memmove_nodrain_avx512f_clflushopt;
-	else if (info->deep_flush == flush_clwb)
+	else if (info->flush == flush_clwb)
 		info->memmove_nodrain = memmove_nodrain_avx512f_clwb;
 	else
 		ASSERT(0);
 
-	if (info->deep_flush == flush_clflush)
+	if (info->flush == flush_clflush)
 		info->memset_nodrain = memset_nodrain_avx512f_clflush;
-	else if (info->deep_flush == flush_clflushopt)
+	else if (info->flush == flush_clflushopt)
 		info->memset_nodrain = memset_nodrain_avx512f_clflushopt;
-	else if (info->deep_flush == flush_clwb)
+	else if (info->flush == flush_clwb)
 		info->memset_nodrain = memset_nodrain_avx512f_clwb;
 	else
 		ASSERT(0);
@@ -298,8 +298,8 @@ pmem_cpuinfo_to_funcs(struct pmem2_arch_info *info, enum memcpy_impl *impl)
 	if (is_cpu_clflush_present()) {
 		LOG(3, "clflush supported");
 
-		info->deep_flush = flush_clflush;
-		info->deep_flush_has_builtin_fence = 1;
+		info->flush = flush_clflush;
+		info->flush_has_builtin_fence = 1;
 		info->fence = memory_barrier;
 	}
 
@@ -310,8 +310,8 @@ pmem_cpuinfo_to_funcs(struct pmem2_arch_info *info, enum memcpy_impl *impl)
 		if (e && strcmp(e, "1") == 0) {
 			LOG(3, "PMEM_NO_CLFLUSHOPT forced no clflushopt");
 		} else {
-			info->deep_flush = flush_clflushopt;
-			info->deep_flush_has_builtin_fence = 0;
+			info->flush = flush_clflushopt;
+			info->flush_has_builtin_fence = 0;
 			info->fence = memory_barrier;
 		}
 	}
@@ -323,8 +323,8 @@ pmem_cpuinfo_to_funcs(struct pmem2_arch_info *info, enum memcpy_impl *impl)
 		if (e && strcmp(e, "1") == 0) {
 			LOG(3, "PMEM_NO_CLWB forced no clwb");
 		} else {
-			info->deep_flush = flush_clwb;
-			info->deep_flush_has_builtin_fence = 0;
+			info->flush = flush_clwb;
+			info->flush_has_builtin_fence = 0;
 			info->fence = memory_barrier;
 		}
 	}
@@ -372,11 +372,11 @@ pmem2_arch_init(struct pmem2_arch_info *info)
 		}
 	}
 
-	if (info->deep_flush == flush_clwb)
+	if (info->flush == flush_clwb)
 		LOG(3, "using clwb");
-	else if (info->deep_flush == flush_clflushopt)
+	else if (info->flush == flush_clflushopt)
 		LOG(3, "using clflushopt");
-	else if (info->deep_flush == flush_clflush)
+	else if (info->flush == flush_clflush)
 		LOG(3, "using clflush");
 	else
 		FATAL("invalid deep flush function address");


### PR DESCRIPTION
deep_flush is a misleading name - the callback behind it is supposed
to only flush the cpu caches and nothing more.

It is used to implement deep_flush **later**.

Splitted out of #4333.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4352)
<!-- Reviewable:end -->
