### PR TITLE
common: fix run-coverity.sh script

### DIFF
--- a/utils/docker/run-coverity.sh
+++ b/utils/docker/run-coverity.sh
@@ -11,10 +11,16 @@ set -e
 # Prepare build environment
 ./prepare-for-build.sh
 
+CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+TEMP_CF=$(mktemp)
+cp $CERT_FILE $TEMP_CF
+
 # Download Coverity certificate
 echo -n | openssl s_client -connect scan.coverity.com:443 | \
 	sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | \
-	sudo tee -a /etc/ssl/certs/ca-;
+	tee -a $TEMP_CF
+
+echo $USERPASS | sudo -S mv $TEMP_CF $CERT_FILE
 
 export COVERITY_SCAN_PROJECT_NAME="$CI_REPO_SLUG"
 [[ "$CI_EVENT_TYPE" == "cron" ]] \


### PR DESCRIPTION
The command:
```
$ sudo tee -a /etc/ssl/certs/ca-
```
fails with the following error on GitHub Actions CI:
```
sudo: no tty present and no askpass program specified
```
This patch fixes this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4592)
<!-- Reviewable:end -->
