### PR TITLE
add BOMs to Windows stuff

### DIFF
--- a/src/benchmarks/pmembench.vcxproj
+++ b/src/benchmarks/pmembench.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/src/common/libpmemcommon.vcxproj
+++ b/src/common/libpmemcommon.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/src/examples/libpmemblk/assetdb/asset_checkin.vcxproj.filters
+++ b/src/examples/libpmemblk/assetdb/asset_checkin.vcxproj.filters
@@ -3,7 +3,7 @@
   <ItemGroup>
     <Filter Include="Source Files">
       <UniqueIdentifier>{7b7d2f5a-464e-4d55-894b-3110e15303f1}</UniqueIdentifier>
-	  <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+        <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
     </Filter>
     <Filter Include="Header Files">
       <UniqueIdentifier>{c2e783a4-4f6d-419d-bbf6-1056eddfdd8f}</UniqueIdentifier>

--- a/src/examples/libpmemblk/assetdb/asset_checkout.vcxproj.filters
+++ b/src/examples/libpmemblk/assetdb/asset_checkout.vcxproj.filters
@@ -3,7 +3,7 @@
   <ItemGroup>
     <Filter Include="Source Files">
       <UniqueIdentifier>{7b7d2f5a-464e-4d55-894b-3110e15303f1}</UniqueIdentifier>
-	  <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+        <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
     </Filter>
     <Filter Include="Header Files">
       <UniqueIdentifier>{c2e783a4-4f6d-419d-bbf6-1056eddfdd8f}</UniqueIdentifier>

--- a/src/examples/libpmemblk/assetdb/asset_list.vcxproj.filters
+++ b/src/examples/libpmemblk/assetdb/asset_list.vcxproj.filters
@@ -3,7 +3,7 @@
   <ItemGroup>
     <Filter Include="Source Files">
       <UniqueIdentifier>{7b7d2f5a-464e-4d55-894b-3110e15303f1}</UniqueIdentifier>
-	  <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+        <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
     </Filter>
     <Filter Include="Header Files">
       <UniqueIdentifier>{c2e783a4-4f6d-419d-bbf6-1056eddfdd8f}</UniqueIdentifier>

--- a/src/examples/libpmemblk/assetdb/asset_load.vcxproj.filters
+++ b/src/examples/libpmemblk/assetdb/asset_load.vcxproj.filters
@@ -3,7 +3,7 @@
   <ItemGroup>
     <Filter Include="Source Files">
       <UniqueIdentifier>{7b7d2f5a-464e-4d55-894b-3110e15303f1}</UniqueIdentifier>
-	  <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+        <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
     </Filter>
     <Filter Include="Header Files">
       <UniqueIdentifier>{c2e783a4-4f6d-419d-bbf6-1056eddfdd8f}</UniqueIdentifier>

--- a/src/libpmem2/libpmem2.vcxproj
+++ b/src/libpmem2/libpmem2.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/src/libpmem2/libpmem2.vcxproj.filters
+++ b/src/libpmem2/libpmem2.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Header Files">

--- a/src/test/blk_non_zero/blk_non_zero.vcxproj
+++ b/src/test/blk_non_zero/blk_non_zero.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/src/test/blk_pool/blk_pool.vcxproj
+++ b/src/test/blk_pool/blk_pool.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/src/test/blk_pool_lock/blk_pool_lock.vcxproj
+++ b/src/test/blk_pool_lock/blk_pool_lock.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/src/test/blk_rw/blk_rw.vcxproj
+++ b/src/test/blk_rw/blk_rw.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/src/test/blk_rw_mt/blk_rw_mt.vcxproj
+++ b/src/test/blk_rw_mt/blk_rw_mt.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/src/test/obj_persist_count/obj_persist_count.vcxproj.filters
+++ b/src/test/obj_persist_count/obj_persist_count.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">

--- a/src/test/pmem2_config/pmem2_config.vcxproj
+++ b/src/test/pmem2_config/pmem2_config.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/src/test/pmem2_config/pmem2_config.vcxproj.filters
+++ b/src/test/pmem2_config/pmem2_config.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">

--- a/src/test/pmem2_source_size/pmem2_source_size.vcxproj
+++ b/src/test/pmem2_source_size/pmem2_source_size.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/src/test/pmem2_source_size/pmem2_source_size.vcxproj.filters
+++ b/src/test/pmem2_source_size/pmem2_source_size.vcxproj.filters
@@ -29,10 +29,10 @@
     <ClCompile Include="..\..\libpmem2\pmem2_utils.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-	<ClCompile Include="..\..\libpmem2\source.c">
+    <ClCompile Include="..\..\libpmem2\source.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-	<ClCompile Include="..\..\libpmem2\source_windows.c">
+    <ClCompile Include="..\..\libpmem2\source_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/test/pmem2_source_size/pmem2_source_size.vcxproj.filters
+++ b/src/test/pmem2_source_size/pmem2_source_size.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">

--- a/src/windows/srcversion/srcversion.vcxproj
+++ b/src/windows/srcversion/srcversion.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">


### PR DESCRIPTION
U+FEFF is an annoying dropping that MSVC adds.  Let's keep it consistent to avoid mysterious diffs with seemingly unchanged lines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4631)
<!-- Reviewable:end -->
