### PR TITLE
common: check if Coverity build can be run on forked repos

### DIFF
--- a/utils/docker/run-coverity.sh
+++ b/utils/docker/run-coverity.sh
@@ -8,6 +8,17 @@
 
 set -e
 
+if [[ "$CI_REPO_SLUG" != "$GITHUB_REPO" \
+   && ( "$COVERITY_SCAN_NOTIFICATION_EMAIL" == "" \
+     || "$COVERITY_SCAN_TOKEN" == "" ) ]]; then
+	echo
+	echo "Skipping Coverity build:"\
+		"COVERITY_SCAN_TOKEN=\"$COVERITY_SCAN_TOKEN\" or"\
+		"COVERITY_SCAN_NOTIFICATION_EMAIL="\
+		"\"$COVERITY_SCAN_NOTIFICATION_EMAIL\" is not set"
+	exit 0
+fi
+
 # Prepare build environment
 ./prepare-for-build.sh
 


### PR DESCRIPTION
Skip running Coverity build on forked repos
if `COVERITY_SCAN_TOKEN` or `COVERITY_SCAN_NOTIFICATION_EMAIL` is not set,
because those variables have to be set in Coverity build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4630)
<!-- Reviewable:end -->
