### PR TITLE
common: fix automatic gh-pages docs update

### DIFF
--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -62,12 +62,15 @@ fi
 
 # Add and push changes.
 # git commit command may fail if there is nothing to commit.
-# In that case we want to force push anyway (there might be open pull request with
-# changes which were reverted).
+# In that case we want to force push anyway (there might be open pull request
+# with changes which were reverted).
 git add -A
 git commit -m "doc: automatic gh-pages docs update" && true
 git push -f ${ORIGIN} $GH_PAGES_NAME
 
-hub pull-request -f -b ${USER_NAME}:gh-pages -h ${BOT_NAME}:${GH_PAGES_NAME} -m "doc: automatic gh-pages docs update" && true
+GITHUB_TOKEN=${DOC_UPDATE_GITHUB_TOKEN} hub pull-request -f \
+	-b ${USER_NAME}:gh-pages \
+	-h ${BOT_NAME}:${GH_PAGES_NAME} \
+	-m "doc: automatic gh-pages docs update" && true
 
 exit 0


### PR DESCRIPTION
The 'hub' command fails now with the following error:
```
  Error creating pull request: Unauthorized (HTTP 401)
  Requires authentication
  github.com username: github.com password for  (never stored):
```
and it does not create a pull request with an automatic update
of documentation.

GitHub token has to be stored in the 'GITHUB_TOKEN' environment variable,
so that authentication of the 'hub' command worked correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4621)
<!-- Reviewable:end -->
