### PR TITLE
rpmem: fix a lane misalignment

### DIFF
--- a/src/librpmem/rpmem_fip.c
+++ b/src/librpmem/rpmem_fip.c
@@ -523,11 +523,13 @@ rpmem_fip_lanes_init_common(struct rpmem_fip *fip)
 {
 	int ret;
 
-	fip->lanes = calloc(fip->nlanes, sizeof(*fip->lanes));
-	if (!fip->lanes) {
+	ret = posix_memalign((void **)&fip->lanes, LANE_ALIGN_SIZE,
+		fip->nlanes * sizeof(*fip->lanes));
+	if (ret) {
 		RPMEM_LOG(ERR, "!allocating lanes");
 		goto err_alloc_lanes;
 	}
+	memset(fip->lanes, 0, fip->nlanes * sizeof(*fip->lanes));
 
 	unsigned i;
 	for (i = 0; i < fip->nlanes; i++) {


### PR DESCRIPTION
The struct is declared as `__attribute__((aligned(LANE_ALIGN_SIZE)))` (64) so we should obey that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4354)
<!-- Reviewable:end -->
