### PR TITLE
common: change SDK version needed by PMDK to 10.0.17134.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ see https://github.com/pmem/pmdk/issues/4207.
 ### Windows
 
 * **MS Visual Studio 2015**
-* [Windows SDK 10.0.16299.15](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk)
+* [Windows SDK 10.0.17134.12](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk)
 * **perl** (i.e. [StrawberryPerl](http://strawberryperl.com/))
 * **PowerShell 5**
 

--- a/src/benchmarks/pmembench.vcxproj
+++ b/src/benchmarks/pmembench.vcxproj
@@ -174,7 +174,7 @@
     <ProjectGuid>{CB906E89-1313-4929-AFF7-86FBF1CC301F}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmembench</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/common/libpmemcommon.vcxproj
+++ b/src/common/libpmemcommon.vcxproj
@@ -66,7 +66,7 @@
     <ProjectGuid>{492BAA3D-0D5D-478E-9765-500463AE69AA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libpmemcommon</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/core/libpmemcore.vcxproj
+++ b/src/core/libpmemcore.vcxproj
@@ -41,7 +41,7 @@
     <ProjectGuid>{2FA3155B-6F26-4D15-AC03-9D82D48DBC42}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libpmemcore</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/examples/libpmem/full_copy.vcxproj
+++ b/src/examples/libpmem/full_copy.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{0287C3DC-AE03-4714-AAFF-C52F062ECA6F}</ProjectGuid>
     <RootNamespace>pmem</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/src/examples/libpmem/manpage.vcxproj
+++ b/src/examples/libpmem/manpage.vcxproj
@@ -16,7 +16,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{FCD0587A-4504-4F5E-8E9C-468CC03D250A}</ProjectGuid>
     <RootNamespace>pmem</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/src/examples/libpmem/simple_copy.vcxproj
+++ b/src/examples/libpmem/simple_copy.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D062166F-0EC7-4C13-A772-0C7157EEFE41}</ProjectGuid>
     <RootNamespace>pmem</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/src/examples/libpmem2/advanced/advanced.vcxproj
+++ b/src/examples/libpmem2/advanced/advanced.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D2964B88-EB05-4EBF-ACDA-44596FBFECB6}</ProjectGuid>
     <RootNamespace>pmem2</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/src/examples/libpmem2/basic/basic.vcxproj
+++ b/src/examples/libpmem2/basic/basic.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A9ADD224-1755-407F-906D-C13EC37FF7B0}</ProjectGuid>
     <RootNamespace>pmem2</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/src/examples/libpmem2/log/log.vcxproj
+++ b/src/examples/libpmem2/log/log.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3EC20BDD-2E48-4291-A9EE-D0675AF77C7F}</ProjectGuid>
     <RootNamespace>pmem2</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/src/examples/libpmem2/redo/redo.vcxproj
+++ b/src/examples/libpmem2/redo/redo.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D6A1F30D-C9E5-4F5C-9A16-50430AB1F26D}</ProjectGuid>
     <RootNamespace>pmem2</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/src/examples/libpmemblk/assetdb/asset_checkin.vcxproj
+++ b/src/examples/libpmemblk/assetdb/asset_checkin.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{581B3A58-F3F0-4765-91E5-D0C82816A528}</ProjectGuid>
     <RootNamespace>pmemblk</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemblk\libpmemblk.vcxproj">

--- a/src/examples/libpmemblk/assetdb/asset_checkout.vcxproj
+++ b/src/examples/libpmemblk/assetdb/asset_checkout.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{513C4CFA-BD5B-4470-BA93-F6D43778A754}</ProjectGuid>
     <RootNamespace>pmemblk</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemblk\libpmemblk.vcxproj">

--- a/src/examples/libpmemblk/assetdb/asset_list.vcxproj
+++ b/src/examples/libpmemblk/assetdb/asset_list.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8008010F-8718-4C5F-86B2-195AEBF73422}</ProjectGuid>
     <RootNamespace>pmemblk</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemblk\libpmemblk.vcxproj">

--- a/src/examples/libpmemblk/assetdb/asset_load.vcxproj
+++ b/src/examples/libpmemblk/assetdb/asset_load.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C7E42AE1-052F-4024-B8BA-DE5DCE6BBEEC}</ProjectGuid>
     <RootNamespace>pmemblk</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemblk\libpmemblk.vcxproj">

--- a/src/examples/libpmemblk/manpage.vcxproj
+++ b/src/examples/libpmemblk/manpage.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8010BBB0-C71B-4EFF-95EB-65C01E5EC197}</ProjectGuid>
     <RootNamespace>pmemblk</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/examples/libpmemlog/logfile/addlog.vcxproj
+++ b/src/examples/libpmemlog/logfile/addlog.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A7CA7975-CEDB-48E6-9AEB-1209DCBD07F2}</ProjectGuid>
     <RootNamespace>pmemlog</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemlog\libpmemlog.vcxproj">

--- a/src/examples/libpmemlog/logfile/printlog.vcxproj
+++ b/src/examples/libpmemlog/logfile/printlog.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C3CEE34C-29E0-4A22-B258-3FBAF662AA19}</ProjectGuid>
     <RootNamespace>pmemlog</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemlog\libpmemlog.vcxproj">

--- a/src/examples/libpmemlog/manpage.vcxproj
+++ b/src/examples/libpmemlog/manpage.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{9FF51F3E-AF36-4F45-A797-C5F03A090298}</ProjectGuid>
     <RootNamespace>pememlog</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/examples/libpmemobj/array/array.vcxproj
+++ b/src/examples/libpmemobj/array/array.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{7264C8F6-73FB-4830-9306-1558D3EAC71B}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/btree.vcxproj
+++ b/src/examples/libpmemobj/btree.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{0FB8F0FD-276C-413B-97A8-67ABE0C9043B}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/buffons_needle_problem.vcxproj
+++ b/src/examples/libpmemobj/buffons_needle_problem.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{BA0EF7F5-BE6C-4B61-9D5F-1480462EE001}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/hashmap/hashmap_atomic.vcxproj
+++ b/src/examples/libpmemobj/hashmap/hashmap_atomic.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{F5E2F6C4-19BA-497A-B754-232E469BE647}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/hashmap/hashmap_rp.vcxproj
+++ b/src/examples/libpmemobj/hashmap/hashmap_rp.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{F5E2F6C4-19BA-497A-B754-232E4666E647}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/hashmap/hashmap_tx.vcxproj
+++ b/src/examples/libpmemobj/hashmap/hashmap_tx.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D93A2683-6D99-4F18-B378-91195D23E007}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/linkedlist/fifo.vcxproj
+++ b/src/examples/libpmemobj/linkedlist/fifo.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D3A99F36-4B72-4766-ABCD-CCEDC26DD139}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/list_map/list_map.vcxproj
+++ b/src/examples/libpmemobj/list_map/list_map.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3799BA67-3C4F-4AE0-85DC-5BAAEA01A180}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/lists.vcxproj
+++ b/src/examples/libpmemobj/lists.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{2CD7408E-2F60-43C3-ACEB-C7D58CDD8462}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/manpage.vcxproj
+++ b/src/examples/libpmemobj/manpage.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{EDA88BAB-9FA7-4A2D-8974-EFCFA24B3FEB}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/examples/libpmemobj/map/data_store.vcxproj
+++ b/src/examples/libpmemobj/map/data_store.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{5B2B9C0D-1B6D-4357-8307-6DE1EE0A41A3}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/map/libmap.vcxproj
+++ b/src/examples/libpmemobj/map/libmap.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{49A7CC5A-D5E7-4A07-917F-C6918B982BE8}</ProjectGuid>
     <TargetName>$(ProjectName)</TargetName>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <Manifest>

--- a/src/examples/libpmemobj/map/mapcli.vcxproj
+++ b/src/examples/libpmemobj/map/mapcli.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{BB248BAC-6E1B-433C-A254-75140A273AB5}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/pi.vcxproj
+++ b/src/examples/libpmemobj/pi.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{11D76FBC-DFAA-4B31-9DB0-206E171E3F94}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/pmemblk/obj_pmemblk.vcxproj
+++ b/src/examples/libpmemobj/pmemblk/obj_pmemblk.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8C42CA7C-1543-4F1B-A55F-28CD419C7D35}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/pmemlog/obj_pmemlog.vcxproj
+++ b/src/examples/libpmemobj/pmemlog/obj_pmemlog.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{60206D22-E132-4695-8486-10BECA32C5CC}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/pmemlog/obj_pmemlog_macros.vcxproj
+++ b/src/examples/libpmemobj/pmemlog/obj_pmemlog_macros.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{06877FED-15BA-421F-85C9-1A964FB97446}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/pmemlog/obj_pmemlog_minimal.vcxproj
+++ b/src/examples/libpmemobj/pmemlog/obj_pmemlog_minimal.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{0056B0B6-CB3E-4F0E-B6DC-48D59CB8E235}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/pmemlog/obj_pmemlog_simple.vcxproj
+++ b/src/examples/libpmemobj/pmemlog/obj_pmemlog_simple.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{5DB2E259-0D19-4A89-B8EC-B2912F39924D}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/string_store/reader.vcxproj
+++ b/src/examples/libpmemobj/string_store/reader.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{0BFD78AA-FD94-4DB1-8495-8F5CC06D8F03}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/string_store/writer.vcxproj
+++ b/src/examples/libpmemobj/string_store/writer.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{F5D850C9-D353-4B84-99BC-E336C231018C}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/string_store_tx/reader.vcxproj
+++ b/src/examples/libpmemobj/string_store_tx/reader.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{59D7A9CD-9912-40E4-96E1-8A873F777F62}</ProjectGuid>
     <RootNamespace>pmemobj_tx</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/string_store_tx/writer.vcxproj
+++ b/src/examples/libpmemobj/string_store_tx/writer.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{7337E34A-97B0-44FC-988B-7E6AE7E0FBBF}</ProjectGuid>
     <RootNamespace>pmemobj_tx</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/string_store_tx_type/reader.vcxproj
+++ b/src/examples/libpmemobj/string_store_tx_type/reader.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{74D655D5-F661-4887-A1EB-5A6222AF5FCA}</ProjectGuid>
     <RootNamespace>pmemobj_tx_type</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/string_store_tx_type/writer.vcxproj
+++ b/src/examples/libpmemobj/string_store_tx_type/writer.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1EB3DE5B-6357-498D-8CAC-EEC0209EA454}</ProjectGuid>
     <RootNamespace>pmemobj_tx_type</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/tree_map/btree_map.vcxproj
+++ b/src/examples/libpmemobj/tree_map/btree_map.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{79D37FFE-FF76-44B3-BB27-3DCAEFF2EBE9}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/tree_map/ctree_map.vcxproj
+++ b/src/examples/libpmemobj/tree_map/ctree_map.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{BE18F227-A9F0-4B38-B689-4E2F9F09CA5F}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/tree_map/rbtree_map.vcxproj
+++ b/src/examples/libpmemobj/tree_map/rbtree_map.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{17A4B817-68B1-4719-A9EF-BD8FAB747DE6}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/examples/libpmemobj/tree_map/rtree_map.vcxproj
+++ b/src/examples/libpmemobj/tree_map/rtree_map.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3ED56E55-84A6-422C-A8D4-A8439FB8F245}</ProjectGuid>
     <RootNamespace>pmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(SolutionName)'=='PMDK'">
     <ProjectReference Include="..\..\..\libpmemobj\libpmemobj.vcxproj">

--- a/src/libpmem/libpmem.vcxproj
+++ b/src/libpmem/libpmem.vcxproj
@@ -117,7 +117,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/libpmem2/libpmem2.vcxproj
+++ b/src/libpmem2/libpmem2.vcxproj
@@ -98,7 +98,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/libpmemblk/libpmemblk.vcxproj
+++ b/src/libpmemblk/libpmemblk.vcxproj
@@ -98,7 +98,7 @@
     <RootNamespace>libpmemblk</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/libpmemlog/libpmemlog.vcxproj
+++ b/src/libpmemlog/libpmemlog.vcxproj
@@ -95,7 +95,7 @@
     <RootNamespace>libpmemlog</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/libpmemobj/libpmemobj.vcxproj
+++ b/src/libpmemobj/libpmemobj.vcxproj
@@ -152,7 +152,7 @@
     <RootNamespace>libpmemobj</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/libpmempool/libpmempool.vcxproj
+++ b/src/libpmempool/libpmempool.vcxproj
@@ -119,7 +119,7 @@
     <RootNamespace>libpmempool</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/test/arch_flags/arch_flags.vcxproj
+++ b/src/test/arch_flags/arch_flags.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{53115A01-460C-4339-A2C8-AE1323A6E7EA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>arch_flags</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/blk_include/blk_include.vcxproj
+++ b/src/test/blk_include/blk_include.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{29D9376B-DC36-4940-83F1-A7CBE38A2103}</ProjectGuid>
     <RootNamespace>blk_include</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/blk_nblock/blk_nblock.vcxproj
+++ b/src/test/blk_nblock/blk_nblock.vcxproj
@@ -40,7 +40,7 @@
     <ProjectGuid>{A38EFCDB-53D6-4474-97F3-0DDC6CE70D76}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>blk_nblock</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/blk_non_zero/blk_non_zero.vcxproj
+++ b/src/test/blk_non_zero/blk_non_zero.vcxproj
@@ -61,7 +61,7 @@
     <ProjectGuid>{18E90E1A-F2E0-40DF-9900-A14E560C9EB4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>blk_non_zero</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/blk_pool/blk_pool.vcxproj
+++ b/src/test/blk_pool/blk_pool.vcxproj
@@ -89,7 +89,7 @@
     <ProjectGuid>{95B683BD-B9DC-400F-9BC0-8F1505F08BF5}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>blk_pool</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/blk_pool_lock/blk_pool_lock.vcxproj
+++ b/src/test/blk_pool_lock/blk_pool_lock.vcxproj
@@ -31,7 +31,7 @@
     <ProjectGuid>{779425B1-2211-499B-A7CC-4F9EC6CB0D25}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>blk_pool_lock</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/blk_pool_win/blk_pool_win.vcxproj
+++ b/src/test/blk_pool_win/blk_pool_win.vcxproj
@@ -34,7 +34,7 @@
     <ProjectGuid>{80AF1B7D-B8CE-4AF0-AE3B-1DABED1B57E7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>blk_pool_win</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/blk_recovery/blk_recovery.vcxproj
+++ b/src/test/blk_recovery/blk_recovery.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{DB68AB21-510B-4BA1-9E6F-E5731D8647BC}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>blk_recovery</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/blk_rw/blk_rw.vcxproj
+++ b/src/test/blk_rw/blk_rw.vcxproj
@@ -45,7 +45,7 @@
     <ProjectGuid>{6851356E-A5D9-46A6-8262-A7E208729F18}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>blk_rw</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/blk_rw_mt/blk_rw_mt.vcxproj
+++ b/src/test/blk_rw_mt/blk_rw_mt.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{628FADA9-7047-4DD9-BD17-9FE4B5A1ADB0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>blk_rw_mt</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/blk_rw_mt/blk_rw_mt.vcxproj.filters
+++ b/src/test/blk_rw_mt/blk_rw_mt.vcxproj.filters
@@ -18,6 +18,9 @@
     <ClCompile Include="blk_rw_mt.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\common\rand.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="TEST0.PS1">

--- a/src/test/bttdevice/bttdevice.vcxproj
+++ b/src/test/bttdevice/bttdevice.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{25758581-DD46-4AE4-99D9-11E736F72AD1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>bttdevice</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/checksum/checksum.vcxproj
+++ b/src/test/checksum/checksum.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{AF0B7480-EBE3-486B-B0C8-134910BC9324}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>checksum</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/compat_incompat_features/compat_incompat_features.vcxproj
+++ b/src/test/compat_incompat_features/compat_incompat_features.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{924B2937-0B53-4DC6-B7E1-5F3102728F89}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>compat_incompat_features</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/ctl_cow/ctl_cow.vcxproj
+++ b/src/test/ctl_cow/ctl_cow.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{46B82069-10BE-432A-8D93-F4D995148555}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_cow</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/ex_libpmem/ex_libpmem.vcxproj
+++ b/src/test/ex_libpmem/ex_libpmem.vcxproj
@@ -30,7 +30,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{7DFEB4A5-8B04-4302-9D09-8144918FCF81}</ProjectGuid>
     <RootNamespace>ex_libpmem</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/ex_libpmem2/ex_libpmem2.vcxproj
+++ b/src/test/ex_libpmem2/ex_libpmem2.vcxproj
@@ -27,7 +27,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C2D5E690-748B-4138-B572-1774B99A8572}</ProjectGuid>
     <RootNamespace>ex_libpmem2</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/ex_libpmemblk/ex_libpmemblk.vcxproj
+++ b/src/test/ex_libpmemblk/ex_libpmemblk.vcxproj
@@ -35,7 +35,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1B9B0D6D-E530-44A6-ADAE-09EA2BDC47DE}</ProjectGuid>
     <RootNamespace>ex_libpmemblk</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/ex_libpmemlog/ex_libpmemlog.vcxproj
+++ b/src/test/ex_libpmemlog/ex_libpmemlog.vcxproj
@@ -26,7 +26,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D8317F1D-7A70-4A39-977A-EAB05A04A87B}</ProjectGuid>
     <RootNamespace>ex_libpmemlog</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/ex_libpmemobj/ex_libpmemobj.vcxproj
+++ b/src/test/ex_libpmemobj/ex_libpmemobj.vcxproj
@@ -104,7 +104,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{F63FB47F-1DCE-48E5-9CBD-F3E0A354472B}</ProjectGuid>
     <RootNamespace>ex_libpmemobj</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/ex_linkedlist/ex_linkedlist.vcxproj
+++ b/src/test/ex_linkedlist/ex_linkedlist.vcxproj
@@ -35,7 +35,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B440BB05-37A8-42EA-98D3-D83EB113E497}</ProjectGuid>
     <RootNamespace>ex_linkedlist</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/getopt/getopt.vcxproj
+++ b/src/test/getopt/getopt.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{433F7840-C597-4950-84C9-E4FF7DF6A298}</ProjectGuid>
     <RootNamespace>getopt</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/libpmempool_api/libpmempool_test.vcxproj
+++ b/src/test/libpmempool_api/libpmempool_test.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{A2A0FAEA-2B7C-4FC3-B904-1DB4DEACF88D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libpmempool_test</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/libpmempool_api_win/libpmempool_test_win.vcxproj
+++ b/src/test/libpmempool_api_win/libpmempool_test_win.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{27FA11C6-431D-41D1-A417-FAB7C4F93DCA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libpmempool_test_win</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/libpmempool_backup/libpmempool_backup.vcxproj
+++ b/src/test/libpmempool_backup/libpmempool_backup.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{60B463D4-8CD5-4BF6-A25B-01BE13B87590}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libpmempool_backup</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/libpmempool_bttdev/libpmempool_bttdev.vcxproj
+++ b/src/test/libpmempool_bttdev/libpmempool_bttdev.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{E85E017F-04C0-4716-BF21-949C82C68912}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libpmempool_bttdev</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/libpmempool_check_version/libpmempool_check_version.vcxproj
+++ b/src/test/libpmempool_check_version/libpmempool_check_version.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{A39D1640-8DBA-450D-9103-2533C248991A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libpmempool_check_version</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/libpmempool_feature/libpmempool_feature.vcxproj
+++ b/src/test/libpmempool_feature/libpmempool_feature.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{6F776280-B383-4DCE-8F42-9670164D038D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libpmempool_feature</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/libpmempool_feature/libpmempool_feature.vcxproj.filters
+++ b/src/test/libpmempool_feature/libpmempool_feature.vcxproj.filters
@@ -30,14 +30,12 @@
     <None Include="TEST2.PS1">
       <Filter>Test Scripts</Filter>
     </None>
-    <None Include="grep0.log .match">
-      <Filter>Match Files</Filter>
-    </None>
     <None Include="grep1.log.match">
       <Filter>Match Files</Filter>
     </None>
     <None Include="grep2.log.match">
       <Filter>Match Files</Filter>
     </None>
+    <None Include="grep0.log.match" />
   </ItemGroup>
 </Project>

--- a/src/test/libpmempool_include/libpmempool_include.vcxproj
+++ b/src/test/libpmempool_include/libpmempool_include.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4E334022-7A71-4197-9E15-878F7EFC877E}</ProjectGuid>
     <RootNamespace>libpmempool_include</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/libpmempool_map_flog/libpmempool_map_flog.vcxproj
+++ b/src/test/libpmempool_map_flog/libpmempool_map_flog.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{ED2A831F-4AAF-4CF7-A953-3C45B0EC1BE6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libpmempool_map_flog</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/libpmempool_rm/libpmempool_rm.vcxproj
+++ b/src/test/libpmempool_rm/libpmempool_rm.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{5F2B687A-1B42-439C-AEEC-135DD22FB851}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libpmempool_rm</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/libpmempool_rm_win/libpmempool_rm_win.vcxproj
+++ b/src/test/libpmempool_rm_win/libpmempool_rm_win.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{67AC1343-98FD-4143-92C0-559C55F749F5}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libpmempool_rm_win</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/libpmempool_sync/libpmempool_sync.vcxproj
+++ b/src/test/libpmempool_sync/libpmempool_sync.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{AE1C32FB-9B52-4760-ABFC-0D2FA2C7A6C8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libpmempool_sync</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/libpmempool_sync_win/libpmempool_sync_win.vcxproj
+++ b/src/test/libpmempool_sync_win/libpmempool_sync_win.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{B6DA6617-D98F-4A4D-A7C4-A317212924BF}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libpmempool_sync_win</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/libpmempool_transform/libpmempool_transform.vcxproj
+++ b/src/test/libpmempool_transform/libpmempool_transform.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{FB2D2B18-E616-4639-8593-0E1AF2DA01A8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libpmempool_transform</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/libpmempool_transform_win/libpmempool_transform_win.vcxproj
+++ b/src/test/libpmempool_transform_win/libpmempool_transform_win.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{B30C6212-A160-405A-8FE7-340E721738A2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libpmempool_transform_win</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/log_basic/log_basic.vcxproj
+++ b/src/test/log_basic/log_basic.vcxproj
@@ -44,7 +44,7 @@
     <ProjectGuid>{FBB77433-639E-42DC-9355-EA94CAE294D2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>log_pool</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/log_include/log_include.vcxproj
+++ b/src/test/log_include/log_include.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{0A049EAD-652F-4E20-8026-90FD99AEE77A}</ProjectGuid>
     <RootNamespace>log_include</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/log_pool/log_pool.vcxproj
+++ b/src/test/log_pool/log_pool.vcxproj
@@ -74,7 +74,7 @@
     <ProjectGuid>{3CF270CD-0F56-48E3-AD84-82F369C568BF}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>log_pool</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/log_pool_lock/log_pool_lock.vcxproj
+++ b/src/test/log_pool_lock/log_pool_lock.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{E68DEB59-C709-4945-AF80-EEBCADDED944}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>log_pool_lock</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/log_pool_win/log_pool_win.vcxproj
+++ b/src/test/log_pool_win/log_pool_win.vcxproj
@@ -34,7 +34,7 @@
     <ProjectGuid>{C71DAF3E-9361-4723-93E2-C475D1D0C0D0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>log_pool_win</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/log_recovery/log_recovery.vcxproj
+++ b/src/test/log_recovery/log_recovery.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{E901B756-EA72-4B8D-967F-85F109D0D1DE}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>log_recovery</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/log_walker/log_walker.vcxproj
+++ b/src/test/log_walker/log_walker.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{4FB4FF90-4E92-4CFB-A01F-C73D6861CA03}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>log_walker</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/mmap/mmap.vcxproj
+++ b/src/test/mmap/mmap.vcxproj
@@ -24,7 +24,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{5580D11C-FDA6-4CF2-A0E8-1C2D3FBC11F1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <ProjectName>mmap</ProjectName>
     <RootNamespace>mmap</RootNamespace>
   </PropertyGroup>

--- a/src/test/mmap_fixed/mmap_fixed.vcxproj
+++ b/src/test/mmap_fixed/mmap_fixed.vcxproj
@@ -25,7 +25,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{FEA09B48-34C2-4963-8A5A-F97BDA136D72}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <ProjectName>mmap_fixed</ProjectName>
     <RootNamespace>mmap_fixed</RootNamespace>
   </PropertyGroup>

--- a/src/test/obj_action/obj_action.vcxproj
+++ b/src/test/obj_action/obj_action.vcxproj
@@ -31,7 +31,7 @@
     <ProjectGuid>{2ED26FDA-3C4E-4514-B387-5E77C302FF71}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_action</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_alloc/obj_alloc.vcxproj
+++ b/src/test/obj_alloc/obj_alloc.vcxproj
@@ -28,7 +28,7 @@
     <ProjectGuid>{42B97D47-F800-4100-BFA2-B3AC357E8B6B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_alloc</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_basic_integration/obj_basic_integration.vcxproj
+++ b/src/test/obj_basic_integration/obj_basic_integration.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{58386481-30B7-40FC-96AF-0723A4A7B228}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_basic_integration</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_bucket/obj_bucket.vcxproj
+++ b/src/test/obj_bucket/obj_bucket.vcxproj
@@ -61,7 +61,7 @@
     <ProjectGuid>{8A4872D7-A234-4B9B-8215-82C6BB15F3A2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_bucket</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_check/obj_check.vcxproj
+++ b/src/test/obj_check/obj_check.vcxproj
@@ -48,7 +48,7 @@
     <ProjectGuid>{71D182E0-345A-4375-B0FA-3536821B0EE3}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_check</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_constructor/obj_constructor.vcxproj
+++ b/src/test/obj_constructor/obj_constructor.vcxproj
@@ -31,7 +31,7 @@
     <ProjectGuid>{E7691F81-86EF-467D-82E1-F5B9416386F9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_constructor</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_critnib/obj_critnib.vcxproj
+++ b/src/test/obj_critnib/obj_critnib.vcxproj
@@ -29,7 +29,7 @@
     <ProjectGuid>{0CDCEB97-3270-4939-A290-EA2D3BE34B0C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_critnib</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_critnib_mt/obj_critnib_mt.vcxproj
+++ b/src/test/obj_critnib_mt/obj_critnib_mt.vcxproj
@@ -30,7 +30,7 @@
     <ProjectGuid>{7701627C-CFD9-48F6-942E-EAACC8D057FA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_critnib_mt</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_critnib_mt/obj_critnib_mt.vcxproj.filters
+++ b/src/test/obj_critnib_mt/obj_critnib_mt.vcxproj.filters
@@ -17,6 +17,9 @@
     <ClCompile Include="..\..\libpmemobj\critnib.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\common\rand.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="TEST0.PS1">

--- a/src/test/obj_ctl_alignment/obj_ctl_alignment.vcxproj
+++ b/src/test/obj_ctl_alignment/obj_ctl_alignment.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{6DBD8C02-0C75-4DB0-BFDA-CD053B1B2D89}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_ctl_alignment</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_ctl_alloc_class/obj_ctl_alloc_class.vcxproj
+++ b/src/test/obj_ctl_alloc_class/obj_ctl_alloc_class.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{E07C9A5F-B2E4-44FB-AA87-FBC885AC955D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_ctl_alloc_class</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_ctl_alloc_class_config/obj_ctl_alloc_class_config.vcxproj
+++ b/src/test/obj_ctl_alloc_class_config/obj_ctl_alloc_class_config.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{A79E3093-B157-4B09-BABD-29266EA16407}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_ctl_alloc_class_config</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_ctl_arenas/obj_ctl_arenas.vcxproj
+++ b/src/test/obj_ctl_arenas/obj_ctl_arenas.vcxproj
@@ -37,7 +37,7 @@
     <ProjectGuid>{019F5586-5558-4C87-B319-85906D4AE407}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_ctl_arenas</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_ctl_config/obj_ctl_config.vcxproj
+++ b/src/test/obj_ctl_config/obj_ctl_config.vcxproj
@@ -47,7 +47,7 @@
     <ProjectGuid>{AEAA72CD-E060-417C-9CA1-49B4738384E0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_ctl_config</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_ctl_debug/obj_ctl_debug.vcxproj
+++ b/src/test/obj_ctl_debug/obj_ctl_debug.vcxproj
@@ -31,7 +31,7 @@
     <ProjectGuid>{AEAA72CD-E060-417C-9CA1-49B4766684E0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_ctl_debug</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_ctl_heap_size/obj_ctl_heap_size.vcxproj
+++ b/src/test/obj_ctl_heap_size/obj_ctl_heap_size.vcxproj
@@ -32,7 +32,7 @@
     <ProjectGuid>{B379539C-E130-460D-AE82-4EBDD1A97845}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_ctl_config</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_ctl_stats/obj_ctl_stats.vcxproj
+++ b/src/test/obj_ctl_stats/obj_ctl_stats.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{03228F84-4F41-4BCC-8C2D-F329DC87B289}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_ctl_stats</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_debug/obj_debug.vcxproj
+++ b/src/test/obj_debug/obj_debug.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{85DBDA9B-AEF6-43E7-B8B5-05FF2BEC61A3}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_debug</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_defrag/obj_defrag.vcxproj
+++ b/src/test/obj_defrag/obj_defrag.vcxproj
@@ -31,7 +31,7 @@
     <ProjectGuid>{FF6E5B0C-DC00-4C93-B9C2-63D1E858BA80}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_defrag</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_defrag_advanced/obj_defrag_advanced.vcxproj
+++ b/src/test/obj_defrag_advanced/obj_defrag_advanced.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{AE952763-5C84-43FC-B344-CACC950F056C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_defrag_advanced</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_defrag_advanced/obj_defrag_advanced.vcxproj.filters
+++ b/src/test/obj_defrag_advanced/obj_defrag_advanced.vcxproj.filters
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <None Include="README" />
     <None Include="TESTS.py">
       <Filter>Test Scripts</Filter>
     </None>

--- a/src/test/obj_direct/obj_direct.vcxproj
+++ b/src/test/obj_direct/obj_direct.vcxproj
@@ -39,7 +39,7 @@
     <ProjectGuid>{10469175-EEF7-44A0-9961-AC4E45EFD800}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_direct</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_direct_volatile/obj_direct_volatile.vcxproj
+++ b/src/test/obj_direct_volatile/obj_direct_volatile.vcxproj
@@ -34,7 +34,7 @@
     <ProjectGuid>{03B54A12-7793-4827-B820-C07491F7F45E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_direct</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_extend/obj_extend.vcxproj
+++ b/src/test/obj_extend/obj_extend.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{7ABF755C-821B-49CD-8EDE-83C16594FF7F}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_extend</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_first_next/obj_first_next.vcxproj
+++ b/src/test/obj_first_next/obj_first_next.vcxproj
@@ -34,7 +34,7 @@
     <ProjectGuid>{BABC6427-E533-4DCF-91E3-B5B2ED253F46}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_first_next</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_fragmentation/obj_fragmentation.vcxproj
+++ b/src/test/obj_fragmentation/obj_fragmentation.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{60EF55C7-8399-4543-B5B2-3AE2C532C67E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_fragmentation</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_fragmentation2/obj_fragmentation2.vcxproj
+++ b/src/test/obj_fragmentation2/obj_fragmentation2.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{2B2DE575-1422-4FBF-97BE-35AEDA0AB465}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_fragmentation2</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_fragmentation2/obj_fragmentation2.vcxproj.filters
+++ b/src/test/obj_fragmentation2/obj_fragmentation2.vcxproj.filters
@@ -14,6 +14,9 @@
     <ClCompile Include="obj_fragmentation2.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\common\rand.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="TESTS.py">

--- a/src/test/obj_heap/obj_heap.vcxproj
+++ b/src/test/obj_heap/obj_heap.vcxproj
@@ -47,7 +47,7 @@
     <ProjectGuid>{85D4076B-896B-4EBB-8F3A-8B44C24CD452}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_heap</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_heap_interrupt/obj_heap_interrupt.vcxproj
+++ b/src/test/obj_heap_interrupt/obj_heap_interrupt.vcxproj
@@ -65,7 +65,7 @@
     <ProjectGuid>{07A153D9-DF17-4DE8-A3C2-EBF171B961AE}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_heap_interrupt</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -114,4 +114,3 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>
-

--- a/src/test/obj_heap_state/obj_heap_state.vcxproj
+++ b/src/test/obj_heap_state/obj_heap_state.vcxproj
@@ -36,7 +36,7 @@
     <ProjectGuid>{86EE22CC-6D3C-4F81-ADC8-394946F0DA81}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_heap_state</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_include/obj_include.vcxproj
+++ b/src/test/obj_include/obj_include.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{AB15A115-E429-4123-BEBF-206FBA4CF615}</ProjectGuid>
     <RootNamespace>obj_include</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_lane/obj_lane.vcxproj
+++ b/src/test/obj_lane/obj_lane.vcxproj
@@ -59,7 +59,7 @@
     <ProjectGuid>{CCA9B681-D10B-45E4-98CC-531503D2EDE8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_lane</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_layout/obj_layout.vcxproj
+++ b/src/test/obj_layout/obj_layout.vcxproj
@@ -52,7 +52,7 @@
     <ProjectGuid>{BB1120CF-B721-4EF9-8735-58F76AE51D2F}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_layout</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_list/obj_list.vcxproj
+++ b/src/test/obj_list/obj_list.vcxproj
@@ -93,7 +93,7 @@
     <ProjectGuid>{729E3905-FF7D-49C5-9871-6D35D839183E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_list</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_list_insert/obj_list_insert.vcxproj
+++ b/src/test/obj_list_insert/obj_list_insert.vcxproj
@@ -26,7 +26,7 @@
     <ProjectGuid>{C2C36D03-26EE-4BD8-8FFC-86CFE16C1218}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_list_insert</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_list_macro/obj_list_macro.vcxproj
+++ b/src/test/obj_list_macro/obj_list_macro.vcxproj
@@ -46,7 +46,7 @@
     <ProjectGuid>{6BCEF2A5-0CEC-4CC6-9CB0-D3FBF871A408}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_list_insert</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_list_move/obj_list_move.vcxproj
+++ b/src/test/obj_list_move/obj_list_move.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{BAE107BA-7618-4972-8188-2D3CDAAE0453}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_list_move</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_list_recovery/obj_list_recovery.vcxproj
+++ b/src/test/obj_list_recovery/obj_list_recovery.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{B887EA26-846C-4D6A-B0E4-432487506BC7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_list_recovery</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_list_remove/obj_list_remove.vcxproj
+++ b/src/test/obj_list_remove/obj_list_remove.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{FF6E5B0C-DC00-4C93-B9C2-63D1E858BA79}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_list_remove</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_locks/obj_locks.vcxproj
+++ b/src/test/obj_locks/obj_locks.vcxproj
@@ -34,7 +34,7 @@
     <ProjectGuid>{2DE6B085-3C19-49B1-894A-AD9376000E09}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_locks</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_many_size_allocs/obj_many_size_allocs.vcxproj
+++ b/src/test/obj_many_size_allocs/obj_many_size_allocs.vcxproj
@@ -36,7 +36,7 @@
     <ProjectGuid>{5D362DB7-D2BD-4907-AAD8-4B8627E72282}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_many_size_allocs</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_mem/obj_mem.vcxproj
+++ b/src/test/obj_mem/obj_mem.vcxproj
@@ -34,7 +34,7 @@
     <ProjectGuid>{B3AF8A19-5802-4A34-9157-27BBE4E53C0A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_mem</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_memblock/obj_memblock.vcxproj
+++ b/src/test/obj_memblock/obj_memblock.vcxproj
@@ -62,7 +62,7 @@
     <ProjectGuid>{0388E945-A655-41A7-AF27-8981CEE0E49A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_memblock</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_memops/obj_memops.vcxproj
+++ b/src/test/obj_memops/obj_memops.vcxproj
@@ -50,7 +50,7 @@
     <ProjectGuid>{740ED97D-005F-4F58-98B2-4EF5EF5776E8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_memops</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_oid_thread/obj_oid_thread.vcxproj
+++ b/src/test/obj_oid_thread/obj_oid_thread.vcxproj
@@ -34,7 +34,7 @@
     <ProjectGuid>{8C6D73E0-0A6F-4487-A040-0EC78D7D6D9A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_oid_thread</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <ProjectName>obj_oid_thread</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/test/obj_out_of_memory/obj_out_of_memory.vcxproj
+++ b/src/test/obj_out_of_memory/obj_out_of_memory.vcxproj
@@ -38,7 +38,7 @@
     <ProjectGuid>{70EE1D40-0C65-4985-8EFC-BD40EE3A89B2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_out_of_memory</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_persist_count/obj_persist_count.vcxproj
+++ b/src/test/obj_persist_count/obj_persist_count.vcxproj
@@ -79,7 +79,7 @@
     <ProjectGuid>{8D75FA1A-EC74-4F88-8AC1-CE3F98E4D828}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_pmalloc_basic</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_pmalloc_basic/obj_pmalloc_basic.vcxproj
+++ b/src/test/obj_pmalloc_basic/obj_pmalloc_basic.vcxproj
@@ -56,7 +56,7 @@
     <ProjectGuid>{65D92D98-97E1-48F7-AEF6-75221CF48EA4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_pmalloc_basic</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_pmalloc_mt/obj_pmalloc_mt.vcxproj
+++ b/src/test/obj_pmalloc_mt/obj_pmalloc_mt.vcxproj
@@ -56,7 +56,7 @@
     <ProjectGuid>{9FF62356-30B4-42A1-8DC7-45262A18DD44}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_pmalloc_mt</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_pmalloc_oom_mt/obj_pmalloc_oom_mt.vcxproj
+++ b/src/test/obj_pmalloc_oom_mt/obj_pmalloc_oom_mt.vcxproj
@@ -34,7 +34,7 @@
     <ProjectGuid>{88D239E4-EB7D-4E0A-BE3A-AD78B9F408FC}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_pmalloc_oom_mt</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_pmalloc_rand_mt/obj_pmalloc_rand_mt.vcxproj
+++ b/src/test/obj_pmalloc_rand_mt/obj_pmalloc_rand_mt.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{D140560D-FDEC-4D3D-8F58-BF5FD5E4DAA1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_pmalloc_rand_mt</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_pmalloc_rand_mt/obj_pmalloc_rand_mt.vcxproj.filters
+++ b/src/test/obj_pmalloc_rand_mt/obj_pmalloc_rand_mt.vcxproj.filters
@@ -14,6 +14,9 @@
     <ClCompile Include="obj_pmalloc_rand_mt.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\common\rand.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="TEST1.PS1">

--- a/src/test/obj_pool/obj_pool.vcxproj
+++ b/src/test/obj_pool/obj_pool.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{3ECCB0F1-3ADF-486A-91C5-79DF0FC22F78}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_pool</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_pool_lock/obj_pool_lock.vcxproj
+++ b/src/test/obj_pool_lock/obj_pool_lock.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{63B8184D-85E0-4E6A-9729-558C567D1D1D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_pool_lock</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_pool_lookup/obj_pool_lookup.vcxproj
+++ b/src/test/obj_pool_lookup/obj_pool_lookup.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{4850F425-9128-4E91-973C-5AE7BD97395B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_pool_lookup</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_pool_win/obj_pool_win.vcxproj
+++ b/src/test/obj_pool_win/obj_pool_win.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{B775480C-5B32-4F64-B026-47367280EC56}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_pool</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_realloc/obj_realloc.vcxproj
+++ b/src/test/obj_realloc/obj_realloc.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{91E19AEB-7B75-43E0-B8B4-D2BB60D839EA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_realloc</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_recovery/obj_recovery.vcxproj
+++ b/src/test/obj_recovery/obj_recovery.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{2498FCDA-E2CC-43EF-9A35-8CD63F253171}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_recovery</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_recreate/obj_recreate.vcxproj
+++ b/src/test/obj_recreate/obj_recreate.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{1464398A-100F-4518-BDB9-939A6362B6CF}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_recreate</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_root/obj_root.vcxproj
+++ b/src/test/obj_root/obj_root.vcxproj
@@ -28,7 +28,7 @@
     <ProjectGuid>{FC2248F5-3E9E-495B-9767-87F59614047C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_root</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_sds/obj_sds.vcxproj
+++ b/src/test/obj_sds/obj_sds.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{EDD5FA29-69AF-445F-842A-132E65D3C92B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_sds</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_strdup/obj_strdup.vcxproj
+++ b/src/test/obj_strdup/obj_strdup.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{C2F94489-A483-4C44-B8A7-11A75F6AEC66}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_strdup</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_sync/obj_sync.vcxproj
+++ b/src/test/obj_sync/obj_sync.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{6516D6CF-8000-4341-9487-312BC83EE370}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_sync</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_toid/obj_toid.vcxproj
+++ b/src/test/obj_toid/obj_toid.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{296F3C5D-3951-423E-8E2F-FD4A37958C72}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_toid</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_tx_add_range/obj_tx_add_range.vcxproj
+++ b/src/test/obj_tx_add_range/obj_tx_add_range.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{F3E5650D-834E-45E6-90C7-3FC2AA954929}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_tx_add_range</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_tx_add_range_direct/obj_tx_add_range_direct.vcxproj
+++ b/src/test/obj_tx_add_range_direct/obj_tx_add_range_direct.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{89F947CA-DDEF-4131-8AFB-584ABA4A1302}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_tx_add_range_direct</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_tx_alloc/obj_tx_alloc.vcxproj
+++ b/src/test/obj_tx_alloc/obj_tx_alloc.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{4C429783-0B01-449F-A36F-C2019233890B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_tx_alloc</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_tx_callbacks/obj_tx_callbacks.vcxproj
+++ b/src/test/obj_tx_callbacks/obj_tx_callbacks.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{0529575C-F6E8-44FD-BB82-82A29948D0F2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_tx_callbacks</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_tx_flow/obj_tx_flow.vcxproj
+++ b/src/test/obj_tx_flow/obj_tx_flow.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{8E374371-30E1-4623-8755-2A2F3742170B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_tx_flow</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_tx_free/obj_tx_free.vcxproj
+++ b/src/test/obj_tx_free/obj_tx_free.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{7F51CD29-3BCD-4DD8-B327-F384B5A616D1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_tx_free</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_tx_invalid/obj_tx_invalid.vcxproj
+++ b/src/test/obj_tx_invalid/obj_tx_invalid.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{9D9E33EB-4C24-4646-A3FB-35DA17247917}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_tx_invalid</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_tx_lock/obj_tx_lock.vcxproj
+++ b/src/test/obj_tx_lock/obj_tx_lock.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{D88187D2-1977-4C5F-B0CD-83C69BD6C1BC}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_tx_lock</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_tx_locks/obj_tx_locks.vcxproj
+++ b/src/test/obj_tx_locks/obj_tx_locks.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{E9E079D6-25BF-46E3-8075-7D733303DD59}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_tx_locks</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_tx_locks_abort/obj_tx_locks_abort.vcxproj
+++ b/src/test/obj_tx_locks_abort/obj_tx_locks_abort.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{6F4953DA-FDC3-46CF-BF24-3752CCF2E1CB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_tx_locks_abort</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_tx_mt/obj_tx_mt.vcxproj
+++ b/src/test/obj_tx_mt/obj_tx_mt.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{0703E813-9CC8-4DEA-AA33-42B099CD172D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_tx_mt</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_tx_realloc/obj_tx_realloc.vcxproj
+++ b/src/test/obj_tx_realloc/obj_tx_realloc.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{9AE2DAF9-10C4-4EC3-AE52-AD5EE9C77C55}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_tx_realloc</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_tx_strdup/obj_tx_strdup.vcxproj
+++ b/src/test/obj_tx_strdup/obj_tx_strdup.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{643B82A1-D009-46A9-92A0-2883399B05C2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_tx_strdup</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_tx_user_data/obj_tx_user_data.vcxproj
+++ b/src/test/obj_tx_user_data/obj_tx_user_data.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{5E7305DB-93E6-448B-AE44-90EAF916A776}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_tx_user_data</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_ulog_size/obj_ulog_size.vcxproj
+++ b/src/test/obj_ulog_size/obj_ulog_size.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{C35052AF-2383-4F9C-B18B-55A01829F2BF}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_ulog_size</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/obj_zones/obj_zones.vcxproj
+++ b/src/test/obj_zones/obj_zones.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{CF9F4CEA-EC66-4E78-A086-107EB29E0637}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>obj_zones</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/out_err/out_err.vcxproj
+++ b/src/test/out_err/out_err.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{8A0FA780-068A-4534-AA2F-4FF4CF977AF2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>out_err</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/out_err_mt/out_err_mt.vcxproj
+++ b/src/test/out_err_mt/out_err_mt.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{063037B2-CA35-4520-811C-19D9C4ED891E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>out_err_mt</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/out_err_mt_win/out_err_mt_win.vcxproj
+++ b/src/test/out_err_mt_win/out_err_mt_win.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{2B1A5104-A324-4D02-B5C7-D021FB8F880C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>out_err_mt_win</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/out_err_win/out_err_win.vcxproj
+++ b/src/test/out_err_win/out_err_win.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{A57D9365-172E-4782-ADC6-82A594E30943}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>out_err_win</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem2_compat/pmem2_compat.vcxproj
+++ b/src/test/pmem2_compat/pmem2_compat.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B6C0521B-EECA-47EF-BFA8-147F9C3F6DFE}</ProjectGuid>
     <RootNamespace>pmem2_compat</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem2_config/pmem2_config.vcxproj
+++ b/src/test/pmem2_config/pmem2_config.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{DE068BE1-A8E9-48A2-B216-92A7CE5EA4CE}</ProjectGuid>
     <RootNamespace>pmem2_config</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem2_granularity/pmem2_granularity.vcxproj
+++ b/src/test/pmem2_granularity/pmem2_granularity.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{EF951090-8938-4F7D-8674-7F6FB1F2C25E}</ProjectGuid>
     <RootNamespace>pmem2_granularity</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem2_include/pmem2_include.vcxproj
+++ b/src/test/pmem2_include/pmem2_include.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B6C0521B-EECA-47EF-BFA8-147F9C3F6DFF}</ProjectGuid>
     <RootNamespace>pmem2_include</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem2_integration/pmem2_integration.vcxproj
+++ b/src/test/pmem2_integration/pmem2_integration.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C7025EE1-57E5-44B9-A4F5-3CB059601FC3}</ProjectGuid>
     <RootNamespace>pmem2_integration</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem2_map/pmem2_map.vcxproj
+++ b/src/test/pmem2_map/pmem2_map.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D9A70E35-0C85-4A09-ACA8-B15B21B66F50}</ProjectGuid>
     <RootNamespace>pmem2_map</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem2_mem_ext/pmem2_mem_ext.vcxproj
+++ b/src/test/pmem2_mem_ext/pmem2_mem_ext.vcxproj
@@ -31,7 +31,7 @@
     <ProjectGuid>{5632B41F-19DD-4BA7-A6EB-74F9E8A7EF8A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem2_mem_ext</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem2_memcpy/pmem2_memcpy.vcxproj
+++ b/src/test/pmem2_memcpy/pmem2_memcpy.vcxproj
@@ -36,7 +36,7 @@
     <ProjectGuid>{D43FCFB6-97D2-44B2-8577-94B43B97D7CA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem2_memcpy</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem2_memmove/pmem2_memmove.vcxproj
+++ b/src/test/pmem2_memmove/pmem2_memmove.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{4EE3C4D6-F707-4A05-8032-8FC2A44D29E8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem_memmove</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem2_memset/pmem2_memset.vcxproj
+++ b/src/test/pmem2_memset/pmem2_memset.vcxproj
@@ -36,7 +36,7 @@
     <ProjectGuid>{6770917C-5B8E-49F1-9297-163FAB76DAFB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem2_memset</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem2_movnt/pmem2_movnt.vcxproj
+++ b/src/test/pmem2_movnt/pmem2_movnt.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{10B732EF-1783-4B61-B431-36BA5A2A3C9C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem2_movnt</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem2_movnt_align/pmem2_movnt_align.vcxproj
+++ b/src/test/pmem2_movnt_align/pmem2_movnt_align.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{9233FC80-B51C-4A89-AF58-5AE86C068F6A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem2_movnt_align</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem2_perror/pmem2_perror.vcxproj
+++ b/src/test/pmem2_perror/pmem2_perror.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{0DF30DE0-7F7D-43D3-940A-809EC27D3061}</ProjectGuid>
     <RootNamespace>pmem2_perror</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem2_perror/pmem2_perror.vcxproj.filters
+++ b/src/test/pmem2_perror/pmem2_perror.vcxproj.filters
@@ -15,26 +15,12 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="TESTS.py">
-      <Filter>Test Scripts</Filter>
-    </None>
-    <None Include="test0.log.match">
-      <Filter>Match Files</Filter>
-    </None>
-    <None Include="test1.log.match">
-      <Filter>Match Files</Filter>
-    </None>
-    <None Include="test2.log.match">
-      <Filter>Match Files</Filter>
-    </None>
-    <None Include="test3.log.match">
-      <Filter>Match Files</Filter>
-    </None>
-    <None Include="test4.log.match">
-      <Filter>Match Files</Filter>
-    </None>
-    <None Include="test5.log.match">
-      <Filter>Match Files</Filter>
-    </None>
+    <None Include="test0.log.match" />
+    <None Include="test1.log.match" />
+    <None Include="test2.log.match" />
+    <None Include="test3.log.match" />
+    <None Include="test4.log.match" />
+    <None Include="test5.log.match" />
+    <None Include="TESTS.py" />
   </ItemGroup>
 </Project>

--- a/src/test/pmem2_persist/pmem2_persist.vcxproj
+++ b/src/test/pmem2_persist/pmem2_persist.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1C986F2C-9AF1-45E0-9E9B-8CABE9CAF437}</ProjectGuid>
     <RootNamespace>pmem2_persist</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem2_source/pmem2_source.vcxproj
+++ b/src/test/pmem2_source/pmem2_source.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{34F31D9D-3D33-4C09-85A3-4749A8AB8EBB}</ProjectGuid>
     <RootNamespace>pmem2_config</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem2_source_alignment/pmem2_source_alignment.vcxproj
+++ b/src/test/pmem2_source_alignment/pmem2_source_alignment.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3B44D717-EEDE-470A-B631-C9D6BFE4ADF2}</ProjectGuid>
     <RootNamespace>pmem2_source_alignment</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem2_source_size/pmem2_source_size.vcxproj
+++ b/src/test/pmem2_source_size/pmem2_source_size.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{DE068BE1-A8E9-48A2-B216-92A7CE5EA4CF}</ProjectGuid>
     <RootNamespace>pmem2_source_size</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem_deep_persist/pmem_deep_persist.vcxproj
+++ b/src/test/pmem_deep_persist/pmem_deep_persist.vcxproj
@@ -102,7 +102,7 @@
     <ProjectGuid>{0D4E38EF-A9D5-4797-8994-5DBB1125C9EA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem_deep_persist</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem_deep_persist/pmem_deep_persist.vcxproj.filters
+++ b/src/test/pmem_deep_persist/pmem_deep_persist.vcxproj.filters
@@ -93,12 +93,10 @@
     <ClCompile Include="..\..\libpmemobj\ulog.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\libpmem\x86_64\cpu.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\windows\win_mmap.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\libpmem2\x86_64\cpu.c" />
   </ItemGroup>
   <ItemGroup>
     <None Include="TEST0.PS1">

--- a/src/test/pmem_has_auto_flush_win/pmem_has_auto_flush_win.vcxproj
+++ b/src/test/pmem_has_auto_flush_win/pmem_has_auto_flush_win.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{DEA3CD0A-8781-4ABE-9A7D-00B91132FED0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem_has_auto_flush_win</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <ProjectName>pmem_has_auto_flush_win</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/test/pmem_include/pmem_include.vcxproj
+++ b/src/test/pmem_include/pmem_include.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{2B7772E6-9DAA-4F38-B0BC-7B2399366325}</ProjectGuid>
     <RootNamespace>pmem_include</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem_is_pmem/pmem_is_pmem.vcxproj
+++ b/src/test/pmem_is_pmem/pmem_is_pmem.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{E4E2EC33-7902-45D0-9C3C-ADBAFA46874A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem_is_pmem</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem_is_pmem_windows/pmem_is_pmem_windows.vcxproj
+++ b/src/test/pmem_is_pmem_windows/pmem_is_pmem_windows.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{5F8A56F8-2C5B-48B6-9654-DD642D3E5F5C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem_is_pmem_windows</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem_map_file/pmem_map_file.vcxproj
+++ b/src/test/pmem_map_file/pmem_map_file.vcxproj
@@ -51,7 +51,7 @@
     <ProjectGuid>{12A1A3EF-202C-4DD0-9B5A-F5126CAB078F}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem_map_file</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem_map_file_trunc/pmem_map_file_trunc.vcxproj
+++ b/src/test/pmem_map_file_trunc/pmem_map_file_trunc.vcxproj
@@ -29,7 +29,7 @@
     <ProjectGuid>{34DB4951-DA08-45F1-938D-B08E5FF5AB46}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem_map_file_trunc</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem_map_file_win/pmem_map_file_win.vcxproj
+++ b/src/test/pmem_map_file_win/pmem_map_file_win.vcxproj
@@ -51,7 +51,7 @@
     <ProjectGuid>{5AD07646-5E16-4CEF-B80A-BE5EE4D54FEF}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem_map_file_win</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem_memcpy/pmem_memcpy.vcxproj
+++ b/src/test/pmem_memcpy/pmem_memcpy.vcxproj
@@ -35,7 +35,7 @@
     <ProjectGuid>{673277EC-D26B-414D-92E3-84EE873316A8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem_memcpy</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem_memmove/pmem_memmove.vcxproj
+++ b/src/test/pmem_memmove/pmem_memmove.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{5A391A14-8E29-4788-93FC-EDADED31D32F}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem_memmove</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem_memset/pmem_memset.vcxproj
+++ b/src/test/pmem_memset/pmem_memset.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{B36F115C-8139-4C35-A3E7-E6BF9F3DA793}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem_memset</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem_movnt/pmem_movnt.vcxproj
+++ b/src/test/pmem_movnt/pmem_movnt.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{96D00A19-5CEF-4CC5-BDE8-E33C68BCE90F}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem_movnt</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem_movnt_align/pmem_movnt_align.vcxproj
+++ b/src/test/pmem_movnt_align/pmem_movnt_align.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{025E7D51-41F2-4CBA-956E-C37A4443DB1B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem_movnt_align</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmem_unmap/pmem_unmap.vcxproj
+++ b/src/test/pmem_unmap/pmem_unmap.vcxproj
@@ -28,7 +28,7 @@
     <ProjectGuid>{6EC93484-AAF3-487E-84E4-5ABFBA0AFC53}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmem_unmap</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmemobjcli/pmemobjcli.vcxproj
+++ b/src/test/pmemobjcli/pmemobjcli.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D28F5FF6-8401-4E0D-94F9-3A1FD7ED64E3}</ProjectGuid>
     <RootNamespace>pmemobjcli</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <ProjectName>tools_pmemobjcli</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/test/pmempool_check/pmempool_check.vcxproj
+++ b/src/test/pmempool_check/pmempool_check.vcxproj
@@ -52,7 +52,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CDD9DFC6-5C3D-42F7-B822-FE29A1C21752}</ProjectGuid>
     <RootNamespace>pmempool_check</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmempool_create/pmempool_create.vcxproj
+++ b/src/test/pmempool_create/pmempool_create.vcxproj
@@ -30,7 +30,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{92388A20-50FC-45F8-89E3-71F1618EFABB}</ProjectGuid>
     <RootNamespace>pmempool_create</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmempool_dump/pmempool_dump.vcxproj
+++ b/src/test/pmempool_dump/pmempool_dump.vcxproj
@@ -35,7 +35,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{2A1D6AF2-7336-4966-A4B3-0BE9A24BAE00}</ProjectGuid>
     <RootNamespace>pmempool_dump</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmempool_feature/pmempool_feature.vcxproj
+++ b/src/test/pmempool_feature/pmempool_feature.vcxproj
@@ -26,7 +26,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{AF038868-2432-4159-A62F-941F11D12C5D}</ProjectGuid>
     <RootNamespace>pmempool_feature</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmempool_help/pmempool_help.vcxproj
+++ b/src/test/pmempool_help/pmempool_help.vcxproj
@@ -25,7 +25,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D4035736-1AD6-4100-9FA9-A8A0C1DAE0C7}</ProjectGuid>
     <RootNamespace>pmempool_help</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmempool_info/pmempool_info.vcxproj
+++ b/src/test/pmempool_info/pmempool_info.vcxproj
@@ -58,7 +58,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{42CCEF95-5ADD-460C-967E-DD5B2C744943}</ProjectGuid>
     <RootNamespace>pmempool_info</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmempool_rm/pmempool_rm.vcxproj
+++ b/src/test/pmempool_rm/pmempool_rm.vcxproj
@@ -28,7 +28,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{99F7F00F-1DE5-45EA-992B-64BA282FAC76}</ProjectGuid>
     <RootNamespace>pmempool_rm</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmempool_sync/pmempool_sync.vcxproj
+++ b/src/test/pmempool_sync/pmempool_sync.vcxproj
@@ -42,7 +42,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C5E8B8DB-2507-4904-847F-A52196B075F0}</ProjectGuid>
     <RootNamespace>pmempool_sync</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmempool_transform/pmempool_transform.vcxproj
+++ b/src/test/pmempool_transform/pmempool_transform.vcxproj
@@ -37,7 +37,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{26166DF1-3C94-44AF-9075-BA31DCD2F6BB}</ProjectGuid>
     <RootNamespace>pmempool_transform</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/pmemspoil/pmemspoil.vcxproj
+++ b/src/test/pmemspoil/pmemspoil.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B6F4B85D-FE55-4A1B-AE97-D4A9ECFE195F}</ProjectGuid>
     <RootNamespace>pmemspoil</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <ProjectName>tools_pmemspoil</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/test/scope/scope.vcxproj
+++ b/src/test/scope/scope.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{C0E811E0-8942-4CFD-A817-74D99E9E6577}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>scope</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/set_funcs/set_funcs.vcxproj
+++ b/src/test/set_funcs/set_funcs.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{6D7C1169-3246-465F-B630-ECFEF4F3179A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>set_funcs</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/signal_handle/signal_handle.vcxproj
+++ b/src/test/signal_handle/signal_handle.vcxproj
@@ -26,7 +26,7 @@
     <ProjectGuid>{AE9E908D-BAEC-491F-9914-436B3CE35E94}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>signal_handle</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/tools/bttcreate/bttcreate.vcxproj
+++ b/src/test/tools/bttcreate/bttcreate.vcxproj
@@ -32,7 +32,7 @@
     <ProjectGuid>{3142CB13-CADA-48D3-9A25-E6ACB243760A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>bttcreate</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/tools/cmpmap/cmpmap.vcxproj
+++ b/src/test/tools/cmpmap/cmpmap.vcxproj
@@ -29,7 +29,7 @@
     <ProjectGuid>{1B871BA2-3F70-4BC9-9DF4-725EB07F6628}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>cmpmap</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <ProjectName>cmpmap</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/test/tools/cpufd/cpufd.vcxproj
+++ b/src/test/tools/cpufd/cpufd.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{FC998FE5-C843-42BA-9731-F46DB02F1853}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>cpufd</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/tools/ddmap/ddmap.vcxproj
+++ b/src/test/tools/ddmap/ddmap.vcxproj
@@ -31,7 +31,7 @@
     <ProjectGuid>{A216BF23-FC5C-4426-BF20-8568A2AA5FA0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ddmap</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/tools/dllview/dllview.vcxproj
+++ b/src/test/tools/dllview/dllview.vcxproj
@@ -25,7 +25,7 @@
     <ProjectGuid>{179BEB5A-2C90-44F5-A734-FA756A5E668C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>dllview</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/tools/gran_detecto/gran_detecto.vcxproj
+++ b/src/test/tools/gran_detecto/gran_detecto.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{A18B076A-CE8C-49A6-8B80-F02843E4BF0A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>gran_detecto</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/tools/pmemalloc/pmemalloc.vcxproj
+++ b/src/test/tools/pmemalloc/pmemalloc.vcxproj
@@ -37,7 +37,7 @@
     <ProjectGuid>{4C6E7F0A-7E6A-4713-B1D2-B7B4ADC992AF}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmemalloc</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/tools/pmemdetect/pmemdetect.vcxproj
+++ b/src/test/tools/pmemdetect/pmemdetect.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{2EFFC590-BF5E-46A2-AF04-E67E1D571D2E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmemdetect</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/tools/pmemobjcli/pmemobjcli.vcxproj
+++ b/src/test/tools/pmemobjcli/pmemobjcli.vcxproj
@@ -31,7 +31,7 @@
     <ProjectGuid>{D2C30C7E-A7D3-487A-956E-418CECAFFE8E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmemspoil</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/tools/pmemspoil/pmemspoil.vcxproj
+++ b/src/test/tools/pmemspoil/pmemspoil.vcxproj
@@ -44,7 +44,7 @@
     <ProjectGuid>{11E158AE-C85A-4A6E-B66A-ED2994709276}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmemspoil</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/tools/pmemwrite/pmemwrite.vcxproj
+++ b/src/test/tools/pmemwrite/pmemwrite.vcxproj
@@ -40,7 +40,7 @@
     <ProjectGuid>{B35BFA09-DE68-483B-AB61-8790E8F060A8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmemwrite</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/tools/sparsefile/sparsefile.vcxproj
+++ b/src/test/tools/sparsefile/sparsefile.vcxproj
@@ -26,7 +26,7 @@
     <ProjectGuid>{3EC30D6A-BDA4-4971-879A-8814204EAE31}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>sparsefile</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/traces/traces.vcxproj
+++ b/src/test/traces/traces.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{CA4BBB24-D33E-42E2-A495-F10D80DE8C1D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>traces</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/traces_custom_function/traces_custom_function.vcxproj
+++ b/src/test/traces_custom_function/traces_custom_function.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{02BC3B44-C7F1-4793-86C1-6F36CA8A7F53}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>traces_custom_function</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/traces_pmem/traces_pmem.vcxproj
+++ b/src/test/traces_pmem/traces_pmem.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{3B23831B-E5DE-4A62-9D0B-27D0D9F293F4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>traces_pmem</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/unittest/libut.vcxproj
+++ b/src/test/unittest/libut.vcxproj
@@ -36,7 +36,7 @@
     <ProjectGuid>{CE3F2DFB-8470-4802-AD37-21CAF6CB2681}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libut</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/util_cpuid/util_cpuid.vcxproj
+++ b/src/test/util_cpuid/util_cpuid.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{98ACBE5D-1A92-46F9-AA81-533412172952}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>util_cpuid</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/util_ctl/util_ctl.vcxproj
+++ b/src/test/util_ctl/util_ctl.vcxproj
@@ -28,7 +28,7 @@
     <ProjectGuid>{E796AA20-D664-4D05-ABD9-C93A4FBE3E5C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>util_ctl</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/util_file_create/util_file_create.vcxproj
+++ b/src/test/util_file_create/util_file_create.vcxproj
@@ -33,7 +33,7 @@
     <ProjectGuid>{D829DB63-E046-474D-8EA3-43A6659294D8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>util_file_create</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/util_file_open/util_file_open.vcxproj
+++ b/src/test/util_file_open/util_file_open.vcxproj
@@ -31,7 +31,7 @@
     <ProjectGuid>{715EADD7-0FFE-4F1F-94E7-49302968DF79}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>util_file_open</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/util_is_absolute/util_is_absolute.vcxproj
+++ b/src/test/util_is_absolute/util_is_absolute.vcxproj
@@ -29,7 +29,7 @@
     <ProjectGuid>{C973CD39-D63B-4F5C-BE1D-DED17388B5A4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>util_is_absolute</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/util_is_poolset/util_is_poolset.vcxproj
+++ b/src/test/util_is_poolset/util_is_poolset.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{F0B613C4-1D9A-4259-BD0E-C1B9FF2AA3A0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>util_is_poolset</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/util_is_zeroed/util_is_zeroed.vcxproj
+++ b/src/test/util_is_zeroed/util_is_zeroed.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{FD726AA3-D4FA-4597-B435-08CC7752888D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>util_is_zeroed</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/util_parse_size/util_parse_size.vcxproj
+++ b/src/test/util_parse_size/util_parse_size.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{08B62E36-63D2-4FF1-A605-4BBABAEE73FB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>util_parse_size</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/util_poolset/util_poolset.vcxproj
+++ b/src/test/util_poolset/util_poolset.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{6F06A19B-0921-4B71-A3A5-B350B5FFEADB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>util_poolset</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/util_poolset_foreach/util_poolset_foreach.vcxproj
+++ b/src/test/util_poolset_foreach/util_poolset_foreach.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{E648732D-78FA-427A-928C-9A59222D37B7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>util_poolset_foreach</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/util_poolset_parse/util_poolset_parse.vcxproj
+++ b/src/test/util_poolset_parse/util_poolset_parse.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{50FD1E47-2131-48D2-9435-5CB28DF6B15A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>util_poolset_parse</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/util_poolset_size/util_poolset_size.vcxproj
+++ b/src/test/util_poolset_size/util_poolset_size.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{6B492754-9F80-44B3-A2A7-1D98AF06F3B2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>util_poolset_size</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/util_ravl/util_ravl.vcxproj
+++ b/src/test/util_ravl/util_ravl.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{72C9DB46-C665-48AD-B805-BA885B40CA3E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>util_ravl</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/util_sds/util_sds.vcxproj
+++ b/src/test/util_sds/util_sds.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{5EC35099-9777-45E8-9520-EB2EE75BDF88}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>util_sds</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/util_uuid_generate/util_uuid_generate.vcxproj
+++ b/src/test/util_uuid_generate/util_uuid_generate.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{9A4078F8-B8E4-4EC6-A6FF-4F29DAD9CE48}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>util_uuid_generate</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/util_vec/util_vec.vcxproj
+++ b/src/test/util_vec/util_vec.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{FD726AA3-D4FA-4597-B435-08CC7752888C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>util_vec</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/util_vecq/util_vecq.vcxproj
+++ b/src/test/util_vecq/util_vecq.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{FD726AA3-D4FA-4597-B435-08CC7752888E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>util_vecq</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/win_common/win_common.vcxproj
+++ b/src/test/win_common/win_common.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{6AE1B8BE-D46A-4E99-87A2-F160FB950DCA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>win_common</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/win_lists/win_lists.vcxproj
+++ b/src/test/win_lists/win_lists.vcxproj
@@ -28,7 +28,7 @@
     <ProjectGuid>{1F2E1C51-2B14-4047-BE6D-52E00FC3C780}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>win_lists</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <ProjectName>win_lists</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/test/win_mmap_dtor/win_mmap_dtor.vcxproj
+++ b/src/test/win_mmap_dtor/win_mmap_dtor.vcxproj
@@ -26,7 +26,7 @@
     <ProjectGuid>{F03DABEE-A03E-4437-BFD3-D012836F2D94}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>win_mmap_dtor</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/win_poolset_unmap/win_poolset_unmap.vcxproj
+++ b/src/test/win_poolset_unmap/win_poolset_unmap.vcxproj
@@ -29,7 +29,7 @@
     <ProjectGuid>{810DB909-6581-42D8-9616-906888F12149}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>win_poolset_unmap</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/test/win_signal/win_signal.vcxproj
+++ b/src/test/win_signal/win_signal.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{F13108C4-4C86-4D56-A317-A4E5892A8AF7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>win_signal</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/tools/pmempool/pmempool.vcxproj
+++ b/src/tools/pmempool/pmempool.vcxproj
@@ -88,7 +88,7 @@
     <ProjectGuid>{7DC3B3DD-73ED-4602-9AF3-8D7053620DEA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pmempool</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/tools/pmempool/pmempool.vcxproj.filters
+++ b/src/tools/pmempool/pmempool.vcxproj.filters
@@ -110,6 +110,9 @@
     <ClCompile Include="..\..\libpmemobj\heap.c">
       <Filter>libs</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\libpmem2/badblocks.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="check.h">

--- a/src/windows/getopt/getopt.vcxproj
+++ b/src/windows/getopt/getopt.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{9186EAC4-2F34-4F17-B940-6585D7869BCD}</ProjectGuid>
     <RootNamespace>getopt</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/windows/srcversion/srcversion.vcxproj
+++ b/src/windows/srcversion/srcversion.vcxproj
@@ -17,7 +17,7 @@
     <ProjectGuid>{901F04DB-E1A5-4A41-8B81-9D31C19ACD59}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>srcversion</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/utils/check_sdk_version.py
+++ b/utils/check_sdk_version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2019, Intel Corporation
+# Copyright 2019-2020, Intel Corporation
 
 import argparse
 import os
@@ -10,7 +10,7 @@ import shlex
 from xml.dom import minidom
 from xml.parsers.expat import ExpatError
 
-VALID_SDK_VERSION = '10.0.16299.0'
+VALID_SDK_VERSION = '10.0.17134.0'
 
 
 def get_vcxproj_files(root_dir, ignored):


### PR DESCRIPTION
This is the very first version of SDK, which supports VirtualAlloc2 function, which is crucial for vm_reservation and replace mappings feature in windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4735)
<!-- Reviewable:end -->
