### PR TITLE
Adding DOC variable to Makefile that enables/disables building & installing documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ BUILD_PACKAGE_CHECK ?= y
 BUILD_RPMEM ?= y
 TEST_CONFIG_FILE ?= "$(CURDIR)"/src/test/testconfig.sh
 PMEM2_INSTALL ?= n
+DOC ?= y
 
 rpm : override DESTDIR="$(CURDIR)/$(RPM_BUILDDIR)"
 dpkg: override DESTDIR="$(CURDIR)/$(DPKG_BUILDDIR)"
@@ -55,17 +56,23 @@ all: doc
 	$(MAKE) -C src $@
 
 doc:
+ifeq ($(DOC),y)
 	test -f .skip-doc || $(MAKE) -C doc all
+endif
 
 clean:
 	$(MAKE) -C src $@
+ifeq ($(DOC),y)
 	test -f .skip-doc || $(MAKE) -C doc $@
+endif
 	$(RM) -r $(RPM_BUILDDIR) $(DPKG_BUILDDIR)
 	$(RM) -f $(GIT_VERSION)
 
 clobber:
 	$(MAKE) -C src $@
+ifeq ($(DOC),y)
 	test -f .skip-doc || $(MAKE) -C doc $@
+endif
 	$(RM) -r $(RPM_BUILDDIR) $(DPKG_BUILDDIR) rpm dpkg
 	$(RM) -f $(GIT_VERSION)
 
@@ -116,7 +123,9 @@ install: all
 
 install uninstall:
 	$(MAKE) -C src $@
+ifeq ($(DOC),y)
 	$(MAKE) -C doc $@
+endif
 
 .PHONY: all clean clobber test check cstyle check-license install uninstall\
 	source rpm dpkg pkg-clean pcheck check-remote format doc require-rpmem\


### PR DESCRIPTION
With this patch, setting explicitly DOC=n disables building and installing documentation, for instance: 
`make DOC=n install `

Some reasons behind a such change:
 - drop dependency on pandoc
 - build and install pmdk without documentation on deployment nodes

See https://github.com/pmem/pmdk/issues/4590

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4596)
<!-- Reviewable:end -->
