### PR TITLE
common: prepend release number to version when using GIT_VERSION

### DIFF
--- a/GIT_VERSION
+++ b/GIT_VERSION
@@ -1,1 +1,1 @@
-$Format:%h %d$
+$Format:%h$

--- a/utils/SRCVERSION.ps1
+++ b/utils/SRCVERSION.ps1
@@ -1,5 +1,5 @@
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -70,19 +70,14 @@ if (Test-Path $file_path) {
 }
 
 $git_version = ""
-$git_version_tag = ""
 $git_version_hash = ""
 
 if (Test-Path $git_version_file) {
     $git_version = Get-Content $git_version_file
-    if ($git_version -eq "`$Format:%h %d`$") {
+    if ($git_version -eq "`$Format:%h`$") {
         $git_version = ""
-    } elseif ($git_version -match "tag: ") {
-       if ($git_version -match "tag: (?<tag>[0-9a-z.+-]*)") {
-           $git_version_tag = $matches["tag"];
-       }
     } else {
-        $git_version_hash = ($git_version -split " ")[0]
+        $git_version_hash = $git_version
     }
 }
 
@@ -97,12 +92,6 @@ if ($null -ne $args[0]) {
 } elseif (Test-Path $version_file) {
     $version = Get-Content $version_file
     $ver_array = $version.split("-+")
-} elseif ($null -ne $git) {
-    $version = $(git describe)
-    $ver_array = $(git describe --long).split("-+")
-} elseif ($git_version_tag -ne "") {
-    $version = $git_version_tag
-    $ver_array = $git_version_tag.split("-+")
 } elseif ($git_version_hash -ne "") {
     $MAJOR = 0
     $MINOR = 0
@@ -112,6 +101,9 @@ if ($null -ne $args[0]) {
     $version = $git_version_hash
     $CUSTOM = $true
     $version_custom_msg = "#define VERSION_CUSTOM_MSG `"$git_version_hash`""
+} elseif ($null -ne $git) {
+    $version = $(git describe)
+    $ver_array = $(git describe --long).split("-+")
 } else {
     $MAJOR = 0
     $MINOR = 0

--- a/utils/version.sh
+++ b/utils/version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2018, Intel Corporation
+# Copyright 2017-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -40,7 +40,7 @@ if [ -f "$1/VERSION" ]; then
 fi
 
 if [ -f $1/GIT_VERSION ]; then
-	echo -n "\$Format:%h %d\$" | cmp -s $1/GIT_VERSION - && true
+	echo -n "\$Format:%h\$" | cmp -s $1/GIT_VERSION - && true
 	if [ $? -eq 0 ]; then
 		PARSE_GIT_VERSION=0
 	else
@@ -50,17 +50,13 @@ else
 	PARSE_GIT_VERSION=0
 fi
 
-if [ $PARSE_GIT_VERSION -eq 1 ]; then
-	GIT_VERSION_TAG=$(cat $1/GIT_VERSION | grep tag: | sed 's/.*tag: \([0-9a-z.+-]*\).*/\1/')
-	GIT_VERSION_HASH=$(cat $1/GIT_VERSION | sed -e 's/ .*//')
+LATEST_RELEASE=$(cat $1/ChangeLog | grep "* Version" | cut -d " " -f 3 | sort -rd | head -n1)
 
-	if [ -n "$GIT_VERSION_TAG" ]; then
-		echo "$GIT_VERSION_TAG"
-		exit 0
-	fi
+if [ $PARSE_GIT_VERSION -eq 1 ]; then
+	GIT_VERSION_HASH=$(cat $1/GIT_VERSION)
 
 	if [ -n "$GIT_VERSION_HASH" ]; then
-		echo "$GIT_VERSION_HASH"
+		echo "$LATEST_RELEASE+git.$GIT_VERSION_HASH"
 		exit 0
 	fi
 fi
@@ -78,7 +74,7 @@ fi
 # try commit it, git describe can fail when there are no tags (e.g. with shallow clone, like on Travis)
 GIT_COMMIT=$(git log -1 --format=%h) && true
 if [ -n "$GIT_COMMIT" ]; then
-	echo "$GIT_COMMIT"
+	echo "$LATEST_RELEASE+git.$GIT_COMMIT"
 	exit 0
 fi
 


### PR DESCRIPTION
It allows tools which expect version in form major.minor to work
correctly even in case when pmdk is downloaded as zip archive.

This can be tested by downloading zip archive from my fork (from branches stable-1.5, stable-1.6, stable-1.7, stable-1.8 or test_fix) and running utils/versions.sh

```
wget https://github.com/igchor/pmdk/archive/stable-1.6.zip
unzip stable-1.6.zip
cd pmdk-stable-1.6
utils/version.sh .
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4569)
<!-- Reviewable:end -->
