### PR TITLE
test: speed up obj_verify

### DIFF
--- a/src/test/tools/obj_verify/obj_verify.c
+++ b/src/test/tools/obj_verify/obj_verify.c
@@ -40,13 +40,16 @@ struct root_s {
 static void
 fill_data_s(struct data_s *rec, uint64_t number)
 {
+	int value = rand();
+
 	memcpy(rec->signature, Signature, sizeof(rec->signature));
+
 	if (util_snprintf(rec->number_str, NUMBER_LEN, "%09lu", number) < 0)
 		abort();
+
 	rec->number = number;
 
-	for (int i = 0; i < FILL_SIZE; i++)
-		rec->fill[i] = (uint32_t)rand();
+	memset(rec->fill, value, FILL_SIZE * sizeof(int));
 
 	util_checksum(rec, sizeof(*rec), &rec->checksum,
 			1 /* insert */, SKIP_OFFSET);


### PR DESCRIPTION
The pmempool_sync_remote/TEST29 and TEST31 tests
sometimes timeouts, because obj_verify runs too long.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4720)
<!-- Reviewable:end -->
