### PR TITLE
log: fix libpmemlog header alignment

### DIFF
--- a/src/libpmemlog/log.h
+++ b/src/libpmemlog/log.h
@@ -45,6 +45,7 @@
 #include "util.h"
 #include "os_thread.h"
 #include "pool_hdr.h"
+#include "page_size.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -90,7 +91,7 @@ struct pmemlog {
 };
 
 /* data area starts at this alignment after the struct pmemlog above */
-#define LOG_FORMAT_DATA_ALIGN ((uintptr_t)4096)
+#define LOG_FORMAT_DATA_ALIGN ((uintptr_t)PMEM_PAGESIZE)
 
 /*
  * log_convert2h -- convert pmemlog structure to host byte order


### PR DESCRIPTION
For multiplatform compatibility the header should be aligned to the
platforms page size.

Signed-off-by: Lucas A. M. Magalhaes <lamm@linux.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4411)
<!-- Reviewable:end -->
