### PR TITLE
make .gz files reproducible

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -233,7 +233,7 @@ $(MANPAGES_WEBDIR_LINUX) $(MANPAGES_WEBDIR_WINDOWS):
 	man ./$< > $@
 
 %.gz: %
-	gzip -c ./$* > $@
+	gzip -nc ./$* > $@
 
 %.html: %
 	groff -mandoc -Thtml ./$< > $@

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -1,4 +1,4 @@
-# Copyright 2014-2019, Intel Corporation
+# Copyright 2014-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -283,7 +283,7 @@ endif
 endif
 
 %.gz: %
-	gzip -c ./$< > $@
+	gzip -nc ./$< > $@
 
 %.txt: %
 	man ./$< > $@


### PR DESCRIPTION
By default, gzip stores timestamps (which usually are the date the file was last checked out from git), and that makes builds produce different files for every checkout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4496)
<!-- Reviewable:end -->
