### PR TITLE
common: set CI_EVENT_TYPE to 'cron' when GITHUB_EVENT_NAME is 'schedule'

### DIFF
--- a/utils/docker/set-ci-vars.sh
+++ b/utils/docker/set-ci-vars.sh
@@ -55,9 +55,17 @@ elif [ -n "$GITHUB_ACTIONS" ]; then
 	CI_COMMIT=$GITHUB_SHA
 	CI_COMMIT_RANGE=$COMMIT_RANGE_FROM_LAST_MERGE
 	CI_BRANCH=$(echo $GITHUB_REF | cut -d'/' -f3)
-	CI_EVENT_TYPE=$GITHUB_EVENT_NAME
 	CI_REPO_SLUG=$GITHUB_REPOSITORY
 	CI_CPU_ARCH="x86_64" # GitHub Actions supports only x86_64
+
+	case "$GITHUB_EVENT_NAME" in
+	"schedule")
+		CI_EVENT_TYPE="cron"
+		;;
+	*)
+		CI_EVENT_TYPE=$GITHUB_EVENT_NAME
+		;;
+	esac
 
 else
 	CI_COMMIT=$(git log --pretty=%H -1)


### PR DESCRIPTION
Set CI_EVENT_TYPE to 'cron' when GITHUB_EVENT_NAME equals 'schedule'.

It fixes Coverity builds run on GHA. They are not started now,
because CI_EVENT_TYPE equals 'schedule' instead of 'cron'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4618)
<!-- Reviewable:end -->
