### PR TITLE
PPC64LE libpmemblk port

### DIFF
--- a/src/include/libpmemblk.h
+++ b/src/include/libpmemblk.h
@@ -101,8 +101,15 @@ const wchar_t *pmemblk_check_versionW(unsigned major_required,
 /* XXX - unify minimum pool size for both OS-es */
 
 #ifndef _WIN32
+#if defined(__x86_64__) || defined(__M_X64__) || defined(__aarch64__)
 /* minimum pool size: 16MiB + 4KiB (minimum BTT size + mmap alignment) */
 #define PMEMBLK_MIN_POOL ((size_t)((1u << 20) * 16 + (1u << 10) * 8))
+#elif defined(__PPC64__)
+/* minimum pool size: 16MiB + 128KiB (minimum BTT size + mmap alignment) */
+#define PMEMBLK_MIN_POOL ((size_t)((1u << 20) * 16 + (1u << 10) * 128))
+#else
+#error unable to recognize ISA at compile time
+#endif
 #else
 /* minimum pool size: 16MiB + 64KiB (minimum BTT size + mmap alignment) */
 #define PMEMBLK_MIN_POOL ((size_t)((1u << 20) * 16 + (1u << 10) * 64))

--- a/src/libpmemblk/blk.h
+++ b/src/libpmemblk/blk.h
@@ -42,6 +42,7 @@
 #include "ctl.h"
 #include "os_thread.h"
 #include "pool_hdr.h"
+#include "page_size.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -99,7 +100,7 @@ struct pmemblk {
 };
 
 /* data area starts at this alignment after the struct pmemblk above */
-#define BLK_FORMAT_DATA_ALIGN ((uintptr_t)4096)
+#define BLK_FORMAT_DATA_ALIGN ((uintptr_t)PMEM_PAGESIZE)
 
 #if FAULT_INJECTION
 void

--- a/src/test/blk_non_zero/TEST0
+++ b/src/test/blk_non_zero/TEST0
@@ -43,11 +43,13 @@ require_test_type medium
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
+exclude_ppc64
 
 setup
 
+SIZE=$(blk_pool_desc_size)
 # single arena and minimum pmemblk pool file case
-create_nonzeroed_file 17M 8K $DIR/testfile1
+create_nonzeroed_file 17M ${SIZE} $DIR/testfile1
 
 #
 # All reads to an unwritten block pool should return zeros.

--- a/src/test/blk_non_zero/TEST1
+++ b/src/test/blk_non_zero/TEST1
@@ -42,6 +42,7 @@
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
 require_test_type long
+exclude_ppc64
 
 setup
 

--- a/src/test/blk_non_zero/TEST11
+++ b/src/test/blk_non_zero/TEST11
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
 # Copyright 2015-2019, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,8 +34,10 @@
 #
 
 #
-# src/test/blk_non_zero/TEST7 -- unit test for
+# src/test/blk_non_zero/TEST11 -- unit test for
 # pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST0 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
@@ -42,21 +46,21 @@ require_test_type medium
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
-exclude_ppc64
+require_ppc64
 
 setup
 
-# mix writes with set_zero and set_error and check results
-FILE_SIZE=$((1024*1024*1024))
-require_free_space $FILE_SIZE
+SIZE=$(blk_pool_desc_size)
+# single arena and minimum pmemblk pool file case
+create_nonzeroed_file 17M ${SIZE} $DIR/testfile1
 
-expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c $FILE_SIZE\
-	w:100 w:200 w:300 w:400\
-	r:100 r:200 r:300 r:400\
-	w:100 z:200 w:300 z:400\
-	r:100 r:200 r:300 r:400\
-	e:100 w:200 e:300 w:400\
-	r:100 r:200 r:300 r:400
+#
+# All reads to an unwritten block pool should return zeros.
+# Block 32202 is out of range and should return EINVAL.
+# Attempts to zero uninitialized blocks are nops (should succeed).
+#
+expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
+	r:0 r:1 r:33979 r:34280 z:0 z:1 r:0 e:3 r:4
 
 check
 

--- a/src/test/blk_non_zero/TEST12
+++ b/src/test/blk_non_zero/TEST12
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
 # Copyright 2015-2019, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,31 +34,26 @@
 #
 
 #
-# src/test/blk_non_zero/TEST7 -- unit test for
+# src/test/blk_non_zero/TEST12 -- unit test for
 # pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST1 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
 
-require_test_type medium
-
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
-exclude_ppc64
+require_test_type long
+require_ppc64
 
 setup
 
-# mix writes with set_zero and set_error and check results
-FILE_SIZE=$((1024*1024*1024))
-require_free_space $FILE_SIZE
+# single arena write case
+create_nonzeroed_file 1G 824K $DIR/testfile1
 
-expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c $FILE_SIZE\
-	w:100 w:200 w:300 w:400\
-	r:100 r:200 r:300 r:400\
-	w:100 z:200 w:300 z:400\
-	r:100 r:200 r:300 r:400\
-	e:100 w:200 e:300 w:400\
-	r:100 r:200 r:300 r:400
+expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
+	w:0 r:1 r:0 w:1 r:0 r:1 r:2
 
 check
 

--- a/src/test/blk_non_zero/TEST13
+++ b/src/test/blk_non_zero/TEST13
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
 # Copyright 2015-2019, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,31 +34,29 @@
 #
 
 #
-# src/test/blk_non_zero/TEST7 -- unit test for
+# src/test/blk_non_zero/TEST13 -- unit test for
 # pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST2 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
 
-require_test_type medium
-
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
-exclude_ppc64
+require_test_type long
+require_ppc64
 
 setup
 
-# mix writes with set_zero and set_error and check results
-FILE_SIZE=$((1024*1024*1024))
-require_free_space $FILE_SIZE
+# write re-use test case
+create_nonzeroed_file 1G 824M $DIR/testfile1
 
-expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c $FILE_SIZE\
-	w:100 w:200 w:300 w:400\
-	r:100 r:200 r:300 r:400\
-	w:100 z:200 w:300 z:400\
-	r:100 r:200 r:300 r:400\
-	e:100 w:200 e:300 w:400\
-	r:100 r:200 r:300 r:400
+expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
+	w:0 w:1 w:2 w:3 w:4 r:4 r:3 r:2 r:1 r:0
+
+expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 o\
+	w:0 r:4 r:3 r:2 r:1 r:0 w:0 r:0
 
 check
 

--- a/src/test/blk_non_zero/TEST14
+++ b/src/test/blk_non_zero/TEST14
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
 # Copyright 2015-2019, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,25 +34,25 @@
 #
 
 #
-# src/test/blk_non_zero/TEST7 -- unit test for
+# src/test/blk_non_zero/TEST14 -- unit test for
 # pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST3 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
 
-require_test_type medium
-
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
-exclude_ppc64
+require_test_type long
+require_ppc64
 
 setup
 
 # mix writes with set_zero and set_error and check results
-FILE_SIZE=$((1024*1024*1024))
-require_free_space $FILE_SIZE
+create_nonzeroed_file 1G 824M $DIR/testfile1
 
-expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c $FILE_SIZE\
+expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
 	w:100 w:200 w:300 w:400\
 	r:100 r:200 r:300 r:400\
 	w:100 z:200 w:300 z:400\

--- a/src/test/blk_non_zero/TEST15
+++ b/src/test/blk_non_zero/TEST15
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
 # Copyright 2015-2019, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,31 +34,31 @@
 #
 
 #
-# src/test/blk_non_zero/TEST7 -- unit test for
+# src/test/blk_non_zero/TEST15 -- unit test for
 # pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST4 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
 
-require_test_type medium
-
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
-exclude_ppc64
+require_test_type long
+require_ppc64
 
 setup
 
 # mix writes with set_zero and set_error and check results
-FILE_SIZE=$((1024*1024*1024))
-require_free_space $FILE_SIZE
+create_nonzeroed_file 1G 824M $DIR/testfile1
 
-expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c $FILE_SIZE\
-	w:100 w:200 w:300 w:400\
-	r:100 r:200 r:300 r:400\
-	w:100 z:200 w:300 z:400\
-	r:100 r:200 r:300 r:400\
-	e:100 w:200 e:300 w:400\
-	r:100 r:200 r:300 r:400
+expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
+		e:1 r:1\
+		e:2 w:2 r:2\
+		z:3 e:3 r:3\
+		e:4 z:4 r:4\
+		w:5 e:5 z:5 r:5\
+		w:6 z:6 e:6 r:6
 
 check
 

--- a/src/test/blk_non_zero/TEST16
+++ b/src/test/blk_non_zero/TEST16
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # Copyright 2015-2019, Intel Corporation
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,8 +33,10 @@
 #
 
 #
-# src/test/blk_non_zero/TEST7 -- unit test for
+# src/test/blk_non_zero/TEST16 -- unit test for
 # pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST5 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
@@ -42,21 +45,20 @@ require_test_type medium
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
-exclude_ppc64
+require_ppc64
 
 setup
 
-# mix writes with set_zero and set_error and check results
-FILE_SIZE=$((1024*1024*1024))
-require_free_space $FILE_SIZE
+# single arena and minimum pmemblk pool file case
+MIN_POOL_SIZE=$((16*1024*1024 + 128*1024))
 
-expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c $FILE_SIZE\
-	w:100 w:200 w:300 w:400\
-	r:100 r:200 r:300 r:400\
-	w:100 z:200 w:300 z:400\
-	r:100 r:200 r:300 r:400\
-	e:100 w:200 e:300 w:400\
-	r:100 r:200 r:300 r:400
+#
+# All reads to an unwritten block pool should return zeros.
+# Block 32202 is out of range and should return EINVAL.
+# Attempts to zero uninitialized blocks are nops (should succeed).
+#
+expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c $MIN_POOL_SIZE\
+	r:0 r:1 r:32201 r:32202 z:0 z:1 r:0
 
 check
 

--- a/src/test/blk_non_zero/TEST17
+++ b/src/test/blk_non_zero/TEST17
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # Copyright 2015-2019, Intel Corporation
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,8 +33,10 @@
 #
 
 #
-# src/test/blk_non_zero/TEST7 -- unit test for
+# src/test/blk_non_zero/TEST17 -- unit test for
 # pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST6 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
@@ -42,21 +45,16 @@ require_test_type medium
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
-exclude_ppc64
+require_ppc64
 
 setup
 
-# mix writes with set_zero and set_error and check results
+# single arena write case
 FILE_SIZE=$((1024*1024*1024))
 require_free_space $FILE_SIZE
 
 expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c $FILE_SIZE\
-	w:100 w:200 w:300 w:400\
-	r:100 r:200 r:300 r:400\
-	w:100 z:200 w:300 z:400\
-	r:100 r:200 r:300 r:400\
-	e:100 w:200 e:300 w:400\
-	r:100 r:200 r:300 r:400
+	w:0 r:1 r:0 w:1 r:0 r:1 r:2
 
 check
 

--- a/src/test/blk_non_zero/TEST18
+++ b/src/test/blk_non_zero/TEST18
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # Copyright 2015-2019, Intel Corporation
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,8 +33,10 @@
 #
 
 #
-# src/test/blk_non_zero/TEST7 -- unit test for
+# src/test/blk_non_zero/TEST18 -- unit test for
 # pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST7 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
@@ -42,7 +45,7 @@ require_test_type medium
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
-exclude_ppc64
+require_ppc64
 
 setup
 

--- a/src/test/blk_non_zero/TEST19
+++ b/src/test/blk_non_zero/TEST19
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # Copyright 2015-2019, Intel Corporation
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,8 +33,10 @@
 #
 
 #
-# src/test/blk_non_zero/TEST7 -- unit test for
+# src/test/blk_non_zero/TEST19 -- unit test for
 # pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST8 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
@@ -42,7 +45,7 @@ require_test_type medium
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
-exclude_ppc64
+require_ppc64
 
 setup
 
@@ -51,12 +54,12 @@ FILE_SIZE=$((1024*1024*1024))
 require_free_space $FILE_SIZE
 
 expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c $FILE_SIZE\
-	w:100 w:200 w:300 w:400\
-	r:100 r:200 r:300 r:400\
-	w:100 z:200 w:300 z:400\
-	r:100 r:200 r:300 r:400\
-	e:100 w:200 e:300 w:400\
-	r:100 r:200 r:300 r:400
+		e:1 r:1\
+		e:2 w:2 r:2\
+		z:3 e:3 r:3\
+		e:4 z:4 r:4\
+		w:5 e:5 z:5 r:5\
+		w:6 z:6 e:6 r:6
 
 check
 

--- a/src/test/blk_non_zero/TEST2
+++ b/src/test/blk_non_zero/TEST2
@@ -42,6 +42,7 @@
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
 require_test_type long
+exclude_ppc64
 
 setup
 

--- a/src/test/blk_non_zero/TEST3
+++ b/src/test/blk_non_zero/TEST3
@@ -42,6 +42,7 @@
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
 require_test_type long
+exclude_ppc64
 
 setup
 

--- a/src/test/blk_non_zero/TEST4
+++ b/src/test/blk_non_zero/TEST4
@@ -42,6 +42,7 @@
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
 require_test_type long
+exclude_ppc64
 
 setup
 

--- a/src/test/blk_non_zero/TEST5
+++ b/src/test/blk_non_zero/TEST5
@@ -42,6 +42,7 @@ require_test_type medium
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
+exclude_ppc64
 
 setup
 

--- a/src/test/blk_non_zero/TEST6
+++ b/src/test/blk_non_zero/TEST6
@@ -42,6 +42,7 @@ require_test_type medium
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
+exclude_ppc64
 
 setup
 

--- a/src/test/blk_non_zero/TEST8
+++ b/src/test/blk_non_zero/TEST8
@@ -42,6 +42,7 @@ require_test_type medium
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
+exclude_ppc64
 
 setup
 

--- a/src/test/blk_non_zero/out11.log.match
+++ b/src/test/blk_non_zero/out11.log.match
@@ -1,0 +1,14 @@
+blk_non_zero$(nW)TEST11: START: blk_non_zero
+ $(nW)blk_non_zero$(nW) 512 $(nW)testfile1 c 0 r:0 r:1 r:33979 r:34280 z:0 z:1 r:0 e:3 r:4
+512 block size 512 usable blocks 33980
+is zeroed:	0
+read      lba 0: {0}
+read      lba 1: {0}
+read      lba 33979: {0}
+read      lba 34280: Invalid argument
+set_zero  lba 0
+set_zero  lba 1
+read      lba 0: {0}
+set_error lba 3
+read      lba 4: {0}
+blk_non_zero$(nW)TEST11: DONE

--- a/src/test/blk_non_zero/out12.log.match
+++ b/src/test/blk_non_zero/out12.log.match
@@ -1,0 +1,12 @@
+blk_non_zero$(nW)TEST12: START: blk_non_zero
+ $(nW)blk_non_zero$(nW) 512 $(nW)testfile1 c 0 w:0 r:1 r:0 w:1 r:0 r:1 r:2
+512 block size 512 usable blocks 2080329
+is zeroed:	0
+write     lba 0: {1}
+read      lba 1: {0}
+read      lba 0: {1}
+write     lba 1: {2}
+read      lba 0: {1}
+read      lba 1: {2}
+read      lba 2: {0}
+blk_non_zero$(nW)TEST12: DONE

--- a/src/test/blk_non_zero/out13.log.match
+++ b/src/test/blk_non_zero/out13.log.match
@@ -1,0 +1,13 @@
+blk_non_zero$(nW)TEST13: START: blk_non_zero
+ $(nW)blk_non_zero$(nW) 512 $(nW)testfile1 o w:0 r:4 r:3 r:2 r:1 r:0 w:0 r:0
+512 block size 512 usable blocks 2080329
+is zeroed:	0
+write     lba 0: {1}
+read      lba 4: {5}
+read      lba 3: {4}
+read      lba 2: {3}
+read      lba 1: {2}
+read      lba 0: {1}
+write     lba 0: {2}
+read      lba 0: {2}
+blk_non_zero$(nW)TEST13: DONE

--- a/src/test/blk_non_zero/out14.log.match
+++ b/src/test/blk_non_zero/out14.log.match
@@ -1,0 +1,29 @@
+blk_non_zero$(nW)TEST14: START: blk_non_zero
+ $(nW)blk_non_zero$(nW) 512 $(nW)testfile1 c 0 w:100 w:200 w:300 w:400 r:100 r:200 r:300 r:400 w:100 z:200 w:300 z:400 r:100 r:200 r:300 r:400 e:100 w:200 e:300 w:400 r:100 r:200 r:300 r:400
+512 block size 512 usable blocks 2080329
+is zeroed:	0
+write     lba 100: {1}
+write     lba 200: {2}
+write     lba 300: {3}
+write     lba 400: {4}
+read      lba 100: {1}
+read      lba 200: {2}
+read      lba 300: {3}
+read      lba 400: {4}
+write     lba 100: {5}
+set_zero  lba 200
+write     lba 300: {6}
+set_zero  lba 400
+read      lba 100: {5}
+read      lba 200: {0}
+read      lba 300: {6}
+read      lba 400: {0}
+set_error lba 100
+write     lba 200: {7}
+set_error lba 300
+write     lba 400: {8}
+read      lba 100: Input/output error
+read      lba 200: {7}
+read      lba 300: Input/output error
+read      lba 400: {8}
+blk_non_zero$(nW)TEST14: DONE

--- a/src/test/blk_non_zero/out15.log.match
+++ b/src/test/blk_non_zero/out15.log.match
@@ -1,0 +1,24 @@
+blk_non_zero$(nW)TEST15: START: blk_non_zero
+ $(nW)blk_non_zero$(nW) 512 $(nW)testfile1 c 0 e:1 r:1 e:2 w:2 r:2 z:3 e:3 r:3 e:4 z:4 r:4 w:5 e:5 z:5 r:5 w:6 z:6 e:6 r:6
+512 block size 512 usable blocks 2080329
+is zeroed:	0
+set_error lba 1
+read      lba 1: Input/output error
+set_error lba 2
+write     lba 2: {1}
+read      lba 2: {1}
+set_zero  lba 3
+set_error lba 3
+read      lba 3: Input/output error
+set_error lba 4
+set_zero  lba 4
+read      lba 4: {0}
+write     lba 5: {2}
+set_error lba 5
+set_zero  lba 5
+read      lba 5: {0}
+write     lba 6: {3}
+set_zero  lba 6
+set_error lba 6
+read      lba 6: Input/output error
+blk_non_zero$(nW)TEST15: DONE

--- a/src/test/blk_non_zero/out16.log.match
+++ b/src/test/blk_non_zero/out16.log.match
@@ -1,0 +1,12 @@
+blk_non_zero$(nW)TEST16: START: blk_non_zero
+ $(nW)blk_non_zero$(nW) 512 $(nW)testfile1 c $(N)$(S) r:0 r:1 r:32201 r:32202 z:0 z:1 r:0
+512 block size 512 usable blocks 32202
+is zeroed:	1
+read      lba 0: {0}
+read      lba 1: {0}
+read      lba 32201: {0}
+read      lba 32202: Invalid argument
+set_zero  lba 0
+set_zero  lba 1
+read      lba 0: {0}
+blk_non_zero$(nW)TEST16: DONE

--- a/src/test/blk_non_zero/out17.log.match
+++ b/src/test/blk_non_zero/out17.log.match
@@ -1,0 +1,12 @@
+blk_non_zero$(nW)TEST17: START: blk_non_zero
+ $(nW)blk_non_zero$(nW) 512 $(nW)testfile1 c $(N) w:0 r:1 r:0 w:1 r:0 r:1 r:2
+512 block size 512 usable blocks 2080329
+is zeroed:	1
+write     lba 0: {1}
+read      lba 1: {0}
+read      lba 0: {1}
+write     lba 1: {2}
+read      lba 0: {1}
+read      lba 1: {2}
+read      lba 2: {0}
+blk_non_zero$(nW)TEST17: DONE

--- a/src/test/blk_non_zero/out18.log.match
+++ b/src/test/blk_non_zero/out18.log.match
@@ -1,0 +1,29 @@
+blk_non_zero$(nW)/TEST18: START: blk_non_zero
+ $(nW)blk_non_zero$(nW) 512 $(nW)testfile1 c $(N) w:100 w:200 w:300 w:400 r:100 r:200 r:300 r:400 w:100 z:200 w:300 z:400 r:100 r:200 r:300 r:400 e:100 w:200 e:300 w:400 r:100 r:200 r:300 r:400
+512 block size 512 usable blocks 2080329
+is zeroed:	1
+write     lba 100: {1}
+write     lba 200: {2}
+write     lba 300: {3}
+write     lba 400: {4}
+read      lba 100: {1}
+read      lba 200: {2}
+read      lba 300: {3}
+read      lba 400: {4}
+write     lba 100: {5}
+set_zero  lba 200
+write     lba 300: {6}
+set_zero  lba 400
+read      lba 100: {5}
+read      lba 200: {0}
+read      lba 300: {6}
+read      lba 400: {0}
+set_error lba 100
+write     lba 200: {7}
+set_error lba 300
+write     lba 400: {8}
+read      lba 100: Input/output error
+read      lba 200: {7}
+read      lba 300: Input/output error
+read      lba 400: {8}
+blk_non_zero$(nW)TEST18: DONE

--- a/src/test/blk_non_zero/out19.log.match
+++ b/src/test/blk_non_zero/out19.log.match
@@ -1,0 +1,24 @@
+blk_non_zero$(nW)TEST19: START: blk_non_zero
+ $(nW)blk_non_zero$(nW) 512 $(nW)testfile1 c $(N) e:1 r:1 e:2 w:2 r:2 z:3 e:3 r:3 e:4 z:4 r:4 w:5 e:5 z:5 r:5 w:6 z:6 e:6 r:6
+512 block size 512 usable blocks 2080329
+is zeroed:	1
+set_error lba 1
+read      lba 1: Input/output error
+set_error lba 2
+write     lba 2: {1}
+read      lba 2: {1}
+set_zero  lba 3
+set_error lba 3
+read      lba 3: Input/output error
+set_error lba 4
+set_zero  lba 4
+read      lba 4: {0}
+write     lba 5: {2}
+set_error lba 5
+set_zero  lba 5
+read      lba 5: {0}
+write     lba 6: {3}
+set_zero  lba 6
+set_error lba 6
+read      lba 6: Input/output error
+blk_non_zero$(nW)TEST19: DONE

--- a/src/test/blk_pool/TEST0
+++ b/src/test/blk_pool/TEST0
@@ -38,6 +38,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+exclude_ppc64
 
 setup
 umask 0

--- a/src/test/blk_pool/TEST1
+++ b/src/test/blk_pool/TEST1
@@ -39,6 +39,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+exclude_ppc64
 
 setup
 umask 0

--- a/src/test/blk_pool/TEST13
+++ b/src/test/blk_pool/TEST13
@@ -38,6 +38,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+exclude_ppc64
 
 setup
 umask 0

--- a/src/test/blk_pool/TEST15
+++ b/src/test/blk_pool/TEST15
@@ -38,6 +38,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+exclude_ppc64
 
 setup
 umask 0

--- a/src/test/blk_pool/TEST17
+++ b/src/test/blk_pool/TEST17
@@ -38,6 +38,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+exclude_ppc64
 
 setup
 umask 0

--- a/src/test/blk_pool/TEST34
+++ b/src/test/blk_pool/TEST34
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2019, Intel Corporation
+# Copyright 2015-2019, Intel Corporation
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,34 +33,27 @@
 #
 
 #
-# src/test/blk_pool/TEST33 -- create a pool with the smallest parts
-# possible
+# src/test/blk_pool/TEST34 -- unit test for pmemblk_create
+#
+# This test is equivalent of TEST0 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
 
 require_test_type medium
-exclude_ppc64
+require_ppc64
 
 setup
 umask 0
 
 #
-# TEST33 non-existing file, poolsize >= min required size, bsize > min bsize
-#        part size == min part size (pool set)
+# TEST34 non-existing file, poolsize > 0
 #
-CMD="$DIR/testset"
-MIN_PART=$((2 * 1024 * 1024)) # 2MiB
-for i in {1..9}; do
-	CMD="$CMD $MIN_PART:$DIR/testfile$i:x"
-done
-create_poolset $CMD
+expect_normal_exit ./blk_pool$EXESUFFIX f $DIR/testfile 4096 20 0600
 
-expect_normal_exit ./blk_pool$EXESUFFIX c $DIR/testset 100 0 0640
+expect_normal_exit ./blk_pool$EXESUFFIX c $DIR/testfile 4096 20 0600
 
-check_files $DIR/testset $DIR/testfile1 $DIR/testfile2 $DIR/testfile3 \
-    $DIR/testfile4 $DIR/testfile5 $DIR/testfile6 $DIR/testfile7 $DIR/testfile8 \
-    $DIR/testfile9
+check_files $DIR/testfile
 
 check
 

--- a/src/test/blk_pool/TEST35
+++ b/src/test/blk_pool/TEST35
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2019, Intel Corporation
+# Copyright 2015-2019, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,34 +34,28 @@
 #
 
 #
-# src/test/blk_pool/TEST33 -- create a pool with the smallest parts
-# possible
+# src/test/blk_pool/TEST35 -- unit test for pmemblk_create
+#
+# This test is equivalent of TEST1 for ppc64le platform
 #
 
 . ../unittest/unittest.sh
 
 require_test_type medium
-exclude_ppc64
+require_ppc64
 
 setup
 umask 0
 
-#
-# TEST33 non-existing file, poolsize >= min required size, bsize > min bsize
-#        part size == min part size (pool set)
-#
-CMD="$DIR/testset"
-MIN_PART=$((2 * 1024 * 1024)) # 2MiB
-for i in {1..9}; do
-	CMD="$CMD $MIN_PART:$DIR/testfile$i:x"
-done
-create_poolset $CMD
+create_holey_file 40M $DIR/testfile
+chmod 0600 $DIR/testfile
 
-expect_normal_exit ./blk_pool$EXESUFFIX c $DIR/testset 100 0 0640
+#
+# TEST35 existing file, file length >= min required size, poolsize == 0
+#
+expect_normal_exit ./blk_pool$EXESUFFIX c $DIR/testfile 4096 0 0600
 
-check_files $DIR/testset $DIR/testfile1 $DIR/testfile2 $DIR/testfile3 \
-    $DIR/testfile4 $DIR/testfile5 $DIR/testfile6 $DIR/testfile7 $DIR/testfile8 \
-    $DIR/testfile9
+check_files $DIR/testfile
 
 check
 

--- a/src/test/blk_pool/TEST36
+++ b/src/test/blk_pool/TEST36
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2019, Intel Corporation
+# Copyright 2015-2019, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,34 +34,29 @@
 #
 
 #
-# src/test/blk_pool/TEST33 -- create a pool with the smallest parts
-# possible
+# src/test/blk_pool/TEST36 -- unit test for pmemblk_create
+#
+# This test is equivalent of TEST8 for ppc64le platform
 #
 
 . ../unittest/unittest.sh
 
 require_test_type medium
-exclude_ppc64
+require_ppc64
 
 setup
 umask 0
 
-#
-# TEST33 non-existing file, poolsize >= min required size, bsize > min bsize
-#        part size == min part size (pool set)
-#
-CMD="$DIR/testset"
-MIN_PART=$((2 * 1024 * 1024)) # 2MiB
-for i in {1..9}; do
-	CMD="$CMD $MIN_PART:$DIR/testfile$i:x"
-done
-create_poolset $CMD
+create_nonzeroed_file 17M 8K $DIR/testfile
+chmod 0600 $DIR/testfile
 
-expect_normal_exit ./blk_pool$EXESUFFIX c $DIR/testset 100 0 0640
+#
+# TEST36 existing file, file length >= min required size, poolsize == 0
+#       (file contains garbage, except for header)
+#
+expect_normal_exit ./blk_pool$EXESUFFIX c $DIR/testfile 4096 0 0600
 
-check_files $DIR/testset $DIR/testfile1 $DIR/testfile2 $DIR/testfile3 \
-    $DIR/testfile4 $DIR/testfile5 $DIR/testfile6 $DIR/testfile7 $DIR/testfile8 \
-    $DIR/testfile9
+check_files $DIR/testfile
 
 check
 

--- a/src/test/blk_pool/TEST37
+++ b/src/test/blk_pool/TEST37
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2019, Intel Corporation
+# Copyright 2015-2019, Intel Corporation
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,34 +33,25 @@
 #
 
 #
-# src/test/blk_pool/TEST33 -- create a pool with the smallest parts
-# possible
+# src/test/blk_pool/TEST37 -- unit test for pmemblk_create
+#
+# This test is equivalent of TEST13 for ppc64le platform
 #
 
 . ../unittest/unittest.sh
 
 require_test_type medium
-exclude_ppc64
+require_ppc64
 
 setup
 umask 0
 
 #
-# TEST33 non-existing file, poolsize >= min required size, bsize > min bsize
-#        part size == min part size (pool set)
+# TEST37 non-existing file, poolsize >= min required size, bsize < min bsize
 #
-CMD="$DIR/testset"
-MIN_PART=$((2 * 1024 * 1024)) # 2MiB
-for i in {1..9}; do
-	CMD="$CMD $MIN_PART:$DIR/testfile$i:x"
-done
-create_poolset $CMD
+expect_normal_exit ./blk_pool$EXESUFFIX c $DIR/testfile 10 20 0600
 
-expect_normal_exit ./blk_pool$EXESUFFIX c $DIR/testset 100 0 0640
-
-check_files $DIR/testset $DIR/testfile1 $DIR/testfile2 $DIR/testfile3 \
-    $DIR/testfile4 $DIR/testfile5 $DIR/testfile6 $DIR/testfile7 $DIR/testfile8 \
-    $DIR/testfile9
+check_files $DIR/testfile
 
 check
 

--- a/src/test/blk_pool/TEST38
+++ b/src/test/blk_pool/TEST38
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2019, Intel Corporation
+# Copyright 2016-2019, Intel Corporation
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,34 +33,28 @@
 #
 
 #
-# src/test/blk_pool/TEST33 -- create a pool with the smallest parts
-# possible
+# src/test/blk_pool/TEST38 -- unit test for pmemblk_create
+#
+# This test is equivalent of TEST15 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
 
 require_test_type medium
-exclude_ppc64
+require_ppc64
 
 setup
 umask 0
 
 #
-# TEST33 non-existing file, poolsize >= min required size, bsize > min bsize
-#        part size == min part size (pool set)
+# TEST38 non-existing file, poolsize >= min required size, bsize > min bsize
+#        (pool set)
 #
-CMD="$DIR/testset"
-MIN_PART=$((2 * 1024 * 1024)) # 2MiB
-for i in {1..9}; do
-	CMD="$CMD $MIN_PART:$DIR/testfile$i:x"
-done
-create_poolset $CMD
+create_poolset $DIR/testset 20M:$DIR/testfile1:x 20M:$DIR/testfile2:x
 
 expect_normal_exit ./blk_pool$EXESUFFIX c $DIR/testset 100 0 0640
 
-check_files $DIR/testset $DIR/testfile1 $DIR/testfile2 $DIR/testfile3 \
-    $DIR/testfile4 $DIR/testfile5 $DIR/testfile6 $DIR/testfile7 $DIR/testfile8 \
-    $DIR/testfile9
+check_files $DIR/testset $DIR/testfile1 $DIR/testfile2
 
 check
 

--- a/src/test/blk_pool/TEST39
+++ b/src/test/blk_pool/TEST39
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # Copyright 2017-2019, Intel Corporation
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,34 +33,26 @@
 #
 
 #
-# src/test/blk_pool/TEST33 -- create a pool with the smallest parts
-# possible
+# src/test/blk_pool/TEST39 -- unit test for pmemblk_create with unicode
+#
+# This test is equivalent of TEST17 for ppc64le platform
 #
 
 . ../unittest/unittest.sh
 
 require_test_type medium
-exclude_ppc64
+require_ppc64
 
 setup
 umask 0
 
 #
-# TEST33 non-existing file, poolsize >= min required size, bsize > min bsize
-#        part size == min part size (pool set)
+# TEST39 non-existing file, poolsize > 0
 #
-CMD="$DIR/testset"
-MIN_PART=$((2 * 1024 * 1024)) # 2MiB
-for i in {1..9}; do
-	CMD="$CMD $MIN_PART:$DIR/testfile$i:x"
-done
-create_poolset $CMD
 
-expect_normal_exit ./blk_pool$EXESUFFIX c $DIR/testset 100 0 0640
+expect_normal_exit ./blk_pool$EXESUFFIX c $DIR/ㅹestㆅile 4096 20 0600
 
-check_files $DIR/testset $DIR/testfile1 $DIR/testfile2 $DIR/testfile3 \
-    $DIR/testfile4 $DIR/testfile5 $DIR/testfile6 $DIR/testfile7 $DIR/testfile8 \
-    $DIR/testfile9
+check_files $DIR/ㅹestㆅile
 
 check
 

--- a/src/test/blk_pool/TEST40
+++ b/src/test/blk_pool/TEST40
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # Copyright 2017-2019, Intel Corporation
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,20 +33,22 @@
 #
 
 #
-# src/test/blk_pool/TEST33 -- create a pool with the smallest parts
+# src/test/blk_pool/TEST40 -- create a pool with the smallest parts
 # possible
+#
+# This test is equivalent of TEST33 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
 
 require_test_type medium
-exclude_ppc64
+require_ppc64
 
 setup
 umask 0
 
 #
-# TEST33 non-existing file, poolsize >= min required size, bsize > min bsize
+# TEST40 non-existing file, poolsize >= min required size, bsize > min bsize
 #        part size == min part size (pool set)
 #
 CMD="$DIR/testset"

--- a/src/test/blk_pool/TEST8
+++ b/src/test/blk_pool/TEST8
@@ -39,6 +39,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+exclude_ppc64
 
 setup
 umask 0

--- a/src/test/blk_pool/out34.log.match
+++ b/src/test/blk_pool/out34.log.match
@@ -1,0 +1,4 @@
+blk_pool$(nW)TEST34: START: blk_pool
+ $(nW)blk_pool$(nW) c $(nW)testfile 4096 20 0600
+$(nW)testfile: file size 20971520 usable blocks 4820 mode 0600
+blk_pool$(nW)TEST34: DONE

--- a/src/test/blk_pool/out35.log.match
+++ b/src/test/blk_pool/out35.log.match
@@ -1,0 +1,4 @@
+blk_pool$(nW)TEST35: START: blk_pool
+ $(nW)blk_pool$(nW) c $(nW)testfile 4096 0 0600
+$(nW)testfile: file size 41943040 usable blocks 9935 mode 0600
+blk_pool$(nW)TEST35: DONE

--- a/src/test/blk_pool/out36.log.match
+++ b/src/test/blk_pool/out36.log.match
@@ -1,0 +1,4 @@
+blk_pool$(nW)TEST36: START: blk_pool
+ $(nW)blk_pool$(nW) c $(nW)testfile 4096 0 0600
+$(nW)testfile: pmemblk_create: File exists
+blk_pool$(nW)TEST36: DONE

--- a/src/test/blk_pool/out37.log.match
+++ b/src/test/blk_pool/out37.log.match
@@ -1,0 +1,4 @@
+blk_pool$(nW)TEST37: START: blk_pool
+ $(nW)blk_pool$(nW) c $(nW)testfile 10 20 0600
+$(nW)testfile: file size 20971520 usable blocks 40076 mode 0600
+blk_pool$(nW)TEST37: DONE

--- a/src/test/blk_pool/out38.log.match
+++ b/src/test/blk_pool/out38.log.match
@@ -1,0 +1,4 @@
+blk_pool$(nW)TEST38: START: blk_pool
+ $(nW)blk_pool$(nW) c $(nW)testset 100 0 0640
+$(nW)testset: file size 172 usable blocks 80592 mode 0666
+blk_pool$(nW)TEST38: DONE

--- a/src/test/blk_pool/out39.log.match
+++ b/src/test/blk_pool/out39.log.match
@@ -1,0 +1,4 @@
+blk_pool$(nW)TEST39: START: blk_pool
+ $(nW)blk_pool$(nW) c $(nW)ㅹestㆅile 4096 20 0600
+$(nW)ㅹestㆅile: file size 20971520 usable blocks 4820 mode 0600
+blk_pool$(nW)TEST39: DONE

--- a/src/test/blk_pool/out40.log.match
+++ b/src/test/blk_pool/out40.log.match
@@ -1,0 +1,4 @@
+blk_pool$(nW)TEST40: START: blk_pool
+ $(nW)blk_pool$(nW) c $(nW)testset 100 0 0640
+$(nW)testset: file size 768 usable blocks 34996 mode 0666
+blk_pool$(nW)TEST40: DONE

--- a/src/test/blk_rw/TEST0
+++ b/src/test/blk_rw/TEST0
@@ -39,6 +39,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+exclude_ppc64
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem

--- a/src/test/blk_rw/TEST1
+++ b/src/test/blk_rw/TEST1
@@ -38,6 +38,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+exclude_ppc64
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem

--- a/src/test/blk_rw/TEST14
+++ b/src/test/blk_rw/TEST14
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
 # Copyright 2014-2019, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,28 +34,31 @@
 #
 
 #
-# src/test/blk_rw/TEST6 -- unit test for pmemblk_read/write/set_zero/set_error
+# src/test/blk_rw/TEST14 -- unit test for pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST0 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
 
 require_test_type medium
-exclude_ppc64
+require_ppc64
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
 
 setup
 
-# mix writes with set_zero and set_error and check results
-truncate -s 1G $DIR/testfile1
+# single arena and minimum pmemblk pool file case
+MIN_POOL_SIZE=$((16*1024*1024 + 128*1024))
+truncate -s $MIN_POOL_SIZE $DIR/testfile1
+#
+# All reads to an unwritten block pool should return zeros.
+# Block 32313 is out of range and should return EINVAL.
+# Attempts to zero uninitialized blocks are nops (should succeed).
+#
 expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testfile1 c\
-		e:1 r:1\
-		e:2 w:2 r:2\
-		z:3 e:3 r:3\
-		e:4 z:4 r:4\
-		w:5 e:5 z:5 r:5\
-		w:6 z:6 e:6 r:6
+	r:0 r:1 r:32201 r:32313 z:0 z:1 r:0
 
 check_pool $DIR/testfile1
 

--- a/src/test/blk_rw/TEST15
+++ b/src/test/blk_rw/TEST15
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # Copyright 2014-2019, Intel Corporation
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,28 +33,34 @@
 #
 
 #
-# src/test/blk_rw/TEST6 -- unit test for pmemblk_read/write/set_zero/set_error
+# src/test/blk_rw/TEST15 -- unit test for pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST1 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
 
 require_test_type medium
-exclude_ppc64
+require_ppc64
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
+require_unlimited_vm
+
+# this test creates huge file
+configure_valgrind force-disable
 
 setup
 
-# mix writes with set_zero and set_error and check results
-truncate -s 1G $DIR/testfile1
+# multi-arena case
+truncate -s 1026G $DIR/testfile1
+#
+# All reads to an unwritten block pool should return zeros.
+# Block 2134997374 is out of range and should return EINVAL.
+# Attempts to zero uninitialized blocks are nops (should succeed).
+#
 expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testfile1 c\
-		e:1 r:1\
-		e:2 w:2 r:2\
-		z:3 e:3 r:3\
-		e:4 z:4 r:4\
-		w:5 e:5 z:5 r:5\
-		w:6 z:6 e:6 r:6
+	r:0 r:1 r:4161480 r:2134997087 r:2134997088 z:0 z:4161480
 
 check_pool $DIR/testfile1
 

--- a/src/test/blk_rw/TEST16
+++ b/src/test/blk_rw/TEST16
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # Copyright 2014-2019, Intel Corporation
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,28 +33,34 @@
 #
 
 #
-# src/test/blk_rw/TEST6 -- unit test for pmemblk_read/write/set_zero/set_error
+# src/test/blk_rw/TEST16 -- unit test for pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST2 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
 
 require_test_type medium
-exclude_ppc64
+require_ppc64
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
+require_unlimited_vm
+
+# this test creates huge file
+configure_valgrind force-disable
 
 setup
 
-# mix writes with set_zero and set_error and check results
-truncate -s 1G $DIR/testfile1
-expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testfile1 c\
-		e:1 r:1\
-		e:2 w:2 r:2\
-		z:3 e:3 r:3\
-		e:4 z:4 r:4\
-		w:5 e:5 z:5 r:5\
-		w:6 z:6 e:6 r:6
+# multi-arena case
+truncate -s 1026G $DIR/testfile1
+#
+# All reads to an unwritten block pool should return zeros.
+# Block 268696557 is out of range and should return EINVAL.
+# Attempts to zero uninitialized blocks are nops (should succeed).
+#
+expect_normal_exit ./blk_rw$EXESUFFIX 4096 $DIR/testfile1 c\
+	r:0 r:1 r:4161480 r:268696520 r:268696521 z:0 z:4161480
 
 check_pool $DIR/testfile1
 

--- a/src/test/blk_rw/TEST17
+++ b/src/test/blk_rw/TEST17
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # Copyright 2014-2019, Intel Corporation
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,28 +33,25 @@
 #
 
 #
-# src/test/blk_rw/TEST6 -- unit test for pmemblk_read/write/set_zero/set_error
+# src/test/blk_rw/TEST17 -- unit test for pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST3 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
 
 require_test_type medium
-exclude_ppc64
+require_ppc64
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
 
 setup
 
-# mix writes with set_zero and set_error and check results
+# single arena write case
 truncate -s 1G $DIR/testfile1
 expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testfile1 c\
-		e:1 r:1\
-		e:2 w:2 r:2\
-		z:3 e:3 r:3\
-		e:4 z:4 r:4\
-		w:5 e:5 z:5 r:5\
-		w:6 z:6 e:6 r:6
+	w:0 r:1 r:0 w:1 r:0 r:1 r:2
 
 check_pool $DIR/testfile1
 

--- a/src/test/blk_rw/TEST18
+++ b/src/test/blk_rw/TEST18
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # Copyright 2014-2019, Intel Corporation
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,28 +33,27 @@
 #
 
 #
-# src/test/blk_rw/TEST6 -- unit test for pmemblk_read/write/set_zero/set_error
+# src/test/blk_rw/TEST18 -- unit test for pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST4 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
 
 require_test_type medium
-exclude_ppc64
+require_ppc64
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
 
 setup
 
-# mix writes with set_zero and set_error and check results
+# write re-use test case
 truncate -s 1G $DIR/testfile1
 expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testfile1 c\
-		e:1 r:1\
-		e:2 w:2 r:2\
-		z:3 e:3 r:3\
-		e:4 z:4 r:4\
-		w:5 e:5 z:5 r:5\
-		w:6 z:6 e:6 r:6
+	w:0 w:1 w:2 w:3 w:4 r:4 r:3 r:2 r:1 r:0
+expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testfile1 o\
+	w:0 r:4 r:3 r:2 r:1 r:0 w:0 r:0
 
 check_pool $DIR/testfile1
 

--- a/src/test/blk_rw/TEST19
+++ b/src/test/blk_rw/TEST19
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # Copyright 2014-2019, Intel Corporation
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,13 +33,15 @@
 #
 
 #
-# src/test/blk_rw/TEST6 -- unit test for pmemblk_read/write/set_zero/set_error
+# src/test/blk_rw/TEST19 -- unit test for pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST5 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
 
 require_test_type medium
-exclude_ppc64
+require_ppc64
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
@@ -48,12 +51,12 @@ setup
 # mix writes with set_zero and set_error and check results
 truncate -s 1G $DIR/testfile1
 expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testfile1 c\
-		e:1 r:1\
-		e:2 w:2 r:2\
-		z:3 e:3 r:3\
-		e:4 z:4 r:4\
-		w:5 e:5 z:5 r:5\
-		w:6 z:6 e:6 r:6
+	w:100 w:200 w:300 w:400\
+	r:100 r:200 r:300 r:400\
+	w:100 z:200 w:300 z:400\
+	r:100 r:200 r:300 r:400\
+	e:100 w:200 e:300 w:400\
+	r:100 r:200 r:300 r:400
 
 check_pool $DIR/testfile1
 

--- a/src/test/blk_rw/TEST2
+++ b/src/test/blk_rw/TEST2
@@ -38,6 +38,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+exclude_ppc64
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem

--- a/src/test/blk_rw/TEST20
+++ b/src/test/blk_rw/TEST20
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # Copyright 2014-2019, Intel Corporation
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,13 +33,15 @@
 #
 
 #
-# src/test/blk_rw/TEST6 -- unit test for pmemblk_read/write/set_zero/set_error
+# src/test/blk_rw/TEST20 -- unit test for pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST6 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
 
 require_test_type medium
-exclude_ppc64
+require_ppc64
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem

--- a/src/test/blk_rw/TEST21
+++ b/src/test/blk_rw/TEST21
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Copyright 2014-2019, Intel Corporation
+# Copyright 2015-2019, Intel Corporation
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,21 +33,23 @@
 #
 
 #
-# src/test/blk_rw/TEST6 -- unit test for pmemblk_read/write/set_zero/set_error
+# src/test/blk_rw/TEST21 -- unit test for pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST7 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
 
-require_test_type medium
-exclude_ppc64
-
-# doesn't make sense to run in local directory
-require_fs_type pmem non-pmem
-
+# long test, run only on pmem
+require_ppc64
+require_fs_type pmem
+require_test_type long
+configure_valgrind pmemcheck force-enable
 setup
 
 # mix writes with set_zero and set_error and check results
-truncate -s 1G $DIR/testfile1
+truncate -s 128M $DIR/testfile1
+
 expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testfile1 c\
 		e:1 r:1\
 		e:2 w:2 r:2\

--- a/src/test/blk_rw/TEST22
+++ b/src/test/blk_rw/TEST22
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Copyright 2014-2019, Intel Corporation
+# Copyright 2015-2019, Intel Corporation
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,30 +33,30 @@
 #
 
 #
-# src/test/blk_rw/TEST6 -- unit test for pmemblk_read/write/set_zero/set_error
+# src/test/blk_rw/TEST22 -- unit test for pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST8 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
 
 require_test_type medium
-exclude_ppc64
+require_ppc64
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
 
 setup
 
-# mix writes with set_zero and set_error and check results
-truncate -s 1G $DIR/testfile1
-expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testfile1 c\
-		e:1 r:1\
-		e:2 w:2 r:2\
-		z:3 e:3 r:3\
-		e:4 z:4 r:4\
-		w:5 e:5 z:5 r:5\
-		w:6 z:6 e:6 r:6
+require_free_space 2G
 
-check_pool $DIR/testfile1
+create_poolset $DIR/testset1 1G:$DIR/testfile1:x 1G:$DIR/testfile2:x
+
+expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testset1 c\
+	w:0 w:1 r:1 r:0\
+	w:4161096 r:4161096
+
+check_pool $DIR/testfile2
 
 check
 

--- a/src/test/blk_rw/TEST23
+++ b/src/test/blk_rw/TEST23
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Copyright 2014-2019, Intel Corporation
+# Copyright 2015-2019, Intel Corporation
+# Copyright 2019, IBM Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,30 +33,27 @@
 #
 
 #
-# src/test/blk_rw/TEST6 -- unit test for pmemblk_read/write/set_zero/set_error
+# src/test/blk_rw/TEST23 -- unit test for pmemblk_read/write/set_zero/set_error
+#
+# This test is equivalent of TEST9 for ppc64le platform.
 #
 
 . ../unittest/unittest.sh
 
 require_test_type medium
-exclude_ppc64
+require_ppc64
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem
 
 setup
 
-# mix writes with set_zero and set_error and check results
-truncate -s 1G $DIR/testfile1
-expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testfile1 c\
-		e:1 r:1\
-		e:2 w:2 r:2\
-		z:3 e:3 r:3\
-		e:4 z:4 r:4\
-		w:5 e:5 z:5 r:5\
-		w:6 z:6 e:6 r:6
+require_free_space 2G
 
-check_pool $DIR/testfile1
+create_poolset $DIR/testset1 1G:$DIR/testfile1:x 1G:$DIR/testfile2:x
+
+expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testset1 c\
+	w:-1 r:-1 z:-1 e:-1
 
 check
 

--- a/src/test/blk_rw/TEST3
+++ b/src/test/blk_rw/TEST3
@@ -38,6 +38,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+exclude_ppc64
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem

--- a/src/test/blk_rw/TEST4
+++ b/src/test/blk_rw/TEST4
@@ -36,6 +36,7 @@
 #
 
 . ../unittest/unittest.sh
+exclude_ppc64
 
 require_test_type medium
 

--- a/src/test/blk_rw/TEST5
+++ b/src/test/blk_rw/TEST5
@@ -38,6 +38,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+exclude_ppc64
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem

--- a/src/test/blk_rw/TEST7
+++ b/src/test/blk_rw/TEST7
@@ -38,6 +38,7 @@
 . ../unittest/unittest.sh
 
 # long test, run only on pmem
+exclude_ppc64
 require_fs_type pmem
 require_test_type long
 configure_valgrind pmemcheck force-enable

--- a/src/test/blk_rw/TEST8
+++ b/src/test/blk_rw/TEST8
@@ -38,6 +38,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+exclude_ppc64
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem

--- a/src/test/blk_rw/TEST9
+++ b/src/test/blk_rw/TEST9
@@ -38,6 +38,7 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
+exclude_ppc64
 
 # doesn't make sense to run in local directory
 require_fs_type pmem non-pmem

--- a/src/test/blk_rw/out14.log.match
+++ b/src/test/blk_rw/out14.log.match
@@ -1,0 +1,11 @@
+blk_rw$(nW)TEST14: START: blk_rw
+ $(nW)blk_rw$(nW) 512 $(nW)testfile1 c r:0 r:1 r:32201 r:32313 z:0 z:1 r:0
+512 block size 512 usable blocks 32202
+read      lba 0: {0}
+read      lba 1: {0}
+read      lba 32201: {0}
+read      lba 32313: Invalid argument
+set_zero  lba 0
+set_zero  lba 1
+read      lba 0: {0}
+blk_rw$(nW)TEST14: DONE

--- a/src/test/blk_rw/out15.log.match
+++ b/src/test/blk_rw/out15.log.match
@@ -1,0 +1,11 @@
+blk_rw$(nW)TEST15: START: blk_rw
+ $(nW)blk_rw$(nW) 512 $(nW)testfile1 c r:0 r:1 r:4161480 r:2134997087 r:2134997088 z:0 z:4161480
+512 block size 512 usable blocks 2134997088
+read      lba 0: {0}
+read      lba 1: {0}
+read      lba 4161480: {0}
+read      lba 2134997087: {0}
+read      lba 2134997088: Invalid argument
+set_zero  lba 0
+set_zero  lba 4161480
+blk_rw$(nW)TEST15: DONE

--- a/src/test/blk_rw/out16.log.match
+++ b/src/test/blk_rw/out16.log.match
@@ -1,0 +1,11 @@
+blk_rw$(nW)TEST16: START: blk_rw
+ $(nW)blk_rw$(nW) 4096 $(nW)testfile1 c r:0 r:1 r:4161480 r:268696520 r:268696521 z:0 z:4161480
+4096 block size 4096 usable blocks 268696521
+read      lba 0: {0}
+read      lba 1: {0}
+read      lba 4161480: {0}
+read      lba 268696520: {0}
+read      lba 268696521: Invalid argument
+set_zero  lba 0
+set_zero  lba 4161480
+blk_rw$(nW)TEST16: DONE

--- a/src/test/blk_rw/out17.log.match
+++ b/src/test/blk_rw/out17.log.match
@@ -1,0 +1,11 @@
+blk_rw$(nW)TEST17: START: blk_rw
+ $(nW)blk_rw$(nW) 512 $(nW)testfile1 c w:0 r:1 r:0 w:1 r:0 r:1 r:2
+512 block size 512 usable blocks 2080329
+write     lba 0: {1}
+read      lba 1: {0}
+read      lba 0: {1}
+write     lba 1: {2}
+read      lba 0: {1}
+read      lba 1: {2}
+read      lba 2: {0}
+blk_rw$(nW)TEST17: DONE

--- a/src/test/blk_rw/out18.log.match
+++ b/src/test/blk_rw/out18.log.match
@@ -1,0 +1,12 @@
+blk_rw$(nW)TEST18: START: blk_rw
+ $(nW)blk_rw$(nW) 512 $(nW)testfile1 o w:0 r:4 r:3 r:2 r:1 r:0 w:0 r:0
+512 block size 512 usable blocks 2080329
+write     lba 0: {1}
+read      lba 4: {5}
+read      lba 3: {4}
+read      lba 2: {3}
+read      lba 1: {2}
+read      lba 0: {1}
+write     lba 0: {2}
+read      lba 0: {2}
+blk_rw$(nW)TEST18: DONE

--- a/src/test/blk_rw/out19.log.match
+++ b/src/test/blk_rw/out19.log.match
@@ -1,0 +1,28 @@
+blk_rw$(nW)TEST19: START: blk_rw
+ $(nW)blk_rw$(nW) 512 $(nW)testfile1 c w:100 w:200 w:300 w:400 r:100 r:200 r:300 r:400 w:100 z:200 w:300 z:400 r:100 r:200 r:300 r:400 e:100 w:200 e:300 w:400 r:100 r:200 r:300 r:400
+512 block size 512 usable blocks 2080329
+write     lba 100: {1}
+write     lba 200: {2}
+write     lba 300: {3}
+write     lba 400: {4}
+read      lba 100: {1}
+read      lba 200: {2}
+read      lba 300: {3}
+read      lba 400: {4}
+write     lba 100: {5}
+set_zero  lba 200
+write     lba 300: {6}
+set_zero  lba 400
+read      lba 100: {5}
+read      lba 200: {0}
+read      lba 300: {6}
+read      lba 400: {0}
+set_error lba 100
+write     lba 200: {7}
+set_error lba 300
+write     lba 400: {8}
+read      lba 100: Input/output error
+read      lba 200: {7}
+read      lba 300: Input/output error
+read      lba 400: {8}
+blk_rw$(nW)TEST19: DONE

--- a/src/test/blk_rw/out20.log.match
+++ b/src/test/blk_rw/out20.log.match
@@ -1,0 +1,23 @@
+blk_rw$(nW)TEST20: START: blk_rw
+ $(nW)blk_rw$(nW) 512 $(nW)testfile1 c e:1 r:1 e:2 w:2 r:2 z:3 e:3 r:3 e:4 z:4 r:4 w:5 e:5 z:5 r:5 w:6 z:6 e:6 r:6
+512 block size 512 usable blocks 2080329
+set_error lba 1
+read      lba 1: Input/output error
+set_error lba 2
+write     lba 2: {1}
+read      lba 2: {1}
+set_zero  lba 3
+set_error lba 3
+read      lba 3: Input/output error
+set_error lba 4
+set_zero  lba 4
+read      lba 4: {0}
+write     lba 5: {2}
+set_error lba 5
+set_zero  lba 5
+read      lba 5: {0}
+write     lba 6: {3}
+set_zero  lba 6
+set_error lba 6
+read      lba 6: Input/output error
+blk_rw$(nW)TEST20: DONE

--- a/src/test/blk_rw/out22.log.match
+++ b/src/test/blk_rw/out22.log.match
@@ -1,0 +1,10 @@
+blk_rw$(nW)TEST22: START: blk_rw
+ $(nW)blk_rw$(nW) 512 $(nW)testset1 c w:0 w:1 r:1 r:0 w:4161096 r:4161096
+512 block size 512 usable blocks 4161097
+write     lba 0: {1}
+write     lba 1: {2}
+read      lba 1: {2}
+read      lba 0: {1}
+write     lba 4161096: {3}
+read      lba 4161096: {3}
+blk_rw$(nW)TEST22: DONE

--- a/src/test/blk_rw/out23.log.match
+++ b/src/test/blk_rw/out23.log.match
@@ -1,0 +1,8 @@
+blk_rw$(nW)TEST23: START: blk_rw
+ $(nW)blk_rw$(nW) 512 $(nW)testset1 c w:-1 r:-1 z:-1 e:-1
+512 block size 512 usable blocks 4161097
+write     lba -1: Invalid argument
+read      lba -1: Invalid argument
+set_zero  lba -1: Invalid argument
+set_error lba -1: Invalid argument
+blk_rw$(nW)TEST23: DONE

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -2588,6 +2588,17 @@ function log_pool_desc_size() {
 }
 
 #
+# blk_pool_desc_size -- returns the minimum size of pool header
+# in bytes which is two times the actual pagesize.
+#
+# This should be use to calculate the minimum zero size for pool
+# creation on some tests.
+#
+function blk_pool_desc_size() {
+	echo "$(expr $(getconf PAGESIZE) \* 2)"
+}
+
+#
 # create_holey_file_on_node -- create holey files of a given length
 #   usage: create_holey_file_on_node <node> <size>
 #


### PR DESCRIPTION
This is a initial ppc64le port for libpmemblk.
At this point all `blk_*` tests should be passing 
for ppc64le and x86_64.

One point of discussion is if `BTT_ALIGNMENT`
should change to `PMEM_PAGESIZE`. What are
implications of changing it? For now I kept it as 
`4096`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4367)
<!-- Reviewable:end -->
