### PR TITLE
test: fix rpmem_addr_ext test

### DIFF
--- a/src/test/rpmem_addr_ext/TEST0
+++ b/src/test/rpmem_addr_ext/TEST0
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2017-2018, Intel Corporation
+# Copyright 2017-2020, Intel Corporation
 
 #
 # src/test/rpmem_addr_ext/TEST0 -- advanced unittest for invalid target formats
@@ -9,6 +9,9 @@
 . ../unittest/unittest.sh
 
 require_test_type short
+
+# matching logs works only with the debug version
+require_build_type debug
 
 require_nodes 2
 


### PR DESCRIPTION
It cannot work on nondebug builds, because it matches logs, which are
generated only in debug builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4742)
<!-- Reviewable:end -->
