### PR TITLE
common: resolve Travis' build config issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ arch:
   - ppc64le
   - amd64
 
-sudo: required
-
 language: c
 
 services:
@@ -24,7 +22,7 @@ env:
     - VALGRIND=1
     - SRC_CHECKERS=0
     - EXPERIMENTAL=n
-  matrix:
+  jobs:
     - COVERAGE=1 FAULT_INJECTION=1 TEST_BUILD=debug
 #    - FAULT_INJECTION=1 TEST_BUILD=debug
 #    - FAULT_INJECTION=1 TEST_BUILD=nondebug
@@ -41,7 +39,7 @@ env:
 # keys defined. In this case the only expansion key with more than one entry is
 # the `arch:` key, and that is why ppc64le is first, to save some space here
 # and not have to define `arch:` for each entry.
-matrix:
+jobs:
   include:
     - env: FAULT_INJECTION=1 TEST_BUILD=debug PUSH_IMAGE=1
     - env: OS=fedora OS_VER=31 PMDK_CC=clang PMDK_CXX=clang++ TEST_BUILD=nondebug PUSH_IMAGE=1


### PR DESCRIPTION
Travis' build config validation complains about these:

root: deprecated key sudo (The key `sudo` has no effect anymore.)
env: key matrix is an alias for jobs, using jobs
root: key matrix is an alias for jobs, using jobs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4678)
<!-- Reviewable:end -->
