### PR TITLE
common: Add optimization for debug versions

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -70,7 +70,7 @@ ifeq ($(DEBUG),1)
 # Undefine _FORTIFY_SOURCE in case it's set in system-default or
 # user-defined CFLAGS as it conflicts with -O0.
 DEBUG_CFLAGS += -Wp,-U_FORTIFY_SOURCE
-DEBUG_CFLAGS += -O0 -ggdb -DDEBUG
+DEBUG_CFLAGS += -Og -ggdb -DDEBUG -fno-omit-frame-pointer
 LIB_SUBDIR = /pmdk_debug
 OBJDIR = debug
 else

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -397,7 +397,7 @@ extract_funcs = $(shell \
 
 INCS += -I../unittest -I$(TOP)/src/include -I$(TOP)/src/common -I$(TOP)/src/core
 
-COMMON_FLAGS  = -ggdb
+COMMON_FLAGS  = -ggdb -Og -fno-omit-frame-pointer
 COMMON_FLAGS += -Wall
 COMMON_FLAGS += -Werror
 COMMON_FLAGS += -Wpointer-arith
@@ -409,7 +409,7 @@ COMMON_FLAGS += -fno-common
 
 CXXFLAGS  = -std=c++11
 CXXFLAGS += $(GLIBC_CXXFLAGS)
-CXXFLAGS += -ggdb
+CXXFLAGS += -ggdb -Og -fno-omit-frame-pointer
 CXXFLAGS += $(COMMON_FLAGS)
 CXXFLAGS += $(EXTRA_CXXFLAGS)
 

--- a/src/test/blk_rw/blk_rw.c
+++ b/src/test/blk_rw/blk_rw.c
@@ -63,7 +63,7 @@ main(int argc, char *argv[])
 
 	const char *path = argv[2];
 
-	PMEMblkpool *handle;
+	PMEMblkpool *handle = NULL;
 	switch (*argv[3]) {
 		case 'c':
 			handle = pmemblk_create(path, Bsize, 0,
@@ -126,6 +126,7 @@ main(int argc, char *argv[])
 	}
 
 	FREE(buf);
+	UT_ASSERTne(handle, NULL);
 	pmemblk_close(handle);
 
 	int result = pmemblk_check(path, Bsize);

--- a/src/test/log_basic/log_basic.c
+++ b/src/test/log_basic/log_basic.c
@@ -229,7 +229,7 @@ do_check(const char *path)
 int
 main(int argc, char *argv[])
 {
-	PMEMlogpool *plp;
+	PMEMlogpool *plp = NULL;
 
 	START(argc, argv, "log_basic");
 
@@ -277,6 +277,7 @@ main(int argc, char *argv[])
 			do_fault_injection(plp, path);
 			break;
 		case 'l':
+			UT_ASSERTne(plp, NULL);
 			do_close(plp);
 			break;
 		case 'h':

--- a/src/test/obj_memcheck/Makefile
+++ b/src/test/obj_memcheck/Makefile
@@ -10,4 +10,3 @@ OBJS = obj_memcheck.o
 LIBPMEMOBJ=y
 
 include ../Makefile.inc
-

--- a/src/test/obj_memcheck/memcheck0.log.match
+++ b/src/test/obj_memcheck/memcheck0.log.match
@@ -117,7 +117,7 @@ $(OPT)==$(N)==    by 0x$(X): main $(*)
 $(OPT)==$(N)==  Block was alloc'd at
 $(OPT)==$(N)==    at 0x$(X): test_memcheck_bug2 $(*)
 $(OPT)==$(N)==    by 0x$(X): main $(*)
-==$(N)== 
+$(OPT)==$(N)== 
 ==$(N)== 
 ==$(N)== HEAP SUMMARY:
 ==$(N)==     in use at exit: $(NC) bytes in $(N) blocks
@@ -132,4 +132,4 @@ $(OPT)==$(N)==    still reachable: 0 bytes in 0 blocks
 $(OPT)==$(N)==         suppressed: $(NC) bytes in $(N) blocks
 ==$(N)== 
 ==$(N)== Use --track-origins=yes to see where uninitialised values come from
-==$(N)== ERROR SUMMARY: 10 errors from 8 contexts (suppressed: $(N) from $(N))
+==$(N)== ERROR SUMMARY: $(N) errors from $(N) contexts (suppressed: $(N) from $(N))

--- a/src/test/obj_realloc/obj_realloc.c
+++ b/src/test/obj_realloc/obj_realloc.c
@@ -150,8 +150,8 @@ test_realloc(PMEMobjpool *pop, size_t size_from, size_t size_to,
 
 	UT_ASSERT(usable_size_from >= size_from);
 
-	size_t check_size;
-	uint16_t checksum;
+	size_t check_size = 0;
+	uint16_t checksum = 0;
 
 	if (zrealloc) {
 		UT_ASSERT(util_is_zeroed(D_RO(D_RO(root)->obj),

--- a/src/test/rpmemd_dbg/Makefile
+++ b/src/test/rpmemd_dbg/Makefile
@@ -17,5 +17,8 @@ LIBPMEMCOMMON=y
 
 include ../Makefile.inc
 
-CFLAGS += -I../../tools/rpmemd -DDEBUG
+# The _FORTIFY_SOURCE flag invalidates the mock functions
+# as it will change the syslog call to __syslog_chk. So
+# we need to disable it.
+CFLAGS += -I../../tools/rpmemd -DDEBUG -U_FORTIFY_SOURCE
 LDFLAGS += $(call extract_funcs, ../rpmemd_log/rpmemd_log_test.c)

--- a/src/test/rpmemd_log/Makefile
+++ b/src/test/rpmemd_log/Makefile
@@ -16,5 +16,8 @@ LIBPMEMCOMMON=y
 
 include ../Makefile.inc
 
-CFLAGS += -I../../tools/rpmemd
+# The _FORTIFY_SOURCE flag invalidates the mock functions
+# as it will change the syslog call to __syslog_chk. So
+# we need to disable it.
+CFLAGS += -I../../tools/rpmemd -U_FORTIFY_SOURCE
 LDFLAGS += $(call extract_funcs, rpmemd_log_test.c)


### PR DESCRIPTION
Some tests that took to long to finish will benefit from
an compiler optimization.

The GCC Manual section 3.10 recomends the use of -Og for
debug targets.  This patches implements this and fixes
maybe-unitialized warnings that were introduced by it.

Some tests failed after -Og so they are exclusively compiled
with -O0 for now.

Signed-off-by: Lucas A. M. Magalhaes <lamm@linux.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4520)
<!-- Reviewable:end -->
