### PR TITLE
longify obj_zones/TEST1/ppc64

### DIFF
--- a/src/test/obj_zones/TEST1
+++ b/src/test/obj_zones/TEST1
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2019, Intel Corporation
+# Copyright 2019-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -36,7 +36,15 @@
 # too large
 configure_valgrind force-disable
 
-require_test_type medium
+arch=$(arch)
+if [ "${arch#ppc64}" = "$arch" ]; then
+	require_test_type medium
+else
+	# This test dirties one page per 128KB -- ie, 2GB total on x86 and arm,
+	# 32GB on ppc.  This is more than alotted RAM on distro buildds,
+	# causing swapping and thus timeout.
+	require_test_type long
+fi
 
 # runs too long on debug builds
 require_build_type nondebug


### PR DESCRIPTION
Takes 29min on ppc, as opposed to 5s on x86 or 20s on arm, and has a legitimate explanation for this slowness.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4566)
<!-- Reviewable:end -->
