### PR TITLE
common: fix CI building

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -43,9 +43,6 @@ jobs:
        - name: Clone the git repo
          uses: actions/checkout@v1
 
-       - name: Set CI vars
-         run: cd $WORKDIR && ${{ matrix.CONFIG }} ./set-ci-vars.sh
-
        - name: Pull or rebuild the image
          run: cd $WORKDIR && ${{ matrix.CONFIG }} ./pull-or-rebuild-image.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ before_install:
   - echo $TRAVIS_COMMIT_RANGE
   - export HOST_WORKDIR=`pwd`
   - cd utils/docker
-  - ./set-ci-vars.sh
   - ./pull-or-rebuild-image.sh
 
 script:

--- a/utils/docker/build-travis.sh
+++ b/utils/docker/build-travis.sh
@@ -11,6 +11,7 @@
 
 set -e
 
+source $(dirname $0)/set-ci-vars.sh
 source $(dirname $0)/set-vars.sh
 source $(dirname $0)/valid-branches.sh
 

--- a/utils/docker/images/push-image.sh
+++ b/utils/docker/images/push-image.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2019, Intel Corporation
+# Copyright 2016-2020, Intel Corporation
 
 #
 # push-image.sh <OS-VER> - pushes the Docker image tagged with OS-VER
@@ -12,6 +12,8 @@
 #
 
 set -e
+
+source $(dirname $0)/../set-ci-vars.sh
 
 function usage {
 	echo "Usage:"

--- a/utils/docker/pull-or-rebuild-image.sh
+++ b/utils/docker/pull-or-rebuild-image.sh
@@ -21,6 +21,7 @@
 
 set -e
 
+source $(dirname $0)/set-ci-vars.sh
 source $(dirname $0)/set-vars.sh
 
 if [[ "$CI_EVENT_TYPE" != "cron" && "$CI_BRANCH" != "coverity_scan" \


### PR DESCRIPTION
This patch fixes regression introduced by commit 696786d.

It turned out that passing CI_* variables through environment
does not work - they are not passed through at all.

The 'set-ci-vars.sh' script has to be called directly
in other CI scripts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4591)
<!-- Reviewable:end -->
