### PR TITLE
corrections to docs about ARM64 cache coherency

### DIFF
--- a/src/libpmem2/aarch64/arm_cacheops.h
+++ b/src/libpmem2/aarch64/arm_cacheops.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2014-2019, Intel Corporation */
+/* Copyright 2014-2020, Intel Corporation */
 /*
  * ARM inline assembly to flush and invalidate caches
  * clwb => dc cvac
@@ -25,14 +25,15 @@
  * * DMB [ISH]    MFENCE
  * * DMB [ISH]ST  SFENCE
  * * DMB [ISH]LD  LFENCE
- * We care about persistence not synchronization thus ISH should be enough?
  *
- * Memory domains:
+ * Memory domains (cache coherency):
  * * non-shareable - local to a single core
- * * inner shareable (ISH) - usu. one or multiple processor sockets
- * * outer shareable (OSH) - usu. including GPU
+ * * inner shareable (ISH) - a group of CPU clusters/sockets/other hardware
+ *      Linux requires that anything within one operating system/hypervisor
+ *      is within the same Inner Shareable domain.
+ * * outer shareable (OSH) - one or more separate ISH domains
  * * full system (SY) - anything that can possibly access memory
- * ??? What about RDMA?  No libfabric on ARM thus not a concern for now.
+ * Docs: ARM DDI 0487E.a page B2-144.
  *
  * Exception (privilege) levels:
  * * EL0 - userspace (ring 3)

--- a/src/libpmem2/aarch64/arm_cacheops.h
+++ b/src/libpmem2/aarch64/arm_cacheops.h
@@ -3,8 +3,9 @@
 /*
  * ARM inline assembly to flush and invalidate caches
  * clwb => dc cvac
- * clflush | clflushopt => dc civac
+ * clflushopt => dc civac
  * fence => dmb ish
+ * sfence => dmb ishst
  */
 
 /*


### PR DESCRIPTION
Explain what's an Inner Shareable domain.  Correct wrongness.

Links:
* a [LKML thread](https://lore.kernel.org/linux-arm-kernel/20200323123524.w67fici6oxzdo665@mail.google.com/T/#u)
* book: [ARM DDI 0487E.a](https://static.docs.arm.com/ddi0487/ea/DDI0487E_a_armv8_arm.pdf?_ga=2.164266557.306569205.1570439925-2017736311.1569857310) page B2-144

Note that the distinction between "full coherency" and "IO coherency" affects hardware implementors but not us (if I read things correctly...).

Per Janek's question about whether RDMA needs explicit flushes for global observability.  I'm not 100% sure about whether this is an adequate answer, but this should be a step forward.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4704)
<!-- Reviewable:end -->
