### PR TITLE
pmem2: use PMEM2_E_BUFFER_TOO_SMALL in pmem2_source_device_id

### DIFF
--- a/src/include/libpmem2.h
+++ b/src/include/libpmem2.h
@@ -50,6 +50,7 @@ extern "C" {
 #define PMEM2_E_INVALID_SIZE_FORMAT		(-100014)
 #define PMEM2_E_LENGTH_UNALIGNED		(-100015)
 #define PMEM2_E_MAPPING_NOT_FOUND		(-100016)
+#define PMEM2_E_BUFFER_TOO_SMALL		(-100017)
 
 /* source setup */
 

--- a/src/libpmem2/usc_ndctl.c
+++ b/src/libpmem2/usc_ndctl.c
@@ -324,7 +324,7 @@ pmem2_source_device_id(const struct pmem2_source *src, char *id, size_t *len)
 		const char *dimm_uid = ndctl_dimm_get_unique_id(dimm);
 		count += strlen(dimm_uid);
 		if (count > *len) {
-			ret = PMEM2_E_INVALID_ARG;
+			ret = PMEM2_E_BUFFER_TOO_SMALL;
 			goto end;
 		}
 		strncat(id, dimm_uid, *len);

--- a/src/libpmem2/usc_windows.c
+++ b/src/libpmem2/usc_windows.c
@@ -107,7 +107,7 @@ pmem2_source_device_idW(const struct pmem2_source *src, wchar_t *id,
 
 	if (*len < GUID_SIZE * sizeof(*id)) {
 		ERR("id buffer is to small");
-		return PMEM2_E_INVALID_ARG;
+		return PMEM2_E_BUFFER_TOO_SMALL;
 	}
 
 	GUID guid;
@@ -133,7 +133,7 @@ pmem2_source_device_idU(const struct pmem2_source *src, char *id, size_t *len)
 	}
 	if (*len < GUID_SIZE * sizeof(*id)) {
 		ERR("id buffer is to small");
-		return PMEM2_E_INVALID_ARG;
+		return PMEM2_E_BUFFER_TOO_SMALL;
 	}
 
 	GUID guid;


### PR DESCRIPTION
Fixes build after 021c91e502a32707621148a6f73a09fb925b5a4a.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4595)
<!-- Reviewable:end -->
