### PR TITLE
doc: add dependency between compressed and uncompressed man pages

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -230,7 +230,7 @@ $(MANPAGES_WEBDIR_LINUX) $(MANPAGES_WEBDIR_WINDOWS):
 %.txt: %
 	man ./$< > $@
 
-%.gz:
+%.gz: %
 	gzip -c ./$* > $@
 
 %.html: %


### PR DESCRIPTION
fixes "make install" without "make" on freshly cloned tree

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4495)
<!-- Reviewable:end -->
