### PR TITLE
test: fix util_pool_hdr for page size > 4096

### DIFF
--- a/src/test/util_pool_hdr/util_pool_hdr.c
+++ b/src/test/util_pool_hdr/util_pool_hdr.c
@@ -81,6 +81,9 @@ test_layout()
 	ASSERT_FIELD_SIZE(unused2, POOL_HDR_UNUSED2_LEN_V1);
 	ASSERT_ALIGNED_FIELD(struct pool_hdr, sds);
 	ASSERT_ALIGNED_FIELD(struct pool_hdr, checksum);
+#if PMEM_PAGESIZE > 4096
+	ASSERT_ALIGNED_FIELD(struct pool_hdr, align_pad);
+#endif
 	ASSERT_ALIGNED_CHECK(struct pool_hdr);
 
 	ASSERT_ALIGNED_BEGIN(features_t);


### PR DESCRIPTION
The test was broken on ppc64le because of a missing pad field present
only on platforms with page size bigger than 4096.

Signed-off-by: Lucas A. M. Magalhaes <lamm@linux.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4421)
<!-- Reviewable:end -->
