### PR TITLE
fix test fails when devdax has an odd number of pages

### DIFF
--- a/src/test/pmem2_integration/pmem2_integration.c
+++ b/src/test/pmem2_integration/pmem2_integration.c
@@ -353,8 +353,7 @@ test_len_not_aligned(const struct test_case *tc, int argc, char *argv[])
 	int ret = pmem2_source_size(src, &len);
 	UT_PMEM2_EXPECT_RETURN(ret, 0);
 
-	ret = pmem2_source_alignment(src, &alignment);
-	UT_PMEM2_EXPECT_RETURN(ret, 0);
+	PMEM2_SOURCE_ALIGNMENT(src, &alignment);
 
 	UT_ASSERT(len > alignment);
 	size_t aligned_len = ALIGN_DOWN(len, alignment);
@@ -393,8 +392,7 @@ test_len_aligned(const struct test_case *tc, int argc, char *argv[])
 	int ret = pmem2_source_size(src, &len);
 	UT_PMEM2_EXPECT_RETURN(ret, 0);
 
-	ret = pmem2_source_alignment(src, &alignment);
-	UT_PMEM2_EXPECT_RETURN(ret, 0);
+	PMEM2_SOURCE_ALIGNMENT(src, &alignment);
 
 	UT_ASSERT(len > alignment);
 	size_t aligned_len = ALIGN_DOWN(len, alignment);
@@ -433,8 +431,7 @@ test_offset_not_aligned(const struct test_case *tc, int argc, char *argv[])
 	int ret = pmem2_source_size(src, &len);
 	UT_PMEM2_EXPECT_RETURN(ret, 0);
 
-	ret = pmem2_source_alignment(src, &alignment);
-	UT_PMEM2_EXPECT_RETURN(ret, 0);
+	PMEM2_SOURCE_ALIGNMENT(src, &alignment);
 
 	/* break the offset */
 	size_t offset = alignment - 1;
@@ -478,8 +475,7 @@ test_offset_aligned(const struct test_case *tc, int argc, char *argv[])
 	int ret = pmem2_source_size(src, &len);
 	UT_PMEM2_EXPECT_RETURN(ret, 0);
 
-	ret = pmem2_source_alignment(src, &alignment);
-	UT_PMEM2_EXPECT_RETURN(ret, 0);
+	PMEM2_SOURCE_ALIGNMENT(src, &alignment);
 
 	/* set the aligned offset */
 	size_t offset = alignment;

--- a/src/test/pmem2_integration/pmem2_integration.c
+++ b/src/test/pmem2_integration/pmem2_integration.c
@@ -488,7 +488,7 @@ test_offset_aligned(const struct test_case *tc, int argc, char *argv[])
 
 	UT_ASSERT(len > alignment * 2);
 	/* set the aligned len */
-	size_t map_len = ALIGN_DOWN(len, alignment) / 2;
+	size_t map_len = ALIGN_DOWN(len / 2, alignment);
 	ret = pmem2_config_set_length(cfg, map_len);
 	UT_PMEM2_EXPECT_RETURN(ret, 0);
 

--- a/src/test/pmem2_integration/pmem2_integration.vcxproj
+++ b/src/test/pmem2_integration/pmem2_integration.vcxproj
@@ -68,6 +68,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\unittest\ut_pmem2_config.c" />
     <ClCompile Include="..\unittest\ut_pmem2_utils.c" />
     <ClCompile Include="pmem2_integration.c" />
   </ItemGroup>

--- a/src/test/pmem2_integration/pmem2_integration.vcxproj.filters
+++ b/src/test/pmem2_integration/pmem2_integration.vcxproj.filters
@@ -23,6 +23,9 @@
     <ClCompile Include="pmem2_integration.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\unittest\ut_pmem2_config.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\unittest\ut_pmem2_utils.h">

--- a/src/test/pmem2_map/pmem2_map.c
+++ b/src/test/pmem2_map/pmem2_map.c
@@ -13,7 +13,7 @@
 #include "out.h"
 #include "pmem2.h"
 #include "unittest.h"
-#include "ut_pmem2_utils.h"
+#include "ut_pmem2.h"
 
 #define KILOBYTE (1 << 10)
 #define MEGABYTE (1 << 20)
@@ -152,7 +152,7 @@ get_align_by_name(const char *filename)
 	size_t align;
 	int fd = OPEN(filename, O_RDONLY);
 	prepare_source(&src, fd);
-	pmem2_source_alignment(&src, &align);
+	PMEM2_SOURCE_ALIGNMENT(&src, &align);
 	CLOSE(fd);
 
 	return align;
@@ -599,7 +599,7 @@ test_map_larger_than_unaligned_file_size(const struct test_case *tc, int argc,
 	size_t alignment;
 	prepare_config(&cfg, &src, &fd, file, 0, 0, O_RDWR);
 
-	pmem2_source_alignment(&src, &alignment);
+	PMEM2_SOURCE_ALIGNMENT(&src, &alignment);
 
 	/* validate file length is unaligned */
 	UT_ASSERTne(length % alignment, 0);

--- a/src/test/pmem2_map/pmem2_map.vcxproj
+++ b/src/test/pmem2_map/pmem2_map.vcxproj
@@ -89,6 +89,7 @@
     <ClCompile Include="..\..\libpmem2\pmem2_utils.c" />
     <ClCompile Include="..\..\libpmem2\x86_64\cpu.c" />
     <ClCompile Include="..\..\libpmem2\x86_64\init.c" />
+    <ClCompile Include="..\unittest\ut_pmem2_config.c" />
     <ClCompile Include="..\unittest\ut_pmem2_utils.c" />
     <ClCompile Include="pmem2_map.c" />
   </ItemGroup>

--- a/src/test/pmem2_map/pmem2_map.vcxproj.filters
+++ b/src/test/pmem2_map/pmem2_map.vcxproj.filters
@@ -53,6 +53,9 @@
     <ClCompile Include="..\..\libpmem2\memops_generic.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\unittest\ut_pmem2_config.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\libpmem2\config.h">

--- a/src/test/pmem2_source_alignment/pmem2_source_alignment.c
+++ b/src/test/pmem2_source_alignment/pmem2_source_alignment.c
@@ -12,8 +12,7 @@
 
 #include "libpmem2.h"
 #include "unittest.h"
-#include "ut_pmem2_utils.h"
-#include "ut_pmem2_config.h"
+#include "ut_pmem2.h"
 #include "config.h"
 #include "out.h"
 
@@ -37,8 +36,7 @@ test_get_alignment_success(const struct test_case *tc, int argc,
 	PMEM2_SOURCE_FROM_FD(&src, fd);
 
 	size_t alignment;
-	int ret2 = pmem2_source_alignment(src, &alignment);
-	UT_PMEM2_EXPECT_RETURN(ret2, 0);
+	PMEM2_SOURCE_ALIGNMENT(src, &alignment);
 
 	size_t ref_alignment = Ut_mmap_align;
 

--- a/src/test/unittest/ut_pmem2_config.c
+++ b/src/test/unittest/ut_pmem2_config.c
@@ -87,6 +87,14 @@ ut_pmem2_source_from_fh(const char *file, int line, const char *func,
 }
 
 void
+ut_pmem2_source_alignment(const char *file, int line, const char *func,
+	struct pmem2_source *src, size_t *al)
+{
+	int ret = pmem2_source_alignment(src, al);
+	ut_pmem2_expect_return(file, line, func, ret, 0);
+}
+
+void
 ut_pmem2_source_delete(const char *file, int line, const char *func,
 	struct pmem2_source **src)
 {

--- a/src/test/unittest/ut_pmem2_config.h
+++ b/src/test/unittest/ut_pmem2_config.h
@@ -31,6 +31,10 @@
 #define PMEM2_SOURCE_FROM_FH(src, fh)					\
 	ut_pmem2_source_from_fh(__FILE__, __LINE__, __func__, src, fh)
 
+/* a pmem2_source_alignment() that can't return an error */
+#define PMEM2_SOURCE_ALIGNMENT(src, al)					\
+	ut_pmem2_source_alignment(__FILE__, __LINE__, __func__, src, al)
+
 /* a pmem2_source_delete() that can't return NULL */
 #define PMEM2_SOURCE_DELETE(src)					\
 	ut_pmem2_source_delete(__FILE__, __LINE__, __func__, src)
@@ -50,6 +54,9 @@ void ut_pmem2_source_from_fd(const char *file, int line, const char *func,
 
 void ut_pmem2_source_from_fh(const char *file, int line, const char *func,
 	struct pmem2_source **src, struct FHandle *fhandle);
+
+void ut_pmem2_source_alignment(const char *file, int line, const char *func,
+	struct pmem2_source *src, size_t *alignment);
 
 void ut_pmem2_source_delete(const char *file, int line, const char *func,
 	struct pmem2_source **src);


### PR DESCRIPTION
To reproduce: memmap=4G! with (default) align of 2M, after headers/etc this gives 2015 pages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4652)
<!-- Reviewable:end -->
