### PR TITLE
test: Fix obj_zones for ppc64le

### DIFF
--- a/src/test/obj_zones/obj_zones.c
+++ b/src/test/obj_zones/obj_zones.c
@@ -36,6 +36,7 @@
  */
 
 #include <stddef.h>
+#include <page_size.h>
 
 #include "unittest.h"
 
@@ -104,7 +105,7 @@ test_malloc_free(const char *path)
 			0, S_IWUSR | S_IRUSR)) == NULL)
 		UT_FATAL("!pmemobj_create: %s", path);
 
-	size_t alloc_size = 128 * 1024;
+	size_t alloc_size = PMEM_PAGESIZE * 32;
 	size_t max_allocs = 1000000;
 	PMEMoid *oid = MALLOC(sizeof(PMEMoid) * max_allocs);
 	size_t n = 0;


### PR DESCRIPTION
This test was timing out because of intensive page_fault
handling. By allocating more by each loop we minimize this
issue.

Signed-off-by: Lucas A. M. Magalhaes <lamm@linux.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4578)
<!-- Reviewable:end -->
