### PR TITLE
common: replace 'arch' command with 'uname -m'

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1084,7 +1084,7 @@ function require_procfs() {
 #
 function require_arch() {
 	for i in "$@"; do
-		[[ "$(arch)" == "$i" ]] && return
+		[[ "$(uname -m)" == "$i" ]] && return
 	done
 	msg "$UNITTEST_NAME: SKIP: Only supported on $1"
 	exit 0
@@ -1096,7 +1096,7 @@ function require_arch() {
 #
 function exclude_arch() {
 	for i in "$@"; do
-		if [[ "$(arch)" == "$i" ]]; then
+		if [[ "$(uname -m)" == "$i" ]]; then
 			msg "$UNITTEST_NAME: SKIP: Not supported on $1"
 			exit 0
 		fi


### PR DESCRIPTION
Replace the 'arch' command with 'uname -m',
because the 'arch' command is not available by default
on all Linux distros.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4639)
<!-- Reviewable:end -->
