### PR TITLE
test: Fix pmempool_sync non-pmem cases for ppc64le

### DIFF
--- a/src/test/pmempool_sync/TEST32
+++ b/src/test/pmempool_sync/TEST32
@@ -6,7 +6,7 @@
 # pmempool_sync/TEST32 -- test for sync command
 #                         with bad blocks recovery files
 #                         and one bad block:
-#                         - offset: 16 length: 2000
+#                         - offset: 2 length: 250
 #                         in the 1st part
 #
 
@@ -37,11 +37,11 @@ expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
 turn_on_checking_bad_blocks $POOLSET
 
-# zero blocks: offset: 16 length: 2000
-zero_blocks $DIR/testfile0 16 2000
+# zero blocks: offset: 2 length: 250
+zero_blocks $DIR/testfile0 2 250
 
 # create recovery files
-create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 16 2000
+create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 2 250
 create_recovery_file $DIR/testset1_r0_p1_badblocks.txt
 create_recovery_file $DIR/testset1_r0_p2_badblocks.txt
 create_recovery_file $DIR/testset1_r1_p0_badblocks.txt

--- a/src/test/pmempool_sync/TEST33
+++ b/src/test/pmempool_sync/TEST33
@@ -6,7 +6,7 @@
 # pmempool_sync/TEST33 -- test for sync command
 #                         with bad blocks recovery files
 #                         and one bad block:
-#                         - offset: 0 length: 2000
+#                         - offset: 0 length: 250
 #                         in the 2nd part
 #
 
@@ -37,12 +37,12 @@ expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
 turn_on_checking_bad_blocks $POOLSET
 
-# zero blocks: offset: 0 length: 2000
-zero_blocks $DIR/testfile1 0 2000
+# zero blocks: offset: 0 length: 250
+zero_blocks $DIR/testfile1 0 250
 
 # create recovery files
 create_recovery_file $DIR/testset1_r0_p0_badblocks.txt
-create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 0 2000
+create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 0 250
 create_recovery_file $DIR/testset1_r0_p2_badblocks.txt
 create_recovery_file $DIR/testset1_r1_p0_badblocks.txt
 

--- a/src/test/pmempool_sync/TEST34
+++ b/src/test/pmempool_sync/TEST34
@@ -6,11 +6,13 @@
 # pmempool_sync/TEST34 -- test for sync command
 #                         with bad blocks recovery files
 #                         and one bad block:
-#                         - offset: 8000 length: 2000
+#                         - offset: 1000 length: 250
 #                         in the 1st part
 #
 
 . ../unittest/unittest.sh
+
+. setup.sh
 
 require_test_type medium
 require_fs_type non-pmem
@@ -24,25 +26,25 @@ rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET \
-	8M:$DIR/testfile0:z \
-	8M:$DIR/testfile1:z \
-	8M:$DIR/testfile2:z \
+	${PARTSIZE}M:$DIR/testfile0:z \
+	${PARTSIZE}M:$DIR/testfile1:z \
+	${PARTSIZE}M:$DIR/testfile2:z \
 	R \
-	24M:$DIR/testfile3:z
+	${POOLSIZE_REP}M:$DIR/testfile3:z
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
-# zero blocks: offset: 8000 length: 2000 in the 1st part
-zero_blocks $DIR/testfile0 8000 2000
+# zero blocks: offset: 1000 length: 250 in the 1st part
+zero_blocks $DIR/testfile0 1000 250
 
 # fail because of bad blocks
 expect_abnormal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG"
 
 # create recovery files
-create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 8000 2000
+create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 1000 250
 create_recovery_file $DIR/testset1_r0_p1_badblocks.txt
 create_recovery_file $DIR/testset1_r0_p2_badblocks.txt
 create_recovery_file $DIR/testset1_r1_p0_badblocks.txt

--- a/src/test/pmempool_sync/TEST35
+++ b/src/test/pmempool_sync/TEST35
@@ -6,11 +6,13 @@
 # pmempool_sync/TEST35 -- test for sync command
 #                         with bad blocks recovery files
 #                         and one bad block:
-#                         - offset: 8000 length: 2000
+#                         - offset: 1000 length: 250
 #                         in the 2nd part
 #
 
 . ../unittest/unittest.sh
+
+. setup.sh
 
 require_test_type medium
 require_fs_type non-pmem
@@ -24,26 +26,26 @@ rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET \
-	8M:$DIR/testfile0:z \
-	8M:$DIR/testfile1:z \
-	8M:$DIR/testfile2:z \
+	${PARTSIZE}M:$DIR/testfile0:z \
+	${PARTSIZE}M:$DIR/testfile1:z \
+	${PARTSIZE}M:$DIR/testfile2:z \
 	R \
-	24M:$DIR/testfile3:z
+	${POOLSIZE_REP}M:$DIR/testfile3:z
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
-# zero blocks: offset: 8000 length: 2000 in the 2nd part
-zero_blocks $DIR/testfile1 8000 2000
+# zero blocks: offset: 1000 length: 250 in the 2nd part
+zero_blocks $DIR/testfile1 1000 250
 
 # fail because of bad blocks
 expect_abnormal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG"
 
 # create recovery files
 create_recovery_file $DIR/testset1_r0_p0_badblocks.txt
-create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 8000 2000
+create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 1000 250
 create_recovery_file $DIR/testset1_r0_p2_badblocks.txt
 create_recovery_file $DIR/testset1_r1_p0_badblocks.txt
 

--- a/src/test/pmempool_sync/TEST36
+++ b/src/test/pmempool_sync/TEST36
@@ -6,12 +6,14 @@
 # pmempool_sync/TEST36 -- test for sync command
 #                         with bad blocks recovery files,
 #                         one bad block:
-#                         - offset: 8000 length: 2000
+#                         - offset: 1000 length: 250
 #                         in the 1st part
 #                         and missing one recovery file
 #
 
 . ../unittest/unittest.sh
+
+. setup.sh
 
 require_test_type medium
 require_fs_type non-pmem
@@ -25,11 +27,11 @@ rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET \
-	8M:$DIR/testfile0:z \
-	8M:$DIR/testfile1:z \
-	8M:$DIR/testfile2:z \
+	${PARTSIZE}M:$DIR/testfile0:z \
+	${PARTSIZE}M:$DIR/testfile1:z \
+	${PARTSIZE}M:$DIR/testfile2:z \
 	R \
-	24M:$DIR/testfile3:z
+	${POOLSIZE_REP}M:$DIR/testfile3:z
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
@@ -38,14 +40,14 @@ expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
 turn_on_checking_bad_blocks $POOLSET
 
-# zero blocks: offset: 8000 length: 2000
-zero_blocks $DIR/testfile0 8000 2000
+# zero blocks: offset: 1000 length: 250
+zero_blocks $DIR/testfile0 1000 250
 
 # fail because of bad blocks
 expect_abnormal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG"
 
 # create recovery files
-create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 8000 2000
+create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 1000 250
 create_recovery_file $DIR/testset1_r0_p1_badblocks.txt
 create_recovery_file $DIR/testset1_r0_p2_badblocks.txt
 

--- a/src/test/pmempool_sync/TEST37
+++ b/src/test/pmempool_sync/TEST37
@@ -6,12 +6,14 @@
 # pmempool_sync/TEST37 -- test for sync command
 #                         with bad blocks recovery files,
 #                         one bad block:
-#                         - offset: 1000 length: 1000
+#                         - offset: 125 length: 125
 #                         in the 2nd part
 #                         and missing one recovery file
 #
 
 . ../unittest/unittest.sh
+
+. setup.sh
 
 require_test_type medium
 require_fs_type non-pmem
@@ -25,11 +27,11 @@ rm -f $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET \
-	8M:$DIR/testfile0:z \
-	8M:$DIR/testfile1:z \
-	8M:$DIR/testfile2:z \
+	${PARTSIZE}M:$DIR/testfile0:z \
+	${PARTSIZE}M:$DIR/testfile1:z \
+	${PARTSIZE}M:$DIR/testfile2:z \
 	R \
-	24M:$DIR/testfile3:z
+	${POOLSIZE_REP}M:$DIR/testfile3:z
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
@@ -38,15 +40,15 @@ expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
 turn_on_checking_bad_blocks $POOLSET
 
-# zero blocks: offset: 1000 length: 1000
-zero_blocks $DIR/testfile1 1000 1000
+# zero blocks: offset: 125 length: 125
+zero_blocks $DIR/testfile1 125 125
 
 # fail because of bad blocks
 expect_abnormal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG"
 
 # create recovery files
 create_recovery_file $DIR/testset1_r0_p0_badblocks.txt
-create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 1000 1000
+create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 125 125
 create_recovery_file $DIR/testset1_r0_p2_badblocks.txt
 
 # one recovery file is missing

--- a/src/test/pmempool_sync/TEST42
+++ b/src/test/pmempool_sync/TEST42
@@ -5,8 +5,8 @@
 #
 # pmempool_sync/TEST42 -- test for sync command with badblocks
 #                         - non-overlapping bad blocks in two replicas
-#                           replica #0: blocks: offset: 1000 length: 8
-#                           replica #1: blocks: offset: 1008 length: 8
+#                           replica #0: blocks: offset: 125 length: 1
+#                           replica #1: blocks: offset: 126 length: 1
 #
 
 . ../unittest/unittest.sh
@@ -38,21 +38,21 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOL
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
-# zero blocks: offset: 1000 length: 8 in the replica #0
-zero_blocks $DIR/testfile1 1000 8
+# zero blocks: offset: 125 length: 1 in the replica #0
+zero_blocks $DIR/testfile1 125 1
 
-# zero blocks: offset: 1008 length: 8 in the replica #1
-zero_blocks $DIR/testfile4 1008 8
+# zero blocks: offset: 126 length: 1 in the replica #1
+zero_blocks $DIR/testfile4 126 1
 
 # fail because of bad blocks
 expect_abnormal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG"
 
 # create recovery files
 create_recovery_file $DIR/testset1_r0_p0_badblocks.txt
-create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 1000 8
+create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 125 1
 create_recovery_file $DIR/testset1_r0_p2_badblocks.txt
 create_recovery_file $DIR/testset1_r1_p0_badblocks.txt
-create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 1008 8
+create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 126 1
 create_recovery_file $DIR/testset1_r1_p2_badblocks.txt
 
 # fix bad blocks

--- a/src/test/pmempool_sync/TEST43
+++ b/src/test/pmempool_sync/TEST43
@@ -5,8 +5,8 @@
 #
 # pmempool_sync/TEST43 -- test for sync command with badblocks
 #                         - overlapping bad blocks in two replicas
-#                           replica #0: blocks: offset: 1000 length: 16
-#                           replica #1: blocks: offset: 1008 length: 16
+#                           replica #0: blocks: offset: 125 length: 2
+#                           replica #1: blocks: offset: 126 length: 2
 #
 
 . ../unittest/unittest.sh
@@ -38,21 +38,21 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOL
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
-# zero blocks: offset: 1000 length: 16 in the replica #0
-zero_blocks $DIR/testfile1 1000 16
+# zero blocks: offset: 125 length: 2 in the replica #0
+zero_blocks $DIR/testfile1 125 2
 
-# zero blocks: offset: 1008 length: 16 in the replica #1
-zero_blocks $DIR/testfile4 1008 16
+# zero blocks: offset: 126 length: 2 in the replica #1
+zero_blocks $DIR/testfile4 126 2
 
 # fail because of bad blocks
 expect_abnormal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX v &>> $LOG"
 
 # create recovery files
 create_recovery_file $DIR/testset1_r0_p0_badblocks.txt
-create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 1000 16
+create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 125 2
 create_recovery_file $DIR/testset1_r0_p2_badblocks.txt
 create_recovery_file $DIR/testset1_r1_p0_badblocks.txt
-create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 1008 16
+create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 126 2
 create_recovery_file $DIR/testset1_r1_p2_badblocks.txt
 
 turn_on_checking_bad_blocks $POOLSET

--- a/src/test/pmempool_sync/TEST44
+++ b/src/test/pmempool_sync/TEST44
@@ -6,13 +6,15 @@
 # pmempool_sync/TEST44 -- test for sync command with badblocks
 #                         - overlapping but fixable bad blocks
 #                           in the 1st part of three replicas:
-#                           replica #0: blocks: offset: 8000 length: 16
-#                           replica #1: blocks: offset: 8008 length: 16
-#                           replica #2: blocks: offset: 8000 length: 8
-#                                               offset: 8016 length: 8
+#                           replica #0: blocks: offset: 1000 length: 2
+#                           replica #1: blocks: offset: 1001 length: 2
+#                           replica #2: blocks: offset: 1000 length: 1
+#                                               offset: 1016 length: 1
 #
 
 . ../unittest/unittest.sh
+
+. setup.sh
 
 require_test_type medium
 require_fs_type non-pmem
@@ -28,43 +30,43 @@ rm -rf $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET \
-	8M:$DIR/testfile0:z \
-	8M:$DIR/testfile1:z \
-	8M:$DIR/testfile2:z \
+	${PARTSIZE}M:$DIR/testfile0:z \
+	${PARTSIZE}M:$DIR/testfile1:z \
+	${PARTSIZE}M:$DIR/testfile2:z \
 	R \
-	8M:$DIR/testfile3:z \
-	8M:$DIR/testfile4:z \
-	8M:$DIR/testfile5:z \
+	${PARTSIZE}M:$DIR/testfile3:z \
+	${PARTSIZE}M:$DIR/testfile4:z \
+	${PARTSIZE}M:$DIR/testfile5:z \
 	R \
-	8M:$DIR/testfile6:z \
-	8M:$DIR/testfile7:z \
-	8M:$DIR/testfile8:z
+	${PARTSIZE}M:$DIR/testfile6:z \
+	${PARTSIZE}M:$DIR/testfile7:z \
+	${PARTSIZE}M:$DIR/testfile8:z
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
-# zero blocks: offset: 8000 length: 16 in the replica #0
-zero_blocks $DIR/testfile0 8000 16
+# zero blocks: offset: 1000 length: 2 in the replica #0
+zero_blocks $DIR/testfile0 1000 2
 
-# zero blocks: offset: 8008 length: 16 in the replica #1
-zero_blocks $DIR/testfile3 8008 16
+# zero blocks: offset: 1001 length: 2 in the replica #1
+zero_blocks $DIR/testfile3 1001 2
 
-# zero blocks: offset: 8000 length: 8 in the replica #2
-zero_blocks $DIR/testfile6 8000 8
+# zero blocks: offset: 1000 length: 1 in the replica #2
+zero_blocks $DIR/testfile6 1000 1
 
-# zero blocks: offset: 8016 length: 8 in the replica #2
-zero_blocks $DIR/testfile6 8016 8
+# zero blocks: offset: 1002 length: 1 in the replica #2
+zero_blocks $DIR/testfile6 1002 1
 
 # create recovery files
-create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 8000 16
+create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 1000 2
 create_recovery_file $DIR/testset1_r0_p1_badblocks.txt
 create_recovery_file $DIR/testset1_r0_p2_badblocks.txt
-create_recovery_file $DIR/testset1_r1_p0_badblocks.txt 8008 16
+create_recovery_file $DIR/testset1_r1_p0_badblocks.txt 1001 2
 create_recovery_file $DIR/testset1_r1_p1_badblocks.txt
 create_recovery_file $DIR/testset1_r1_p2_badblocks.txt
-create_recovery_file $DIR/testset1_r2_p0_badblocks.txt 8000 8 8016 8
+create_recovery_file $DIR/testset1_r2_p0_badblocks.txt 1000 1 1002 1
 create_recovery_file $DIR/testset1_r2_p1_badblocks.txt
 create_recovery_file $DIR/testset1_r2_p2_badblocks.txt
 

--- a/src/test/pmempool_sync/TEST45
+++ b/src/test/pmempool_sync/TEST45
@@ -6,10 +6,10 @@
 # pmempool_sync/TEST45 -- test for sync command with badblocks
 #                         - overlapping but fixable bad blocks
 #                           in the 2nd part of three replicas:
-#                           replica #0: blocks: offset: 1000 length: 16
-#                           replica #1: blocks: offset: 1008 length: 16
-#                           replica #2: blocks: offset: 1000 length: 8
-#                                               offset: 1016 length: 8
+#                           replica #0: blocks: offset: 125 length: 2
+#                           replica #1: blocks: offset: 126 length: 2
+#                           replica #2: blocks: offset: 125 length: 1
+#                                               offset: 127 length: 1
 #
 
 . ../unittest/unittest.sh
@@ -45,27 +45,27 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOL
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
-# zero blocks: offset: 1000 length: 16 in the replica #0
-zero_blocks $DIR/testfile1 1000 16
+# zero blocks: offset: 125 length: 2 in the replica #0
+zero_blocks $DIR/testfile1 125 2
 
-# zero blocks: offset: 1008 length: 16 in the replica #1
-zero_blocks $DIR/testfile4 1008 16
+# zero blocks: offset: 126 length: 2 in the replica #1
+zero_blocks $DIR/testfile4 126 2
 
-# zero blocks: offset: 1000 length: 8 in the replica #2
-zero_blocks $DIR/testfile7 1000 8
+# zero blocks: offset: 125 length: 1 in the replica #2
+zero_blocks $DIR/testfile7 125 1
 
-# zero blocks: offset: 1016 length: 8 in the replica #2
-zero_blocks $DIR/testfile7 1016 8
+# zero blocks: offset: 127 length: 1 in the replica #2
+zero_blocks $DIR/testfile7 127 1
 
 # create recovery files
 create_recovery_file $DIR/testset1_r0_p0_badblocks.txt
-create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 1000 16
+create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 125 2
 create_recovery_file $DIR/testset1_r0_p2_badblocks.txt
 create_recovery_file $DIR/testset1_r1_p0_badblocks.txt
-create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 1008 16
+create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 126 2
 create_recovery_file $DIR/testset1_r1_p2_badblocks.txt
 create_recovery_file $DIR/testset1_r2_p0_badblocks.txt
-create_recovery_file $DIR/testset1_r2_p1_badblocks.txt 1000 8 1016 8
+create_recovery_file $DIR/testset1_r2_p1_badblocks.txt 125 1 127 1
 create_recovery_file $DIR/testset1_r2_p2_badblocks.txt
 
 turn_on_checking_bad_blocks $POOLSET

--- a/src/test/pmempool_sync/TEST46
+++ b/src/test/pmempool_sync/TEST46
@@ -6,10 +6,10 @@
 # pmempool_sync/TEST46 -- test for sync command with badblocks
 #                         - overlapping but fixable bad blocks
 #                           in the 3rd part of three replicas:
-#                           replica #0: blocks: offset: 1000 length: 16
-#                           replica #1: blocks: offset: 1008 length: 16
-#                           replica #2: blocks: offset: 1000 length: 8
-#                                               offset: 1016 length: 8
+#                           replica #0: blocks: offset: 125 length: 2
+#                           replica #1: blocks: offset: 126 length: 2
+#                           replica #2: blocks: offset: 125 length: 1
+#                                               offset: 127 length: 1
 #
 
 . ../unittest/unittest.sh
@@ -45,28 +45,28 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOL
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
-# zero blocks: offset: 1000 length: 16 in the replica #0
-zero_blocks $DIR/testfile2 1000 16
+# zero blocks: offset: 125 length: 2 in the replica #0
+zero_blocks $DIR/testfile2 125 2
 
-# zero blocks: offset: 1008 length: 16 in the replica #1
-zero_blocks $DIR/testfile5 1008 16
+# zero blocks: offset: 126 length: 2 in the replica #1
+zero_blocks $DIR/testfile5 126 2
 
-# zero blocks: offset: 1000 length: 8 in the replica #2
-zero_blocks $DIR/testfile8 1000 8
+# zero blocks: offset: 125 length: 1 in the replica #2
+zero_blocks $DIR/testfile8 125 1
 
-# zero blocks: offset: 1016 length: 8 in the replica #2
-zero_blocks $DIR/testfile8 1016 8
+# zero blocks: offset: 127 length: 1 in the replica #2
+zero_blocks $DIR/testfile8 127 1
 
 # create recovery files - no bad blocks
 create_recovery_file $DIR/testset1_r0_p0_badblocks.txt
 create_recovery_file $DIR/testset1_r0_p1_badblocks.txt
-create_recovery_file $DIR/testset1_r0_p2_badblocks.txt 1000 16
+create_recovery_file $DIR/testset1_r0_p2_badblocks.txt 125 2
 create_recovery_file $DIR/testset1_r1_p0_badblocks.txt
 create_recovery_file $DIR/testset1_r1_p1_badblocks.txt
-create_recovery_file $DIR/testset1_r1_p2_badblocks.txt 1008 16
+create_recovery_file $DIR/testset1_r1_p2_badblocks.txt 126 2
 create_recovery_file $DIR/testset1_r2_p0_badblocks.txt
 create_recovery_file $DIR/testset1_r2_p1_badblocks.txt
-create_recovery_file $DIR/testset1_r2_p2_badblocks.txt 1000 8 1016 8
+create_recovery_file $DIR/testset1_r2_p2_badblocks.txt 125 1 127 1
 
 turn_on_checking_bad_blocks $POOLSET
 

--- a/src/test/pmempool_sync/TEST47
+++ b/src/test/pmempool_sync/TEST47
@@ -6,12 +6,14 @@
 # pmempool_sync/TEST47 -- test for sync command with badblocks
 #                         - overlapping but fixable bad blocks:
 #
-#                           replica #0 parts #0 & #1: blocks: offset: 8000 length: 16
-#                           replica #1 parts #1 & #2: blocks: offset: 8000 length: 16
-#                           replica #2 parts #0 & #2: blocks: offset: 8000 length: 16
+#                           replica #0 parts #0 & #1: blocks: offset: 1000 length: 2
+#                           replica #1 parts #1 & #2: blocks: offset: 1000 length: 2
+#                           replica #2 parts #0 & #2: blocks: offset: 1000 length: 2
 #
 
 . ../unittest/unittest.sh
+
+. setup.sh
 
 require_test_type medium
 require_fs_type non-pmem
@@ -27,47 +29,47 @@ rm -rf $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET \
-	8M:$DIR/testfile_r0_p0:z \
-	8M:$DIR/testfile_r0_p1:z \
-	8M:$DIR/testfile_r0_p2:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p2:z \
 	R \
-	8M:$DIR/testfile_r1_p0:z \
-	8M:$DIR/testfile_r1_p1:z \
-	8M:$DIR/testfile_r1_p2:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p2:z \
 	R \
-	8M:$DIR/testfile_r2_p0:z \
-	8M:$DIR/testfile_r2_p1:z \
-	8M:$DIR/testfile_r2_p2:z
+	${PARTSIZE}M:$DIR/testfile_r2_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r2_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r2_p2:z
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
-# zero blocks: offset: 8000 length: 16 in the replica #0 parts #0 & #1
-zero_blocks $DIR/testfile_r0_p0 8000 16
-zero_blocks $DIR/testfile_r0_p1 8000 16
+# zero blocks: offset: 1000 length: 2 in the replica #0 parts #0 & #1
+zero_blocks $DIR/testfile_r0_p0 1000 2
+zero_blocks $DIR/testfile_r0_p1 1000 2
 
-# zero blocks: offset: 8000 length: 16 in the replica #1 parts #1 & #2
-zero_blocks $DIR/testfile_r1_p1 8000 16
-zero_blocks $DIR/testfile_r1_p2 8000 16
+# zero blocks: offset: 1000 length: 2 in the replica #1 parts #1 & #2
+zero_blocks $DIR/testfile_r1_p1 1000 2
+zero_blocks $DIR/testfile_r1_p2 1000 2
 
-# zero blocks: offset: 8000 length: 16 in the replica #2 parts #0 & #2
-zero_blocks $DIR/testfile_r2_p2 8000 16
-zero_blocks $DIR/testfile_r2_p0 8000 16
+# zero blocks: offset: 1000 length: 2 in the replica #2 parts #0 & #2
+zero_blocks $DIR/testfile_r2_p2 1000 2
+zero_blocks $DIR/testfile_r2_p0 1000 2
 
 # create recovery files
-create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 8000 16
-create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 8000 16
+create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 1000 2
+create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 1000 2
 create_recovery_file $DIR/testset1_r0_p2_badblocks.txt
 
 create_recovery_file $DIR/testset1_r1_p0_badblocks.txt
-create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 8000 16
-create_recovery_file $DIR/testset1_r1_p2_badblocks.txt 8000 16
+create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 1000 2
+create_recovery_file $DIR/testset1_r1_p2_badblocks.txt 1000 2
 
-create_recovery_file $DIR/testset1_r2_p0_badblocks.txt 8000 16
+create_recovery_file $DIR/testset1_r2_p0_badblocks.txt 1000 2
 create_recovery_file $DIR/testset1_r2_p1_badblocks.txt
-create_recovery_file $DIR/testset1_r2_p2_badblocks.txt 8000 16
+create_recovery_file $DIR/testset1_r2_p2_badblocks.txt 1000 2
 
 turn_on_checking_bad_blocks $POOLSET
 

--- a/src/test/pmempool_sync/TEST48
+++ b/src/test/pmempool_sync/TEST48
@@ -6,15 +6,17 @@
 # pmempool_sync/TEST48 -- test for sync command with badblocks
 #                         - overlapping but fixable bad blocks:
 #
-#                           replica #0 part #0: blocks: offset: 8000 length: 16
-#                           replica #0 part #1: blocks: offset: 8008 length: 16
-#                           replica #1 part #1: blocks: offset: 8000 length: 16
-#                           replica #1 part #2: blocks: offset: 8008 length: 16
-#                           replica #2 part #2: blocks: offset: 8000 length: 16
-#                           replica #2 part #0: blocks: offset: 8008 length: 16
+#                           replica #0 part #0: blocks: offset: 1000 length: 2
+#                           replica #0 part #1: blocks: offset: 1001 length: 2
+#                           replica #1 part #1: blocks: offset: 1000 length: 2
+#                           replica #1 part #2: blocks: offset: 1001 length: 2
+#                           replica #2 part #2: blocks: offset: 1000 length: 2
+#                           replica #2 part #0: blocks: offset: 1001 length: 2
 #
 
 . ../unittest/unittest.sh
+
+. setup.sh
 
 require_test_type medium
 require_fs_type non-pmem
@@ -30,17 +32,17 @@ rm -rf $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET \
-	8M:$DIR/testfile_r0_p0:z \
-	8M:$DIR/testfile_r0_p1:z \
-	8M:$DIR/testfile_r0_p2:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p2:z \
 	R \
-	8M:$DIR/testfile_r1_p0:z \
-	8M:$DIR/testfile_r1_p1:z \
-	8M:$DIR/testfile_r1_p2:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p2:z \
 	R \
-	8M:$DIR/testfile_r2_p0:z \
-	8M:$DIR/testfile_r2_p1:z \
-	8M:$DIR/testfile_r2_p2:z
+	${PARTSIZE}M:$DIR/testfile_r2_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r2_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r2_p2:z
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
@@ -48,29 +50,29 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOL
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
 # zero blocks:
-zero_blocks $DIR/testfile_r0_p0 8000 16
-zero_blocks $DIR/testfile_r0_p1 8008 16
+zero_blocks $DIR/testfile_r0_p0 1000 2
+zero_blocks $DIR/testfile_r0_p1 1001 2
 
-zero_blocks $DIR/testfile_r1_p1 8000 16
-zero_blocks $DIR/testfile_r1_p2 8008 16
+zero_blocks $DIR/testfile_r1_p1 1000 2
+zero_blocks $DIR/testfile_r1_p2 1001 2
 
-zero_blocks $DIR/testfile_r2_p2 8000 16
-zero_blocks $DIR/testfile_r2_p0 8008 16
+zero_blocks $DIR/testfile_r2_p2 1000 2
+zero_blocks $DIR/testfile_r2_p0 1001 2
 
 # create recovery files - no bad blocks
 
-# create recovery file - one bad block: offset: 8000 length: 16
-create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 8000 16
-create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 8008 16
+# create recovery file - one bad block: offset: 1000 length: 2
+create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 1000 2
+create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 1001 2
 create_recovery_file $DIR/testset1_r0_p2_badblocks.txt
 
 create_recovery_file $DIR/testset1_r1_p0_badblocks.txt
-create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 8000 16
-create_recovery_file $DIR/testset1_r1_p2_badblocks.txt 8008 16
+create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 1000 2
+create_recovery_file $DIR/testset1_r1_p2_badblocks.txt 1001 2
 
-create_recovery_file $DIR/testset1_r2_p0_badblocks.txt 8008 16
+create_recovery_file $DIR/testset1_r2_p0_badblocks.txt 1001 2
 create_recovery_file $DIR/testset1_r2_p1_badblocks.txt
-create_recovery_file $DIR/testset1_r2_p2_badblocks.txt 8000 16
+create_recovery_file $DIR/testset1_r2_p2_badblocks.txt 1000 2
 
 turn_on_checking_bad_blocks $POOLSET
 

--- a/src/test/pmempool_sync/TEST49
+++ b/src/test/pmempool_sync/TEST49
@@ -1,21 +1,23 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2019, Intel Corporation
+# Copyright 2011-2019, Intel Corporation
 #
 #
 # pmempool_sync/TEST49 -- test for sync command with badblocks
 #                         - overlapping but fixable bad blocks:
 #
-#                           replica #0 part #0: blocks: offset: 8008 length: 8
-#                           replica #0 part #1: blocks: offset: 8008 length: 8
-#                           replica #1 part #2: blocks: offset: 8008 length: 8
+#                           replica #0 part #0: blocks: offset: 1001 length: 1
+#                           replica #0 part #1: blocks: offset: 1001 length: 1
+#                           replica #1 part #2: blocks: offset: 1001 length: 1
 #
-#                           replica #2 part #0: blocks: offset: 8000 length: 24
-#                           replica #1 part #1: blocks: offset: 8000 length: 24
-#                           replica #2 part #2: blocks: offset: 8000 length: 24
+#                           replica #2 part #0: blocks: offset: 1000 length: 3
+#                           replica #1 part #1: blocks: offset: 1000 length: 3
+#                           replica #2 part #2: blocks: offset: 1000 length: 3
 #
 
 . ../unittest/unittest.sh
+
+. setup.sh
 
 require_test_type medium
 require_fs_type non-pmem
@@ -31,17 +33,17 @@ rm -rf $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET \
-	8M:$DIR/testfile_r0_p0:z \
-	8M:$DIR/testfile_r0_p1:z \
-	8M:$DIR/testfile_r0_p2:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p2:z \
 	R \
-	8M:$DIR/testfile_r1_p0:z \
-	8M:$DIR/testfile_r1_p1:z \
-	8M:$DIR/testfile_r1_p2:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p2:z \
 	R \
-	8M:$DIR/testfile_r2_p0:z \
-	8M:$DIR/testfile_r2_p1:z \
-	8M:$DIR/testfile_r2_p2:z
+	${PARTSIZE}M:$DIR/testfile_r2_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r2_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r2_p2:z
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
@@ -49,13 +51,13 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOL
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
 # zero blocks:
-zero_blocks $DIR/testfile_r0_p0 8008 8
-zero_blocks $DIR/testfile_r0_p1 8008 8
-zero_blocks $DIR/testfile_r1_p2 8008 8
+zero_blocks $DIR/testfile_r0_p0 1001 1
+zero_blocks $DIR/testfile_r0_p1 1001 1
+zero_blocks $DIR/testfile_r1_p2 1001 1
 
-zero_blocks $DIR/testfile_r1_p1 8000 24
-zero_blocks $DIR/testfile_r2_p2 8000 24
-zero_blocks $DIR/testfile_r2_p0 8000 24
+zero_blocks $DIR/testfile_r1_p1 1000 3
+zero_blocks $DIR/testfile_r2_p2 1000 3
+zero_blocks $DIR/testfile_r2_p0 1000 3
 
 # create recovery files - no bad blocks
 create_recovery_file $DIR/testset1_r1_p0_badblocks.txt
@@ -63,13 +65,13 @@ create_recovery_file $DIR/testset1_r2_p1_badblocks.txt
 create_recovery_file $DIR/testset1_r0_p2_badblocks.txt
 
 # create recovery files - with bad blocks
-create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 8008 8
-create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 8008 8
-create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 8008 8
+create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 1001 1
+create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 1001 1
+create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 1001 1
 
-create_recovery_file $DIR/testset1_r1_p2_badblocks.txt 8000 24
-create_recovery_file $DIR/testset1_r2_p2_badblocks.txt 8000 24
-create_recovery_file $DIR/testset1_r2_p0_badblocks.txt 8000 24
+create_recovery_file $DIR/testset1_r1_p2_badblocks.txt 1000 3
+create_recovery_file $DIR/testset1_r2_p2_badblocks.txt 1000 3
+create_recovery_file $DIR/testset1_r2_p0_badblocks.txt 1000 3
 
 turn_on_checking_bad_blocks $POOLSET
 

--- a/src/test/pmempool_sync/TEST50
+++ b/src/test/pmempool_sync/TEST50
@@ -6,16 +6,18 @@
 # pmempool_sync/TEST50 -- test for sync command with badblocks
 #                         - overlapping but fixable bad blocks:
 #
-#                           replica #0 part #0: blocks: offset: 8000 length: 24
-#                           replica #0 part #1: blocks: offset: 8000 length: 24
-#                           replica #1 part #2: blocks: offset: 8000 length: 24
+#                           replica #0 part #0: blocks: offset: 1000 length: 3
+#                           replica #0 part #1: blocks: offset: 1000 length: 3
+#                           replica #1 part #2: blocks: offset: 1000 length: 3
 #
-#                           replica #1 part #1: blocks: offset: 8008 length: 8
-#                           replica #2 part #2: blocks: offset: 8008 length: 8
-#                           replica #2 part #0: blocks: offset: 8008 length: 8
+#                           replica #1 part #1: blocks: offset: 1001 length: 1
+#                           replica #2 part #2: blocks: offset: 1001 length: 1
+#                           replica #2 part #0: blocks: offset: 1001 length: 1
 #
 
 . ../unittest/unittest.sh
+
+. setup.sh
 
 require_test_type medium
 require_fs_type non-pmem
@@ -31,17 +33,17 @@ rm -rf $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET \
-	8M:$DIR/testfile_r0_p0:z \
-	8M:$DIR/testfile_r0_p1:z \
-	8M:$DIR/testfile_r0_p2:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p2:z \
 	R \
-	8M:$DIR/testfile_r1_p0:z \
-	8M:$DIR/testfile_r1_p1:z \
-	8M:$DIR/testfile_r1_p2:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p2:z \
 	R \
-	8M:$DIR/testfile_r2_p0:z \
-	8M:$DIR/testfile_r2_p1:z \
-	8M:$DIR/testfile_r2_p2:z
+	${PARTSIZE}M:$DIR/testfile_r2_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r2_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r2_p2:z
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
@@ -49,13 +51,13 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOL
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
 # zero blocks:
-zero_blocks $DIR/testfile_r0_p0 8000 24
-zero_blocks $DIR/testfile_r0_p1 8000 24
-zero_blocks $DIR/testfile_r1_p2 8000 24
+zero_blocks $DIR/testfile_r0_p0 1000 3
+zero_blocks $DIR/testfile_r0_p1 1000 3
+zero_blocks $DIR/testfile_r1_p2 1000 3
 
-zero_blocks $DIR/testfile_r1_p1 8008 8
-zero_blocks $DIR/testfile_r2_p2 8008 8
-zero_blocks $DIR/testfile_r2_p0 8008 8
+zero_blocks $DIR/testfile_r1_p1 1001 1
+zero_blocks $DIR/testfile_r2_p2 1001 1
+zero_blocks $DIR/testfile_r2_p0 1001 1
 
 # create recovery files - no bad blocks
 create_recovery_file $DIR/testset1_r0_p2_badblocks.txt
@@ -63,13 +65,13 @@ create_recovery_file $DIR/testset1_r1_p0_badblocks.txt
 create_recovery_file $DIR/testset1_r2_p1_badblocks.txt
 
 # create recovery file - with bad blocks
-create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 8000 24
-create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 8000 24
-create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 8000 24
+create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 1000 3
+create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 1000 3
+create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 1000 3
 
-create_recovery_file $DIR/testset1_r1_p2_badblocks.txt 8008 8
-create_recovery_file $DIR/testset1_r2_p2_badblocks.txt 8008 8
-create_recovery_file $DIR/testset1_r2_p0_badblocks.txt 8008 8
+create_recovery_file $DIR/testset1_r1_p2_badblocks.txt 1001 1
+create_recovery_file $DIR/testset1_r2_p2_badblocks.txt 1001 1
+create_recovery_file $DIR/testset1_r2_p0_badblocks.txt 1001 1
 
 turn_on_checking_bad_blocks $POOLSET
 

--- a/src/test/pmempool_sync/TEST51
+++ b/src/test/pmempool_sync/TEST51
@@ -6,17 +6,19 @@
 # pmempool_sync/TEST51 -- test for sync command with badblocks
 #                         - overlapping but fixable bad blocks:
 #
-#                           replica #0 part #0: blocks: offset: 8008 length: 8
-#                           replica #0 part #1: blocks: offset: 8000 length: 24
+#                           replica #0 part #0: blocks: offset: 1001 length: 1
+#                           replica #0 part #1: blocks: offset: 1000 length: 3
 #
-#                           replica #1 part #1: blocks: offset: 8008 length: 8
-#                           replica #1 part #2: blocks: offset: 8000 length: 24
+#                           replica #1 part #1: blocks: offset: 1001 length: 1
+#                           replica #1 part #2: blocks: offset: 1000 length: 3
 #
-#                           replica #2 part #2: blocks: offset: 8008 length: 8
-#                           replica #2 part #0: blocks: offset: 8000 length: 24
+#                           replica #2 part #2: blocks: offset: 1001 length: 1
+#                           replica #2 part #0: blocks: offset: 1000 length: 3
 #
 
 . ../unittest/unittest.sh
+
+. setup.sh
 
 require_test_type medium
 require_fs_type non-pmem
@@ -32,17 +34,17 @@ rm -rf $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET \
-	8M:$DIR/testfile_r0_p0:z \
-	8M:$DIR/testfile_r0_p1:z \
-	8M:$DIR/testfile_r0_p2:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p2:z \
 	R \
-	8M:$DIR/testfile_r1_p0:z \
-	8M:$DIR/testfile_r1_p1:z \
-	8M:$DIR/testfile_r1_p2:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p2:z \
 	R \
-	8M:$DIR/testfile_r2_p0:z \
-	8M:$DIR/testfile_r2_p1:z \
-	8M:$DIR/testfile_r2_p2:z
+	${PARTSIZE}M:$DIR/testfile_r2_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r2_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r2_p2:z
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
@@ -50,13 +52,13 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOL
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
 # inject errors - zero blocks:
-zero_blocks $DIR/testfile_r0_p0 8008 8
-zero_blocks $DIR/testfile_r1_p1 8008 8
-zero_blocks $DIR/testfile_r2_p2 8008 8
+zero_blocks $DIR/testfile_r0_p0 1001 1
+zero_blocks $DIR/testfile_r1_p1 1001 1
+zero_blocks $DIR/testfile_r2_p2 1001 1
 
-zero_blocks $DIR/testfile_r0_p1 8000 24
-zero_blocks $DIR/testfile_r1_p2 8000 24
-zero_blocks $DIR/testfile_r2_p0 8000 24
+zero_blocks $DIR/testfile_r0_p1 1000 3
+zero_blocks $DIR/testfile_r1_p2 1000 3
+zero_blocks $DIR/testfile_r2_p0 1000 3
 
 # create recovery files - no bad blocks
 create_recovery_file $DIR/testset1_r0_p2_badblocks.txt
@@ -64,13 +66,13 @@ create_recovery_file $DIR/testset1_r1_p0_badblocks.txt
 create_recovery_file $DIR/testset1_r2_p1_badblocks.txt
 
 # create recovery file - with bad blocks
-create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 8008 8
-create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 8008 8
-create_recovery_file $DIR/testset1_r2_p2_badblocks.txt 8008 8
+create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 1001 1
+create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 1001 1
+create_recovery_file $DIR/testset1_r2_p2_badblocks.txt 1001 1
 
-create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 8000 24
-create_recovery_file $DIR/testset1_r1_p2_badblocks.txt 8000 24
-create_recovery_file $DIR/testset1_r2_p0_badblocks.txt 8000 24
+create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 1000 3
+create_recovery_file $DIR/testset1_r1_p2_badblocks.txt 1000 3
+create_recovery_file $DIR/testset1_r2_p0_badblocks.txt 1000 3
 
 turn_on_checking_bad_blocks $POOLSET
 

--- a/src/test/pmempool_sync/TEST52
+++ b/src/test/pmempool_sync/TEST52
@@ -6,12 +6,14 @@
 # pmempool_sync/TEST52 -- test for sync command with badblocks
 #                         - overlapping but fixable bad blocks:
 #
-# replica #0 part #0 & replica #1 part #1: blocks: offset: 8000 length: 1000
-# replica #0 part #1 & replica #1 part #0: blocks: offset: 8016 8032 8048 8064 8080 length: 8
-# replica #2 part #0 & replica #2 part #1: blocks: offset: 7000 9000 length: 32
+# replica #0 part #0 & replica #1 part #1: blocks: offset: 1000 length: 125
+# replica #0 part #1 & replica #1 part #0: blocks: offset: 1002 1004 1006 1008 1010 length: 1
+# replica #2 part #0 & replica #2 part #1: blocks: offset: 175 1125 length: 4
 #
 
 . ../unittest/unittest.sh
+
+. setup.sh
 
 require_test_type medium
 require_fs_type non-pmem
@@ -27,17 +29,17 @@ rm -rf $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET \
-	8M:$DIR/testfile_r0_p0:z \
-	8M:$DIR/testfile_r0_p1:z \
-	8M:$DIR/testfile_r0_p2:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p2:z \
 	R \
-	8M:$DIR/testfile_r1_p0:z \
-	8M:$DIR/testfile_r1_p1:z \
-	8M:$DIR/testfile_r1_p2:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p2:z \
 	R \
-	8M:$DIR/testfile_r2_p0:z \
-	8M:$DIR/testfile_r2_p1:z \
-	8M:$DIR/testfile_r2_p2:z
+	${PARTSIZE}M:$DIR/testfile_r2_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r2_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r2_p2:z
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
@@ -45,24 +47,24 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOL
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
 # inject errors - zero blocks:
-zero_blocks $DIR/testfile_r0_p0 8000 1000
-zero_blocks $DIR/testfile_r1_p1 8000 1000
+zero_blocks $DIR/testfile_r0_p0 1000 125
+zero_blocks $DIR/testfile_r1_p1 1000 125
 
-zero_blocks $DIR/testfile_r0_p1 8016 8 8032 8 8048 8 8064 8 8080 8
-zero_blocks $DIR/testfile_r1_p0 8016 8 8032 8 8048 8 8064 8 8080 8
+zero_blocks $DIR/testfile_r0_p1 1002 1 1004 1 1006 1 1008 1 1010 1
+zero_blocks $DIR/testfile_r1_p0 1002 1 1004 1 1006 1 1008 1 1010 1
 
-zero_blocks $DIR/testfile_r2_p0 7000 32 9000 32
-zero_blocks $DIR/testfile_r2_p1 7000 32 9000 32
+zero_blocks $DIR/testfile_r2_p0 875 4 1125 4
+zero_blocks $DIR/testfile_r2_p1 875 4 1125 4
 
 # create recovery files with bad blocks
-create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 8000 1000
-create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 8000 1000
+create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 1000 125
+create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 1000 125
 
-create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 8016 8 8032 8 8048 8 8064 8 8080 8
-create_recovery_file $DIR/testset1_r1_p0_badblocks.txt 8016 8 8032 8 8048 8 8064 8 8080 8
+create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 1002 1 1004 1 1006 1 1008 1 1010 1
+create_recovery_file $DIR/testset1_r1_p0_badblocks.txt 1002 1 1004 1 1006 1 1008 1 1010 1
 
-create_recovery_file $DIR/testset1_r2_p0_badblocks.txt 7000 32 9000 32
-create_recovery_file $DIR/testset1_r2_p1_badblocks.txt 7000 32 9000 32
+create_recovery_file $DIR/testset1_r2_p0_badblocks.txt 875 4 1125 4
+create_recovery_file $DIR/testset1_r2_p1_badblocks.txt 875 4 1125 4
 
 # create recovery files - no bad blocks
 create_recovery_file $DIR/testset1_r0_p2_badblocks.txt

--- a/src/test/pmempool_sync/TEST53
+++ b/src/test/pmempool_sync/TEST53
@@ -1,19 +1,21 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2019, Intel Corporation
+# Copyright 2011-2019, Intel Corporation
 #
 #
 # pmempool_sync/TEST53 -- test for sync command with badblocks
 #                         - overlapping but fixable bad blocks:
 #
-# replica #0 part #0 & replica #1 part #1: blocks: offset: 8000 length: 1000
-# replica #0 part #1 & replica #1 part #0: blocks: offset: 7992 length: 16
-# replica #0 part #1 & replica #1 part #0: blocks: offset: 8016 8032 8048 8064 8080 length: 8
-# replica #0 part #1 & replica #1 part #0: blocks: offset: 8992 length: 16
-# replica #2 part #0 & replica #2 part #1: blocks: offset: 7000 9000 length: 32
+# replica #0 part #0 & replica #1 part #1: blocks: offset: 1000 length: 125
+# replica #0 part #1 & replica #1 part #0: blocks: offset: 999 length: 2
+# replica #0 part #1 & replica #1 part #0: blocks: offset: 1002 1004 1006 1008 1010 length: 1
+# replica #0 part #1 & replica #1 part #0: blocks: offset: 1124 length: 2
+# replica #2 part #0 & replica #2 part #1: blocks: offset: 875 1125 length: 4
 #
 
 . ../unittest/unittest.sh
+
+. setup.sh
 
 require_test_type medium
 require_fs_type non-pmem
@@ -29,17 +31,17 @@ rm -rf $LOG && touch $LOG
 
 POOLSET=$DIR/testset1
 create_poolset $POOLSET \
-	8M:$DIR/testfile_r0_p0:z \
-	8M:$DIR/testfile_r0_p1:z \
-	8M:$DIR/testfile_r0_p2:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r0_p2:z \
 	R \
-	8M:$DIR/testfile_r1_p0:z \
-	8M:$DIR/testfile_r1_p1:z \
-	8M:$DIR/testfile_r1_p2:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r1_p2:z \
 	R \
-	8M:$DIR/testfile_r2_p0:z \
-	8M:$DIR/testfile_r2_p1:z \
-	8M:$DIR/testfile_r2_p2:z
+	${PARTSIZE}M:$DIR/testfile_r2_p0:z \
+	${PARTSIZE}M:$DIR/testfile_r2_p1:z \
+	${PARTSIZE}M:$DIR/testfile_r2_p2:z
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
@@ -47,24 +49,24 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOL
 expect_normal_exit "$OBJ_VERIFY$EXESUFFIX $POOLSET pmempool$SUFFIX c v &>> $LOG"
 
 # inject errors - zero blocks:
-zero_blocks $DIR/testfile_r0_p0 8000 1000
-zero_blocks $DIR/testfile_r1_p1 8000 1000
+zero_blocks $DIR/testfile_r0_p0 1000 125
+zero_blocks $DIR/testfile_r1_p1 1000 125
 
-zero_blocks $DIR/testfile_r0_p1 7992 16 8016 8 8032 8 8048 8 8064 8 8080 8 8992 16
-zero_blocks $DIR/testfile_r1_p0 7992 16 8016 8 8032 8 8048 8 8064 8 8080 8 8992 16
+zero_blocks $DIR/testfile_r0_p1 999 2 1002 1 1004 1 1006 1 1008 1 1010 1 1124 2
+zero_blocks $DIR/testfile_r1_p0 999 2 1002 1 1004 1 1006 1 1008 1 1010 1 1124 2
 
-zero_blocks $DIR/testfile_r2_p0 7000 32 9000 32
-zero_blocks $DIR/testfile_r2_p1 7000 32 9000 32
+zero_blocks $DIR/testfile_r2_p0 875 4 1125 4
+zero_blocks $DIR/testfile_r2_p1 875 4 1125 4
 
 # create recovery files with bad blocks
-create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 8000 1000
-create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 8000 1000
+create_recovery_file $DIR/testset1_r0_p0_badblocks.txt 1000 125
+create_recovery_file $DIR/testset1_r1_p1_badblocks.txt 1000 125
 
-create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 7992 16 8016 8 8032 8 8048 8 8064 8 8080 8 8992 16
-create_recovery_file $DIR/testset1_r1_p0_badblocks.txt 7992 16 8016 8 8032 8 8048 8 8064 8 8080 8 8992 16
+create_recovery_file $DIR/testset1_r0_p1_badblocks.txt 999 2 1002 1 1004 1 1006 1 1008 1 1010 1 1124 2
+create_recovery_file $DIR/testset1_r1_p0_badblocks.txt 999 2 1002 1 1004 1 1006 1 1008 1 1010 1 1124 2
 
-create_recovery_file $DIR/testset1_r2_p0_badblocks.txt 7000 32 9000 32
-create_recovery_file $DIR/testset1_r2_p1_badblocks.txt 7000 32 9000 32
+create_recovery_file $DIR/testset1_r2_p0_badblocks.txt 875 4 1125 4
+create_recovery_file $DIR/testset1_r2_p1_badblocks.txt 875 4 1125 4
 
 # create recovery files - no bad blocks
 create_recovery_file $DIR/testset1_r0_p2_badblocks.txt

--- a/src/test/pmempool_sync/setup.sh
+++ b/src/test/pmempool_sync/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2020, IBM Corporation
+#
+
+PARTSIZE=$(($(getconf PAGESIZE)/1024*2))
+POOLSIZE_REP=$(($PARTSIZE*3))

--- a/src/test/pmempool_sync_remote/TEST26
+++ b/src/test/pmempool_sync_remote/TEST26
@@ -46,7 +46,7 @@ create_poolset $DIR/$POOLSET_REMOTE \
 	8M:${NODE_DIR[1]}/pool.remote:x
 
 # create the recovery file
-create_recovery_file $RECOVERY_FILE 0 8
+create_recovery_file $RECOVERY_FILE 0 1
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
 copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE

--- a/src/test/pmempool_sync_remote/TEST27
+++ b/src/test/pmempool_sync_remote/TEST27
@@ -46,7 +46,7 @@ create_poolset $DIR/$POOLSET_REMOTE \
 	8M:${NODE_DIR[1]}/pool.remote:x
 
 # create the recovery file
-create_recovery_file $RECOVERY_FILE 8000 8
+create_recovery_file $RECOVERY_FILE 1000 1
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
 copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE

--- a/src/test/pmempool_sync_remote/TEST28
+++ b/src/test/pmempool_sync_remote/TEST28
@@ -51,7 +51,7 @@ create_poolset $DIR/$POOLSET_REMOTE \
 
 # create the recovery files
 create_recovery_file $RECOVERY_FILE_P0
-create_recovery_file $RECOVERY_FILE_P1 0 8
+create_recovery_file $RECOVERY_FILE_P1 0 1
 create_recovery_file $RECOVERY_FILE_P2
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL

--- a/src/test/pmempool_sync_remote/TEST29
+++ b/src/test/pmempool_sync_remote/TEST29
@@ -51,7 +51,7 @@ create_poolset $DIR/$POOLSET_REMOTE \
 
 # create recovery files
 create_recovery_file $RECOVERY_FILE_P0
-create_recovery_file $RECOVERY_FILE_P1 8000 8
+create_recovery_file $RECOVERY_FILE_P1 1000 1
 create_recovery_file $RECOVERY_FILE_P2
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL

--- a/src/test/pmempool_sync_remote/TEST30
+++ b/src/test/pmempool_sync_remote/TEST30
@@ -49,9 +49,9 @@ create_poolset $DIR/$POOLSET_REMOTE \
 	24M:${NODE_DIR[1]}/pool.remote:x
 
 # create the recovery files with bad block
-create_recovery_file $RECOVERY_FILE_P0 0 8
-create_recovery_file $RECOVERY_FILE_P1 0 8
-create_recovery_file $RECOVERY_FILE_P2 0 8
+create_recovery_file $RECOVERY_FILE_P0 0 1
+create_recovery_file $RECOVERY_FILE_P1 0 1
+create_recovery_file $RECOVERY_FILE_P2 0 1
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
 copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE

--- a/src/test/pmempool_sync_remote/TEST31
+++ b/src/test/pmempool_sync_remote/TEST31
@@ -49,9 +49,9 @@ create_poolset $DIR/$POOLSET_REMOTE \
 	24M:${NODE_DIR[1]}/pool.remote:x
 
 # create the recovery files with bad block
-create_recovery_file $RECOVERY_FILE_P0 8000 8
-create_recovery_file $RECOVERY_FILE_P1 8000 8
-create_recovery_file $RECOVERY_FILE_P2 8000 8
+create_recovery_file $RECOVERY_FILE_P0 1000 1
+create_recovery_file $RECOVERY_FILE_P1 1000 1
+create_recovery_file $RECOVERY_FILE_P2 1000 1
 
 copy_files_to_node 0 ${NODE_DIR[0]} $DIR/$POOLSET_LOCAL
 copy_files_to_node 1 ${NODE_DIR[1]} $DIR/$POOLSET_REMOTE

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -3714,6 +3714,8 @@ function require_badblock_tests_enabled_node() {
 #
 # Usage: create_recovery_file <file> [<offset_1> <length_1> ...]
 #
+# Offsets and length should be in page sizes.
+#
 function create_recovery_file() {
 	[ $# -lt 1 ] && fatal "create_recovery_file(): not enough parameters: $*"
 
@@ -3721,11 +3723,12 @@ function create_recovery_file() {
 	shift
 	rm -f $FILE
 
+	local page_size=$(getconf PAGESIZE)
 	while [ $# -ge 2 ]; do
 		OFFSET=$1
 		LENGTH=$2
 		shift 2
-		echo "$(($OFFSET * 512)) $(($LENGTH * 512))" >> $FILE
+		echo "$(($OFFSET * $page_size)) $(($LENGTH * $page_size))" >> $FILE
 	done
 
 	# write the finish flag
@@ -3737,17 +3740,20 @@ function create_recovery_file() {
 #
 # Usage: zero_blocks <file> <offset> <length>
 #
+# Offsets and length should be in page sizes.
+#
 function zero_blocks() {
 	[ $# -lt 3 ] && fatal "zero_blocks(): not enough parameters: $*"
 
 	FILE=$1
 	shift
 
+	local page_size=$(getconf PAGESIZE)
 	while [ $# -ge 2 ]; do
 		OFFSET=$1
 		LENGTH=$2
 		shift 2
-		dd if=/dev/zero of=$FILE bs=512 seek=$OFFSET count=$LENGTH conv=notrunc status=none
+		dd if=/dev/zero of=$FILE bs=$page_size seek=$OFFSET count=$LENGTH conv=notrunc status=none
 	done
 }
 


### PR DESCRIPTION
The pmempool_sync bad block tests for non-pmem medium
needs to take care on offset and zero size calculations.
The zero_blocks offsets and sizes used for 4K page size
systems create overlapping blocks in 64K page size systems.

This commit add a utility calculation for this test cases
to round the offset and zero sizes to avoid overlapped
blocks for systems running with page sizes different from
4K.

Signed-off-by: Lucas A. M. Magalhaes <lamm@linux.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4627)
<!-- Reviewable:end -->
