### PR TITLE
test: fix obj_ulog_size append size

### DIFF
--- a/src/libpmemobj/memops.c
+++ b/src/libpmemobj/memops.c
@@ -578,7 +578,7 @@ operation_user_buffer_verify_align(struct operation_context *ctx,
 		ctx->p_ops) - (intptr_t)userbuf->addr;
 	ssize_t capacity_unaligned = (ssize_t)userbuf->size - size_diff
 		- (ssize_t)sizeof(struct ulog);
-	if (capacity_unaligned <= (ssize_t)CACHELINE_SIZE) {
+	if (capacity_unaligned < (ssize_t)CACHELINE_SIZE) {
 		ERR("Capacity insufficient");
 		return -1;
 	}

--- a/src/test/obj_ulog_size/obj_ulog_size.c
+++ b/src/test/obj_ulog_size/obj_ulog_size.c
@@ -40,6 +40,7 @@
 
 #include "unittest.h"
 
+#include "util.h"
 /*
  * tx.h -- needed for TX_SNAPSHOT_LOG_ENTRY_ALIGNMENT,
  * TX_SNAPSHOT_LOG_BUFFER_OVERHEAD, TX_SNAPSHOT_LOG_ENTRY_OVERHEAD,
@@ -71,6 +72,8 @@
  */
 #define REDO_OVERFLOW ((size_t)((LANE_REDO_EXTERNAL_SIZE\
 		/ TX_INTENT_LOG_ENTRY_OVERHEAD) + 1))
+
+#define APPEND_SIZE SIZEOF_ALIGNED_ULOG(CACHELINE_SIZE)
 
 /*
  * free_pool -- frees the pool from all allocated objects
@@ -617,9 +620,9 @@ do_tx_buffer_overlapping(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
-			ptr + 256, 256);
+			ptr + APPEND_SIZE, APPEND_SIZE);
 		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
-			ptr, 256);
+			ptr, APPEND_SIZE);
 	} TX_ONABORT {
 		UT_ASSERT(0);
 	} TX_ONCOMMIT {
@@ -628,9 +631,9 @@ do_tx_buffer_overlapping(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
-			ptr, 256);
+			ptr, APPEND_SIZE);
 		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
-			ptr + 256, 256);
+			ptr + APPEND_SIZE, APPEND_SIZE);
 	} TX_ONABORT {
 		UT_ASSERT(0);
 	} TX_ONCOMMIT {
@@ -639,9 +642,9 @@ do_tx_buffer_overlapping(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
-			ptr, 256);
+			ptr, APPEND_SIZE);
 		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
-			ptr, 256);
+			ptr, APPEND_SIZE);
 	} TX_ONABORT {
 		UT_OUT("Overlap detected");
 	} TX_ONCOMMIT {
@@ -650,9 +653,9 @@ do_tx_buffer_overlapping(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
-			ptr, 256);
+			ptr, APPEND_SIZE);
 		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
-			ptr + 128, 256);
+			ptr + 128, APPEND_SIZE);
 	} TX_ONABORT {
 		UT_OUT("Overlap detected");
 	} TX_ONCOMMIT {
@@ -661,9 +664,9 @@ do_tx_buffer_overlapping(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
-			ptr + 128, 256);
+			ptr + 128, APPEND_SIZE);
 		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_INTENT,
-			ptr, 256);
+			ptr, APPEND_SIZE);
 	} TX_ONABORT {
 		UT_OUT("Overlap detected");
 	} TX_ONCOMMIT {


### PR DESCRIPTION
For 128 bytes cacheline the append size of 256 are not enough to store a
ulog. In this case the append size are being added one more cacheline
size.

Signed-off-by: Lucas A. M. Magalhaes <lamm@linux.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4427)
<!-- Reviewable:end -->
