### PR TITLE
test: remove logging from the parallelized path

### DIFF
--- a/src/test/obj_defrag_advanced/obj_defrag_advanced.c
+++ b/src/test/obj_defrag_advanced/obj_defrag_advanced.c
@@ -141,8 +141,6 @@ graph_defrag_ntimes(PMEMobjpool *pop, PMEMoid oid, unsigned max_rounds)
 		relocated = graph_defrag(pop, oid);
 		++rounds;
 	} while (relocated > 0 && rounds < max_rounds);
-
-	UT_OUT("# of defragmentation rounds: %u", rounds);
 }
 
 #define HAS_TO_EXIST (1)


### PR DESCRIPTION
Since our logging subsystem is not thread-safe
it should not be used by mulitple threads in parallel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4506)
<!-- Reviewable:end -->
