### PR TITLE
pmem2: (+pmem) avoid triggering harmless warning under pmemcheck

### DIFF
--- a/src/libpmem2/x86_64/memcpy/memcpy_avx.h
+++ b/src/libpmem2/x86_64/memcpy/memcpy_avx.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2017-2019, Intel Corporation */
+/* Copyright 2017-2020, Intel Corporation */
 
 #ifndef PMEM2_MEMCPY_AVX_H
 #define PMEM2_MEMCPY_AVX_H
@@ -81,7 +81,19 @@ le2:
 static force_inline void
 memmove_small_avx(char *dest, const char *src, size_t len)
 {
-	memmove_small_avx_noflush(dest, src, len);
+	/*
+	 * pmemcheck complains about "overwritten stores before they were made
+	 * persistent" for overlapping stores (last instruction in each code
+	 * path) in the optimized version.
+	 * libc's memcpy also does that, so we can't use it here.
+	 */
+	if (On_pmemcheck) {
+		memmove_nodrain_generic(dest, src, len, PMEM2_F_MEM_NOFLUSH,
+				NULL);
+	} else {
+		memmove_small_avx_noflush(dest, src, len);
+	}
+
 	flush(dest, len);
 }
 

--- a/src/libpmem2/x86_64/memcpy/memcpy_sse2.h
+++ b/src/libpmem2/x86_64/memcpy/memcpy_sse2.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2017-2019, Intel Corporation */
+/* Copyright 2017-2020, Intel Corporation */
 
 #ifndef PMEM2_MEMCPY_SSE2_H
 #define PMEM2_MEMCPY_SSE2_H
@@ -97,7 +97,19 @@ le2:
 static force_inline void
 memmove_small_sse2(char *dest, const char *src, size_t len)
 {
-	memmove_small_sse2_noflush(dest, src, len);
+	/*
+	 * pmemcheck complains about "overwritten stores before they were made
+	 * persistent" for overlapping stores (last instruction in each code
+	 * path) in the optimized version.
+	 * libc's memcpy also does that, so we can't use it here.
+	 */
+	if (On_pmemcheck) {
+		memmove_nodrain_generic(dest, src, len, PMEM2_F_MEM_NOFLUSH,
+				NULL);
+	} else {
+		memmove_small_sse2_noflush(dest, src, len);
+	}
+
 	flush(dest, len);
 }
 


### PR DESCRIPTION
To limit the number of used instructions, mem[move|set]_small_*
can store to part of memory twice (for example, they do 2 overlapping
8-byte stores for 15-byte copy).
This confuses pmemcheck's double store checks, which leads to
"overwritten stores before they were made persistent"
warnings.

Avoid that by redirecting small/unaligned mem[move|set] to generic
implementation, when executed under pmemcheck.

Before this patch, it's possible to reproduce this problem by running
obj_list_valgrind test with PMEM_AVX=1.

Note: libc's memcpy does similar optimizations, so it's still possible
to reproduce this problem by running  obj_list_valgrind test with
PMEM_NO_GENERIC_MEMCPY=1 PMEM_NO_MOVNT=1. This code path is undocumented
and exists only for comparisons of memcpy implementations, so we
can safely ignore it.

This PR depends on #4701

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4702)
<!-- Reviewable:end -->
