### PR TITLE
obj: introduce pmemobj_tx_set_abort_on_failure

### DIFF
--- a/doc/libpmemobj/pmemobj_tx_begin.3.md
+++ b/doc/libpmemobj/pmemobj_tx_begin.3.md
@@ -8,7 +8,7 @@ date: pmemobj API version 2.3
 ...
 
 [comment]: <> (SPDX-License-Identifier: BSD-3-Clause)
-[comment]: <> (Copyright 2017-2019, Intel Corporation)
+[comment]: <> (Copyright 2017-2020, Intel Corporation)
 
 [comment]: <> (pmemobj_tx_begin.3 -- man page for transactional object manipulation)
 
@@ -37,7 +37,10 @@ date: pmemobj API version 2.3
 **pmemobj_tx_log_intents_max_size**(),
 
 **pmemobj_tx_set_user_data**(),
-**pmemobj_tx_get_user_data**()
+**pmemobj_tx_get_user_data**(),
+
+**pmemobj_tx_set_failure_behavior**(),
+**pmemobj_tx_get_failure_behavior**()
 - transactional object manipulation
 
 # SYNOPSIS #
@@ -72,6 +75,9 @@ size_t pmemobj_tx_log_intents_max_size(size_t nintents);
 
 void pmemobj_tx_set_user_data(void *data);
 void *pmemobj_tx_get_user_data(void);
+
+void pmemobj_tx_set_failure_behavior(enum pobj_tx_failure_behavior behavior);
+enum pobj_tx_failure_behavior pmemobj_tx_get_failure_behavior(void);
 ```
 
 # DESCRIPTION #
@@ -411,6 +417,17 @@ If **pmemobj_tx_set_user_data**() was not called for a current transaction,
 **pmemobj_tx_get_user_data**() will return NULL. These functions must be called
 during **TX_STAGE_WORK** or **TX_STAGE_ONABORT** or **TX_STAGE_ONCOMMIT** or
 **TX_STAGE_FINALLY**.
+
+**pmemobj_tx_set_failure_behavior**() specifies what should happen in case of an error
+within the transaction. It only affects functions which take a NO_ABORT flag.
+If **pmemobj_tx_set_failure_behavior**() is called with POBJ_TX_FAILURE_RETURN a NO_ABORT
+flag is implicitly passed to all functions which accept this flag. If called
+with POBJ_TX_FAILURE_ABORT then all functions abort the transaction (unless NO_ABORT
+flag is passed explicitly). This setting is inherited by inner transactions. It does
+not affect any of the outer transactions. Aborting on failure is the default behavior.
+**pmemobj_tx_get_failure_behavior**() returns failure behavior for the current transaction.
+Both **pmemobj_tx_set_failure_behavior**() and **pmemobj_tx_get_failure_behavior**()
+must be called during **TX_STAGE_WORK**.
 
 # RETURN VALUE #
 

--- a/src/include/libpmemobj/tx_base.h
+++ b/src/include/libpmemobj/tx_base.h
@@ -50,6 +50,11 @@ enum pobj_log_type {
 	TX_LOG_TYPE_INTENT,
 };
 
+enum pobj_tx_failure_behavior {
+	POBJ_TX_FAILURE_ABORT,
+	POBJ_TX_FAILURE_RETURN,
+};
+
 #if !defined(pmdk_use_attr_deprec_with_msg) && defined(__COVERITY__)
 #define pmdk_use_attr_deprec_with_msg 0
 #endif
@@ -423,6 +428,20 @@ void pmemobj_tx_set_user_data(void *data);
  * transaction.
  */
 void *pmemobj_tx_get_user_data(void);
+
+/*
+ * Sets the failure behavior of transactional functions.
+ *
+ * This function must be called during TX_STAGE_WORK.
+ */
+void pmemobj_tx_set_failure_behavior(enum pobj_tx_failure_behavior behavior);
+
+/*
+ * Returns failure behavior for the current transaction.
+ *
+ * This function must be called during TX_STAGE_WORK.
+ */
+enum pobj_tx_failure_behavior pmemobj_tx_get_failure_behavior(void);
 
 #ifdef __cplusplus
 }

--- a/src/libpmemobj/libpmemobj.def
+++ b/src/libpmemobj/libpmemobj.def
@@ -1,6 +1,6 @@
 ;;;; Begin Copyright Notice
 ; SPDX-License-Identifier: BSD-3-Clause
-; Copyright 2015-2018, Intel Corporation
+; Copyright 2015-2020, Intel Corporation
 ;;;;  End Copyright Notice
 
 LIBRARY libpmemobj
@@ -96,6 +96,8 @@ EXPORTS
 	pmemobj_tx_log_intents_max_size
 	pmemobj_tx_set_user_data
 	pmemobj_tx_get_user_data
+	pmemobj_tx_set_failure_behavior
+	pmemobj_tx_get_failure_behavior
 	pmemobj_memcpy
 	pmemobj_memcpy_persist
 	pmemobj_memmove

--- a/src/libpmemobj/libpmemobj.link.in
+++ b/src/libpmemobj/libpmemobj.link.in
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2014-2019, Intel Corporation
+# Copyright 2014-2020, Intel Corporation
 #
 #
 # src/libpmemobj.link -- linker link file for libpmemobj
@@ -87,6 +87,8 @@ LIBPMEMOBJ_1.0 {
 		pmemobj_tx_log_intents_max_size;
 		pmemobj_tx_set_user_data;
 		pmemobj_tx_get_user_data;
+		pmemobj_tx_set_failure_behavior;
+		pmemobj_tx_get_failure_behavior;
 		pmemobj_memcpy;
 		pmemobj_memcpy_persist;
 		pmemobj_memmove;

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -20,6 +20,7 @@
 struct tx_data {
 	PMDK_SLIST_ENTRY(tx_data) tx_entry;
 	jmp_buf env;
+	enum pobj_tx_failure_behavior failure_behavior;
 };
 
 struct tx {
@@ -719,12 +720,18 @@ pmemobj_tx_begin(PMEMobjpool *pop, jmp_buf env, ...)
 	int err = 0;
 	struct tx *tx = get_tx();
 
+	enum pobj_tx_failure_behavior failure_behavior = POBJ_TX_FAILURE_ABORT;
+
 	if (tx->stage == TX_STAGE_WORK) {
 		ASSERTne(tx->lane, NULL);
 		if (tx->pop != pop) {
 			ERR("nested transaction for different pool");
 			return obj_tx_fail_err(EINVAL, 0);
 		}
+
+		/* inherits this value from the parent transaction */
+		struct tx_data *txd = PMDK_SLIST_FIRST(&tx->tx_entries);
+		failure_behavior = txd->failure_behavior;
 
 		VALGRIND_START_TX;
 	} else if (tx->stage == TX_STAGE_NONE) {
@@ -763,6 +770,8 @@ pmemobj_tx_begin(PMEMobjpool *pop, jmp_buf env, ...)
 		memcpy(txd->env, env, sizeof(jmp_buf));
 	else
 		memset(txd->env, 0, sizeof(jmp_buf));
+
+	txd->failure_behavior = failure_behavior;
 
 	PMDK_SLIST_INSERT_HEAD(&tx->tx_entries, txd, tx_entry);
 
@@ -814,21 +823,37 @@ err_abort:
 }
 
 /*
+ * tx_abort_on_failure_flag -- (internal) return 0 or POBJ_FLAG_TX_NO_ABORT
+ * based on transaction setting
+ */
+static uint64_t
+tx_abort_on_failure_flag(struct tx *tx)
+{
+	struct tx_data *txd = PMDK_SLIST_FIRST(&tx->tx_entries);
+
+	if (txd->failure_behavior == POBJ_TX_FAILURE_RETURN)
+		return POBJ_FLAG_TX_NO_ABORT;
+	return 0;
+}
+
+/*
  * pmemobj_tx_xlock -- get lane from pool and add lock to transaction,
  * with no_abort option
  */
 int
 pmemobj_tx_xlock(enum pobj_tx_param type, void *lockp, uint64_t flags)
 {
+	struct tx *tx = get_tx();
+	ASSERT_IN_TX(tx);
+	ASSERT_TX_STAGE_WORK(tx);
+
+	flags |= tx_abort_on_failure_flag(tx);
+
 	if (flags & ~POBJ_XLOCK_VALID_FLAGS) {
 		ERR("unknown flags 0x%" PRIx64,
 				flags & ~POBJ_XLOCK_VALID_FLAGS);
 		return obj_tx_fail_err(EINVAL, flags);
 	}
-
-	struct tx *tx = get_tx();
-	ASSERT_IN_TX(tx);
-	ASSERT_TX_STAGE_WORK(tx);
 
 	int ret = add_to_tx_and_lock(tx, type, lockp);
 	if (ret)
@@ -1359,22 +1384,24 @@ pmemobj_tx_add_range_direct(const void *ptr, size_t size)
 	ASSERT_IN_TX(tx);
 	ASSERT_TX_STAGE_WORK(tx);
 
-	PMEMobjpool *pop = tx->pop;
+	int ret;
 
-	if (!OBJ_PTR_FROM_POOL(pop, ptr)) {
+	uint64_t flags = tx_abort_on_failure_flag(tx);
+
+	if (!OBJ_PTR_FROM_POOL(tx->pop, ptr)) {
 		ERR("object outside of pool");
-		int ret = obj_tx_fail_err(EINVAL, 0);
+		ret = obj_tx_fail_err(EINVAL, flags);
 		PMEMOBJ_API_END();
 		return ret;
 	}
 
 	struct tx_range_def args = {
-		.offset = (uint64_t)((char *)ptr - (char *)pop),
+		.offset = (uint64_t)((char *)ptr - (char *)tx->pop),
 		.size = size,
-		.flags = 0,
+		.flags = flags,
 	};
 
-	int ret = pmemobj_tx_add_common(tx, &args);
+	ret = pmemobj_tx_add_common(tx, &args);
 
 	PMEMOBJ_API_END();
 	return ret;
@@ -1388,13 +1415,16 @@ int
 pmemobj_tx_xadd_range_direct(const void *ptr, size_t size, uint64_t flags)
 {
 	LOG(3, NULL);
+
+	PMEMOBJ_API_START();
 	struct tx *tx = get_tx();
 
 	ASSERT_IN_TX(tx);
 	ASSERT_TX_STAGE_WORK(tx);
 
-	PMEMOBJ_API_START();
 	int ret;
+
+	flags |= tx_abort_on_failure_flag(tx);
 
 	if (flags & ~POBJ_XADD_VALID_FLAGS) {
 		ERR("unknown flags 0x%" PRIx64, flags
@@ -1437,9 +1467,13 @@ pmemobj_tx_add_range(PMEMoid oid, uint64_t hoff, size_t size)
 	ASSERT_IN_TX(tx);
 	ASSERT_TX_STAGE_WORK(tx);
 
+	int ret;
+
+	uint64_t flags = tx_abort_on_failure_flag(tx);
+
 	if (oid.pool_uuid_lo != tx->pop->uuid_lo) {
 		ERR("invalid pool uuid");
-		int ret = obj_tx_fail_err(EINVAL, 0);
+		ret = obj_tx_fail_err(EINVAL, flags);
 		PMEMOBJ_API_END();
 		return ret;
 	}
@@ -1448,10 +1482,10 @@ pmemobj_tx_add_range(PMEMoid oid, uint64_t hoff, size_t size)
 	struct tx_range_def args = {
 		.offset = oid.off + hoff,
 		.size = size,
-		.flags = 0,
+		.flags = flags,
 	};
 
-	int ret = pmemobj_tx_add_common(tx, &args);
+	ret = pmemobj_tx_add_common(tx, &args);
 
 	PMEMOBJ_API_END();
 	return ret;
@@ -1472,6 +1506,8 @@ pmemobj_tx_xadd_range(PMEMoid oid, uint64_t hoff, size_t size, uint64_t flags)
 	ASSERT_TX_STAGE_WORK(tx);
 
 	int ret;
+
+	flags |= tx_abort_on_failure_flag(tx);
 
 	if (flags & ~POBJ_XADD_VALID_FLAGS) {
 		ERR("unknown flags 0x%" PRIx64, flags
@@ -1496,6 +1532,7 @@ pmemobj_tx_xadd_range(PMEMoid oid, uint64_t hoff, size_t size, uint64_t flags)
 	};
 
 	ret = pmemobj_tx_add_common(tx, &args);
+
 	PMEMOBJ_API_END();
 	return ret;
 }
@@ -1514,16 +1551,18 @@ pmemobj_tx_alloc(size_t size, uint64_t type_num)
 	ASSERT_IN_TX(tx);
 	ASSERT_TX_STAGE_WORK(tx);
 
+	uint64_t flags = tx_abort_on_failure_flag(tx);
+
 	PMEMoid oid;
 	if (size == 0) {
 		ERR("allocation with size 0");
-		oid = obj_tx_fail_null(EINVAL, 0);
+		oid = obj_tx_fail_null(EINVAL, flags);
 		PMEMOBJ_API_END();
 		return oid;
 	}
 
 	oid = tx_alloc_common(tx, size, (type_num_t)type_num,
-			constructor_tx_alloc, ALLOC_ARGS(0));
+			constructor_tx_alloc, ALLOC_ARGS(flags));
 
 	PMEMOBJ_API_END();
 	return oid;
@@ -1541,17 +1580,20 @@ pmemobj_tx_zalloc(size_t size, uint64_t type_num)
 	ASSERT_IN_TX(tx);
 	ASSERT_TX_STAGE_WORK(tx);
 
+	uint64_t flags = POBJ_FLAG_ZERO;
+	flags |= tx_abort_on_failure_flag(tx);
+
 	PMEMOBJ_API_START();
 	PMEMoid oid;
 	if (size == 0) {
 		ERR("allocation with size 0");
-		oid = obj_tx_fail_null(EINVAL, 0);
+		oid = obj_tx_fail_null(EINVAL, flags);
 		PMEMOBJ_API_END();
 		return oid;
 	}
 
 	oid = tx_alloc_common(tx, size, (type_num_t)type_num,
-			constructor_tx_alloc, ALLOC_ARGS(POBJ_FLAG_ZERO));
+			constructor_tx_alloc, ALLOC_ARGS(flags));
 
 	PMEMOBJ_API_END();
 	return oid;
@@ -1568,6 +1610,9 @@ pmemobj_tx_xalloc(size_t size, uint64_t type_num, uint64_t flags)
 
 	ASSERT_IN_TX(tx);
 	ASSERT_TX_STAGE_WORK(tx);
+
+	flags |= tx_abort_on_failure_flag(tx);
+
 	PMEMOBJ_API_START();
 
 	PMEMoid oid;
@@ -1640,16 +1685,18 @@ pmemobj_tx_xstrdup(const char *s, uint64_t type_num, uint64_t flags)
 {
 	LOG(3, NULL);
 
+	struct tx *tx = get_tx();
+
+	ASSERT_IN_TX(tx);
+	ASSERT_TX_STAGE_WORK(tx);
+
+	flags |= tx_abort_on_failure_flag(tx);
+
 	if (flags & ~POBJ_TX_XALLOC_VALID_FLAGS) {
 		ERR("unknown flags 0x%" PRIx64,
 				flags & ~POBJ_TX_XALLOC_VALID_FLAGS);
 		return obj_tx_fail_null(EINVAL, flags);
 	}
-
-	struct tx *tx = get_tx();
-
-	ASSERT_IN_TX(tx);
-	ASSERT_TX_STAGE_WORK(tx);
 
 	PMEMOBJ_API_START();
 	PMEMoid oid;
@@ -1696,16 +1743,18 @@ pmemobj_tx_xwcsdup(const wchar_t *s, uint64_t type_num, uint64_t flags)
 {
 	LOG(3, NULL);
 
+	struct tx *tx = get_tx();
+
+	ASSERT_IN_TX(tx);
+	ASSERT_TX_STAGE_WORK(tx);
+
+	flags |= tx_abort_on_failure_flag(tx);
+
 	if (flags & ~POBJ_TX_XALLOC_VALID_FLAGS) {
 		ERR("unknown flags 0x%" PRIx64,
 				flags & ~POBJ_TX_XALLOC_VALID_FLAGS);
 		return obj_tx_fail_null(EINVAL, flags);
 	}
-
-	struct tx *tx = get_tx();
-
-	ASSERT_IN_TX(tx);
-	ASSERT_TX_STAGE_WORK(tx);
 
 	PMEMOBJ_API_START();
 	PMEMoid oid;
@@ -1753,16 +1802,18 @@ pmemobj_tx_xfree(PMEMoid oid, uint64_t flags)
 {
 	LOG(3, NULL);
 
+	struct tx *tx = get_tx();
+
+	ASSERT_IN_TX(tx);
+	ASSERT_TX_STAGE_WORK(tx);
+
+	flags |= tx_abort_on_failure_flag(tx);
+
 	if (flags & ~POBJ_XFREE_VALID_FLAGS) {
 		ERR("unknown flags 0x%" PRIx64,
 				flags & ~POBJ_XFREE_VALID_FLAGS);
 		return obj_tx_fail_err(EINVAL, flags);
 	}
-
-	struct tx *tx = get_tx();
-
-	ASSERT_IN_TX(tx);
-	ASSERT_TX_STAGE_WORK(tx);
 
 	if (OBJ_OID_IS_NULL(oid))
 		return 0;
@@ -1834,14 +1885,19 @@ pmemobj_tx_free(PMEMoid oid)
 int
 pmemobj_tx_xpublish(struct pobj_action *actv, size_t actvcnt, uint64_t flags)
 {
+	struct tx *tx = get_tx();
+
+	ASSERT_IN_TX(tx);
+	ASSERT_TX_STAGE_WORK(tx);
+
+	flags |= tx_abort_on_failure_flag(tx);
+
 	if (flags & ~POBJ_XPUBLISH_VALID_FLAGS) {
 		ERR("unknown flags 0x%" PRIx64,
 				flags & ~POBJ_XPUBLISH_VALID_FLAGS);
 		return obj_tx_fail_err(EINVAL, flags);
 	}
 
-	struct tx *tx = get_tx();
-	ASSERT_TX_STAGE_WORK(tx);
 	PMEMOBJ_API_START();
 
 	if (tx_action_reserve(tx, actvcnt) != 0) {
@@ -1874,14 +1930,19 @@ int
 pmemobj_tx_xlog_append_buffer(enum pobj_log_type type, void *addr, size_t size,
 		uint64_t flags)
 {
+	struct tx *tx = get_tx();
+
+	ASSERT_IN_TX(tx);
+	ASSERT_TX_STAGE_WORK(tx);
+
+	flags |= tx_abort_on_failure_flag(tx);
+
 	if (flags & ~POBJ_XLOG_APPEND_BUFFER_VALID_FLAGS) {
 		ERR("unknown flags 0x%" PRIx64,
 				flags & ~POBJ_XLOG_APPEND_BUFFER_VALID_FLAGS);
 		return obj_tx_fail_err(EINVAL, flags);
 	}
 
-	struct tx *tx = get_tx();
-	ASSERT_TX_STAGE_WORK(tx);
 	PMEMOBJ_API_START();
 	int err;
 
@@ -2051,6 +2112,44 @@ pmemobj_tx_get_user_data(void)
 	ASSERT_IN_TX(tx);
 
 	return tx->user_data;
+}
+
+/*
+ * pmemobj_tx_set_failure_behavior -- enables or disables automatic transaction
+ * abort in case of an error
+ */
+void
+pmemobj_tx_set_failure_behavior(enum pobj_tx_failure_behavior behavior)
+{
+	LOG(3, "behavior %d", behavior);
+
+	struct tx *tx = get_tx();
+
+	ASSERT_IN_TX(tx);
+	ASSERT_TX_STAGE_WORK(tx);
+
+	struct tx_data *txd = PMDK_SLIST_FIRST(&tx->tx_entries);
+
+	txd->failure_behavior = behavior;
+}
+
+/*
+ * pmemobj_tx_get_failure_behavior -- returns enum specifying failure event
+ * for the current transaction.
+ */
+enum pobj_tx_failure_behavior
+pmemobj_tx_get_failure_behavior(void)
+{
+	LOG(3, NULL);
+
+	struct tx *tx = get_tx();
+
+	ASSERT_IN_TX(tx);
+	ASSERT_TX_STAGE_WORK(tx);
+
+	struct tx_data *txd = PMDK_SLIST_FIRST(&tx->tx_entries);
+
+	return txd->failure_behavior;
 }
 
 /*

--- a/src/test/obj_tx_add_range/obj_tx_add_range.c
+++ b/src/test/obj_tx_add_range/obj_tx_add_range.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2015-2019, Intel Corporation */
+/* Copyright 2015-2020, Intel Corporation */
 
 /*
  * obj_tx_add_range.c -- unit test for pmemobj_tx_add_range
@@ -1048,6 +1048,24 @@ do_tx_add_range_wrong_uuid(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		pmemobj_tx_xadd_range(oid, 0, 0, POBJ_XADD_NO_ABORT);
+	} TX_ONABORT {
+		UT_ASSERT(0);
+	} TX_END
+
+	UT_ASSERTeq(errno, EINVAL);
+
+	TX_BEGIN(pop) {
+		pmemobj_tx_set_failure_behavior(POBJ_TX_FAILURE_RETURN);
+		pmemobj_tx_add_range(oid, 0, 0);
+	} TX_ONABORT {
+		UT_ASSERT(0);
+	} TX_END
+
+	UT_ASSERTeq(errno, EINVAL);
+
+	TX_BEGIN(pop) {
+		pmemobj_tx_set_failure_behavior(POBJ_TX_FAILURE_RETURN);
+		pmemobj_tx_xadd_range(oid, 0, 0, 0);
 	} TX_ONABORT {
 		UT_ASSERT(0);
 	} TX_END

--- a/src/test/obj_tx_add_range_direct/obj_tx_add_range_direct.c
+++ b/src/test/obj_tx_add_range_direct/obj_tx_add_range_direct.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2015-2019, Intel Corporation */
+/* Copyright 2015-2020, Intel Corporation */
 
 /*
  * obj_tx_add_range_direct.c -- unit test for pmemobj_tx_add_range_direct
@@ -747,6 +747,34 @@ do_tx_add_range_too_large(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_xadd_range_direct(pmemobj_direct(obj.oid),
 				PMEMOBJ_MAX_ALLOC_SIZE + 1, POBJ_XADD_NO_ABORT);
+	} TX_ONCOMMIT {
+		UT_ASSERTeq(errno, EINVAL);
+		UT_ASSERTeq(ret, EINVAL);
+	} TX_ONABORT {
+		UT_ASSERT(0);
+	} TX_END
+
+	errno = 0;
+	ret = 0;
+
+	TX_BEGIN(pop) {
+		pmemobj_tx_set_failure_behavior(POBJ_TX_FAILURE_RETURN);
+		ret = pmemobj_tx_add_range_direct(pmemobj_direct(obj.oid),
+				PMEMOBJ_MAX_ALLOC_SIZE + 1);
+	} TX_ONCOMMIT {
+		UT_ASSERTeq(errno, EINVAL);
+		UT_ASSERTeq(ret, EINVAL);
+	} TX_ONABORT {
+		UT_ASSERT(0);
+	} TX_END
+
+	errno = 0;
+	ret = 0;
+
+	TX_BEGIN(pop) {
+		pmemobj_tx_set_failure_behavior(POBJ_TX_FAILURE_RETURN);
+		ret = pmemobj_tx_xadd_range_direct(pmemobj_direct(obj.oid),
+				PMEMOBJ_MAX_ALLOC_SIZE + 1, 0);
 	} TX_ONCOMMIT {
 		UT_ASSERTeq(errno, EINVAL);
 		UT_ASSERTeq(ret, EINVAL);

--- a/src/test/obj_tx_alloc/obj_tx_alloc.c
+++ b/src/test/obj_tx_alloc/obj_tx_alloc.c
@@ -547,6 +547,42 @@ do_tx_xalloc_zerolen(PMEMobjpool *pop)
 
 	UT_ASSERT(TOID_IS_NULL(obj));
 
+	/* alloc 0 with pmemobj_tx_set_failure_behavior called */
+	TX_BEGIN(pop) {
+		pmemobj_tx_set_failure_behavior(POBJ_TX_FAILURE_RETURN);
+		TOID_ASSIGN(obj, pmemobj_tx_alloc(0, TYPE_XABORT));
+	} TX_ONCOMMIT {
+		TOID_ASSIGN(obj, OID_NULL);
+	} TX_ONABORT {
+		UT_ASSERT(0); /* should not get to this point */
+	} TX_END
+
+	UT_ASSERT(TOID_IS_NULL(obj));
+
+	/* xalloc 0 with pmemobj_tx_set_failure_behavior called */
+	TX_BEGIN(pop) {
+		pmemobj_tx_set_failure_behavior(POBJ_TX_FAILURE_RETURN);
+		TOID_ASSIGN(obj, pmemobj_tx_xalloc(0, TYPE_XABORT, 0));
+	} TX_ONCOMMIT {
+		TOID_ASSIGN(obj, OID_NULL);
+	} TX_ONABORT {
+		UT_ASSERT(0); /* should not get to this point */
+	} TX_END
+
+	UT_ASSERT(TOID_IS_NULL(obj));
+
+	/* zalloc 0 with pmemobj_tx_set_failure_behavior called */
+	TX_BEGIN(pop) {
+		pmemobj_tx_set_failure_behavior(POBJ_TX_FAILURE_RETURN);
+		TOID_ASSIGN(obj, pmemobj_tx_zalloc(0, TYPE_XABORT));
+	} TX_ONCOMMIT {
+		TOID_ASSIGN(obj, OID_NULL);
+	} TX_ONABORT {
+		UT_ASSERT(0); /* should not get to this point */
+	} TX_END
+
+	UT_ASSERT(TOID_IS_NULL(obj));
+
 	TOID(struct object) first;
 	TOID_ASSIGN(first, POBJ_FIRST_TYPE_NUM(pop, TYPE_XABORT));
 	UT_ASSERT(TOID_IS_NULL(first));

--- a/src/test/obj_tx_lock/obj_tx_lock.c
+++ b/src/test/obj_tx_lock/obj_tx_lock.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2016-2019, Intel Corporation */
+/* Copyright 2016-2020, Intel Corporation */
 
 /*
  * obj_tx_lock.c -- unit test for pmemobj_tx_lock()
@@ -166,6 +166,29 @@ do_tx_lock_fail(struct transaction_data *data)
 				POBJ_XLOCK_NO_ABORT);
 	} TX_ONCOMMIT {
 		UT_ASSERTne(ret, 0);
+		UT_ASSERTeq(pmemobj_rwlock_unlock(Pop, &data->rwlocks[0]), 0);
+	} TX_ONABORT {
+		UT_ASSERT(0);
+	} TX_END
+	/* return ret without abort transaction */
+	UT_ASSERTeq(pmemobj_rwlock_wrlock(Pop, &data->rwlocks[0]), 0);
+	TX_BEGIN(Pop) {
+		pmemobj_tx_set_failure_behavior(POBJ_TX_FAILURE_RETURN);
+		ret = pmemobj_tx_lock(TX_PARAM_RWLOCK, &data->rwlocks[0]);
+	} TX_ONCOMMIT {
+		UT_ASSERTne(ret, 0);
+		UT_ASSERTeq(pmemobj_rwlock_unlock(Pop, &data->rwlocks[0]), 0);
+	} TX_ONABORT {
+		UT_ASSERT(0);
+	} TX_END
+	/* return ret without abort transaction */
+	UT_ASSERTeq(pmemobj_rwlock_wrlock(Pop, &data->rwlocks[0]), 0);
+	TX_BEGIN(Pop) {
+		pmemobj_tx_set_failure_behavior(POBJ_TX_FAILURE_RETURN);
+		ret = pmemobj_tx_xlock(TX_PARAM_RWLOCK, &data->rwlocks[0], 0);
+	} TX_ONCOMMIT {
+		UT_ASSERTne(ret, 0);
+		UT_ASSERTeq(pmemobj_rwlock_unlock(Pop, &data->rwlocks[0]), 0);
 	} TX_ONABORT {
 		UT_ASSERT(0);
 	} TX_END

--- a/src/test/obj_tx_strdup/obj_tx_strdup.c
+++ b/src/test/obj_tx_strdup/obj_tx_strdup.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2015-2019, Intel Corporation */
+/* Copyright 2015-2020, Intel Corporation */
 
 /*
  * obj_tx_strdup.c -- unit test for pmemobj_tx_strdup
@@ -165,6 +165,24 @@ do_tx_strdup_null(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		pmemobj_tx_xstrdup(NULL, TYPE_ABORT, POBJ_XALLOC_NO_ABORT);
+	} TX_ONCOMMIT {
+		UT_ASSERTeq(errno, EINVAL);
+	} TX_ONABORT {
+		UT_ASSERT(0);
+	} TX_END
+
+	TX_BEGIN(pop) {
+		pmemobj_tx_set_failure_behavior(POBJ_TX_FAILURE_RETURN);
+		pmemobj_tx_strdup(NULL, TYPE_ABORT);
+	} TX_ONCOMMIT {
+		UT_ASSERTeq(errno, EINVAL);
+	} TX_ONABORT {
+		UT_ASSERT(0);
+	} TX_END
+
+	TX_BEGIN(pop) {
+		pmemobj_tx_set_failure_behavior(POBJ_TX_FAILURE_RETURN);
+		pmemobj_tx_xstrdup(NULL, TYPE_ABORT, 0);
 	} TX_ONCOMMIT {
 		UT_ASSERTeq(errno, EINVAL);
 	} TX_ONABORT {

--- a/src/test/obj_ulog_size/obj_ulog_size.c
+++ b/src/test/obj_ulog_size/obj_ulog_size.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2019, Intel Corporation */
+/* Copyright 2019-2020, Intel Corporation */
 
 /*
  * obj_ulog_size.c -- unit tests for pmemobj_action API and
@@ -130,6 +130,28 @@ do_tx_max_alloc_tx_publish_abort(PMEMobjpool *pop)
 	/* it should fail without abort transaction */
 	TX_BEGIN(pop) {
 		pmemobj_tx_xpublish(act, REDO_OVERFLOW, POBJ_XPUBLISH_NO_ABORT);
+	} TX_ONABORT {
+		ASSERT(0);
+	} TX_ONCOMMIT {
+		UT_ASSERTeq(errno, ENOMEM);
+		UT_OUT("!Cannot extend redo log - the pool is full");
+	} TX_END
+
+	/* it should fail without abort transaction */
+	TX_BEGIN(pop) {
+		pmemobj_tx_set_failure_behavior(POBJ_TX_FAILURE_RETURN);
+		pmemobj_tx_publish(act, REDO_OVERFLOW);
+	} TX_ONABORT {
+		ASSERT(0);
+	} TX_ONCOMMIT {
+		UT_ASSERTeq(errno, ENOMEM);
+		UT_OUT("!Cannot extend redo log - the pool is full");
+	} TX_END
+
+	/* it should fail without abort transaction */
+	TX_BEGIN(pop) {
+		pmemobj_tx_set_failure_behavior(POBJ_TX_FAILURE_RETURN);
+		pmemobj_tx_xpublish(act, REDO_OVERFLOW, 0);
 	} TX_ONABORT {
 		ASSERT(0);
 	} TX_ONCOMMIT {
@@ -396,6 +418,32 @@ do_tx_max_alloc_wrong_pop_addr(PMEMobjpool *pop, PMEMobjpool *pop2)
 	TX_BEGIN(pop) {
 		pmemobj_tx_xlog_append_buffer(TX_LOG_TYPE_SNAPSHOT, buff2_addr,
 				buff2_size, POBJ_XLOG_APPEND_BUFFER_NO_ABORT);
+	} TX_ONABORT {
+		UT_ASSERT(0);
+	} TX_ONCOMMIT {
+		UT_ASSERTeq(errno, EINVAL);
+		UT_OUT(
+			"!Cannot append an undo log buffer from a different memory pool");
+	} TX_END
+
+	/* it should fail without abort transaction */
+	TX_BEGIN(pop) {
+		pmemobj_tx_set_failure_behavior(POBJ_TX_FAILURE_RETURN);
+		pmemobj_tx_log_append_buffer(TX_LOG_TYPE_SNAPSHOT, buff2_addr,
+				buff2_size);
+	} TX_ONABORT {
+		UT_ASSERT(0);
+	} TX_ONCOMMIT {
+		UT_ASSERTeq(errno, EINVAL);
+		UT_OUT(
+			"!Cannot append an undo log buffer from a different memory pool");
+	} TX_END
+
+	/* it should fail without abort transaction */
+	TX_BEGIN(pop) {
+		pmemobj_tx_set_failure_behavior(POBJ_TX_FAILURE_RETURN);
+		pmemobj_tx_xlog_append_buffer(TX_LOG_TYPE_SNAPSHOT, buff2_addr,
+				buff2_size, 0);
 	} TX_ONABORT {
 		UT_ASSERT(0);
 	} TX_ONCOMMIT {

--- a/src/test/obj_ulog_size/out0.log.match
+++ b/src/test/obj_ulog_size/out0.log.match
@@ -14,7 +14,11 @@ Disabled auto alloc prevented the undo log grow: ${Cannot allocate memory|Not en
 do_tx_max_alloc_wrong_pop_addr
 Cannot append an undo log buffer from a different memory pool: Invalid argument
 Cannot append an undo log buffer from a different memory pool: Invalid argument
+Cannot append an undo log buffer from a different memory pool: Invalid argument
+Cannot append an undo log buffer from a different memory pool: Invalid argument
 do_tx_max_alloc_tx_publish_abort
+Cannot extend redo log - the pool is full: ${Cannot allocate memory|Not enough space}
+Cannot extend redo log - the pool is full: ${Cannot allocate memory|Not enough space}
 Cannot extend redo log - the pool is full: ${Cannot allocate memory|Not enough space}
 Cannot extend redo log - the pool is full: ${Cannot allocate memory|Not enough space}
 do_tx_buffer_currently_used

--- a/src/test/obj_ulog_size/out1.log.match
+++ b/src/test/obj_ulog_size/out1.log.match
@@ -14,7 +14,11 @@ Disabled auto alloc prevented the undo log grow: ${Cannot allocate memory|Not en
 do_tx_max_alloc_wrong_pop_addr
 Cannot append an undo log buffer from a different memory pool: Invalid argument
 Cannot append an undo log buffer from a different memory pool: Invalid argument
+Cannot append an undo log buffer from a different memory pool: Invalid argument
+Cannot append an undo log buffer from a different memory pool: Invalid argument
 do_tx_max_alloc_tx_publish_abort
+Cannot extend redo log - the pool is full: ${Cannot allocate memory|Not enough space}
+Cannot extend redo log - the pool is full: ${Cannot allocate memory|Not enough space}
 Cannot extend redo log - the pool is full: ${Cannot allocate memory|Not enough space}
 Cannot extend redo log - the pool is full: ${Cannot allocate memory|Not enough space}
 do_tx_buffer_currently_used

--- a/src/test/obj_ulog_size/out2.log.match
+++ b/src/test/obj_ulog_size/out2.log.match
@@ -14,7 +14,11 @@ Disabled auto alloc prevented the undo log grow: ${Cannot allocate memory|Not en
 do_tx_max_alloc_wrong_pop_addr
 Cannot append an undo log buffer from a different memory pool: Invalid argument
 Cannot append an undo log buffer from a different memory pool: Invalid argument
+Cannot append an undo log buffer from a different memory pool: Invalid argument
+Cannot append an undo log buffer from a different memory pool: Invalid argument
 do_tx_max_alloc_tx_publish_abort
+Cannot extend redo log - the pool is full: ${Cannot allocate memory|Not enough space}
+Cannot extend redo log - the pool is full: ${Cannot allocate memory|Not enough space}
 Cannot extend redo log - the pool is full: ${Cannot allocate memory|Not enough space}
 Cannot extend redo log - the pool is full: ${Cannot allocate memory|Not enough space}
 do_tx_buffer_currently_used

--- a/src/test/scope/out11.log.match
+++ b/src/test/scope/out11.log.match
@@ -79,6 +79,7 @@ pmemobj_tx_commit
 pmemobj_tx_end
 pmemobj_tx_errno
 pmemobj_tx_free
+pmemobj_tx_get_failure_behavior
 pmemobj_tx_get_user_data
 pmemobj_tx_lock
 pmemobj_tx_log_append_buffer
@@ -88,6 +89,7 @@ pmemobj_tx_log_snapshots_max_size
 pmemobj_tx_process
 pmemobj_tx_publish
 pmemobj_tx_realloc
+pmemobj_tx_set_failure_behavior
 pmemobj_tx_set_user_data
 pmemobj_tx_stage
 pmemobj_tx_strdup

--- a/src/test/scope/out5.log.match
+++ b/src/test/scope/out5.log.match
@@ -74,6 +74,7 @@ pmemobj_tx_commit
 pmemobj_tx_end
 pmemobj_tx_errno
 pmemobj_tx_free
+pmemobj_tx_get_failure_behavior
 pmemobj_tx_get_user_data
 pmemobj_tx_lock
 pmemobj_tx_log_append_buffer
@@ -83,6 +84,7 @@ pmemobj_tx_log_snapshots_max_size
 pmemobj_tx_process
 pmemobj_tx_publish
 pmemobj_tx_realloc
+pmemobj_tx_set_failure_behavior
 pmemobj_tx_set_user_data
 pmemobj_tx_stage
 pmemobj_tx_strdup


### PR DESCRIPTION
This function can be used to disable or enable aborting tx
in case of an error (for example when allocation fails).

This patch also introduces pmemobj_tx_is_abort_on_failure
which allows to query current setting of a transaction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4654)
<!-- Reviewable:end -->
