### PR TITLE
obj: optimize transactional allocation

### DIFF
--- a/src/include/libpmemobj/action_base.h
+++ b/src/include/libpmemobj/action_base.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2017-2019, Intel Corporation */
+/* Copyright 2017-2020, Intel Corporation */
 
 /*
  * libpmemobj/action_base.h -- definitions of libpmemobj action interface
@@ -26,6 +26,8 @@ enum pobj_action_type {
 struct pobj_action_heap {
 	/* offset to the element being freed/allocated */
 	uint64_t offset;
+	/* usable size of the element being allocated */
+	uint64_t usable_size;
 };
 
 struct pobj_action {

--- a/src/libpmemobj/palloc.c
+++ b/src/libpmemobj/palloc.c
@@ -61,6 +61,7 @@ struct pobj_action_internal {
 		/* valid only when type == POBJ_ACTION_TYPE_HEAP */
 		struct {
 			uint64_t offset;
+			uint64_t usable_size;
 			enum memblock_state new_state;
 			struct memory_block m;
 			struct memory_block_reserved *mresv;
@@ -107,7 +108,7 @@ static int
 alloc_prep_block(struct palloc_heap *heap, const struct memory_block *m,
 	palloc_constr constructor, void *arg,
 	uint64_t extra_field, uint16_t object_flags,
-	uint64_t *offset_value)
+	struct pobj_action_internal *out)
 {
 	void *uptr = m->m_ops->get_user_data(m);
 	size_t usize = m->m_ops->get_user_size(m);
@@ -147,7 +148,8 @@ alloc_prep_block(struct palloc_heap *heap, const struct memory_block *m,
 	 * will be used to set the offset destination pointer provided by the
 	 * caller.
 	 */
-	*offset_value = HEAP_PTR_TO_OFF(heap, uptr);
+	out->offset = HEAP_PTR_TO_OFF(heap, uptr);
+	out->usable_size = usize;
 
 	return 0;
 }
@@ -218,7 +220,7 @@ palloc_reservation_create(struct palloc_heap *heap, size_t size,
 		goto out;
 
 	if (alloc_prep_block(heap, new_block, constructor, arg,
-		extra_field, object_flags, &out->offset) != 0) {
+		extra_field, object_flags, out) != 0) {
 		/*
 		 * Constructor returned non-zero value which means
 		 * the memory block reservation has to be rolled back.

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -592,7 +592,7 @@ tx_alloc_common(struct tx *tx, size_t size, type_num_t type_num,
 	PMEMoid retoid = OID_NULL;
 	retoid.off = action->heap.offset;
 	retoid.pool_uuid_lo = pop->uuid_lo;
-	size = palloc_usable_size(&pop->heap, retoid.off);
+	size = action->heap.usable_size;
 
 	const struct tx_range_def r = {retoid.off, size, args.flags};
 	if (tx_lane_ranges_insert_def(pop, tx, &r) != 0)


### PR DESCRIPTION
Reading metadata of a persistent allocation is almost
always a guaranteed cache miss, so we should avoid doing
so whenever possible.

This patch removes a usable size check from transactional
allocations, avoiding one extraneous cache miss.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4657)
<!-- Reviewable:end -->
