### PR TITLE
common: remove redundant chown from GHA yaml script

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -43,9 +43,6 @@ jobs:
        - name: Clone the git repo
          uses: actions/checkout@v1
 
-       - name: Change ownership of the repo
-         run: sudo chown -R 1000.1000 $HOST_WORKDIR
-
        - name: Pull or rebuild the image
          run: cd $WORKDIR && ${{ matrix.CONFIG }} ./pull-or-rebuild-image.sh
 


### PR DESCRIPTION
Remove redundant chown from GHA yaml script.
It is not needed since 424d420 was merged upstream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4561)
<!-- Reviewable:end -->
