### PR TITLE
common: bump GHA checkout action to v2

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -32,7 +32,7 @@ jobs:
          run: date
 
        - name: Clone the git repo
-         uses: actions/checkout@v1
+         uses: actions/checkout@v2
 
        - name: Pull or rebuild the image
          run: cd $WORKDIR && ${{ matrix.CONFIG }} ./pull-or-rebuild-image.sh

--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -36,7 +36,7 @@ jobs:
                 "N=10 OS=ubuntu OS_VER=19.10 COVERAGE=1 FAULT_INJECTION=1 TEST_BUILD=debug"]
     steps:
        - name: Clone the git repo
-         uses: actions/checkout@v1
+         uses: actions/checkout@v2
 
        - name: Pull or rebuild the image
          run: cd $WORKDIR && ${{ matrix.CONFIG }} ./pull-or-rebuild-image.sh


### PR DESCRIPTION
It fixes the following bug:
https://github.com/actions/checkout/issues/23
occurring recently in PMDK GHA builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4647)
<!-- Reviewable:end -->
