### PR TITLE
obj: fix lock release order in palloc publish

### DIFF
--- a/src/libpmemobj/palloc.c
+++ b/src/libpmemobj/palloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018, Intel Corporation
+ * Copyright 2015-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -454,7 +454,7 @@ palloc_exec_actions(struct palloc_heap *heap,
 
 	operation_process(ctx);
 
-	for (int i = 0; i < actvcnt; ++i) {
+	for (ssize_t i = (ssize_t)actvcnt - 1; i >= 0; --i) {
 		act = &actv[i];
 
 		action_funcs[act->type].on_process(heap, act);
@@ -465,7 +465,7 @@ palloc_exec_actions(struct palloc_heap *heap,
 		}
 	}
 
-	for (int i = 0; i < actvcnt; ++i) {
+	for (ssize_t i = (ssize_t)actvcnt - 1; i >= 0; --i) {
 		act = &actv[i];
 
 		action_funcs[act->type].on_unlock(heap, act);


### PR DESCRIPTION
Given a following (sorted) collection of heap actions on
memory blocks 1, 2:

Alloc 1.1, Alloc 1.2, Free 1.3, Free 2.2, Free 2.5

The algorithm looks at every action and acquires lock
for that memory block if that lock wasn't acquired previously.
In this example, two locks would be acquired (2 blocks).

After this is done, the actions are processed. And finally,
the actions are iterated over again, in the exact same order,
and an "on_process" callback is invoked and the lock for
that action is dropped.

And was the problem. The locks were being dropped before all
actions for the same memory block had their "on_process" callback
invoked.

In this example, the order of operations would be:

lock(m.1);
lock(m.2);

process_actions();

on_process(1.1);
unlock(m.1);
on_process(1.2);
on_process(1.3);
on_process(2.2);
unlock(m.2);
on_process(2.5);

This left some of the on_process() callbacks unprotected, leading
to unintended races.

This patch fixes the problem by reversing the order of unlocking.
So now, the order of operations will be:

lock(m.1);
lock(m.2);

process_actions();

on_process(2.5);
on_process(2.2);
unlock(m.2);
on_process(1.3);
on_process(1.2);
on_process(1.1);
unlock(m.1);

This bug triggered an ASSERT() in debug builds, and in release
builds it might have made runtime calculations related to recycler
inaccurate, possibliy negatively impacting fragmentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4413)
<!-- Reviewable:end -->
