### PR TITLE
pmem: fix pmemcheck support on platforms with eADR

### DIFF
--- a/src/libpmem/libpmem.vcxproj
+++ b/src/libpmem/libpmem.vcxproj
@@ -42,6 +42,7 @@
     <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_nt_sse2_clflushopt.c" />
     <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_nt_sse2_clwb.c" />
     <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_nt_sse2_empty.c" />
+    <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_nt_sse2_noflush.c" />
     <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_nt_avx_clflush.c">
       <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
@@ -58,10 +59,15 @@
       <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
     </ClCompile>
+    <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_nt_avx_noflush.c">
+      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+    </ClCompile>
     <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_t_sse2_clflush.c" />
     <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_t_sse2_clflushopt.c" />
     <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_t_sse2_clwb.c" />
     <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_t_sse2_empty.c" />
+    <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_t_sse2_noflush.c" />
     <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_t_avx_clflush.c">
       <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
@@ -78,10 +84,15 @@
       <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
     </ClCompile>
+    <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_t_avx_noflush.c">
+      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+    </ClCompile>
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_nt_sse2_clflush.c" />
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_nt_sse2_clflushopt.c" />
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_nt_sse2_clwb.c" />
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_nt_sse2_empty.c" />
+    <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_nt_sse2_noflush.c" />
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_nt_avx_clflush.c">
       <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
@@ -98,10 +109,15 @@
       <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
     </ClCompile>
+    <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_nt_avx_noflush.c">
+      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+    </ClCompile>
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_t_sse2_clflush.c" />
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_t_sse2_clflushopt.c" />
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_t_sse2_clwb.c" />
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_t_sse2_empty.c" />
+    <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_t_sse2_noflush.c" />
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_t_avx_clflush.c">
       <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
@@ -115,6 +131,10 @@
       <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
     </ClCompile>
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_t_avx_empty.c">
+      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_t_avx_noflush.c">
       <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
     </ClCompile>

--- a/src/libpmem/libpmem.vcxproj.filters
+++ b/src/libpmem/libpmem.vcxproj.filters
@@ -101,6 +101,9 @@
     <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_nt_sse2_empty.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_nt_sse2_noflush.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_nt_avx_clflush.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -111,6 +114,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_nt_avx_empty.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_nt_avx_noflush.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_t_sse2_clflush.c">
@@ -125,6 +131,9 @@
     <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_t_sse2_empty.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_t_sse2_noflush.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_t_avx_clflush.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -135,6 +144,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_t_avx_empty.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\libpmem\x86_64\memcpy\memcpy_t_avx_noflush.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_nt_sse2_clflush.c">
@@ -149,6 +161,9 @@
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_nt_sse2_empty.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_nt_sse2_noflush.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_nt_avx_clflush.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -159,6 +174,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_nt_avx_empty.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_nt_avx_noflush.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_t_sse2_clflush.c">
@@ -173,6 +191,9 @@
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_t_sse2_empty.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_t_sse2_noflush.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_t_avx_clflush.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -183,6 +204,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_t_avx_empty.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\libpmem\x86_64\memset\memset_t_avx_noflush.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\common\os_auto_flush_windows.c">

--- a/src/libpmem/pmem.h
+++ b/src/libpmem/pmem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,6 +39,7 @@
 #include <stddef.h>
 #include "libpmem.h"
 #include "util.h"
+#include "valgrind_internal.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -78,7 +79,8 @@ void *pmem_map_register(int fd, size_t len, const char *path, int is_dev_dax);
 static force_inline void
 flush_empty_nolog(const void *addr, size_t len)
 {
-	/* NOP */
+	/* NOP, but tell pmemcheck about it */
+	VALGRIND_DO_FLUSH(addr, len);
 }
 
 /*
@@ -87,6 +89,8 @@ flush_empty_nolog(const void *addr, size_t len)
 static force_inline void
 flush64b_empty(const char *addr)
 {
+	/* NOP, but tell pmemcheck about it */
+	VALGRIND_DO_FLUSH(addr, 64);
 }
 
 /*

--- a/src/libpmem/x86_64/flags.inc
+++ b/src/libpmem/x86_64/flags.inc
@@ -1,4 +1,4 @@
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -41,35 +41,43 @@ $(objdir)/memcpy_nt_avx512f_clflush.o: CFLAGS += -mavx512f
 $(objdir)/memcpy_nt_avx512f_clflushopt.o: CFLAGS += -mavx512f
 $(objdir)/memcpy_nt_avx512f_clwb.o: CFLAGS += -mavx512f
 $(objdir)/memcpy_nt_avx512f_empty.o: CFLAGS += -mavx512f
+$(objdir)/memcpy_nt_avx512f_noflush.o: CFLAGS += -mavx512f
 $(objdir)/memset_nt_avx512f_clflush.o: CFLAGS += -mavx512f
 $(objdir)/memset_nt_avx512f_clflushopt.o: CFLAGS += -mavx512f
 $(objdir)/memset_nt_avx512f_clwb.o: CFLAGS += -mavx512f
 $(objdir)/memset_nt_avx512f_empty.o: CFLAGS += -mavx512f
+$(objdir)/memset_nt_avx512f_noflush.o: CFLAGS += -mavx512f
 $(objdir)/memcpy_nt_avx_clflush.o: CFLAGS += -mavx
 $(objdir)/memcpy_nt_avx_clflushopt.o: CFLAGS += -mavx
 $(objdir)/memcpy_nt_avx_clwb.o: CFLAGS += -mavx
 $(objdir)/memcpy_nt_avx_empty.o: CFLAGS += -mavx
+$(objdir)/memcpy_nt_avx_noflush.o: CFLAGS += -mavx
 $(objdir)/memset_nt_avx_clflush.o: CFLAGS += -mavx
 $(objdir)/memset_nt_avx_clflushopt.o: CFLAGS += -mavx
 $(objdir)/memset_nt_avx_clwb.o: CFLAGS += -mavx
 $(objdir)/memset_nt_avx_empty.o: CFLAGS += -mavx
+$(objdir)/memset_nt_avx_noflush.o: CFLAGS += -mavx
 
 $(objdir)/memcpy_t_avx512f_clflush.o: CFLAGS += -mavx512f
 $(objdir)/memcpy_t_avx512f_clflushopt.o: CFLAGS += -mavx512f
 $(objdir)/memcpy_t_avx512f_clwb.o: CFLAGS += -mavx512f
 $(objdir)/memcpy_t_avx512f_empty.o: CFLAGS += -mavx512f
+$(objdir)/memcpy_t_avx512f_noflush.o: CFLAGS += -mavx512f
 $(objdir)/memset_t_avx512f_clflush.o: CFLAGS += -mavx512f
 $(objdir)/memset_t_avx512f_clflushopt.o: CFLAGS += -mavx512f
 $(objdir)/memset_t_avx512f_clwb.o: CFLAGS += -mavx512f
 $(objdir)/memset_t_avx512f_empty.o: CFLAGS += -mavx512f
+$(objdir)/memset_t_avx512f_noflush.o: CFLAGS += -mavx512f
 $(objdir)/memcpy_t_avx_clflush.o: CFLAGS += -mavx
 $(objdir)/memcpy_t_avx_clflushopt.o: CFLAGS += -mavx
 $(objdir)/memcpy_t_avx_clwb.o: CFLAGS += -mavx
 $(objdir)/memcpy_t_avx_empty.o: CFLAGS += -mavx
+$(objdir)/memcpy_t_avx_noflush.o: CFLAGS += -mavx
 $(objdir)/memset_t_avx_clflush.o: CFLAGS += -mavx
 $(objdir)/memset_t_avx_clflushopt.o: CFLAGS += -mavx
 $(objdir)/memset_t_avx_clwb.o: CFLAGS += -mavx
 $(objdir)/memset_t_avx_empty.o: CFLAGS += -mavx
+$(objdir)/memset_t_avx_noflush.o: CFLAGS += -mavx
 
 CFLAGS += -Ix86_64
 

--- a/src/libpmem/x86_64/init.c
+++ b/src/libpmem/x86_64/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -125,7 +125,7 @@ memmove_nodrain_##isa##_##flush(void *dest, const void *src, size_t len, \
 		return dest;\
 \
 	if (flags & PMEM_F_MEM_NOFLUSH) \
-		memmove_mov_##isa##_empty(dest, src, len); \
+		memmove_mov_##isa##_noflush(dest, src, len); \
 	else if (flags & PMEM_F_MEM_MOVNT)\
 		memmove_movnt_##isa ##_##flush(dest, src, len);\
 	else if (flags & PMEM_F_MEM_MOV)\
@@ -146,7 +146,7 @@ memset_nodrain_##isa##_##flush(void *dest, int c, size_t len, unsigned flags)\
 		return dest;\
 \
 	if (flags & PMEM_F_MEM_NOFLUSH) \
-		memset_mov_##isa##_empty(dest, c, len); \
+		memset_mov_##isa##_noflush(dest, c, len); \
 	else if (flags & PMEM_F_MEM_MOVNT)\
 		memset_movnt_##isa##_##flush(dest, c, len);\
 	else if (flags & PMEM_F_MEM_MOV)\

--- a/src/libpmem/x86_64/memcpy/memcpy_nt_avx.h
+++ b/src/libpmem/x86_64/memcpy/memcpy_nt_avx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Intel Corporation
+ * Copyright 2017-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,8 +37,8 @@
 #include "pmem.h"
 #include "avx.h"
 #include "flush.h"
-#include "memcpy_avx.h"
 #include "memcpy_memset.h"
+#include "memcpy_avx.h"
 #include "valgrind_internal.h"
 
 static force_inline void

--- a/src/libpmem/x86_64/memcpy/memcpy_nt_avx512f.h
+++ b/src/libpmem/x86_64/memcpy/memcpy_nt_avx512f.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Intel Corporation
+ * Copyright 2017-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,8 +37,8 @@
 #include "pmem.h"
 #include "avx.h"
 #include "flush.h"
-#include "memcpy_avx512f.h"
 #include "memcpy_memset.h"
+#include "memcpy_avx512f.h"
 #include "libpmem.h"
 #include "valgrind_internal.h"
 

--- a/src/libpmem/x86_64/memcpy/memcpy_nt_avx512f_noflush.c
+++ b/src/libpmem/x86_64/memcpy/memcpy_nt_avx512f_noflush.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define flush noflush
+#define EXPORTED_SYMBOL memmove_movnt_avx512f_noflush
+#define maybe_barrier barrier_after_ntstores
+#include "memcpy_nt_avx512f.h"

--- a/src/libpmem/x86_64/memcpy/memcpy_nt_avx_noflush.c
+++ b/src/libpmem/x86_64/memcpy/memcpy_nt_avx_noflush.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define flush noflush
+#define EXPORTED_SYMBOL memmove_movnt_avx_noflush
+#define maybe_barrier barrier_after_ntstores
+#include "memcpy_nt_avx.h"

--- a/src/libpmem/x86_64/memcpy/memcpy_nt_sse2_noflush.c
+++ b/src/libpmem/x86_64/memcpy/memcpy_nt_sse2_noflush.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define flush noflush
+#define EXPORTED_SYMBOL memmove_movnt_sse2_noflush
+#define maybe_barrier barrier_after_ntstores
+#include "memcpy_nt_sse2.h"

--- a/src/libpmem/x86_64/memcpy/memcpy_t_avx.h
+++ b/src/libpmem/x86_64/memcpy/memcpy_t_avx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Intel Corporation
+ * Copyright 2017-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,8 +37,8 @@
 #include "pmem.h"
 #include "avx.h"
 #include "flush.h"
-#include "memcpy_avx.h"
 #include "memcpy_memset.h"
+#include "memcpy_avx.h"
 
 static force_inline void
 memmove_mov8x64b(char *dest, const char *src)

--- a/src/libpmem/x86_64/memcpy/memcpy_t_avx512f.h
+++ b/src/libpmem/x86_64/memcpy/memcpy_t_avx512f.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Intel Corporation
+ * Copyright 2017-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,8 +37,8 @@
 #include "pmem.h"
 #include "avx.h"
 #include "flush.h"
-#include "memcpy_avx512f.h"
 #include "memcpy_memset.h"
+#include "memcpy_avx512f.h"
 
 static force_inline void
 memmove_mov32x64b(char *dest, const char *src)

--- a/src/libpmem/x86_64/memcpy/memcpy_t_avx512f_noflush.c
+++ b/src/libpmem/x86_64/memcpy/memcpy_t_avx512f_noflush.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define flush64b noflush64b
+#define flush noflush
+#define EXPORTED_SYMBOL memmove_mov_avx512f_noflush
+#include "memcpy_t_avx512f.h"

--- a/src/libpmem/x86_64/memcpy/memcpy_t_avx_noflush.c
+++ b/src/libpmem/x86_64/memcpy/memcpy_t_avx_noflush.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define flush64b noflush64b
+#define flush noflush
+#define EXPORTED_SYMBOL memmove_mov_avx_noflush
+#include "memcpy_t_avx.h"

--- a/src/libpmem/x86_64/memcpy/memcpy_t_sse2_noflush.c
+++ b/src/libpmem/x86_64/memcpy/memcpy_t_sse2_noflush.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define flush64b noflush64b
+#define flush noflush
+#define EXPORTED_SYMBOL memmove_mov_sse2_noflush
+#include "memcpy_t_sse2.h"

--- a/src/libpmem/x86_64/memcpy_memset.h
+++ b/src/libpmem/x86_64/memcpy_memset.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,6 +56,18 @@ no_barrier_after_ntstores(void)
 	 */
 }
 
+static inline void
+noflush(const void *addr, size_t len)
+{
+	/* NOP, not even pmemcheck annotation */
+}
+
+static inline void
+noflush64b(const char *addr)
+{
+	/* NOP, not even pmemcheck annotation */
+}
+
 #ifndef AVX512F_AVAILABLE
 /* XXX not supported in MSVC version we currently use */
 #ifdef _MSC_VER
@@ -78,18 +90,22 @@ void memmove_mov_sse2_clflush(char *dest, const char *src, size_t len);
 void memmove_mov_sse2_clflushopt(char *dest, const char *src, size_t len);
 void memmove_mov_sse2_clwb(char *dest, const char *src, size_t len);
 void memmove_mov_sse2_empty(char *dest, const char *src, size_t len);
+void memmove_mov_sse2_noflush(char *dest, const char *src, size_t len);
 void memmove_movnt_sse2_clflush(char *dest, const char *src, size_t len);
 void memmove_movnt_sse2_clflushopt(char *dest, const char *src, size_t len);
 void memmove_movnt_sse2_clwb(char *dest, const char *src, size_t len);
 void memmove_movnt_sse2_empty(char *dest, const char *src, size_t len);
+void memmove_movnt_sse2_noflush(char *dest, const char *src, size_t len);
 void memset_mov_sse2_clflush(char *dest, int c, size_t len);
 void memset_mov_sse2_clflushopt(char *dest, int c, size_t len);
 void memset_mov_sse2_clwb(char *dest, int c, size_t len);
 void memset_mov_sse2_empty(char *dest, int c, size_t len);
+void memset_mov_sse2_noflush(char *dest, int c, size_t len);
 void memset_movnt_sse2_clflush(char *dest, int c, size_t len);
 void memset_movnt_sse2_clflushopt(char *dest, int c, size_t len);
 void memset_movnt_sse2_clwb(char *dest, int c, size_t len);
 void memset_movnt_sse2_empty(char *dest, int c, size_t len);
+void memset_movnt_sse2_noflush(char *dest, int c, size_t len);
 #endif
 
 #if AVX_AVAILABLE
@@ -97,18 +113,22 @@ void memmove_mov_avx_clflush(char *dest, const char *src, size_t len);
 void memmove_mov_avx_clflushopt(char *dest, const char *src, size_t len);
 void memmove_mov_avx_clwb(char *dest, const char *src, size_t len);
 void memmove_mov_avx_empty(char *dest, const char *src, size_t len);
+void memmove_mov_avx_noflush(char *dest, const char *src, size_t len);
 void memmove_movnt_avx_clflush(char *dest, const char *src, size_t len);
 void memmove_movnt_avx_clflushopt(char *dest, const char *src, size_t len);
 void memmove_movnt_avx_clwb(char *dest, const char *src, size_t len);
 void memmove_movnt_avx_empty(char *dest, const char *src, size_t len);
+void memmove_movnt_avx_noflush(char *dest, const char *src, size_t len);
 void memset_mov_avx_clflush(char *dest, int c, size_t len);
 void memset_mov_avx_clflushopt(char *dest, int c, size_t len);
 void memset_mov_avx_clwb(char *dest, int c, size_t len);
 void memset_mov_avx_empty(char *dest, int c, size_t len);
+void memset_mov_avx_noflush(char *dest, int c, size_t len);
 void memset_movnt_avx_clflush(char *dest, int c, size_t len);
 void memset_movnt_avx_clflushopt(char *dest, int c, size_t len);
 void memset_movnt_avx_clwb(char *dest, int c, size_t len);
 void memset_movnt_avx_empty(char *dest, int c, size_t len);
+void memset_movnt_avx_noflush(char *dest, int c, size_t len);
 #endif
 
 #if AVX512F_AVAILABLE
@@ -116,18 +136,22 @@ void memmove_mov_avx512f_clflush(char *dest, const char *src, size_t len);
 void memmove_mov_avx512f_clflushopt(char *dest, const char *src, size_t len);
 void memmove_mov_avx512f_clwb(char *dest, const char *src, size_t len);
 void memmove_mov_avx512f_empty(char *dest, const char *src, size_t len);
+void memmove_mov_avx512f_noflush(char *dest, const char *src, size_t len);
 void memmove_movnt_avx512f_clflush(char *dest, const char *src, size_t len);
 void memmove_movnt_avx512f_clflushopt(char *dest, const char *src, size_t len);
 void memmove_movnt_avx512f_clwb(char *dest, const char *src, size_t len);
 void memmove_movnt_avx512f_empty(char *dest, const char *src, size_t len);
+void memmove_movnt_avx512f_noflush(char *dest, const char *src, size_t len);
 void memset_mov_avx512f_clflush(char *dest, int c, size_t len);
 void memset_mov_avx512f_clflushopt(char *dest, int c, size_t len);
 void memset_mov_avx512f_clwb(char *dest, int c, size_t len);
 void memset_mov_avx512f_empty(char *dest, int c, size_t len);
+void memset_mov_avx512f_noflush(char *dest, int c, size_t len);
 void memset_movnt_avx512f_clflush(char *dest, int c, size_t len);
 void memset_movnt_avx512f_clflushopt(char *dest, int c, size_t len);
 void memset_movnt_avx512f_clwb(char *dest, int c, size_t len);
 void memset_movnt_avx512f_empty(char *dest, int c, size_t len);
+void memset_movnt_avx512f_noflush(char *dest, int c, size_t len);
 #endif
 
 extern size_t Movnt_threshold;

--- a/src/libpmem/x86_64/memset/memset_nt_avx.h
+++ b/src/libpmem/x86_64/memset/memset_nt_avx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Intel Corporation
+ * Copyright 2017-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,8 +38,8 @@
 #include "avx.h"
 #include "flush.h"
 #include "libpmem.h"
-#include "memset_avx.h"
 #include "memcpy_memset.h"
+#include "memset_avx.h"
 #include "out.h"
 #include "valgrind_internal.h"
 

--- a/src/libpmem/x86_64/memset/memset_nt_avx512f_noflush.c
+++ b/src/libpmem/x86_64/memset/memset_nt_avx512f_noflush.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define flush noflush
+#define EXPORTED_SYMBOL memset_movnt_avx512f_noflush
+#define maybe_barrier barrier_after_ntstores
+#include "memset_nt_avx512f.h"

--- a/src/libpmem/x86_64/memset/memset_nt_avx_noflush.c
+++ b/src/libpmem/x86_64/memset/memset_nt_avx_noflush.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define flush noflush
+#define EXPORTED_SYMBOL memset_movnt_avx_noflush
+#define maybe_barrier barrier_after_ntstores
+#include "memset_nt_avx.h"

--- a/src/libpmem/x86_64/memset/memset_nt_sse2_noflush.c
+++ b/src/libpmem/x86_64/memset/memset_nt_sse2_noflush.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define flush noflush
+#define EXPORTED_SYMBOL memset_movnt_sse2_noflush
+#define maybe_barrier barrier_after_ntstores
+#include "memset_nt_sse2.h"

--- a/src/libpmem/x86_64/memset/memset_t_avx.h
+++ b/src/libpmem/x86_64/memset/memset_t_avx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Intel Corporation
+ * Copyright 2017-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,8 +37,8 @@
 #include "pmem.h"
 #include "avx.h"
 #include "flush.h"
-#include "memset_avx.h"
 #include "memcpy_memset.h"
+#include "memset_avx.h"
 
 static force_inline void
 memset_mov8x64b(char *dest, __m256i ymm)

--- a/src/libpmem/x86_64/memset/memset_t_avx512f.h
+++ b/src/libpmem/x86_64/memset/memset_t_avx512f.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018, Intel Corporation
+ * Copyright 2017-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,8 +37,8 @@
 #include "pmem.h"
 #include "avx.h"
 #include "flush.h"
-#include "memset_avx512f.h"
 #include "memcpy_memset.h"
+#include "memset_avx512f.h"
 
 static force_inline void
 memset_mov32x64b(char *dest, __m512i zmm)

--- a/src/libpmem/x86_64/memset/memset_t_avx512f_noflush.c
+++ b/src/libpmem/x86_64/memset/memset_t_avx512f_noflush.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define flush64b noflush64b
+#define flush noflush
+#define EXPORTED_SYMBOL memset_mov_avx512f_noflush
+#include "memset_t_avx512f.h"

--- a/src/libpmem/x86_64/memset/memset_t_avx_noflush.c
+++ b/src/libpmem/x86_64/memset/memset_t_avx_noflush.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define flush64b noflush64b
+#define flush noflush
+#define EXPORTED_SYMBOL memset_mov_avx_noflush
+#include "memset_t_avx.h"

--- a/src/libpmem/x86_64/memset/memset_t_sse2_noflush.c
+++ b/src/libpmem/x86_64/memset/memset_t_sse2_noflush.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define flush64b noflush64b
+#define flush noflush
+#define EXPORTED_SYMBOL memset_mov_sse2_noflush
+#include "memset_t_sse2.h"

--- a/src/libpmem/x86_64/sources.inc
+++ b/src/libpmem/x86_64/sources.inc
@@ -1,4 +1,4 @@
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -38,34 +38,42 @@ LIBPMEM_ARCH_SOURCE = init.c\
 	memcpy_nt_avx_clflushopt.c\
 	memcpy_nt_avx_clwb.c\
 	memcpy_nt_avx_empty.c\
+	memcpy_nt_avx_noflush.c\
 	memcpy_nt_sse2_clflush.c\
 	memcpy_nt_sse2_clflushopt.c\
 	memcpy_nt_sse2_clwb.c\
 	memcpy_nt_sse2_empty.c\
+	memcpy_nt_sse2_noflush.c\
 	memset_nt_avx_clflush.c\
 	memset_nt_avx_clflushopt.c\
 	memset_nt_avx_clwb.c\
 	memset_nt_avx_empty.c\
+	memset_nt_avx_noflush.c\
 	memset_nt_sse2_clflush.c\
 	memset_nt_sse2_clflushopt.c\
 	memset_nt_sse2_clwb.c\
 	memset_nt_sse2_empty.c\
+	memset_nt_sse2_noflush.c\
 	memcpy_t_avx_clflush.c\
 	memcpy_t_avx_clflushopt.c\
 	memcpy_t_avx_clwb.c\
 	memcpy_t_avx_empty.c\
+	memcpy_t_avx_noflush.c\
 	memcpy_t_sse2_clflush.c\
 	memcpy_t_sse2_clflushopt.c\
 	memcpy_t_sse2_clwb.c\
 	memcpy_t_sse2_empty.c\
+	memcpy_t_sse2_noflush.c\
 	memset_t_avx_clflush.c\
 	memset_t_avx_clflushopt.c\
 	memset_t_avx_clwb.c\
 	memset_t_avx_empty.c\
+	memset_t_avx_noflush.c\
 	memset_t_sse2_clflush.c\
 	memset_t_sse2_clflushopt.c\
 	memset_t_sse2_clwb.c\
-	memset_t_sse2_empty.c
+	memset_t_sse2_empty.c\
+	memset_t_sse2_noflush.c
 
 AVX512F_PROG="\#include <immintrin.h>\n\#include <stdint.h>\nint main(){ uint64_t v[8]; __m512i zmm0 = _mm512_loadu_si512((__m512i *)&v); return 0;}"
 AVX512F_AVAILABLE := $(shell printf $(AVX512F_PROG) |\
@@ -76,17 +84,21 @@ LIBPMEM_ARCH_SOURCE += memcpy_nt_avx512f_clflush.c\
 	memcpy_nt_avx512f_clflushopt.c\
 	memcpy_nt_avx512f_clwb.c\
 	memcpy_nt_avx512f_empty.c\
+	memcpy_nt_avx512f_noflush.c\
 	memset_nt_avx512f_clflush.c\
 	memset_nt_avx512f_clflushopt.c\
 	memset_nt_avx512f_clwb.c\
 	memset_nt_avx512f_empty.c\
+	memset_nt_avx512f_noflush.c\
 	memcpy_t_avx512f_clflush.c\
 	memcpy_t_avx512f_clflushopt.c\
 	memcpy_t_avx512f_clwb.c\
 	memcpy_t_avx512f_empty.c\
+	memcpy_t_avx512f_noflush.c\
 	memset_t_avx512f_clflush.c\
 	memset_t_avx512f_clflushopt.c\
 	memset_t_avx512f_clwb.c\
-	memset_t_avx512f_empty.c
+	memset_t_avx512f_empty.c\
+	memset_t_avx512f_noflush.c
 endif
 


### PR DESCRIPTION
Untested, because it's not possible to fake eADR in libpmem1.

Found by @Greg091 while testing libpmem2, where we can fake eADR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4406)
<!-- Reviewable:end -->
