### PR TITLE
pool: enable logs from 'common' files in pmempool

### DIFF
--- a/doc/pmempool/pmempool.1.md
+++ b/doc/pmempool/pmempool.1.md
@@ -8,7 +8,7 @@ date: pmem Tools version 1.4
 ...
 
 [comment]: <> (SPDX-License-Identifier: BSD-3-Clause)
-[comment]: <> (Copyright 2016-2019, Intel Corporation)
+[comment]: <> (Copyright 2016-2020, Intel Corporation)
 
 [comment]: <> (pmempool.1 -- man page for pmempool)
 
@@ -17,6 +17,7 @@ date: pmem Tools version 1.4
 [DESCRIPTION](#description)<br />
 [OPTIONS](#options)<br />
 [COMMANDS](#commands)<br />
+[DEBUGGING](#debugging)<br />
 [SEE ALSO](#see-also)<br />
 
 # NAME #
@@ -86,6 +87,40 @@ Modifies internal structure of a poolset.
 Toggle or query a poolset features.
 
 In order to get more information about specific *command* you can use **pmempool help <command>.**
+
+# DEBUGGING #
+
+The debug logs are available only in the debug version of the tool,
+which is not provided by binary packages, but can be built from sources.
+The **pmempool.static-debug** binary blob can be found
+in the 'src/tools/pmempool/' subdirectory.
+
++ **PMEMPOOL_TOOL_LOG_LEVEL**
+
+The value of **PMEMPOOL_TOOL_LOG_LEVEL** enables trace points in the debug version
+of the tool, as follows:
+
++ **0** - This is the default level when **PMEMPOOL_TOOL_LOG_LEVEL** is not set.
+No log messages are emitted at this level.
+
++ **1** - Additional details on any errors detected are logged (in addition
+to returning the *errno*-based errors as usual).
+
++ **2** - A trace of basic operations is logged.
+
++ **3** - Enables a very verbose amount of function call tracing in the tool.
+
++ **4** - Enables voluminous and fairly obscure tracing
+information that is likely only useful to the **pmempool** developers.
+
+Unless **PMEMPOOL_TOOL_LOG_FILE** is set, debugging output is written to *stderr*.
+
++ **PMEMPOOL_TOOL_LOG_FILE**
+
+Specifies the name of a file where all logging information should be written.
+If the last character in the name is "-", the *PID* of the current process
+will be appended to the file name when the log file is created.
+If **PMEMPOOL_TOOL_LOG_FILE** is not set, output is written to *stderr*.
 
 # SEE ALSO #
 

--- a/src/tools/pmempool/pmempool.c
+++ b/src/tools/pmempool/pmempool.c
@@ -24,6 +24,7 @@
 #include "transform.h"
 #include "feature.h"
 #include "set.h"
+#include "pmemcommon.h"
 
 #ifndef _WIN32
 #include "rpmem_common.h"
@@ -31,6 +32,10 @@
 #endif
 
 #define APPNAME	"pmempool"
+
+#define PMEMPOOL_TOOL_LOG_PREFIX "pmempool"
+#define PMEMPOOL_TOOL_LOG_LEVEL_VAR "PMEMPOOL_TOOL_LOG_LEVEL"
+#define PMEMPOOL_TOOL_LOG_FILE_VAR "PMEMPOOL_TOOL_LOG_FILE"
 
 /*
  * command -- struct for pmempool commands definition
@@ -233,7 +238,12 @@ main(int argc, char *argv[])
 		}
 	}
 #endif
-	util_init();
+
+	common_init(PMEMPOOL_TOOL_LOG_PREFIX,
+			PMEMPOOL_TOOL_LOG_LEVEL_VAR,
+			PMEMPOOL_TOOL_LOG_FILE_VAR,
+			0 /* major version */,
+			0 /* minor version */);
 
 #ifndef _WIN32
 	util_remote_init();
@@ -278,6 +288,8 @@ end:
 	util_remote_fini();
 	rpmem_util_cmds_fini();
 #endif
+
+	common_fini();
 
 #ifdef _WIN32
 	for (int i = argc; i > 0; i--)


### PR DESCRIPTION
Logs from the 'common' files (for example logs
regarding detecting and fixing bad blocks):
```
<pmempool>: <3> [badblock.c:26 badblocks_new]  
<pmempool>: <3> [badblock_ndctl.c:29 os_badblocks_get] file ./pool badblocks 0x5576d1c72c40
<pmempool>: <3> [os_dimm_ndctl.c:665 os_dimm_files_namespace_badblocks] path ./pool
<pmempool>: <3> [os_dimm_ndctl.c:629 os_dimm_files_namespace_badblocks_bus] ctx 0x5576d1c71f80 path ./pool pbus (nil) badblocks 0x5576d1c72c40
<pmempool>: <3> [os_dimm_ndctl.c:147 os_dimm_region_namespace] ctx 0x5576d1c71f80 stat 0x7ffeddcfff30 pregion 0x7ffeddcfff20 pnamespace 0x7ffeddcfff28
<pmempool>: <3> [os_dimm_ndctl.c:78 os_dimm_match_fsdax] st 0x7ffeddcfff30 devname pmem0
<pmempool>: <10> [os_dimm_ndctl.c:133 os_dimm_match_fsdax] skipping not matching device: /sys/block/pmem0/dev
<pmempool>: <10> [os_dimm_ndctl.c:225 os_dimm_region_namespace] did not found any matching device
<pmempool>: <3> [badblock.c:42 badblocks_delete] badblocks 0x5576d1c72c40
```
are not printed now. This patch fixes this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4580)
<!-- Reviewable:end -->
