### PR TITLE
obj: implement new fragmentation test with highly variable sizes

### DIFF
--- a/src/test/obj_fragmentation2/Makefile
+++ b/src/test/obj_fragmentation2/Makefile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2019, Intel Corporation
+# Copyright 2016-2020, Intel Corporation
 
 #
 # src/test/obj_fragmentation2/Makefile -- build obj_fragmentation2 test
@@ -10,3 +10,5 @@ OBJS = obj_fragmentation2.o
 LIBPMEMOBJ=y
 
 include ../Makefile.inc
+
+LIBS += -lm

--- a/src/test/obj_fragmentation2/TESTS.py
+++ b/src/test/obj_fragmentation2/TESTS.py
@@ -27,7 +27,7 @@ class Base(t.Test):
 # These tests last too long under drd/helgrind/memcheck/pmemcheck
 # Exceptions: workloads no. 6 and 8 under memcheck/pmemcheck (run with TEST1)
 @t.require_valgrind_disabled('drd', 'helgrind', 'memcheck', 'pmemcheck')
-@t.add_params('workload', [0, 1, 2, 3, 4, 5, 7])
+@t.add_params('workload', [0, 1, 2, 3, 4, 5, 7, 9])
 class TEST0(Base):
     pass
 

--- a/src/test/obj_fragmentation2/obj_fragmentation2.c
+++ b/src/test/obj_fragmentation2/obj_fragmentation2.c
@@ -12,13 +12,14 @@
  */
 
 #include <stdlib.h>
+#include <math.h>
 #include "rand.h"
 #include "unittest.h"
 
 #define LAYOUT_NAME "obj_fragmentation"
 
-#define MEGABYTE (1UL << 20)
-#define GIGABYTE (1UL << 30)
+#define MEGABYTE (1ULL << 20)
+#define GIGABYTE (1ULL << 30)
 
 #define RRAND(max, min)\
 ((min) == (max) ? (min) : (rnd64() % ((max) - (min)) + (min)))
@@ -58,13 +59,76 @@ remove_last()
 }
 
 static void
+delete_objects(PMEMobjpool *pop, float pct)
+{
+	size_t nfree = (size_t)(nobjects * pct);
+
+	PMEMoid oid = pmemobj_root(pop, 1);
+
+	shuffle_objects(0, nobjects);
+	while (nfree--) {
+		oid = remove_last();
+
+		allocated_current -= pmemobj_alloc_usable_size(oid);
+
+		pmemobj_free(&oid);
+	}
+}
+
+/*
+ * object_next_size -- generates random sizes in range with
+ *	exponential distribution
+ */
+static size_t
+object_next_size(size_t max, size_t min)
+{
+	float n = rnd64() / (UINT64_MAX / 1.0f);
+	return (size_t)(min + (max - min) * exp(n * - 4.0));
+}
+
+/*
+ * allocate_exponential -- allocates objects from a large range of sizes.
+ *
+ * This is designed to stress the recycler subsystem that will have to
+ * constantly look for freed/empty runs and reuse them.
+ *
+ * For small pools (single digit gigabytes), this test will show large
+ * fragmentation because it can use a large number of runs - which is fine.
+ */
+static void
+allocate_exponential(PMEMobjpool *pop, size_t size_min, size_t size_max)
+{
+	size_t allocated_total = 0;
+
+	PMEMoid oid;
+
+	while (allocated_total < ALLOC_TOTAL) {
+		size_t s = object_next_size(size_max, size_min);
+		int ret = pmemobj_alloc(pop, &oid, s, 0, NULL, NULL);
+		if (ret != 0) {
+			/* delete a random percentage of allocated objects */
+			float delete_pct = (float)RRAND(90, 10) / 100.0f;
+			delete_objects(pop, delete_pct);
+			continue;
+		}
+
+		s = pmemobj_alloc_usable_size(oid);
+
+		objects[nobjects++] = oid;
+		UT_ASSERT(nobjects < MAX_OBJECTS);
+		allocated_total += s;
+		allocated_current += s;
+	}
+}
+
+static void
 allocate_objects(PMEMobjpool *pop, size_t size_min, size_t size_max)
 {
 	size_t allocated_total = 0;
 
 	size_t sstart = 0;
 
-	PMEMoid oid = pmemobj_root(pop, 1);
+	PMEMoid oid;
 
 	while (allocated_total < ALLOC_TOTAL) {
 		size_t s = RRAND(size_max, size_min);
@@ -88,23 +152,6 @@ allocate_objects(PMEMobjpool *pop, size_t size_min, size_t size_max)
 			}
 			sstart = nobjects;
 		}
-	}
-}
-
-static void
-delete_objects(PMEMobjpool *pop, float pct)
-{
-	size_t nfree = (size_t)(nobjects * pct);
-
-	PMEMoid oid = pmemobj_root(pop, 1);
-
-	shuffle_objects(0, nobjects);
-	while (nfree--) {
-		oid = remove_last();
-
-		allocated_current -= pmemobj_alloc_usable_size(oid);
-
-		pmemobj_free(&oid);
 	}
 }
 
@@ -158,25 +205,32 @@ static void w8(PMEMobjpool *pop) {
 	allocate_objects(pop, 2 * MEGABYTE, 2 * MEGABYTE);
 }
 
+static void w9(PMEMobjpool *pop) {
+	allocate_exponential(pop, 1, 5 * MEGABYTE);
+}
+
 static workload *workloads[] = {
-	w0, w1, w2, w3, w4, w5, w6, w7, w8
+	w0, w1, w2, w3, w4, w5, w6, w7, w8, w9
 };
 
 static float workloads_target[] = {
-	0.01f, 0.01f, 0.01f, 0.9f, 0.8f, 0.7f, 0.3f, 0.8f, 0.73f
+	0.01f, 0.01f, 0.01f, 0.9f, 0.8f, 0.7f, 0.3f, 0.8f, 0.73f, 3.0f
 };
 
 static float workloads_defrag_target[] = {
-	0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.05f, 0.09f, 0.13f, 0.01f
+	0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.05f, 0.09f, 0.13f, 0.01f, 0.16f
 };
 
-/* last workload operates only on huge chunks, so run stats are useless */
+/*
+ * Last two workloads operates mostly on huge chunks, so run
+ * stats are useless.
+ */
 static float workloads_stat_target[] = {
-	0.01f, 1.1f, 1.1f, 0.86f, 0.76f, 1.01f, 0.23f, 1.24f, 2100.f
+	0.01f, 1.1f, 1.1f, 0.86f, 0.76f, 1.01f, 0.23f, 1.24f, 2100.f, 2100.f
 };
 
 static float workloads_defrag_stat_target[] = {
-	0.01f, 0.01f, 0.01f, 0.02f, 0.02f, 0.04f, 0.08f, 0.12f, 2100.f
+	0.01f, 0.01f, 0.01f, 0.02f, 0.02f, 0.04f, 0.08f, 0.12f, 2100.f, 2100.f
 };
 
 int


### PR DESCRIPTION
This is a test designed mostly for longer running tests
with larger pools. The intention is to use a large amount of
different allocation classes, and stress the recycler module
of the allocator so that it has to constantly look for new
runs to reuse.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4744)
<!-- Reviewable:end -->
