### PR TITLE
pmem2: add iterator to arguments of pmem2_badblock_clear()

### DIFF
--- a/src/include/libpmem2.h
+++ b/src/include/libpmem2.h
@@ -109,6 +109,7 @@ void pmem2_badblock_iterator_delete(
 		struct pmem2_badblock_iterator **pbb);
 
 int pmem2_badblock_clear(const struct pmem2_source *cfg,
+		struct pmem2_badblock_iterator *pbb,
 		const struct pmem2_badblock *bb);
 
 /* config setup */

--- a/src/libpmem2/source.c
+++ b/src/libpmem2/source.c
@@ -43,6 +43,7 @@ void pmem2_badblock_iterator_delete(
 
 int
 pmem2_badblock_clear(const struct pmem2_source *src,
+	struct pmem2_badblock_iterator *pbb,
 	const struct pmem2_badblock *bb)
 {
 	return PMEM2_E_NOSUPP;


### PR DESCRIPTION
Clearing bad blocks on DAX devices requires following data saved
in pmem2_badblock_iterator:
1) ndctl context (struct ndctl_ctx)
2) ndctl bus (struct ndctl_bus)
3) address of the namespace

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4700)
<!-- Reviewable:end -->
