### PR TITLE
common: rename build-travis.sh to build-CI.sh

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -38,4 +38,4 @@ jobs:
          run: cd $WORKDIR && ${{ matrix.CONFIG }} ./pull-or-rebuild-image.sh
 
        - name: Run the build
-         run: cd $WORKDIR && ${{ matrix.CONFIG }} ./build-travis.sh
+         run: cd $WORKDIR && ${{ matrix.CONFIG }} ./build-CI.sh

--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -42,7 +42,7 @@ jobs:
          run: cd $WORKDIR && ${{ matrix.CONFIG }} ./pull-or-rebuild-image.sh
 
        - name: Run the build
-         run: cd $WORKDIR && ${{ matrix.CONFIG }} ./build-travis.sh
+         run: cd $WORKDIR && ${{ matrix.CONFIG }} ./build-CI.sh
 
        - name: Push the image
          run: cd $WORKDIR && source ./set-vars.sh && ${{ matrix.CONFIG }} /bin/bash -c "if [[ -f ${CI_FILE_PUSH_IMAGE_TO_REPO} ]]; then images/push-image.sh; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_install:
   - ./pull-or-rebuild-image.sh
 
 script:
-  - ./build-travis.sh
+  - ./build-CI.sh
 
 after_success:
   - source ./set-vars.sh

--- a/doc/RELEASE_STEPS.md
+++ b/doc/RELEASE_STEPS.md
@@ -46,6 +46,6 @@ Publish package and make it official:
 - announce the release on pmem group
 
 Later, for major release:
-- bump version of Docker images (build-travis.sh, build-local.sh, build-image.sh, push-image.sh, pull-or-rebuild-image.sh) to $VERSION+1
+- bump version of Docker images (build-CI.sh, build-local.sh, build-image.sh, push-image.sh, pull-or-rebuild-image.sh) to $VERSION+1
 - add new branch to valid-branches.sh
 - once gh-pages contains new documentation, add $VERSION section in _data/releases_linux.yml and _data/releases_windows.yml on gh-pages branch

--- a/utils/docker/README
+++ b/utils/docker/README
@@ -7,13 +7,13 @@ or fedora-based environment and build PMDK project inside it.
 
 'build-local.sh' can be used to build PMDK locally.
 
-'build-travis.sh' is used for building PMDK on Travis.
+'build-CI.sh' is used for building PMDK on Travis and GitHub Actions CIs
 
 NOTE:
-(for those, who have Travis builds enabled for their fork of the PMDK project)
 If you commit changes to any Dockerfile or shell script in the 'images'
 subdirectory and then do git-rebase before pushing your commits to the
 repository, make sure that you do not squash the commit which is the head in
-your repository. This will let Travis recreate Docker images used during the
-build before the build. Otherwise the not-updated Docker image will be pulled
-from the Docker Hub and used during the build on Travis.
+your repository. This will let Travis and GitHub Actions CIs recreate
+Docker images used during the build before the build. Otherwise the not-updated
+Docker image will be pulled from the Docker Hub and used during the build on
+Travis and GitHub Actions CIs.

--- a/utils/docker/build-CI.sh
+++ b/utils/docker/build-CI.sh
@@ -3,10 +3,10 @@
 # Copyright 2016-2020, Intel Corporation
 
 #
-# build-travis.sh - runs a Docker container from a Docker image with environment
+# build-CI.sh - runs a Docker container from a Docker image with environment
 #                   prepared for building PMDK project and starts building PMDK
 #
-# this script is for building PMDK on Travis only
+# this script is used for building PMDK on Travis and GitHub Actions CIs
 #
 
 set -e


### PR DESCRIPTION
Rename 'build-travis.sh' to 'build-CI.sh'
and note that this script is used for building PMDK
on Travis and GitHub Actions CIs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4612)
<!-- Reviewable:end -->
