### PR TITLE
kill eatmydata in some tests

### DIFF
--- a/src/test/out_err_mt/TEST0
+++ b/src/test/out_err_mt/TEST0
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2015-2019, Intel Corporation
+# Copyright 2015-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,6 +39,7 @@
 
 require_test_type medium
 require_fs_type any
+disable_eatmydata
 
 setup
 

--- a/src/test/out_err_mt/TEST1
+++ b/src/test/out_err_mt/TEST1
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2015-2019, Intel Corporation
+# Copyright 2015-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,6 +39,7 @@
 
 require_test_type medium
 require_fs_type any
+disable_eatmydata
 
 require_valgrind 3.7
 configure_valgrind drd force-enable

--- a/src/test/out_err_mt/TEST2
+++ b/src/test/out_err_mt/TEST2
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2015-2019, Intel Corporation
+# Copyright 2015-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,6 +39,7 @@
 
 require_test_type medium
 require_fs_type any
+disable_eatmydata
 
 require_valgrind 3.7
 configure_valgrind helgrind force-enable

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1455,6 +1455,19 @@ require_dax_device_alignments() {
 }
 
 #
+# disable_eatmydata -- ensure invalid msyncs fail
+#
+# Distros (and people) like to use eatmydata to kill fsync-likes during builds
+# and testing. This is nice for speed, but we actually rely on msync failing
+# in some tests.
+#
+disable_eatmydata() {
+	export LD_PRELOAD="${LD_PRELOAD/#libeatmydata.so/}"
+	export LD_PRELOAD="${LD_PRELOAD/ libeatmydata.so/}"
+	export LD_PRELOAD="${LD_PRELOAD/:libeatmydata.so/}"
+}
+
+#
 # require_fs_type -- only allow script to continue for a certain fs type
 #
 function require_fs_type() {


### PR DESCRIPTION
It allows msyncs to succeeded even when called with intentionally bogus arguments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4482)
<!-- Reviewable:end -->
