### PR TITLE
get rid of $(nW)$(nW) in tests

### DIFF
--- a/src/test/blk_rw/out0.log.match
+++ b/src/test/blk_rw/out0.log.match
@@ -1,5 +1,5 @@
 blk_rw$(nW)TEST0: START: blk_rw
- $(nW)blk_rw$(nW) 512 $(nW)$(nW)testfile1 c r:0 r:1 r:32201 r:32313 z:0 z:1 r:0
+ $(nW)blk_rw$(nW) 512 $(nW)testfile1 c r:0 r:1 r:32201 r:32313 z:0 z:1 r:0
 512 block size 512 usable blocks 32313
 read      lba 0: {0}
 read      lba 1: {0}

--- a/src/test/blk_rw/out1.log.match
+++ b/src/test/blk_rw/out1.log.match
@@ -1,5 +1,5 @@
 blk_rw$(nW)TEST1: START: blk_rw
- $(nW)blk_rw$(nW) 512 $(nW)$(nW)testfile1 c r:0 r:1 r:4161480 r:2134997325 r:2134997326 z:0 z:4161480
+ $(nW)blk_rw$(nW) 512 $(nW)testfile1 c r:0 r:1 r:4161480 r:2134997325 r:2134997326 z:0 z:4161480
 512 block size 512 usable blocks 2134997326
 read      lba 0: {0}
 read      lba 1: {0}

--- a/src/test/blk_rw/out2.log.match
+++ b/src/test/blk_rw/out2.log.match
@@ -1,5 +1,5 @@
 blk_rw$(nW)TEST2: START: blk_rw
- $(nW)blk_rw$(nW) 4096 $(nW)$(nW)testfile1 c r:0 r:1 r:4161480 r:268696550 r:268696551 z:0 z:4161480
+ $(nW)blk_rw$(nW) 4096 $(nW)testfile1 c r:0 r:1 r:4161480 r:268696550 r:268696551 z:0 z:4161480
 4096 block size 4096 usable blocks 268696551
 read      lba 0: {0}
 read      lba 1: {0}

--- a/src/test/blk_rw/out3.log.match
+++ b/src/test/blk_rw/out3.log.match
@@ -1,5 +1,5 @@
 blk_rw$(nW)TEST3: START: blk_rw
- $(nW)blk_rw$(nW) 512 $(nW)$(nW)testfile1 c w:0 r:1 r:0 w:1 r:0 r:1 r:2
+ $(nW)blk_rw$(nW) 512 $(nW)testfile1 c w:0 r:1 r:0 w:1 r:0 r:1 r:2
 512 block size 512 usable blocks 2080567
 write     lba 0: {1}
 read      lba 1: {0}

--- a/src/test/blk_rw/out4.log.match
+++ b/src/test/blk_rw/out4.log.match
@@ -1,5 +1,5 @@
 blk_rw$(nW)TEST4: START: blk_rw
- $(nW)blk_rw$(nW) 512 $(nW)$(nW)testfile1 o w:0 r:4 r:3 r:2 r:1 r:0 w:0 r:0
+ $(nW)blk_rw$(nW) 512 $(nW)testfile1 o w:0 r:4 r:3 r:2 r:1 r:0 w:0 r:0
 512 block size 512 usable blocks 2080567
 write     lba 0: {1}
 read      lba 4: {5}

--- a/src/test/blk_rw/out5.log.match
+++ b/src/test/blk_rw/out5.log.match
@@ -1,5 +1,5 @@
 blk_rw$(nW)TEST5: START: blk_rw
- $(nW)blk_rw$(nW) 512 $(nW)$(nW)testfile1 c w:100 w:200 w:300 w:400 r:100 r:200 r:300 r:400 w:100 z:200 w:300 z:400 r:100 r:200 r:300 r:400 e:100 w:200 e:300 w:400 r:100 r:200 r:300 r:400
+ $(nW)blk_rw$(nW) 512 $(nW)testfile1 c w:100 w:200 w:300 w:400 r:100 r:200 r:300 r:400 w:100 z:200 w:300 z:400 r:100 r:200 r:300 r:400 e:100 w:200 e:300 w:400 r:100 r:200 r:300 r:400
 512 block size 512 usable blocks 2080567
 write     lba 100: {1}
 write     lba 200: {2}

--- a/src/test/blk_rw/out6.log.match
+++ b/src/test/blk_rw/out6.log.match
@@ -1,5 +1,5 @@
 blk_rw$(nW)TEST6: START: blk_rw
- $(nW)blk_rw$(nW) 512 $(nW)$(nW)testfile1 c e:1 r:1 e:2 w:2 r:2 z:3 e:3 r:3 e:4 z:4 r:4 w:5 e:5 z:5 r:5 w:6 z:6 e:6 r:6
+ $(nW)blk_rw$(nW) 512 $(nW)testfile1 c e:1 r:1 e:2 w:2 r:2 z:3 e:3 r:3 e:4 z:4 r:4 w:5 e:5 z:5 r:5 w:6 z:6 e:6 r:6
 512 block size 512 usable blocks 2080567
 set_error lba 1
 read      lba 1: Input/output error

--- a/src/test/blk_rw/out7.log.match
+++ b/src/test/blk_rw/out7.log.match
@@ -1,5 +1,5 @@
 blk_rw$(nW)TEST7: START: blk_rw
- $(nW)blk_rw$(nW) 512 $(nW)$(nW)testfile1 c e:1 r:1 e:2 w:2 r:2 z:3 e:3 r:3 e:4 z:4 r:4 w:5 e:5 z:5 r:5 w:6 z:6 e:6 r:6
+ $(nW)blk_rw$(nW) 512 $(nW)testfile1 c e:1 r:1 e:2 w:2 r:2 z:3 e:3 r:3 e:4 z:4 r:4 w:5 e:5 z:5 r:5 w:6 z:6 e:6 r:6
 512 block size 512 usable blocks 259784
 set_error lba 1
 read      lba 1: Input/output error

--- a/src/test/blk_rw/out8.log.match
+++ b/src/test/blk_rw/out8.log.match
@@ -1,5 +1,5 @@
 blk_rw$(nW)TEST8: START: blk_rw
- $(nW)blk_rw$(nW) 512 $(nW)$(nW)testset1 c w:0 w:1 r:1 r:0 w:4161445 r:4161445
+ $(nW)blk_rw$(nW) 512 $(nW)testset1 c w:0 w:1 r:1 r:0 w:4161445 r:4161445
 512 block size 512 usable blocks 4161454
 write     lba 0: {1}
 write     lba 1: {2}

--- a/src/test/blk_rw/out8w.log.match
+++ b/src/test/blk_rw/out8w.log.match
@@ -1,5 +1,5 @@
 blk_rw$(nW)TEST8w: START: blk_rw
- $(nW)blk_rw$(nW) 512 $(nW)$(nW)testset1 c w:0 w:1 r:1 r:0 w:4161325 r:4161325
+ $(nW)blk_rw$(nW) 512 $(nW)testset1 c w:0 w:1 r:1 r:0 w:4161325 r:4161325
 512 block size 512 usable blocks 4161335
 write     lba 0: {1}
 write     lba 1: {2}

--- a/src/test/blk_rw/out9.log.match
+++ b/src/test/blk_rw/out9.log.match
@@ -1,5 +1,5 @@
 blk_rw$(nW)TEST9: START: blk_rw
- $(nW)blk_rw$(nW) 512 $(nW)$(nW)testset1 c w:-1 r:-1 z:-1 e:-1
+ $(nW)blk_rw$(nW) 512 $(nW)testset1 c w:-1 r:-1 z:-1 e:-1
 512 block size 512 usable blocks 4161454
 write     lba -1: Invalid argument
 read      lba -1: Invalid argument

--- a/src/test/blk_rw/out9w.log.match
+++ b/src/test/blk_rw/out9w.log.match
@@ -1,5 +1,5 @@
 blk_rw$(nW)TEST9w: START: blk_rw
- $(nW)blk_rw$(nW) 512 $(nW)$(nW)testset1 c w:-1 r:-1 z:-1 e:-1
+ $(nW)blk_rw$(nW) 512 $(nW)testset1 c w:-1 r:-1 z:-1 e:-1
 512 block size 512 usable blocks 4161335
 write     lba -1: Invalid argument
 read      lba -1: Invalid argument

--- a/src/test/blk_rw_mt/out1.log.match
+++ b/src/test/blk_rw_mt/out1.log.match
@@ -1,4 +1,4 @@
 blk_rw_mt$(nW)TEST1: START: blk_rw_mt
- $(nW)blk_rw_mt$(nW) 4096 $(nW)$(nW)testfile1 456 100 100
+ $(nW)blk_rw_mt$(nW) 4096 $(nW)testfile1 456 100 100
 4096 block size 4096 usable blocks 100
 blk_rw_mt$(nW)TEST1: DONE

--- a/src/test/blk_rw_mt/out2.log.match
+++ b/src/test/blk_rw_mt/out2.log.match
@@ -1,4 +1,4 @@
 blk_rw_mt$(nW)TEST2: START: blk_rw_mt
- $(nW)blk_rw_mt$(nW) 4096 $(nW)$(nW)testfile1 789 300 100000
+ $(nW)blk_rw_mt$(nW) 4096 $(nW)testfile1 789 300 100000
 4096 block size 4096 usable blocks 100
 blk_rw_mt$(nW)TEST2: DONE

--- a/src/test/obj_basic_integration/out1.log.match
+++ b/src/test/obj_basic_integration/out1.log.match
@@ -1,5 +1,5 @@
 obj_basic_integration$(nW)TEST1: START: obj_basic_integration
- $(nW)obj_basic_integration$(nW) $(nW)$(nW)testfile1
+ $(nW)obj_basic_integration$(nW) $(nW)testfile1
 alloc: 128, size: $(N)
 realloc: 128 => 655360, size: $(N)
 realloc: 655360 => 1, size: $(N)

--- a/src/test/obj_tx_locks_abort/out0.log.match
+++ b/src/test/obj_tx_locks_abort/out0.log.match
@@ -1,5 +1,5 @@
 obj_tx_locks_abort$(nW)TEST0: START: obj_tx_locks_abort
- $(nW)obj_tx_locks_abort$(nW) $(nW)$(nW)testfile1
+ $(nW)obj_tx_locks_abort$(nW) $(nW)testfile1
 initial state
 data = 100
 data = 101

--- a/src/test/obj_tx_locks_abort/out1.log.match
+++ b/src/test/obj_tx_locks_abort/out1.log.match
@@ -1,5 +1,5 @@
 obj_tx_locks_abort$(nW)TEST1: START: obj_tx_locks_abort
- $(nW)obj_tx_locks_abort$(nW) $(nW)$(nW)testfile1
+ $(nW)obj_tx_locks_abort$(nW) $(nW)testfile1
 initial state
 data = 100
 data = 101

--- a/src/test/obj_tx_locks_abort/out2.log.match
+++ b/src/test/obj_tx_locks_abort/out2.log.match
@@ -1,5 +1,5 @@
 obj_tx_locks_abort$(nW)TEST2: START: obj_tx_locks_abort
- $(nW)obj_tx_locks_abort$(nW) $(nW)$(nW)testfile1
+ $(nW)obj_tx_locks_abort$(nW) $(nW)testfile1
 initial state
 data = 100
 data = 101


### PR DESCRIPTION
lucmaga noticed and dropped them when copying ppc64 parts, let's drop them elsewhere as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4387)
<!-- Reviewable:end -->
