### PR TITLE
test: unbreak obj_tx_add_range{,direct} on valgrind-3.14

### DIFF
--- a/src/test/obj_tx_add_range/memcheck3.log.match
+++ b/src/test/obj_tx_add_range/memcheck3.log.match
@@ -35,6 +35,7 @@ $(OPT)==$(*)==      possibly lost: 0 bytes in 0 blocks
 $(OPT)==$(*)==    still reachable: 0 bytes in 0 blocks
 $(OPT)==$(*)==         suppressed: $(*) bytes in $(*) blocks
 ==$(*)== 
+$(OPT)==$(*)== For counts of detected and suppressed errors, rerun with: -v
 ==$(*)== Use --track-origins=yes to see where uninitialised values come from
 $(OPT)==$(*)== For lists of detected and suppressed errors, rerun with: -s
 ==$(*)== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: $(*) from $(*))

--- a/src/test/obj_tx_add_range_direct/memcheck2.log.match
+++ b/src/test/obj_tx_add_range_direct/memcheck2.log.match
@@ -35,6 +35,7 @@ $(OPT)==$(*)==      possibly lost: 0 bytes in 0 blocks
 $(OPT)==$(*)==    still reachable: 0 bytes in 0 blocks
 $(OPT)==$(*)==         suppressed: $(*) bytes in $(*) blocks
 ==$(*)== 
+$(OPT)==$(*)== For counts of detected and suppressed errors, rerun with: -v
 ==$(*)== Use --track-origins=yes to see where uninitialised values come from
 $(OPT)==$(*)== For lists of detected and suppressed errors, rerun with: -s
 ==$(*)== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: $(*) from $(*))


### PR DESCRIPTION
The order and wording of an advice message is different vs 3.15.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4524)
<!-- Reviewable:end -->
