### PR TITLE
rpmem: add a missing case for GPSPM + FLUSH_STRICT

### DIFF
--- a/src/librpmem/rpmem_fip.c
+++ b/src/librpmem/rpmem_fip.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019, Intel Corporation
+ * Copyright 2016-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1412,35 +1412,6 @@ rpmem_fip_persist_gpspm(struct rpmem_fip *fip, size_t offset,
 }
 
 /*
- * rpmem_fip_flush_gpspm -- (internal) perform flush operation for GPSPM
- */
-static ssize_t
-rpmem_fip_flush_gpspm(struct rpmem_fip *fip, size_t offset,
-	size_t len, unsigned lane, unsigned flags)
-{
-	/* Limit len to the max value of the return type. */
-	len = min(len, SSIZE_MAX);
-
-	int ret = rpmem_fip_wq_flush_check(fip, &fip->lanes[lane], &flags);
-	if (unlikely(ret))
-		return -abs(ret);
-
-	/*
-	 * Probably splitting Send-after-Write into two stages (flush + drain)
-	 * will give some performance gains also for GPSPM mode.
-	 * Since for now GPSPM mode is considered auxiliary and its performance
-	 * is not critical, the flush is emulated with a persist.
-	 */
-	ret = rpmem_fip_persist_saw(fip, offset, len, lane, flags);
-	if (ret)
-		return -abs(ret);
-
-	rpmem_fip_wq_set_empty(&fip->lanes[lane]);
-
-	return (ssize_t)len;
-}
-
-/*
  * rpmem_fip_drain_nop -- (internal) perform drain operation as NOP
  */
 static int
@@ -1562,12 +1533,17 @@ rpmem_fip_post_lanes_common(struct rpmem_fip *fip)
 
 /*
  * rpmem_fip_ops -- some operations specific for persistency method used
+ *
+ * Note: GPSPM flush is emulated by persist whereas drain is a nop.
+ *
+ * Probably splitting Send-after-Write into two stages (flush + drain)
+ * will give some performance gains for GPSPM mode.
  */
 static const struct rpmem_fip_ops
 rpmem_fip_ops[MAX_RPMEM_PROV][MAX_RPMEM_PM] = {
 	[RPMEM_PROV_LIBFABRIC_VERBS] = {
 		[RPMEM_PM_GPSPM] = {
-			.flush = rpmem_fip_flush_gpspm,
+			.flush = rpmem_fip_persist_gpspm,
 			.drain = rpmem_fip_drain_nop,
 			.persist = rpmem_fip_persist_gpspm,
 			.lanes_init = rpmem_fip_init_lanes_common,
@@ -1587,7 +1563,7 @@ rpmem_fip_ops[MAX_RPMEM_PROV][MAX_RPMEM_PM] = {
 	},
 	[RPMEM_PROV_LIBFABRIC_SOCKETS] = {
 		[RPMEM_PM_GPSPM] = {
-			.flush = rpmem_fip_flush_gpspm,
+			.flush = rpmem_fip_persist_gpspm_sockets,
 			.drain = rpmem_fip_drain_nop,
 			.persist = rpmem_fip_persist_gpspm_sockets,
 			.lanes_init = rpmem_fip_init_lanes_common,


### PR DESCRIPTION
```rpmem_flush()``` may provide two possible ```flags``` values:
- ```RPMEM_FLUSH_WRITE``` where data is sent over RDMA.Write after which RDMA.Send is triggering ```pmem_persist()``` on the remote side (**Send-after-Write**)
- ```RPMEM_PERSIST_SEND``` where data is send inlined over RDMA.Send where on the remote side it is feed into ```pmem_memcpy_persist()``` (**Send-inline**)

The issue was ```rpmem_fip_flush_gpspm()``` assumed the **Send-after-Write** is fair enough but ```flags``` may still indicate **Send-after-Write** as well as **Send-inline**. Feeding ```flags``` indicating **Send-inline** into **Send-after-Write** caused RDMA.Send, meant for triggering ```pmem_persist()``` on the remote side, to be used for ```pmem_memcpy_persist()```, where the data for copying was missing, causing SIGSEGV. The ```flags``` value on the remote side is interpreted in the ```rpmemd_fip_process_recv()``` function.

Because ```rpmem_fip_flush_gpspm()``` is exactly the same as ```rpmem_fip_persist_gpspm()``` we have decided to keep only a single copy and replace all ```rpmem_fip_flush_gpspm()``` occurances with ```rpmem_fip_persist_gpspm()```.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4424)
<!-- Reviewable:end -->
