### PR TITLE
pytest: use proper (in-tree) libs rather than system ones

### DIFF
--- a/src/test/unittest/tools.py
+++ b/src/test/unittest/tools.py
@@ -29,12 +29,12 @@ class Tools:
         global_lib_path = envconfig['GLOBAL_LIB_PATH']
 
         if sys.platform == 'win32':
-            futils.add_env_common(self.env, {'PATH': build.libdir})
             futils.add_env_common(self.env, {'PATH': global_lib_path})
+            futils.add_env_common(self.env, {'PATH': build.libdir})
         else:
-            futils.add_env_common(self.env, {'LD_LIBRARY_PATH': build.libdir})
             futils.add_env_common(self.env,
                                   {'LD_LIBRARY_PATH': global_lib_path})
+            futils.add_env_common(self.env, {'LD_LIBRARY_PATH': build.libdir})
 
     def _run_test_tool(self, name, *args):
         exe = futils.get_test_tool_path(self.build, name)


### PR DESCRIPTION
This made us test the wrong version if there's anything installed on the system.

Ref #4359

The LD_LIBRARY_PATH still gets multiple copies, but that's a cosmetic problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4651)
<!-- Reviewable:end -->
