### PR TITLE
obj: remove fill ratio optimization from defrag

### DIFF
--- a/src/libpmemobj/palloc.c
+++ b/src/libpmemobj/palloc.c
@@ -1043,19 +1043,6 @@ palloc_defrag(struct palloc_heap *heap, uint64_t **objv, size_t objcnt,
 
 		uint64_t new_offset = reserve->heap.offset;
 
-		struct memory_block nm = memblock_from_offset(heap, new_offset);
-
-		mlock = nm.m_ops->get_lock(&nm);
-		os_mutex_lock(mlock);
-		unsigned new_fillpct = nm.m_ops->fill_pct(&nm);
-		os_mutex_unlock(mlock);
-
-		if (original_fillpct > new_fillpct) {
-			palloc_cancel(heap, reserve, 1);
-			VEC_POP_BACK(&actv);
-			continue;
-		}
-
 		VALGRIND_ADD_TO_TX(
 			HEAP_OFF_TO_PTR(heap, new_offset),
 			user_size);

--- a/src/test/obj_fragmentation2/obj_fragmentation2.c
+++ b/src/test/obj_fragmentation2/obj_fragmentation2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019, Intel Corporation
+ * Copyright 2017-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -196,7 +196,7 @@ static float workloads_target[] = {
 };
 
 static float workloads_defrag_target[] = {
-	0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.056f, 0.1f, 0.13f, 0.01f
+	0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.05f, 0.09f, 0.13f, 0.01f
 };
 
 /* last workload operates only on huge chunks, so run stats are useless */


### PR DESCRIPTION
This patch removes a check from defrag that prevented
realloc of objects from highly filled runs to low filled runs.
This was originally done as a performance optimization to
reduce the number of realloced objects.

Turns out this has non-negligible negative impact on
effectivness of defrag.

Ref: #4477 #4473 #4474

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4492)
<!-- Reviewable:end -->
