### PR TITLE
common: make sure WORKDIR has correct access rights

### DIFF
--- a/utils/docker/prepare-for-build.sh
+++ b/utils/docker/prepare-for-build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2016-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -40,6 +40,10 @@ set -e
 
 # Mount filesystem for tests
 echo $USERPASS | sudo -S mount -t tmpfs none /tmp -osize=6G
+
+# Make sure $WORKDIR has correct access rights
+# - set them to the current UID and GID
+echo $USERPASS | sudo -S chown -R $(id -u).$(id -g) $WORKDIR
 
 # Configure tests (e.g. ssh for remote tests) unless the current configuration
 # should be preserved


### PR DESCRIPTION
Travis has recently changed UID.GID of its user to 2000.2000
while the Docker user has: UID=1000(pmdkuser) and GID=27(sudo)
and it cannot write to the WORKDIR:
```
...
$ ./build-travis.sh
[sudo] password for pmdkuser: ./configure-tests.sh: line 41: /pmdk/src/test/testconfig.sh: Permission denied
The command "./build-travis.sh" exited with 1.
```
Make sure WORKDIR has correct access rights
by setting them to the current UID and GID.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4540)
<!-- Reviewable:end -->
