### PR TITLE
obj: detect msync failures in non-pmem variants of mem[cpy|move|set]

### DIFF
--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -317,6 +317,17 @@ obj_drain_empty(void)
 }
 
 /*
+ * obj_msync_nofail -- (internal) pmem_msync wrapper that never fails from
+ * caller's perspective
+ */
+static void
+obj_msync_nofail(const void *addr, size_t size)
+{
+	if (pmem_msync(addr, size))
+		FATAL("!pmem_msync");
+}
+
+/*
  * obj_nopmem_memcpy -- (internal) memcpy followed by an msync
  */
 static void *
@@ -331,7 +342,7 @@ obj_nopmem_memcpy(void *dest, const void *src, size_t len, unsigned flags)
 	 * libc memcpy does not.
 	 */
 	pmem_memcpy(dest, src, len, PMEM_F_MEM_NOFLUSH);
-	pmem_msync(dest, len);
+	obj_msync_nofail(dest, len);
 	return dest;
 }
 
@@ -345,7 +356,7 @@ obj_nopmem_memmove(void *dest, const void *src, size_t len, unsigned flags)
 
 	/* see comment in obj_nopmem_memcpy */
 	pmem_memmove(dest, src, len, PMEM_F_MEM_NOFLUSH);
-	pmem_msync(dest, len);
+	obj_msync_nofail(dest, len);
 	return dest;
 }
 
@@ -359,7 +370,7 @@ obj_nopmem_memset(void *dest, int c, size_t len, unsigned flags)
 
 	/* see comment in obj_nopmem_memcpy */
 	pmem_memset(dest, c, len, PMEM_F_MEM_NOFLUSH);
-	pmem_msync(dest, len);
+	obj_msync_nofail(dest, len);
 	return dest;
 }
 
@@ -963,17 +974,6 @@ obj_descr_check(PMEMobjpool *pop, const char *layout, size_t poolsize)
 	}
 
 	return 0;
-}
-
-/*
- * obj_msync_nofail -- (internal) pmem_msync wrapper that never fails from
- * caller's perspective
- */
-static void
-obj_msync_nofail(const void *addr, size_t size)
-{
-	if (pmem_msync(addr, size))
-		FATAL("!pmem_msync");
 }
 
 /*

--- a/src/test/obj_tx_alloc/obj_tx_alloc.c
+++ b/src/test/obj_tx_alloc/obj_tx_alloc.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2015-2019, Intel Corporation */
+/* Copyright 2015-2020, Intel Corporation */
 
 /*
  * obj_tx_alloc.c -- unit test for pmemobj_tx_alloc and pmemobj_tx_zalloc
@@ -67,7 +67,7 @@ do_tx_alloc_oom(PMEMobjpool *pop)
 
 	size_t bitmap_size = howmany(alloc_cnt, 8);
 	char *bitmap = (char *)MALLOC(bitmap_size);
-	pmemobj_memset_persist(pop, bitmap, 0, bitmap_size);
+	memset(bitmap, 0, bitmap_size);
 
 	size_t obj_cnt = 0;
 	TOID(struct object) i;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4555)
<!-- Reviewable:end -->
