### PR TITLE
obj: fix zone size calculations

### DIFF
--- a/src/test/obj_heap/TEST0
+++ b/src/test/obj_heap/TEST0
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2015-2019, Intel Corporation
+# Copyright 2015-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -42,5 +42,7 @@ require_test_type medium
 setup
 
 expect_normal_exit ./obj_heap$EXESUFFIX t
+expect_normal_exit ./obj_heap$EXESUFFIX d
+expect_normal_exit ./obj_heap$EXESUFFIX e
 
 pass


### PR DESCRIPTION
The calculations for total available heap size for user
allocations didn't take all possible metadata into account,
leading to situations where certain for certain heap sizes
the zone size was too large by a chunk.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4502)
<!-- Reviewable:end -->
