### PR TITLE
pmem2: rename pmem2_source_file_size to pmem2_source_size

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -97,7 +97,7 @@ MANPAGES_5_MD_PMEM2 =
 MANPAGES_3_MD_PMEM2 = libpmem2/pmem2_errormsg.3.md libpmem2/pmem2_config_new.3.md libpmem2/pmem2_map.3.md \
 		libpmem2/pmem2_unmap.3.md libpmem2/pmem2_map_get_address.3.md libpmem2/pmem2_map_get_size.3.md \
 		libpmem2/pmem2_source_from_fd.3.md libpmem2/pmem2_config_set_required_store_granularity.3.md \
-		libpmem2/pmem2_source_file_size.3.md libpmem2/pmem2_source_alignment.3.md \
+		libpmem2/pmem2_source_size.3.md libpmem2/pmem2_source_alignment.3.md \
 		libpmem2/pmem2_config_set_length.3.md libpmem2/pmem2_config_set_offset.3.md \
 		libpmem2/pmem2_map_get_store_granularity.3.md libpmem2/pmem2_get_flush_fn.3.md \
 		libpmem2/pmem2_get_drain_fn.3.md libpmem2/pmem2_get_persist_fn.3.md

--- a/doc/libpmem2/.gitignore
+++ b/doc/libpmem2/.gitignore
@@ -12,6 +12,6 @@ pmem2_map_get_address.3
 pmem2_map_get_size.3
 pmem2_map_get_store_granularity.3
 pmem2_source_alignment.3
-pmem2_source_file_size.3
 pmem2_source_from_fd.3
+pmem2_source_size.3
 pmem2_unmap.3

--- a/doc/libpmem2/pmem2_map.3.md
+++ b/doc/libpmem2/pmem2_map.3.md
@@ -8,7 +8,7 @@ date: pmem2 API version 1.0
 ...
 
 [comment]: <> (SPDX-License-Identifier: BSD-3-Clause)
-[comment]: <> (Copyright 2019, Intel Corporation)
+[comment]: <> (Copyright 2019-2020, Intel Corporation)
 
 [comment]: <> (pmem2_map.3 -- man page for libpmem2 pmem2_map operation)
 
@@ -82,11 +82,11 @@ It can also return **-EACCES**, **-EAGAIN**, **-EBADF**, **-ENFILE**,
 append-only file.
 
 It can also return all errors from the underlying
-**pmem2_source_file_size**() and **pmem2_source_alignment**() functions.
+**pmem2_source_size**() and **pmem2_source_alignment**() functions.
 
 # SEE ALSO #
 
 **pmem2_unmap**(3), **pmem2_source_from_fd**(3),
-**pmem2_source_file_size**(3), **pmem2_source_alignment**(3),
+**pmem2_source_size**(3), **pmem2_source_alignment**(3),
 **libpmem2**(7), **mmap**(2), **open**(3) and
 **<http://pmem.io>**

--- a/doc/libpmem2/pmem2_source_size.3.md
+++ b/doc/libpmem2/pmem2_source_size.3.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: _MP(PMEM2_CONFIG_GET_FILE_SIZE, 3)
+title: _MP(PMEM2_SOURCE_SIZE, 3)
 collection: libpmem2
 header: PMDK
 date: pmem2 API version 1.0
@@ -10,7 +10,7 @@ date: pmem2 API version 1.0
 [comment]: <> (SPDX-License-Identifier: BSD-3-Clause)
 [comment]: <> (Copyright 2019-2020, Intel Corporation)
 
-[comment]: <> (pmem2_source_file_size.3 -- man page for pmem2_source_file_size)
+[comment]: <> (pmem2_source_size.3 -- man page for pmem2_source_size)
 
 [NAME](#name)<br />
 [SYNOPSIS](#synopsis)<br />
@@ -20,7 +20,7 @@ date: pmem2 API version 1.0
 
 # NAME #
 
-**pmem2_source_file_size**() - returns the size of the data source
+**pmem2_source_size**() - returns the size of the data source
 
 # SYNOPSIS #
 
@@ -28,12 +28,12 @@ date: pmem2 API version 1.0
 #include <libpmem2.h>
 
 struct pmem2_source;
-int pmem2_source_file_size(const struct pmem2_source *source, size_t *size);
+int pmem2_source_size(const struct pmem2_source *source, size_t *size);
 ```
 
 # DESCRIPTION #
 
-The **pmem2_source_file_size**() function retrieves the size of the file
+The **pmem2_source_size**() function retrieves the size of the file
 in bytes pointed by file descriptor or handle stored in the *source* and puts
 it in *\*size*.
 
@@ -42,13 +42,13 @@ On Linux, it hides the quirkiness of Device DAX size detection.
 
 # RETURN VALUE #
 
-The **pmem2_source_file_size**() function returns 0 on success.
+The **pmem2_source_size**() function returns 0 on success.
 If the function fails, the *\*size* variable is left unmodified, and one of
 the following errors is returned:
 
 On all systems:
 
-* **PMEM2_E_INVALID_FILE_HANDLE** - config contains an invalid file handle.
+* **PMEM2_E_INVALID_FILE_HANDLE** - source contains an invalid file handle.
 
 On Windows:
 

--- a/src/PMDK.sln
+++ b/src/PMDK.sln
@@ -709,7 +709,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "blk_recovery", "test\blk_re
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pmem2_config", "test\pmem2_config\pmem2_config.vcxproj", "{DE068BE1-A8E9-48A2-B216-92A7CE5EA4CE}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pmem2_source_file_size", "test\pmem2_source_file_size\pmem2_source_file_size.vcxproj", "{DE068BE1-A8E9-48A2-B216-92A7CE5EA4CF}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pmem2_source_size", "test\pmem2_source_size\pmem2_source_size.vcxproj", "{DE068BE1-A8E9-48A2-B216-92A7CE5EA4CF}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pmem_has_auto_flush_win", "test\pmem_has_auto_flush_win\pmem_has_auto_flush_win.vcxproj", "{DEA3CD0A-8781-4ABE-9A7D-00B91132FED0}"
 EndProject

--- a/src/common/file.c
+++ b/src/common/file.c
@@ -178,7 +178,7 @@ util_fd_get_size(int fd)
 		return -1;
 	}
 
-	ret = pmem2_source_file_size(src, &size);
+	ret = pmem2_source_size(src, &size);
 
 	pmem2_source_delete(&src);
 

--- a/src/include/libpmem2.h
+++ b/src/include/libpmem2.h
@@ -62,7 +62,10 @@ int pmem2_source_from_anon(struct pmem2_source **src);
 int pmem2_source_from_handle(struct pmem2_source **src, HANDLE handle);
 #endif
 
-int pmem2_source_file_size(const struct pmem2_source *src, size_t *size);
+int pmem2_source_size(const struct pmem2_source *src, size_t *size);
+
+/* XXX compatibility, remove later */
+#define pmem2_source_file_size pmem2_source_size
 
 int pmem2_source_alignment(const struct pmem2_source *src,
 		size_t *alignment);

--- a/src/libpmem2/libpmem2.def
+++ b/src/libpmem2/libpmem2.def
@@ -1,6 +1,6 @@
 ;;;; Begin Copyright Notice
 ; SPDX-License-Identifier: BSD-3-Clause
-; Copyright 2019, Intel Corporation
+; Copyright 2019-2020, Intel Corporation
 ;;;;  End Copyright Notice
 
 LIBRARY libpmem2
@@ -34,12 +34,12 @@ EXPORTS
 	pmem2_source_from_fd
 	pmem2_source_from_anon
 	pmem2_source_from_handle
-	pmem2_source_file_size
 	pmem2_source_alignment
 	pmem2_source_delete
 	pmem2_source_device_idW
 	pmem2_source_device_idU
 	pmem2_source_device_usc
+	pmem2_source_size
 	pmem2_errormsgU
 	pmem2_errormsgW
 

--- a/src/libpmem2/libpmem2.link.in
+++ b/src/libpmem2/libpmem2.link.in
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2019, Intel Corporation
+# Copyright 2019-2020, Intel Corporation
 #
 #
 # src/libpmem2.link -- linker link file for libpmem2
@@ -32,11 +32,11 @@ LIBPMEM2_1.0 {
 		pmem2_source_from_fd;
 		pmem2_source_from_anon;
 		pmem2_source_from_handle;
-		pmem2_source_file_size;
 		pmem2_source_alignment;
 		pmem2_source_delete;
 		pmem2_source_device_id;
 		pmem2_source_device_usc;
+		pmem2_source_size;
 		pmem2_errormsg;
 	local:
 		*;

--- a/src/libpmem2/map_posix.c
+++ b/src/libpmem2/map_posix.c
@@ -273,7 +273,7 @@ pmem2_map(const struct pmem2_config *cfg, const struct pmem2_source *src,
 		return ret;
 
 	/* get file size */
-	ret = pmem2_source_file_size(src, &file_len);
+	ret = pmem2_source_size(src, &file_len);
 	if (ret)
 		return ret;
 

--- a/src/libpmem2/map_windows.c
+++ b/src/libpmem2/map_windows.c
@@ -122,7 +122,7 @@ pmem2_map(const struct pmem2_config *cfg, const struct pmem2_source *src,
 		return PMEM2_E_GRANULARITY_NOT_SET;
 	}
 
-	ret = pmem2_source_file_size(src, &file_size);
+	ret = pmem2_source_size(src, &file_size);
 	if (ret)
 		return ret;
 

--- a/src/libpmem2/source_posix.c
+++ b/src/libpmem2/source_posix.c
@@ -75,11 +75,11 @@ pmem2_source_from_fd(struct pmem2_source **src, int fd)
 }
 
 /*
- * pmem2_source_file_size -- get a file size of the file descriptor stored in
- * the provided config
+ * pmem2_source_size -- get a size of the file descriptor stored in the provided
+ * source
  */
 int
-pmem2_source_file_size(const struct pmem2_source *src, size_t *size)
+pmem2_source_size(const struct pmem2_source *src, size_t *size)
 {
 	LOG(3, "fd %d", src->fd);
 
@@ -115,7 +115,7 @@ pmem2_source_file_size(const struct pmem2_source *src, size_t *size)
 		break;
 	default:
 		FATAL(
-			"BUG: unhandled file type in pmem2_source_file_size");
+			"BUG: unhandled file type in pmem2_source_size");
 	}
 
 	LOG(4, "file length %zu", *size);

--- a/src/libpmem2/source_windows.c
+++ b/src/libpmem2/source_windows.c
@@ -100,11 +100,11 @@ pmem2_source_from_handle(struct pmem2_source **src, HANDLE handle)
 }
 
 /*
- * pmem2_source_file_size -- get a file size of the file handle stored in
- * the provided source
+ * pmem2_source_size -- get a size of the file handle stored in the provided
+ * source
  */
 int
-pmem2_source_file_size(const struct pmem2_source *src, size_t *size)
+pmem2_source_size(const struct pmem2_source *src, size_t *size)
 {
 	LOG(3, "handle %p", src->handle);
 

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -200,7 +200,7 @@ PMEM2_TESTS = \
 	pmem2_config\
 	pmem2_source\
 	pmem2_source_alignment\
-	pmem2_source_file_size\
+	pmem2_source_size\
 	pmem2_granularity\
 	pmem2_include\
 	pmem2_integration\

--- a/src/test/pmem2_integration/pmem2_integration.c
+++ b/src/test/pmem2_integration/pmem2_integration.c
@@ -74,7 +74,7 @@ test_reuse_cfg(const struct test_case *tc, int argc, char *argv[])
 	prepare_config(&cfg, &src, fd, PMEM2_GRANULARITY_PAGE);
 
 	size_t size;
-	UT_ASSERTeq(pmem2_source_file_size(src, &size), 0);
+	UT_ASSERTeq(pmem2_source_size(src, &size), 0);
 
 	struct pmem2_map *map1 = map_valid(cfg, src, size);
 	struct pmem2_map *map2 = map_valid(cfg, src, size);
@@ -107,7 +107,7 @@ test_reuse_cfg_with_diff_fd(const struct test_case *tc, int argc, char *argv[])
 	prepare_config(&cfg, &src, fd1, PMEM2_GRANULARITY_PAGE);
 
 	size_t size1;
-	UT_ASSERTeq(pmem2_source_file_size(src, &size1), 0);
+	UT_ASSERTeq(pmem2_source_size(src, &size1), 0);
 
 	struct pmem2_map *map1 = map_valid(cfg, src, size1);
 
@@ -119,7 +119,7 @@ test_reuse_cfg_with_diff_fd(const struct test_case *tc, int argc, char *argv[])
 	UT_ASSERTeq(pmem2_source_from_fd(&src2, fd2), 0);
 
 	size_t size2;
-	UT_ASSERTeq(pmem2_source_file_size(src2, &size2), 0);
+	UT_ASSERTeq(pmem2_source_size(src2, &size2), 0);
 
 	struct pmem2_map *map2 = map_valid(cfg, src2, size2);
 
@@ -153,7 +153,7 @@ test_register_pmem(const struct test_case *tc, int argc, char *argv[])
 	prepare_config(&cfg, &src, fd, PMEM2_GRANULARITY_PAGE);
 
 	size_t size;
-	UT_ASSERTeq(pmem2_source_file_size(src, &size), 0);
+	UT_ASSERTeq(pmem2_source_size(src, &size), 0);
 
 	struct pmem2_map *map = map_valid(cfg, src, size);
 
@@ -189,7 +189,7 @@ test_use_misc_lens_and_offsets(const struct test_case *tc,
 	prepare_config(&cfg, &src, fd, PMEM2_GRANULARITY_PAGE);
 
 	size_t len;
-	UT_ASSERTeq(pmem2_source_file_size(src, &len), 0);
+	UT_ASSERTeq(pmem2_source_size(src, &len), 0);
 
 	struct pmem2_map *map = map_valid(cfg, src, len);
 	char *base = pmem2_map_get_address(map);
@@ -348,7 +348,7 @@ test_len_not_aligned(const struct test_case *tc, int argc, char *argv[])
 	prepare_config(&cfg, &src, fd, PMEM2_GRANULARITY_PAGE);
 
 	size_t len, alignment;
-	int ret = pmem2_source_file_size(src, &len);
+	int ret = pmem2_source_size(src, &len);
 	UT_PMEM2_EXPECT_RETURN(ret, 0);
 
 	ret = pmem2_source_alignment(src, &alignment);
@@ -388,7 +388,7 @@ test_len_aligned(const struct test_case *tc, int argc, char *argv[])
 	prepare_config(&cfg, &src, fd, PMEM2_GRANULARITY_PAGE);
 
 	size_t len, alignment;
-	int ret = pmem2_source_file_size(src, &len);
+	int ret = pmem2_source_size(src, &len);
 	UT_PMEM2_EXPECT_RETURN(ret, 0);
 
 	ret = pmem2_source_alignment(src, &alignment);
@@ -428,7 +428,7 @@ test_offset_not_aligned(const struct test_case *tc, int argc, char *argv[])
 	prepare_config(&cfg, &src, fd, PMEM2_GRANULARITY_PAGE);
 
 	size_t len, alignment;
-	int ret = pmem2_source_file_size(src, &len);
+	int ret = pmem2_source_size(src, &len);
 	UT_PMEM2_EXPECT_RETURN(ret, 0);
 
 	ret = pmem2_source_alignment(src, &alignment);
@@ -473,7 +473,7 @@ test_offset_aligned(const struct test_case *tc, int argc, char *argv[])
 	prepare_config(&cfg, &src, fd, PMEM2_GRANULARITY_PAGE);
 
 	size_t len, alignment;
-	int ret = pmem2_source_file_size(src, &len);
+	int ret = pmem2_source_size(src, &len);
 	UT_PMEM2_EXPECT_RETURN(ret, 0);
 
 	ret = pmem2_source_alignment(src, &alignment);

--- a/src/test/pmem2_persist_valgrind/pmem2_persist_valgrind.c
+++ b/src/test/pmem2_persist_valgrind/pmem2_persist_valgrind.c
@@ -52,7 +52,7 @@ test_init(const struct test_case *tc, int argc, char *argv[],
 	UT_ASSERTne(ctx->map, NULL);
 
 	size_t size;
-	UT_ASSERTeq(pmem2_source_file_size(src, &size), 0);
+	UT_ASSERTeq(pmem2_source_size(src, &size), 0);
 	UT_ASSERTeq(pmem2_map_get_size(ctx->map), size);
 
 	pmem2_config_delete(&cfg);

--- a/src/test/pmem2_source_file_size/.gitignore
+++ b/src/test/pmem2_source_file_size/.gitignore
@@ -1,1 +1,0 @@
-pmem2_source_file_size

--- a/src/test/pmem2_source_size/.gitignore
+++ b/src/test/pmem2_source_size/.gitignore
@@ -1,0 +1,1 @@
+pmem2_source_size

--- a/src/test/pmem2_source_size/Makefile
+++ b/src/test/pmem2_source_size/Makefile
@@ -2,8 +2,7 @@
 # Copyright 2019-2020, Intel Corporation
 
 #
-# src/test/pmem2_source_file_size/Makefile -- build
-# pmem2_source_file_size unit test
+# src/test/pmem2_source_size/Makefile -- build pmem2_source_size unit test
 #
 TOP = ../../..
 
@@ -11,9 +10,9 @@ vpath %.c $(TOP)/src/test/unittest
 vpath %.c $(TOP)/src/libpmem2
 
 INCS += -I$(TOP)/src/libpmem2
-TARGET = pmem2_source_file_size
+TARGET = pmem2_source_size
 OBJS += errormsg.o\
-	pmem2_source_file_size.o\
+	pmem2_source_size.o\
 	ut_pmem2_config.o\
 	ut_pmem2_utils.o
 

--- a/src/test/pmem2_source_size/TESTS.py
+++ b/src/test/pmem2_source_size/TESTS.py
@@ -12,7 +12,7 @@ class NormalFile(t.Test):
 
     def run(self, ctx):
         filepath = ctx.create_holey_file(self.size, 'testfile')
-        ctx.exec('pmem2_source_file_size', self.test_case,
+        ctx.exec('pmem2_source_size', self.test_case,
                  filepath, self.size)
 
 
@@ -45,7 +45,7 @@ class TEST4(t.Test):
     test_type = t.Short
 
     def run(self, ctx):
-        ctx.exec('pmem2_source_file_size', 'test_tmpfile_fd',
+        ctx.exec('pmem2_source_size', 'test_tmpfile_fd',
                  ctx.testdir, 16 * t.MiB)
 
 
@@ -55,7 +55,7 @@ class TEST4(t.Test):
 #    test_type = t.Short
 #
 #    def run(self, ctx):
-#        ctx.exec('pmem2_source_file_size', 'tmp_file_handle',
+#        ctx.exec('pmem2_source_size', 'tmp_file_handle',
 #                 ctx.testdir, str(16 * t.MiB))
 
 
@@ -66,5 +66,5 @@ class TEST6(t.Test):
 
     def run(self, ctx):
         dd = ctx.devdaxes.devdax1
-        ctx.exec('pmem2_source_file_size',
+        ctx.exec('pmem2_source_size',
                  'test_normal_file_fd', dd.path, dd.size)

--- a/src/test/pmem2_source_size/pmem2_source_size.c
+++ b/src/test/pmem2_source_size/pmem2_source_size.c
@@ -2,7 +2,7 @@
 /* Copyright 2019-2020, Intel Corporation */
 
 /*
- * pmem2_source_file_size.c -- pmem2_source_file_size unittests
+ * pmem2_source_size.c -- pmem2_source_size unittests
  */
 
 #include <stdint.h>
@@ -30,7 +30,7 @@ test_normal_file(const char *path, os_off_t expected_size,
 	PMEM2_SOURCE_FROM_FH(&src, fh);
 
 	size_t size;
-	int ret = pmem2_source_file_size(src, &size);
+	int ret = pmem2_source_size(src, &size);
 
 	UT_PMEM2_EXPECT_RETURN(ret, 0);
 	UT_ASSERTeq(size, expected_size);
@@ -88,7 +88,7 @@ test_tmpfile(const char *dir, os_off_t requested_size,
 	PMEM2_SOURCE_FROM_FH(&src, fh);
 
 	size_t size = SIZE_MAX;
-	int ret = pmem2_source_file_size(src, &size);
+	int ret = pmem2_source_size(src, &size);
 
 	UT_PMEM2_EXPECT_RETURN(ret, 0);
 	UT_ASSERTeq(size, requested_size);
@@ -145,11 +145,10 @@ static struct test_case test_cases[] = {
 int
 main(int argc, char **argv)
 {
-	START(argc, argv, "pmem2_source_file_size");
+	START(argc, argv, "pmem2_source_size");
 
 	util_init();
-	out_init("pmem2_source_file_size", "TEST_LOG_LEVEL",
-			"TEST_LOG_FILE", 0, 0);
+	out_init("pmem2_source_size", "TEST_LOG_LEVEL", "TEST_LOG_FILE", 0, 0);
 	TEST_CASE_PROCESS(argc, argv, test_cases, NTESTS);
 	out_fini();
 

--- a/src/test/pmem2_source_size/pmem2_source_size.vcxproj
+++ b/src/test/pmem2_source_size/pmem2_source_size.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{DE068BE1-A8E9-48A2-B216-92A7CE5EA4CF}</ProjectGuid>
-    <RootNamespace>pmem2_source_file_size</RootNamespace>
+    <RootNamespace>pmem2_source_size</RootNamespace>
     <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -83,7 +83,7 @@
     <ClCompile Include="..\..\libpmem2\pmem2_utils.c" />
     <ClCompile Include="..\unittest\ut_pmem2_config.c" />
     <ClCompile Include="..\unittest\ut_pmem2_utils.c" />
-    <ClCompile Include="pmem2_source_file_size.c" />
+    <ClCompile Include="pmem2_source_size.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\libpmem2\config.h" />

--- a/src/test/pmem2_source_size/pmem2_source_size.vcxproj.filters
+++ b/src/test/pmem2_source_size/pmem2_source_size.vcxproj.filters
@@ -11,7 +11,7 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="pmem2_source_file_size.c">
+    <ClCompile Include="pmem2_source_size.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\libpmem2\errormsg.c">

--- a/src/test/scope/out13.log.match
+++ b/src/test/scope/out13.log.match
@@ -25,7 +25,7 @@ pmem2_source_alignment
 pmem2_source_delete
 pmem2_source_device_id
 pmem2_source_device_usc
-pmem2_source_file_size
 pmem2_source_from_anon
 pmem2_source_from_fd
+pmem2_source_size
 pmem2_unmap


### PR DESCRIPTION
Source may not necessarily be a file.

pmem2_source_file_size is now an alias for pmem2_source_size. It will be removed once other PRs, that might still use it, will be merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4585)
<!-- Reviewable:end -->
