### PR TITLE
obj: fix zone size calculations

### DIFF
--- a/src/test/obj_heap/TEST0
+++ b/src/test/obj_heap/TEST0
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2015-2018, Intel Corporation
+# Copyright 2015-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_heap/obj_heap.c
+++ b/src/test/obj_heap/obj_heap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018, Intel Corporation
+ * Copyright 2015-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -300,6 +300,132 @@ test_heap(void)
 	MUNMAP_ANON_ALIGNED(mpop, MOCK_POOL_SIZE);
 }
 
+/*
+ * test_heap_with_size -- tests scenarios with not-nicely aligned sizes
+ */
+static void
+test_heap_with_size()
+{
+	/*
+	 * To trigger bug with incorrect metadata alignment we need to
+	 * use a size that uses exactly the size used in bugged zone size
+	 * calculations.
+	 */
+	size_t size = PMEMOBJ_MIN_POOL + sizeof(struct zone_header) +
+		sizeof(struct chunk_header) * MAX_CHUNK +
+		sizeof(PMEMobjpool);
+
+	struct mock_pop *mpop = MMAP_ANON_ALIGNED(size,
+		Ut_mmap_align);
+	PMEMobjpool *pop = &mpop->p;
+	memset(pop, 0, size);
+	pop->heap_offset = (uint64_t)((uint64_t)&mpop->heap - (uint64_t)mpop);
+	pop->p_ops.persist = obj_heap_persist;
+	pop->p_ops.flush = obj_heap_flush;
+	pop->p_ops.drain = obj_heap_drain;
+	pop->p_ops.memset = obj_heap_memset;
+	pop->p_ops.base = pop;
+	pop->set = MALLOC(sizeof(*(pop->set)));
+	pop->set->options = 0;
+	pop->set->directory_based = 0;
+
+	void *heap_start = (char *)pop + pop->heap_offset;
+	uint64_t heap_size = size - sizeof(PMEMobjpool);
+	struct palloc_heap *heap = &pop->heap;
+	struct pmem_ops *p_ops = &pop->p_ops;
+
+	UT_ASSERT(heap_check(heap_start, heap_size) != 0);
+	UT_ASSERT(heap_init(heap_start, heap_size,
+		&pop->heap_size, p_ops) == 0);
+	UT_ASSERT(heap_boot(heap, heap_start, heap_size,
+		&pop->heap_size,
+		pop, p_ops, NULL, pop->set) == 0);
+	UT_ASSERT(heap_buckets_init(heap) == 0);
+	UT_ASSERT(pop->heap.rt != NULL);
+
+	struct bucket *b_def = heap_bucket_acquire_by_id(heap,
+		DEFAULT_ALLOC_CLASS_ID);
+
+	struct memory_block mb;
+	mb.size_idx = 1;
+	while (heap_get_bestfit_block(heap, b_def, &mb) == 0);
+
+	uint32_t last_chunk_id = mb.chunk_id;
+
+	/* mb should now be the last chunk in the heap */
+	char *ptr = mb.m_ops->get_real_data(&mb);
+	size_t s = mb.m_ops->get_real_size(&mb);
+
+	/* last chunk should be within the heap and accessible */
+	UT_ASSERT((size_t)ptr + s <= (size_t)mpop + size);
+
+	VALGRIND_DO_MAKE_MEM_DEFINED(ptr, s);
+	memset(ptr, 0xc, s);
+
+	heap_bucket_release(heap, b_def);
+
+	UT_ASSERT(heap_check(heap_start, heap_size) == 0);
+	heap_cleanup(heap);
+	UT_ASSERT(heap->rt == NULL);
+
+	/* let's simulate a bug where the zone is too big */
+	pop->heap_size -= CHUNKSIZE;
+
+	UT_ASSERT(heap_boot(heap, heap_start, heap_size,
+		&pop->heap_size,
+		pop, p_ops, NULL, pop->set) == 0);
+	UT_ASSERT(heap_buckets_init(heap) == 0);
+	UT_ASSERT(pop->heap.rt != NULL);
+
+	b_def = heap_bucket_acquire_by_id(heap,
+		DEFAULT_ALLOC_CLASS_ID);
+
+	mb.size_idx = 1;
+	while (heap_get_bestfit_block(heap, b_def, &mb) == 0);
+
+	uint32_t new_chunk_id = mb.chunk_id;
+
+	UT_ASSERTeq(new_chunk_id, last_chunk_id - 1);
+
+	heap_bucket_release(heap, b_def);
+
+	UT_ASSERT(heap_check(heap_start, heap_size) == 0);
+	heap_cleanup(heap);
+
+	/* again, but this time with a run */
+	pop->heap_size -= CHUNKSIZE;
+
+	init_run_with_score(pop->heap.layout, new_chunk_id, 256);
+
+	struct chunk_run *run = (struct chunk_run *)
+		&heap->layout->zone0.chunks[new_chunk_id];
+	size_t clearbits = 0;
+	uint64_t *bitmap = (uint64_t *)run->content;
+	for (int i = 0; i < RUN_DEFAULT_BITMAP_VALUES; ++i)
+		clearbits += util_popcount64(~bitmap[i]);
+
+	UT_ASSERT(heap_boot(heap, heap_start, heap_size,
+		&pop->heap_size,
+		pop, p_ops, NULL, pop->set) == 0);
+	UT_ASSERT(heap_buckets_init(heap) == 0);
+	UT_ASSERT(pop->heap.rt != NULL);
+
+	UT_ASSERT(heap_check(heap_start, heap_size) == 0);
+	heap_cleanup(heap);
+
+	size_t new_clearbits = 0;
+	for (int i = 0; i < RUN_DEFAULT_BITMAP_VALUES; ++i)
+		new_clearbits += util_popcount64(~bitmap[i]);
+	/*
+	 * The fixup method masks of last 128 bits, so they
+	 * should be "allocated" after heap open.
+	 */
+	UT_ASSERTeq(clearbits, new_clearbits + 128);
+
+	FREE(pop->set);
+	MUNMAP_ANON_ALIGNED(mpop, size);
+}
+
 static void
 test_recycler(void)
 {
@@ -456,6 +582,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_heap");
 
 	test_heap();
+	test_heap_with_size();
 	test_recycler();
 
 	DONE(NULL);


### PR DESCRIPTION
The calculations for total available heap size for user
allocations didn't take all possible metadata into account,
leading to situations where for certain heap sizes
the zone size was too large by a chunk.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4509)
<!-- Reviewable:end -->
