### PR TITLE
pmem: (+pmem2) insert compiler barriers after NT stores

### DIFF
--- a/src/core/util.h
+++ b/src/core/util.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2014-2020, Intel Corporation */
 /*
- * Copyright (c) 2016, Microsoft Corporation. All rights reserved.
+ * Copyright (c) 2016-2020, Microsoft Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -133,9 +133,11 @@ void util_set_alloc_funcs(
 #ifdef _MSC_VER
 #define force_inline inline __forceinline
 #define NORETURN __declspec(noreturn)
+#define barrier() _ReadWriteBarrier()
 #else
 #define force_inline __attribute__((always_inline)) inline
 #define NORETURN __attribute__((noreturn))
+#define barrier() asm volatile("" ::: "memory")
 #endif
 
 #ifdef _MSC_VER

--- a/src/libpmem2/x86_64/memcpy/memcpy_nt_avx.c
+++ b/src/libpmem2/x86_64/memcpy/memcpy_nt_avx.c
@@ -22,6 +22,7 @@ static force_inline void
 mm256_stream_si256(char *dest, unsigned idx, __m256i src)
 {
 	_mm256_stream_si256((__m256i *)dest + idx, src);
+	barrier();
 }
 
 static force_inline void

--- a/src/libpmem2/x86_64/memcpy/memcpy_nt_avx.c
+++ b/src/libpmem2/x86_64/memcpy/memcpy_nt_avx.c
@@ -12,88 +12,100 @@
 #include "memcpy_avx.h"
 #include "valgrind_internal.h"
 
+static force_inline __m256i
+mm256_loadu_si256(const char *src, unsigned idx)
+{
+	return _mm256_loadu_si256((const __m256i *)src + idx);
+}
+
+static force_inline void
+mm256_stream_si256(char *dest, unsigned idx, __m256i src)
+{
+	_mm256_stream_si256((__m256i *)dest + idx, src);
+}
+
 static force_inline void
 memmove_movnt8x64b(char *dest, const char *src)
 {
-	__m256i ymm0 = _mm256_loadu_si256((__m256i *)src + 0);
-	__m256i ymm1 = _mm256_loadu_si256((__m256i *)src + 1);
-	__m256i ymm2 = _mm256_loadu_si256((__m256i *)src + 2);
-	__m256i ymm3 = _mm256_loadu_si256((__m256i *)src + 3);
-	__m256i ymm4 = _mm256_loadu_si256((__m256i *)src + 4);
-	__m256i ymm5 = _mm256_loadu_si256((__m256i *)src + 5);
-	__m256i ymm6 = _mm256_loadu_si256((__m256i *)src + 6);
-	__m256i ymm7 = _mm256_loadu_si256((__m256i *)src + 7);
-	__m256i ymm8 = _mm256_loadu_si256((__m256i *)src + 8);
-	__m256i ymm9 = _mm256_loadu_si256((__m256i *)src + 9);
-	__m256i ymm10 = _mm256_loadu_si256((__m256i *)src + 10);
-	__m256i ymm11 = _mm256_loadu_si256((__m256i *)src + 11);
-	__m256i ymm12 = _mm256_loadu_si256((__m256i *)src + 12);
-	__m256i ymm13 = _mm256_loadu_si256((__m256i *)src + 13);
-	__m256i ymm14 = _mm256_loadu_si256((__m256i *)src + 14);
-	__m256i ymm15 = _mm256_loadu_si256((__m256i *)src + 15);
+	__m256i ymm0 = mm256_loadu_si256(src, 0);
+	__m256i ymm1 = mm256_loadu_si256(src, 1);
+	__m256i ymm2 = mm256_loadu_si256(src, 2);
+	__m256i ymm3 = mm256_loadu_si256(src, 3);
+	__m256i ymm4 = mm256_loadu_si256(src, 4);
+	__m256i ymm5 = mm256_loadu_si256(src, 5);
+	__m256i ymm6 = mm256_loadu_si256(src, 6);
+	__m256i ymm7 = mm256_loadu_si256(src, 7);
+	__m256i ymm8 = mm256_loadu_si256(src, 8);
+	__m256i ymm9 = mm256_loadu_si256(src, 9);
+	__m256i ymm10 = mm256_loadu_si256(src, 10);
+	__m256i ymm11 = mm256_loadu_si256(src, 11);
+	__m256i ymm12 = mm256_loadu_si256(src, 12);
+	__m256i ymm13 = mm256_loadu_si256(src, 13);
+	__m256i ymm14 = mm256_loadu_si256(src, 14);
+	__m256i ymm15 = mm256_loadu_si256(src, 15);
 
-	_mm256_stream_si256((__m256i *)dest + 0, ymm0);
-	_mm256_stream_si256((__m256i *)dest + 1, ymm1);
-	_mm256_stream_si256((__m256i *)dest + 2, ymm2);
-	_mm256_stream_si256((__m256i *)dest + 3, ymm3);
-	_mm256_stream_si256((__m256i *)dest + 4, ymm4);
-	_mm256_stream_si256((__m256i *)dest + 5, ymm5);
-	_mm256_stream_si256((__m256i *)dest + 6, ymm6);
-	_mm256_stream_si256((__m256i *)dest + 7, ymm7);
-	_mm256_stream_si256((__m256i *)dest + 8, ymm8);
-	_mm256_stream_si256((__m256i *)dest + 9, ymm9);
-	_mm256_stream_si256((__m256i *)dest + 10, ymm10);
-	_mm256_stream_si256((__m256i *)dest + 11, ymm11);
-	_mm256_stream_si256((__m256i *)dest + 12, ymm12);
-	_mm256_stream_si256((__m256i *)dest + 13, ymm13);
-	_mm256_stream_si256((__m256i *)dest + 14, ymm14);
-	_mm256_stream_si256((__m256i *)dest + 15, ymm15);
+	mm256_stream_si256(dest, 0, ymm0);
+	mm256_stream_si256(dest, 1, ymm1);
+	mm256_stream_si256(dest, 2, ymm2);
+	mm256_stream_si256(dest, 3, ymm3);
+	mm256_stream_si256(dest, 4, ymm4);
+	mm256_stream_si256(dest, 5, ymm5);
+	mm256_stream_si256(dest, 6, ymm6);
+	mm256_stream_si256(dest, 7, ymm7);
+	mm256_stream_si256(dest, 8, ymm8);
+	mm256_stream_si256(dest, 9, ymm9);
+	mm256_stream_si256(dest, 10, ymm10);
+	mm256_stream_si256(dest, 11, ymm11);
+	mm256_stream_si256(dest, 12, ymm12);
+	mm256_stream_si256(dest, 13, ymm13);
+	mm256_stream_si256(dest, 14, ymm14);
+	mm256_stream_si256(dest, 15, ymm15);
 }
 
 static force_inline void
 memmove_movnt4x64b(char *dest, const char *src)
 {
-	__m256i ymm0 = _mm256_loadu_si256((__m256i *)src + 0);
-	__m256i ymm1 = _mm256_loadu_si256((__m256i *)src + 1);
-	__m256i ymm2 = _mm256_loadu_si256((__m256i *)src + 2);
-	__m256i ymm3 = _mm256_loadu_si256((__m256i *)src + 3);
-	__m256i ymm4 = _mm256_loadu_si256((__m256i *)src + 4);
-	__m256i ymm5 = _mm256_loadu_si256((__m256i *)src + 5);
-	__m256i ymm6 = _mm256_loadu_si256((__m256i *)src + 6);
-	__m256i ymm7 = _mm256_loadu_si256((__m256i *)src + 7);
+	__m256i ymm0 = mm256_loadu_si256(src, 0);
+	__m256i ymm1 = mm256_loadu_si256(src, 1);
+	__m256i ymm2 = mm256_loadu_si256(src, 2);
+	__m256i ymm3 = mm256_loadu_si256(src, 3);
+	__m256i ymm4 = mm256_loadu_si256(src, 4);
+	__m256i ymm5 = mm256_loadu_si256(src, 5);
+	__m256i ymm6 = mm256_loadu_si256(src, 6);
+	__m256i ymm7 = mm256_loadu_si256(src, 7);
 
-	_mm256_stream_si256((__m256i *)dest + 0, ymm0);
-	_mm256_stream_si256((__m256i *)dest + 1, ymm1);
-	_mm256_stream_si256((__m256i *)dest + 2, ymm2);
-	_mm256_stream_si256((__m256i *)dest + 3, ymm3);
-	_mm256_stream_si256((__m256i *)dest + 4, ymm4);
-	_mm256_stream_si256((__m256i *)dest + 5, ymm5);
-	_mm256_stream_si256((__m256i *)dest + 6, ymm6);
-	_mm256_stream_si256((__m256i *)dest + 7, ymm7);
+	mm256_stream_si256(dest, 0, ymm0);
+	mm256_stream_si256(dest, 1, ymm1);
+	mm256_stream_si256(dest, 2, ymm2);
+	mm256_stream_si256(dest, 3, ymm3);
+	mm256_stream_si256(dest, 4, ymm4);
+	mm256_stream_si256(dest, 5, ymm5);
+	mm256_stream_si256(dest, 6, ymm6);
+	mm256_stream_si256(dest, 7, ymm7);
 }
 
 static force_inline void
 memmove_movnt2x64b(char *dest, const char *src)
 {
-	__m256i ymm0 = _mm256_loadu_si256((__m256i *)src + 0);
-	__m256i ymm1 = _mm256_loadu_si256((__m256i *)src + 1);
-	__m256i ymm2 = _mm256_loadu_si256((__m256i *)src + 2);
-	__m256i ymm3 = _mm256_loadu_si256((__m256i *)src + 3);
+	__m256i ymm0 = mm256_loadu_si256(src, 0);
+	__m256i ymm1 = mm256_loadu_si256(src, 1);
+	__m256i ymm2 = mm256_loadu_si256(src, 2);
+	__m256i ymm3 = mm256_loadu_si256(src, 3);
 
-	_mm256_stream_si256((__m256i *)dest + 0, ymm0);
-	_mm256_stream_si256((__m256i *)dest + 1, ymm1);
-	_mm256_stream_si256((__m256i *)dest + 2, ymm2);
-	_mm256_stream_si256((__m256i *)dest + 3, ymm3);
+	mm256_stream_si256(dest, 0, ymm0);
+	mm256_stream_si256(dest, 1, ymm1);
+	mm256_stream_si256(dest, 2, ymm2);
+	mm256_stream_si256(dest, 3, ymm3);
 }
 
 static force_inline void
 memmove_movnt1x64b(char *dest, const char *src)
 {
-	__m256i ymm0 = _mm256_loadu_si256((__m256i *)src + 0);
-	__m256i ymm1 = _mm256_loadu_si256((__m256i *)src + 1);
+	__m256i ymm0 = mm256_loadu_si256(src, 0);
+	__m256i ymm1 = mm256_loadu_si256(src, 1);
 
-	_mm256_stream_si256((__m256i *)dest + 0, ymm0);
-	_mm256_stream_si256((__m256i *)dest + 1, ymm1);
+	mm256_stream_si256(dest, 0, ymm0);
+	mm256_stream_si256(dest, 1, ymm1);
 }
 
 static force_inline void
@@ -101,7 +113,7 @@ memmove_movnt1x32b(char *dest, const char *src)
 {
 	__m256i ymm0 = _mm256_loadu_si256((__m256i *)src);
 
-	_mm256_stream_si256((__m256i *)dest, ymm0);
+	mm256_stream_si256(dest, 0, ymm0);
 }
 
 static force_inline void

--- a/src/libpmem2/x86_64/memcpy/memcpy_nt_avx512f.c
+++ b/src/libpmem2/x86_64/memcpy/memcpy_nt_avx512f.c
@@ -12,166 +12,178 @@
 #include "memcpy_avx512f.h"
 #include "valgrind_internal.h"
 
+static force_inline __m512i
+mm512_loadu_si512(const char *src, unsigned idx)
+{
+	return _mm512_loadu_si512((const __m512i *)src + idx);
+}
+
+static force_inline void
+mm512_stream_si512(char *dest, unsigned idx, __m512i src)
+{
+	_mm512_stream_si512((__m512i *)dest + idx, src);
+}
+
 static force_inline void
 memmove_movnt32x64b(char *dest, const char *src)
 {
-	__m512i zmm0 = _mm512_loadu_si512((__m512i *)src + 0);
-	__m512i zmm1 = _mm512_loadu_si512((__m512i *)src + 1);
-	__m512i zmm2 = _mm512_loadu_si512((__m512i *)src + 2);
-	__m512i zmm3 = _mm512_loadu_si512((__m512i *)src + 3);
-	__m512i zmm4 = _mm512_loadu_si512((__m512i *)src + 4);
-	__m512i zmm5 = _mm512_loadu_si512((__m512i *)src + 5);
-	__m512i zmm6 = _mm512_loadu_si512((__m512i *)src + 6);
-	__m512i zmm7 = _mm512_loadu_si512((__m512i *)src + 7);
-	__m512i zmm8 = _mm512_loadu_si512((__m512i *)src + 8);
-	__m512i zmm9 = _mm512_loadu_si512((__m512i *)src + 9);
-	__m512i zmm10 = _mm512_loadu_si512((__m512i *)src + 10);
-	__m512i zmm11 = _mm512_loadu_si512((__m512i *)src + 11);
-	__m512i zmm12 = _mm512_loadu_si512((__m512i *)src + 12);
-	__m512i zmm13 = _mm512_loadu_si512((__m512i *)src + 13);
-	__m512i zmm14 = _mm512_loadu_si512((__m512i *)src + 14);
-	__m512i zmm15 = _mm512_loadu_si512((__m512i *)src + 15);
-	__m512i zmm16 = _mm512_loadu_si512((__m512i *)src + 16);
-	__m512i zmm17 = _mm512_loadu_si512((__m512i *)src + 17);
-	__m512i zmm18 = _mm512_loadu_si512((__m512i *)src + 18);
-	__m512i zmm19 = _mm512_loadu_si512((__m512i *)src + 19);
-	__m512i zmm20 = _mm512_loadu_si512((__m512i *)src + 20);
-	__m512i zmm21 = _mm512_loadu_si512((__m512i *)src + 21);
-	__m512i zmm22 = _mm512_loadu_si512((__m512i *)src + 22);
-	__m512i zmm23 = _mm512_loadu_si512((__m512i *)src + 23);
-	__m512i zmm24 = _mm512_loadu_si512((__m512i *)src + 24);
-	__m512i zmm25 = _mm512_loadu_si512((__m512i *)src + 25);
-	__m512i zmm26 = _mm512_loadu_si512((__m512i *)src + 26);
-	__m512i zmm27 = _mm512_loadu_si512((__m512i *)src + 27);
-	__m512i zmm28 = _mm512_loadu_si512((__m512i *)src + 28);
-	__m512i zmm29 = _mm512_loadu_si512((__m512i *)src + 29);
-	__m512i zmm30 = _mm512_loadu_si512((__m512i *)src + 30);
-	__m512i zmm31 = _mm512_loadu_si512((__m512i *)src + 31);
+	__m512i zmm0 = mm512_loadu_si512(src, 0);
+	__m512i zmm1 = mm512_loadu_si512(src, 1);
+	__m512i zmm2 = mm512_loadu_si512(src, 2);
+	__m512i zmm3 = mm512_loadu_si512(src, 3);
+	__m512i zmm4 = mm512_loadu_si512(src, 4);
+	__m512i zmm5 = mm512_loadu_si512(src, 5);
+	__m512i zmm6 = mm512_loadu_si512(src, 6);
+	__m512i zmm7 = mm512_loadu_si512(src, 7);
+	__m512i zmm8 = mm512_loadu_si512(src, 8);
+	__m512i zmm9 = mm512_loadu_si512(src, 9);
+	__m512i zmm10 = mm512_loadu_si512(src, 10);
+	__m512i zmm11 = mm512_loadu_si512(src, 11);
+	__m512i zmm12 = mm512_loadu_si512(src, 12);
+	__m512i zmm13 = mm512_loadu_si512(src, 13);
+	__m512i zmm14 = mm512_loadu_si512(src, 14);
+	__m512i zmm15 = mm512_loadu_si512(src, 15);
+	__m512i zmm16 = mm512_loadu_si512(src, 16);
+	__m512i zmm17 = mm512_loadu_si512(src, 17);
+	__m512i zmm18 = mm512_loadu_si512(src, 18);
+	__m512i zmm19 = mm512_loadu_si512(src, 19);
+	__m512i zmm20 = mm512_loadu_si512(src, 20);
+	__m512i zmm21 = mm512_loadu_si512(src, 21);
+	__m512i zmm22 = mm512_loadu_si512(src, 22);
+	__m512i zmm23 = mm512_loadu_si512(src, 23);
+	__m512i zmm24 = mm512_loadu_si512(src, 24);
+	__m512i zmm25 = mm512_loadu_si512(src, 25);
+	__m512i zmm26 = mm512_loadu_si512(src, 26);
+	__m512i zmm27 = mm512_loadu_si512(src, 27);
+	__m512i zmm28 = mm512_loadu_si512(src, 28);
+	__m512i zmm29 = mm512_loadu_si512(src, 29);
+	__m512i zmm30 = mm512_loadu_si512(src, 30);
+	__m512i zmm31 = mm512_loadu_si512(src, 31);
 
-	_mm512_stream_si512((__m512i *)dest + 0, zmm0);
-	_mm512_stream_si512((__m512i *)dest + 1, zmm1);
-	_mm512_stream_si512((__m512i *)dest + 2, zmm2);
-	_mm512_stream_si512((__m512i *)dest + 3, zmm3);
-	_mm512_stream_si512((__m512i *)dest + 4, zmm4);
-	_mm512_stream_si512((__m512i *)dest + 5, zmm5);
-	_mm512_stream_si512((__m512i *)dest + 6, zmm6);
-	_mm512_stream_si512((__m512i *)dest + 7, zmm7);
-	_mm512_stream_si512((__m512i *)dest + 8, zmm8);
-	_mm512_stream_si512((__m512i *)dest + 9, zmm9);
-	_mm512_stream_si512((__m512i *)dest + 10, zmm10);
-	_mm512_stream_si512((__m512i *)dest + 11, zmm11);
-	_mm512_stream_si512((__m512i *)dest + 12, zmm12);
-	_mm512_stream_si512((__m512i *)dest + 13, zmm13);
-	_mm512_stream_si512((__m512i *)dest + 14, zmm14);
-	_mm512_stream_si512((__m512i *)dest + 15, zmm15);
-	_mm512_stream_si512((__m512i *)dest + 16, zmm16);
-	_mm512_stream_si512((__m512i *)dest + 17, zmm17);
-	_mm512_stream_si512((__m512i *)dest + 18, zmm18);
-	_mm512_stream_si512((__m512i *)dest + 19, zmm19);
-	_mm512_stream_si512((__m512i *)dest + 20, zmm20);
-	_mm512_stream_si512((__m512i *)dest + 21, zmm21);
-	_mm512_stream_si512((__m512i *)dest + 22, zmm22);
-	_mm512_stream_si512((__m512i *)dest + 23, zmm23);
-	_mm512_stream_si512((__m512i *)dest + 24, zmm24);
-	_mm512_stream_si512((__m512i *)dest + 25, zmm25);
-	_mm512_stream_si512((__m512i *)dest + 26, zmm26);
-	_mm512_stream_si512((__m512i *)dest + 27, zmm27);
-	_mm512_stream_si512((__m512i *)dest + 28, zmm28);
-	_mm512_stream_si512((__m512i *)dest + 29, zmm29);
-	_mm512_stream_si512((__m512i *)dest + 30, zmm30);
-	_mm512_stream_si512((__m512i *)dest + 31, zmm31);
+	mm512_stream_si512(dest, 0, zmm0);
+	mm512_stream_si512(dest, 1, zmm1);
+	mm512_stream_si512(dest, 2, zmm2);
+	mm512_stream_si512(dest, 3, zmm3);
+	mm512_stream_si512(dest, 4, zmm4);
+	mm512_stream_si512(dest, 5, zmm5);
+	mm512_stream_si512(dest, 6, zmm6);
+	mm512_stream_si512(dest, 7, zmm7);
+	mm512_stream_si512(dest, 8, zmm8);
+	mm512_stream_si512(dest, 9, zmm9);
+	mm512_stream_si512(dest, 10, zmm10);
+	mm512_stream_si512(dest, 11, zmm11);
+	mm512_stream_si512(dest, 12, zmm12);
+	mm512_stream_si512(dest, 13, zmm13);
+	mm512_stream_si512(dest, 14, zmm14);
+	mm512_stream_si512(dest, 15, zmm15);
+	mm512_stream_si512(dest, 16, zmm16);
+	mm512_stream_si512(dest, 17, zmm17);
+	mm512_stream_si512(dest, 18, zmm18);
+	mm512_stream_si512(dest, 19, zmm19);
+	mm512_stream_si512(dest, 20, zmm20);
+	mm512_stream_si512(dest, 21, zmm21);
+	mm512_stream_si512(dest, 22, zmm22);
+	mm512_stream_si512(dest, 23, zmm23);
+	mm512_stream_si512(dest, 24, zmm24);
+	mm512_stream_si512(dest, 25, zmm25);
+	mm512_stream_si512(dest, 26, zmm26);
+	mm512_stream_si512(dest, 27, zmm27);
+	mm512_stream_si512(dest, 28, zmm28);
+	mm512_stream_si512(dest, 29, zmm29);
+	mm512_stream_si512(dest, 30, zmm30);
+	mm512_stream_si512(dest, 31, zmm31);
 }
 
 static force_inline void
 memmove_movnt16x64b(char *dest, const char *src)
 {
-	__m512i zmm0 = _mm512_loadu_si512((__m512i *)src + 0);
-	__m512i zmm1 = _mm512_loadu_si512((__m512i *)src + 1);
-	__m512i zmm2 = _mm512_loadu_si512((__m512i *)src + 2);
-	__m512i zmm3 = _mm512_loadu_si512((__m512i *)src + 3);
-	__m512i zmm4 = _mm512_loadu_si512((__m512i *)src + 4);
-	__m512i zmm5 = _mm512_loadu_si512((__m512i *)src + 5);
-	__m512i zmm6 = _mm512_loadu_si512((__m512i *)src + 6);
-	__m512i zmm7 = _mm512_loadu_si512((__m512i *)src + 7);
-	__m512i zmm8 = _mm512_loadu_si512((__m512i *)src + 8);
-	__m512i zmm9 = _mm512_loadu_si512((__m512i *)src + 9);
-	__m512i zmm10 = _mm512_loadu_si512((__m512i *)src + 10);
-	__m512i zmm11 = _mm512_loadu_si512((__m512i *)src + 11);
-	__m512i zmm12 = _mm512_loadu_si512((__m512i *)src + 12);
-	__m512i zmm13 = _mm512_loadu_si512((__m512i *)src + 13);
-	__m512i zmm14 = _mm512_loadu_si512((__m512i *)src + 14);
-	__m512i zmm15 = _mm512_loadu_si512((__m512i *)src + 15);
+	__m512i zmm0 = mm512_loadu_si512(src, 0);
+	__m512i zmm1 = mm512_loadu_si512(src, 1);
+	__m512i zmm2 = mm512_loadu_si512(src, 2);
+	__m512i zmm3 = mm512_loadu_si512(src, 3);
+	__m512i zmm4 = mm512_loadu_si512(src, 4);
+	__m512i zmm5 = mm512_loadu_si512(src, 5);
+	__m512i zmm6 = mm512_loadu_si512(src, 6);
+	__m512i zmm7 = mm512_loadu_si512(src, 7);
+	__m512i zmm8 = mm512_loadu_si512(src, 8);
+	__m512i zmm9 = mm512_loadu_si512(src, 9);
+	__m512i zmm10 = mm512_loadu_si512(src, 10);
+	__m512i zmm11 = mm512_loadu_si512(src, 11);
+	__m512i zmm12 = mm512_loadu_si512(src, 12);
+	__m512i zmm13 = mm512_loadu_si512(src, 13);
+	__m512i zmm14 = mm512_loadu_si512(src, 14);
+	__m512i zmm15 = mm512_loadu_si512(src, 15);
 
-	_mm512_stream_si512((__m512i *)dest + 0, zmm0);
-	_mm512_stream_si512((__m512i *)dest + 1, zmm1);
-	_mm512_stream_si512((__m512i *)dest + 2, zmm2);
-	_mm512_stream_si512((__m512i *)dest + 3, zmm3);
-	_mm512_stream_si512((__m512i *)dest + 4, zmm4);
-	_mm512_stream_si512((__m512i *)dest + 5, zmm5);
-	_mm512_stream_si512((__m512i *)dest + 6, zmm6);
-	_mm512_stream_si512((__m512i *)dest + 7, zmm7);
-	_mm512_stream_si512((__m512i *)dest + 8, zmm8);
-	_mm512_stream_si512((__m512i *)dest + 9, zmm9);
-	_mm512_stream_si512((__m512i *)dest + 10, zmm10);
-	_mm512_stream_si512((__m512i *)dest + 11, zmm11);
-	_mm512_stream_si512((__m512i *)dest + 12, zmm12);
-	_mm512_stream_si512((__m512i *)dest + 13, zmm13);
-	_mm512_stream_si512((__m512i *)dest + 14, zmm14);
-	_mm512_stream_si512((__m512i *)dest + 15, zmm15);
+	mm512_stream_si512(dest, 0, zmm0);
+	mm512_stream_si512(dest, 1, zmm1);
+	mm512_stream_si512(dest, 2, zmm2);
+	mm512_stream_si512(dest, 3, zmm3);
+	mm512_stream_si512(dest, 4, zmm4);
+	mm512_stream_si512(dest, 5, zmm5);
+	mm512_stream_si512(dest, 6, zmm6);
+	mm512_stream_si512(dest, 7, zmm7);
+	mm512_stream_si512(dest, 8, zmm8);
+	mm512_stream_si512(dest, 9, zmm9);
+	mm512_stream_si512(dest, 10, zmm10);
+	mm512_stream_si512(dest, 11, zmm11);
+	mm512_stream_si512(dest, 12, zmm12);
+	mm512_stream_si512(dest, 13, zmm13);
+	mm512_stream_si512(dest, 14, zmm14);
+	mm512_stream_si512(dest, 15, zmm15);
 }
 
 static force_inline void
 memmove_movnt8x64b(char *dest, const char *src)
 {
-	__m512i zmm0 = _mm512_loadu_si512((__m512i *)src + 0);
-	__m512i zmm1 = _mm512_loadu_si512((__m512i *)src + 1);
-	__m512i zmm2 = _mm512_loadu_si512((__m512i *)src + 2);
-	__m512i zmm3 = _mm512_loadu_si512((__m512i *)src + 3);
-	__m512i zmm4 = _mm512_loadu_si512((__m512i *)src + 4);
-	__m512i zmm5 = _mm512_loadu_si512((__m512i *)src + 5);
-	__m512i zmm6 = _mm512_loadu_si512((__m512i *)src + 6);
-	__m512i zmm7 = _mm512_loadu_si512((__m512i *)src + 7);
+	__m512i zmm0 = mm512_loadu_si512(src, 0);
+	__m512i zmm1 = mm512_loadu_si512(src, 1);
+	__m512i zmm2 = mm512_loadu_si512(src, 2);
+	__m512i zmm3 = mm512_loadu_si512(src, 3);
+	__m512i zmm4 = mm512_loadu_si512(src, 4);
+	__m512i zmm5 = mm512_loadu_si512(src, 5);
+	__m512i zmm6 = mm512_loadu_si512(src, 6);
+	__m512i zmm7 = mm512_loadu_si512(src, 7);
 
-	_mm512_stream_si512((__m512i *)dest + 0, zmm0);
-	_mm512_stream_si512((__m512i *)dest + 1, zmm1);
-	_mm512_stream_si512((__m512i *)dest + 2, zmm2);
-	_mm512_stream_si512((__m512i *)dest + 3, zmm3);
-	_mm512_stream_si512((__m512i *)dest + 4, zmm4);
-	_mm512_stream_si512((__m512i *)dest + 5, zmm5);
-	_mm512_stream_si512((__m512i *)dest + 6, zmm6);
-	_mm512_stream_si512((__m512i *)dest + 7, zmm7);
+	mm512_stream_si512(dest, 0, zmm0);
+	mm512_stream_si512(dest, 1, zmm1);
+	mm512_stream_si512(dest, 2, zmm2);
+	mm512_stream_si512(dest, 3, zmm3);
+	mm512_stream_si512(dest, 4, zmm4);
+	mm512_stream_si512(dest, 5, zmm5);
+	mm512_stream_si512(dest, 6, zmm6);
+	mm512_stream_si512(dest, 7, zmm7);
 }
 
 static force_inline void
 memmove_movnt4x64b(char *dest, const char *src)
 {
-	__m512i zmm0 = _mm512_loadu_si512((__m512i *)src + 0);
-	__m512i zmm1 = _mm512_loadu_si512((__m512i *)src + 1);
-	__m512i zmm2 = _mm512_loadu_si512((__m512i *)src + 2);
-	__m512i zmm3 = _mm512_loadu_si512((__m512i *)src + 3);
+	__m512i zmm0 = mm512_loadu_si512(src, 0);
+	__m512i zmm1 = mm512_loadu_si512(src, 1);
+	__m512i zmm2 = mm512_loadu_si512(src, 2);
+	__m512i zmm3 = mm512_loadu_si512(src, 3);
 
-	_mm512_stream_si512((__m512i *)dest + 0, zmm0);
-	_mm512_stream_si512((__m512i *)dest + 1, zmm1);
-	_mm512_stream_si512((__m512i *)dest + 2, zmm2);
-	_mm512_stream_si512((__m512i *)dest + 3, zmm3);
+	mm512_stream_si512(dest, 0, zmm0);
+	mm512_stream_si512(dest, 1, zmm1);
+	mm512_stream_si512(dest, 2, zmm2);
+	mm512_stream_si512(dest, 3, zmm3);
 }
 
 static force_inline void
 memmove_movnt2x64b(char *dest, const char *src)
 {
-	__m512i zmm0 = _mm512_loadu_si512((__m512i *)src + 0);
-	__m512i zmm1 = _mm512_loadu_si512((__m512i *)src + 1);
+	__m512i zmm0 = mm512_loadu_si512(src, 0);
+	__m512i zmm1 = mm512_loadu_si512(src, 1);
 
-	_mm512_stream_si512((__m512i *)dest + 0, zmm0);
-	_mm512_stream_si512((__m512i *)dest + 1, zmm1);
+	mm512_stream_si512(dest, 0, zmm0);
+	mm512_stream_si512(dest, 1, zmm1);
 }
 
 static force_inline void
 memmove_movnt1x64b(char *dest, const char *src)
 {
-	__m512i zmm0 = _mm512_loadu_si512((__m512i *)src + 0);
+	__m512i zmm0 = mm512_loadu_si512(src, 0);
 
-	_mm512_stream_si512((__m512i *)dest + 0, zmm0);
+	mm512_stream_si512(dest, 0, zmm0);
 }
 
 static force_inline void

--- a/src/libpmem2/x86_64/memcpy/memcpy_nt_avx512f.c
+++ b/src/libpmem2/x86_64/memcpy/memcpy_nt_avx512f.c
@@ -22,6 +22,7 @@ static force_inline void
 mm512_stream_si512(char *dest, unsigned idx, __m512i src)
 {
 	_mm512_stream_si512((__m512i *)dest + idx, src);
+	barrier();
 }
 
 static force_inline void

--- a/src/libpmem2/x86_64/memcpy/memcpy_nt_sse2.c
+++ b/src/libpmem2/x86_64/memcpy/memcpy_nt_sse2.c
@@ -11,96 +11,108 @@
 #include "memcpy_sse2.h"
 #include "valgrind_internal.h"
 
+static force_inline __m128i
+mm_loadu_si128(const char *src, unsigned idx)
+{
+	return _mm_loadu_si128((const __m128i *)src + idx);
+}
+
+static force_inline void
+mm_stream_si128(char *dest, unsigned idx, __m128i src)
+{
+	_mm_stream_si128((__m128i *)dest + idx, src);
+}
+
 static force_inline void
 memmove_movnt4x64b(char *dest, const char *src)
 {
-	__m128i xmm0 = _mm_loadu_si128((__m128i *)src + 0);
-	__m128i xmm1 = _mm_loadu_si128((__m128i *)src + 1);
-	__m128i xmm2 = _mm_loadu_si128((__m128i *)src + 2);
-	__m128i xmm3 = _mm_loadu_si128((__m128i *)src + 3);
-	__m128i xmm4 = _mm_loadu_si128((__m128i *)src + 4);
-	__m128i xmm5 = _mm_loadu_si128((__m128i *)src + 5);
-	__m128i xmm6 = _mm_loadu_si128((__m128i *)src + 6);
-	__m128i xmm7 = _mm_loadu_si128((__m128i *)src + 7);
-	__m128i xmm8 = _mm_loadu_si128((__m128i *)src + 8);
-	__m128i xmm9 = _mm_loadu_si128((__m128i *)src + 9);
-	__m128i xmm10 = _mm_loadu_si128((__m128i *)src + 10);
-	__m128i xmm11 = _mm_loadu_si128((__m128i *)src + 11);
-	__m128i xmm12 = _mm_loadu_si128((__m128i *)src + 12);
-	__m128i xmm13 = _mm_loadu_si128((__m128i *)src + 13);
-	__m128i xmm14 = _mm_loadu_si128((__m128i *)src + 14);
-	__m128i xmm15 = _mm_loadu_si128((__m128i *)src + 15);
+	__m128i xmm0 = mm_loadu_si128(src, 0);
+	__m128i xmm1 = mm_loadu_si128(src, 1);
+	__m128i xmm2 = mm_loadu_si128(src, 2);
+	__m128i xmm3 = mm_loadu_si128(src, 3);
+	__m128i xmm4 = mm_loadu_si128(src, 4);
+	__m128i xmm5 = mm_loadu_si128(src, 5);
+	__m128i xmm6 = mm_loadu_si128(src, 6);
+	__m128i xmm7 = mm_loadu_si128(src, 7);
+	__m128i xmm8 = mm_loadu_si128(src, 8);
+	__m128i xmm9 = mm_loadu_si128(src, 9);
+	__m128i xmm10 = mm_loadu_si128(src, 10);
+	__m128i xmm11 = mm_loadu_si128(src, 11);
+	__m128i xmm12 = mm_loadu_si128(src, 12);
+	__m128i xmm13 = mm_loadu_si128(src, 13);
+	__m128i xmm14 = mm_loadu_si128(src, 14);
+	__m128i xmm15 = mm_loadu_si128(src, 15);
 
-	_mm_stream_si128((__m128i *)dest + 0, xmm0);
-	_mm_stream_si128((__m128i *)dest + 1, xmm1);
-	_mm_stream_si128((__m128i *)dest + 2, xmm2);
-	_mm_stream_si128((__m128i *)dest + 3, xmm3);
-	_mm_stream_si128((__m128i *)dest + 4, xmm4);
-	_mm_stream_si128((__m128i *)dest + 5, xmm5);
-	_mm_stream_si128((__m128i *)dest + 6, xmm6);
-	_mm_stream_si128((__m128i *)dest + 7, xmm7);
-	_mm_stream_si128((__m128i *)dest + 8, xmm8);
-	_mm_stream_si128((__m128i *)dest + 9, xmm9);
-	_mm_stream_si128((__m128i *)dest + 10, xmm10);
-	_mm_stream_si128((__m128i *)dest + 11, xmm11);
-	_mm_stream_si128((__m128i *)dest + 12, xmm12);
-	_mm_stream_si128((__m128i *)dest + 13, xmm13);
-	_mm_stream_si128((__m128i *)dest + 14, xmm14);
-	_mm_stream_si128((__m128i *)dest + 15, xmm15);
+	mm_stream_si128(dest, 0, xmm0);
+	mm_stream_si128(dest, 1, xmm1);
+	mm_stream_si128(dest, 2, xmm2);
+	mm_stream_si128(dest, 3, xmm3);
+	mm_stream_si128(dest, 4, xmm4);
+	mm_stream_si128(dest, 5, xmm5);
+	mm_stream_si128(dest, 6, xmm6);
+	mm_stream_si128(dest, 7, xmm7);
+	mm_stream_si128(dest, 8, xmm8);
+	mm_stream_si128(dest, 9, xmm9);
+	mm_stream_si128(dest, 10, xmm10);
+	mm_stream_si128(dest, 11, xmm11);
+	mm_stream_si128(dest, 12, xmm12);
+	mm_stream_si128(dest, 13, xmm13);
+	mm_stream_si128(dest, 14, xmm14);
+	mm_stream_si128(dest, 15, xmm15);
 }
 
 static force_inline void
 memmove_movnt2x64b(char *dest, const char *src)
 {
-	__m128i xmm0 = _mm_loadu_si128((__m128i *)src + 0);
-	__m128i xmm1 = _mm_loadu_si128((__m128i *)src + 1);
-	__m128i xmm2 = _mm_loadu_si128((__m128i *)src + 2);
-	__m128i xmm3 = _mm_loadu_si128((__m128i *)src + 3);
-	__m128i xmm4 = _mm_loadu_si128((__m128i *)src + 4);
-	__m128i xmm5 = _mm_loadu_si128((__m128i *)src + 5);
-	__m128i xmm6 = _mm_loadu_si128((__m128i *)src + 6);
-	__m128i xmm7 = _mm_loadu_si128((__m128i *)src + 7);
+	__m128i xmm0 = mm_loadu_si128(src, 0);
+	__m128i xmm1 = mm_loadu_si128(src, 1);
+	__m128i xmm2 = mm_loadu_si128(src, 2);
+	__m128i xmm3 = mm_loadu_si128(src, 3);
+	__m128i xmm4 = mm_loadu_si128(src, 4);
+	__m128i xmm5 = mm_loadu_si128(src, 5);
+	__m128i xmm6 = mm_loadu_si128(src, 6);
+	__m128i xmm7 = mm_loadu_si128(src, 7);
 
-	_mm_stream_si128((__m128i *)dest + 0, xmm0);
-	_mm_stream_si128((__m128i *)dest + 1, xmm1);
-	_mm_stream_si128((__m128i *)dest + 2, xmm2);
-	_mm_stream_si128((__m128i *)dest + 3, xmm3);
-	_mm_stream_si128((__m128i *)dest + 4, xmm4);
-	_mm_stream_si128((__m128i *)dest + 5, xmm5);
-	_mm_stream_si128((__m128i *)dest + 6, xmm6);
-	_mm_stream_si128((__m128i *)dest + 7, xmm7);
+	mm_stream_si128(dest, 0, xmm0);
+	mm_stream_si128(dest, 1, xmm1);
+	mm_stream_si128(dest, 2, xmm2);
+	mm_stream_si128(dest, 3, xmm3);
+	mm_stream_si128(dest, 4, xmm4);
+	mm_stream_si128(dest, 5, xmm5);
+	mm_stream_si128(dest, 6, xmm6);
+	mm_stream_si128(dest, 7, xmm7);
 }
 
 static force_inline void
 memmove_movnt1x64b(char *dest, const char *src)
 {
-	__m128i xmm0 = _mm_loadu_si128((__m128i *)src + 0);
-	__m128i xmm1 = _mm_loadu_si128((__m128i *)src + 1);
-	__m128i xmm2 = _mm_loadu_si128((__m128i *)src + 2);
-	__m128i xmm3 = _mm_loadu_si128((__m128i *)src + 3);
+	__m128i xmm0 = mm_loadu_si128(src, 0);
+	__m128i xmm1 = mm_loadu_si128(src, 1);
+	__m128i xmm2 = mm_loadu_si128(src, 2);
+	__m128i xmm3 = mm_loadu_si128(src, 3);
 
-	_mm_stream_si128((__m128i *)dest + 0, xmm0);
-	_mm_stream_si128((__m128i *)dest + 1, xmm1);
-	_mm_stream_si128((__m128i *)dest + 2, xmm2);
-	_mm_stream_si128((__m128i *)dest + 3, xmm3);
+	mm_stream_si128(dest, 0, xmm0);
+	mm_stream_si128(dest, 1, xmm1);
+	mm_stream_si128(dest, 2, xmm2);
+	mm_stream_si128(dest, 3, xmm3);
 }
 
 static force_inline void
 memmove_movnt1x32b(char *dest, const char *src)
 {
-	__m128i xmm0 = _mm_loadu_si128((__m128i *)src + 0);
-	__m128i xmm1 = _mm_loadu_si128((__m128i *)src + 1);
+	__m128i xmm0 = mm_loadu_si128(src, 0);
+	__m128i xmm1 = mm_loadu_si128(src, 1);
 
-	_mm_stream_si128((__m128i *)dest + 0, xmm0);
-	_mm_stream_si128((__m128i *)dest + 1, xmm1);
+	mm_stream_si128(dest, 0, xmm0);
+	mm_stream_si128(dest, 1, xmm1);
 }
 
 static force_inline void
 memmove_movnt1x16b(char *dest, const char *src)
 {
-	__m128i xmm0 = _mm_loadu_si128((__m128i *)src);
+	__m128i xmm0 = mm_loadu_si128(src, 0);
 
-	_mm_stream_si128((__m128i *)dest, xmm0);
+	mm_stream_si128(dest, 0, xmm0);
 }
 
 static force_inline void

--- a/src/libpmem2/x86_64/memcpy/memcpy_nt_sse2.c
+++ b/src/libpmem2/x86_64/memcpy/memcpy_nt_sse2.c
@@ -21,6 +21,7 @@ static force_inline void
 mm_stream_si128(char *dest, unsigned idx, __m128i src)
 {
 	_mm_stream_si128((__m128i *)dest + idx, src);
+	barrier();
 }
 
 static force_inline void

--- a/src/libpmem2/x86_64/memcpy/memcpy_t_avx.c
+++ b/src/libpmem2/x86_64/memcpy/memcpy_t_avx.c
@@ -11,42 +11,54 @@
 #include "memcpy_memset.h"
 #include "memcpy_avx.h"
 
+static force_inline __m256i
+mm256_loadu_si256(const char *src, unsigned idx)
+{
+	return _mm256_loadu_si256((const __m256i *)src + idx);
+}
+
+static force_inline void
+mm256_store_si256(char *dest, unsigned idx, __m256i src)
+{
+	_mm256_store_si256((__m256i *)dest + idx, src);
+}
+
 static force_inline void
 memmove_mov8x64b(char *dest, const char *src, flush64b_fn flush64b)
 {
-	__m256i ymm0 = _mm256_loadu_si256((__m256i *)src + 0);
-	__m256i ymm1 = _mm256_loadu_si256((__m256i *)src + 1);
-	__m256i ymm2 = _mm256_loadu_si256((__m256i *)src + 2);
-	__m256i ymm3 = _mm256_loadu_si256((__m256i *)src + 3);
-	__m256i ymm4 = _mm256_loadu_si256((__m256i *)src + 4);
-	__m256i ymm5 = _mm256_loadu_si256((__m256i *)src + 5);
-	__m256i ymm6 = _mm256_loadu_si256((__m256i *)src + 6);
-	__m256i ymm7 = _mm256_loadu_si256((__m256i *)src + 7);
-	__m256i ymm8 = _mm256_loadu_si256((__m256i *)src + 8);
-	__m256i ymm9 = _mm256_loadu_si256((__m256i *)src + 9);
-	__m256i ymm10 = _mm256_loadu_si256((__m256i *)src + 10);
-	__m256i ymm11 = _mm256_loadu_si256((__m256i *)src + 11);
-	__m256i ymm12 = _mm256_loadu_si256((__m256i *)src + 12);
-	__m256i ymm13 = _mm256_loadu_si256((__m256i *)src + 13);
-	__m256i ymm14 = _mm256_loadu_si256((__m256i *)src + 14);
-	__m256i ymm15 = _mm256_loadu_si256((__m256i *)src + 15);
+	__m256i ymm0 = mm256_loadu_si256(src, 0);
+	__m256i ymm1 = mm256_loadu_si256(src, 1);
+	__m256i ymm2 = mm256_loadu_si256(src, 2);
+	__m256i ymm3 = mm256_loadu_si256(src, 3);
+	__m256i ymm4 = mm256_loadu_si256(src, 4);
+	__m256i ymm5 = mm256_loadu_si256(src, 5);
+	__m256i ymm6 = mm256_loadu_si256(src, 6);
+	__m256i ymm7 = mm256_loadu_si256(src, 7);
+	__m256i ymm8 = mm256_loadu_si256(src, 8);
+	__m256i ymm9 = mm256_loadu_si256(src, 9);
+	__m256i ymm10 = mm256_loadu_si256(src, 10);
+	__m256i ymm11 = mm256_loadu_si256(src, 11);
+	__m256i ymm12 = mm256_loadu_si256(src, 12);
+	__m256i ymm13 = mm256_loadu_si256(src, 13);
+	__m256i ymm14 = mm256_loadu_si256(src, 14);
+	__m256i ymm15 = mm256_loadu_si256(src, 15);
 
-	_mm256_store_si256((__m256i *)dest + 0, ymm0);
-	_mm256_store_si256((__m256i *)dest + 1, ymm1);
-	_mm256_store_si256((__m256i *)dest + 2, ymm2);
-	_mm256_store_si256((__m256i *)dest + 3, ymm3);
-	_mm256_store_si256((__m256i *)dest + 4, ymm4);
-	_mm256_store_si256((__m256i *)dest + 5, ymm5);
-	_mm256_store_si256((__m256i *)dest + 6, ymm6);
-	_mm256_store_si256((__m256i *)dest + 7, ymm7);
-	_mm256_store_si256((__m256i *)dest + 8, ymm8);
-	_mm256_store_si256((__m256i *)dest + 9, ymm9);
-	_mm256_store_si256((__m256i *)dest + 10, ymm10);
-	_mm256_store_si256((__m256i *)dest + 11, ymm11);
-	_mm256_store_si256((__m256i *)dest + 12, ymm12);
-	_mm256_store_si256((__m256i *)dest + 13, ymm13);
-	_mm256_store_si256((__m256i *)dest + 14, ymm14);
-	_mm256_store_si256((__m256i *)dest + 15, ymm15);
+	mm256_store_si256(dest, 0, ymm0);
+	mm256_store_si256(dest, 1, ymm1);
+	mm256_store_si256(dest, 2, ymm2);
+	mm256_store_si256(dest, 3, ymm3);
+	mm256_store_si256(dest, 4, ymm4);
+	mm256_store_si256(dest, 5, ymm5);
+	mm256_store_si256(dest, 6, ymm6);
+	mm256_store_si256(dest, 7, ymm7);
+	mm256_store_si256(dest, 8, ymm8);
+	mm256_store_si256(dest, 9, ymm9);
+	mm256_store_si256(dest, 10, ymm10);
+	mm256_store_si256(dest, 11, ymm11);
+	mm256_store_si256(dest, 12, ymm12);
+	mm256_store_si256(dest, 13, ymm13);
+	mm256_store_si256(dest, 14, ymm14);
+	mm256_store_si256(dest, 15, ymm15);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -61,23 +73,23 @@ memmove_mov8x64b(char *dest, const char *src, flush64b_fn flush64b)
 static force_inline void
 memmove_mov4x64b(char *dest, const char *src, flush64b_fn flush64b)
 {
-	__m256i ymm0 = _mm256_loadu_si256((__m256i *)src + 0);
-	__m256i ymm1 = _mm256_loadu_si256((__m256i *)src + 1);
-	__m256i ymm2 = _mm256_loadu_si256((__m256i *)src + 2);
-	__m256i ymm3 = _mm256_loadu_si256((__m256i *)src + 3);
-	__m256i ymm4 = _mm256_loadu_si256((__m256i *)src + 4);
-	__m256i ymm5 = _mm256_loadu_si256((__m256i *)src + 5);
-	__m256i ymm6 = _mm256_loadu_si256((__m256i *)src + 6);
-	__m256i ymm7 = _mm256_loadu_si256((__m256i *)src + 7);
+	__m256i ymm0 = mm256_loadu_si256(src, 0);
+	__m256i ymm1 = mm256_loadu_si256(src, 1);
+	__m256i ymm2 = mm256_loadu_si256(src, 2);
+	__m256i ymm3 = mm256_loadu_si256(src, 3);
+	__m256i ymm4 = mm256_loadu_si256(src, 4);
+	__m256i ymm5 = mm256_loadu_si256(src, 5);
+	__m256i ymm6 = mm256_loadu_si256(src, 6);
+	__m256i ymm7 = mm256_loadu_si256(src, 7);
 
-	_mm256_store_si256((__m256i *)dest + 0, ymm0);
-	_mm256_store_si256((__m256i *)dest + 1, ymm1);
-	_mm256_store_si256((__m256i *)dest + 2, ymm2);
-	_mm256_store_si256((__m256i *)dest + 3, ymm3);
-	_mm256_store_si256((__m256i *)dest + 4, ymm4);
-	_mm256_store_si256((__m256i *)dest + 5, ymm5);
-	_mm256_store_si256((__m256i *)dest + 6, ymm6);
-	_mm256_store_si256((__m256i *)dest + 7, ymm7);
+	mm256_store_si256(dest, 0, ymm0);
+	mm256_store_si256(dest, 1, ymm1);
+	mm256_store_si256(dest, 2, ymm2);
+	mm256_store_si256(dest, 3, ymm3);
+	mm256_store_si256(dest, 4, ymm4);
+	mm256_store_si256(dest, 5, ymm5);
+	mm256_store_si256(dest, 6, ymm6);
+	mm256_store_si256(dest, 7, ymm7);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -88,15 +100,15 @@ memmove_mov4x64b(char *dest, const char *src, flush64b_fn flush64b)
 static force_inline void
 memmove_mov2x64b(char *dest, const char *src, flush64b_fn flush64b)
 {
-	__m256i ymm0 = _mm256_loadu_si256((__m256i *)src + 0);
-	__m256i ymm1 = _mm256_loadu_si256((__m256i *)src + 1);
-	__m256i ymm2 = _mm256_loadu_si256((__m256i *)src + 2);
-	__m256i ymm3 = _mm256_loadu_si256((__m256i *)src + 3);
+	__m256i ymm0 = mm256_loadu_si256(src, 0);
+	__m256i ymm1 = mm256_loadu_si256(src, 1);
+	__m256i ymm2 = mm256_loadu_si256(src, 2);
+	__m256i ymm3 = mm256_loadu_si256(src, 3);
 
-	_mm256_store_si256((__m256i *)dest + 0, ymm0);
-	_mm256_store_si256((__m256i *)dest + 1, ymm1);
-	_mm256_store_si256((__m256i *)dest + 2, ymm2);
-	_mm256_store_si256((__m256i *)dest + 3, ymm3);
+	mm256_store_si256(dest, 0, ymm0);
+	mm256_store_si256(dest, 1, ymm1);
+	mm256_store_si256(dest, 2, ymm2);
+	mm256_store_si256(dest, 3, ymm3);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -105,11 +117,11 @@ memmove_mov2x64b(char *dest, const char *src, flush64b_fn flush64b)
 static force_inline void
 memmove_mov1x64b(char *dest, const char *src, flush64b_fn flush64b)
 {
-	__m256i ymm0 = _mm256_loadu_si256((__m256i *)src + 0);
-	__m256i ymm1 = _mm256_loadu_si256((__m256i *)src + 1);
+	__m256i ymm0 = mm256_loadu_si256(src, 0);
+	__m256i ymm1 = mm256_loadu_si256(src, 1);
 
-	_mm256_store_si256((__m256i *)dest + 0, ymm0);
-	_mm256_store_si256((__m256i *)dest + 1, ymm1);
+	mm256_store_si256(dest, 0, ymm0);
+	mm256_store_si256(dest, 1, ymm1);
 
 	flush64b(dest + 0 * 64);
 }

--- a/src/libpmem2/x86_64/memcpy/memcpy_t_avx512f.c
+++ b/src/libpmem2/x86_64/memcpy/memcpy_t_avx512f.c
@@ -11,74 +11,86 @@
 #include "memcpy_memset.h"
 #include "memcpy_avx512f.h"
 
+static force_inline __m512i
+mm512_loadu_si512(const char *src, unsigned idx)
+{
+	return _mm512_loadu_si512((const __m512i *)src + idx);
+}
+
+static force_inline void
+mm512_store_si512(char *dest, unsigned idx, __m512i src)
+{
+	_mm512_store_si512((__m512i *)dest + idx, src);
+}
+
 static force_inline void
 memmove_mov32x64b(char *dest, const char *src, flush64b_fn flush64b)
 {
-	__m512i zmm0 = _mm512_loadu_si512((__m512i *)src + 0);
-	__m512i zmm1 = _mm512_loadu_si512((__m512i *)src + 1);
-	__m512i zmm2 = _mm512_loadu_si512((__m512i *)src + 2);
-	__m512i zmm3 = _mm512_loadu_si512((__m512i *)src + 3);
-	__m512i zmm4 = _mm512_loadu_si512((__m512i *)src + 4);
-	__m512i zmm5 = _mm512_loadu_si512((__m512i *)src + 5);
-	__m512i zmm6 = _mm512_loadu_si512((__m512i *)src + 6);
-	__m512i zmm7 = _mm512_loadu_si512((__m512i *)src + 7);
-	__m512i zmm8 = _mm512_loadu_si512((__m512i *)src + 8);
-	__m512i zmm9 = _mm512_loadu_si512((__m512i *)src + 9);
-	__m512i zmm10 = _mm512_loadu_si512((__m512i *)src + 10);
-	__m512i zmm11 = _mm512_loadu_si512((__m512i *)src + 11);
-	__m512i zmm12 = _mm512_loadu_si512((__m512i *)src + 12);
-	__m512i zmm13 = _mm512_loadu_si512((__m512i *)src + 13);
-	__m512i zmm14 = _mm512_loadu_si512((__m512i *)src + 14);
-	__m512i zmm15 = _mm512_loadu_si512((__m512i *)src + 15);
-	__m512i zmm16 = _mm512_loadu_si512((__m512i *)src + 16);
-	__m512i zmm17 = _mm512_loadu_si512((__m512i *)src + 17);
-	__m512i zmm18 = _mm512_loadu_si512((__m512i *)src + 18);
-	__m512i zmm19 = _mm512_loadu_si512((__m512i *)src + 19);
-	__m512i zmm20 = _mm512_loadu_si512((__m512i *)src + 20);
-	__m512i zmm21 = _mm512_loadu_si512((__m512i *)src + 21);
-	__m512i zmm22 = _mm512_loadu_si512((__m512i *)src + 22);
-	__m512i zmm23 = _mm512_loadu_si512((__m512i *)src + 23);
-	__m512i zmm24 = _mm512_loadu_si512((__m512i *)src + 24);
-	__m512i zmm25 = _mm512_loadu_si512((__m512i *)src + 25);
-	__m512i zmm26 = _mm512_loadu_si512((__m512i *)src + 26);
-	__m512i zmm27 = _mm512_loadu_si512((__m512i *)src + 27);
-	__m512i zmm28 = _mm512_loadu_si512((__m512i *)src + 28);
-	__m512i zmm29 = _mm512_loadu_si512((__m512i *)src + 29);
-	__m512i zmm30 = _mm512_loadu_si512((__m512i *)src + 30);
-	__m512i zmm31 = _mm512_loadu_si512((__m512i *)src + 31);
+	__m512i zmm0 = mm512_loadu_si512(src, 0);
+	__m512i zmm1 = mm512_loadu_si512(src, 1);
+	__m512i zmm2 = mm512_loadu_si512(src, 2);
+	__m512i zmm3 = mm512_loadu_si512(src, 3);
+	__m512i zmm4 = mm512_loadu_si512(src, 4);
+	__m512i zmm5 = mm512_loadu_si512(src, 5);
+	__m512i zmm6 = mm512_loadu_si512(src, 6);
+	__m512i zmm7 = mm512_loadu_si512(src, 7);
+	__m512i zmm8 = mm512_loadu_si512(src, 8);
+	__m512i zmm9 = mm512_loadu_si512(src, 9);
+	__m512i zmm10 = mm512_loadu_si512(src, 10);
+	__m512i zmm11 = mm512_loadu_si512(src, 11);
+	__m512i zmm12 = mm512_loadu_si512(src, 12);
+	__m512i zmm13 = mm512_loadu_si512(src, 13);
+	__m512i zmm14 = mm512_loadu_si512(src, 14);
+	__m512i zmm15 = mm512_loadu_si512(src, 15);
+	__m512i zmm16 = mm512_loadu_si512(src, 16);
+	__m512i zmm17 = mm512_loadu_si512(src, 17);
+	__m512i zmm18 = mm512_loadu_si512(src, 18);
+	__m512i zmm19 = mm512_loadu_si512(src, 19);
+	__m512i zmm20 = mm512_loadu_si512(src, 20);
+	__m512i zmm21 = mm512_loadu_si512(src, 21);
+	__m512i zmm22 = mm512_loadu_si512(src, 22);
+	__m512i zmm23 = mm512_loadu_si512(src, 23);
+	__m512i zmm24 = mm512_loadu_si512(src, 24);
+	__m512i zmm25 = mm512_loadu_si512(src, 25);
+	__m512i zmm26 = mm512_loadu_si512(src, 26);
+	__m512i zmm27 = mm512_loadu_si512(src, 27);
+	__m512i zmm28 = mm512_loadu_si512(src, 28);
+	__m512i zmm29 = mm512_loadu_si512(src, 29);
+	__m512i zmm30 = mm512_loadu_si512(src, 30);
+	__m512i zmm31 = mm512_loadu_si512(src, 31);
 
-	_mm512_store_si512((__m512i *)dest + 0, zmm0);
-	_mm512_store_si512((__m512i *)dest + 1, zmm1);
-	_mm512_store_si512((__m512i *)dest + 2, zmm2);
-	_mm512_store_si512((__m512i *)dest + 3, zmm3);
-	_mm512_store_si512((__m512i *)dest + 4, zmm4);
-	_mm512_store_si512((__m512i *)dest + 5, zmm5);
-	_mm512_store_si512((__m512i *)dest + 6, zmm6);
-	_mm512_store_si512((__m512i *)dest + 7, zmm7);
-	_mm512_store_si512((__m512i *)dest + 8, zmm8);
-	_mm512_store_si512((__m512i *)dest + 9, zmm9);
-	_mm512_store_si512((__m512i *)dest + 10, zmm10);
-	_mm512_store_si512((__m512i *)dest + 11, zmm11);
-	_mm512_store_si512((__m512i *)dest + 12, zmm12);
-	_mm512_store_si512((__m512i *)dest + 13, zmm13);
-	_mm512_store_si512((__m512i *)dest + 14, zmm14);
-	_mm512_store_si512((__m512i *)dest + 15, zmm15);
-	_mm512_store_si512((__m512i *)dest + 16, zmm16);
-	_mm512_store_si512((__m512i *)dest + 17, zmm17);
-	_mm512_store_si512((__m512i *)dest + 18, zmm18);
-	_mm512_store_si512((__m512i *)dest + 19, zmm19);
-	_mm512_store_si512((__m512i *)dest + 20, zmm20);
-	_mm512_store_si512((__m512i *)dest + 21, zmm21);
-	_mm512_store_si512((__m512i *)dest + 22, zmm22);
-	_mm512_store_si512((__m512i *)dest + 23, zmm23);
-	_mm512_store_si512((__m512i *)dest + 24, zmm24);
-	_mm512_store_si512((__m512i *)dest + 25, zmm25);
-	_mm512_store_si512((__m512i *)dest + 26, zmm26);
-	_mm512_store_si512((__m512i *)dest + 27, zmm27);
-	_mm512_store_si512((__m512i *)dest + 28, zmm28);
-	_mm512_store_si512((__m512i *)dest + 29, zmm29);
-	_mm512_store_si512((__m512i *)dest + 30, zmm30);
-	_mm512_store_si512((__m512i *)dest + 31, zmm31);
+	mm512_store_si512(dest, 0, zmm0);
+	mm512_store_si512(dest, 1, zmm1);
+	mm512_store_si512(dest, 2, zmm2);
+	mm512_store_si512(dest, 3, zmm3);
+	mm512_store_si512(dest, 4, zmm4);
+	mm512_store_si512(dest, 5, zmm5);
+	mm512_store_si512(dest, 6, zmm6);
+	mm512_store_si512(dest, 7, zmm7);
+	mm512_store_si512(dest, 8, zmm8);
+	mm512_store_si512(dest, 9, zmm9);
+	mm512_store_si512(dest, 10, zmm10);
+	mm512_store_si512(dest, 11, zmm11);
+	mm512_store_si512(dest, 12, zmm12);
+	mm512_store_si512(dest, 13, zmm13);
+	mm512_store_si512(dest, 14, zmm14);
+	mm512_store_si512(dest, 15, zmm15);
+	mm512_store_si512(dest, 16, zmm16);
+	mm512_store_si512(dest, 17, zmm17);
+	mm512_store_si512(dest, 18, zmm18);
+	mm512_store_si512(dest, 19, zmm19);
+	mm512_store_si512(dest, 20, zmm20);
+	mm512_store_si512(dest, 21, zmm21);
+	mm512_store_si512(dest, 22, zmm22);
+	mm512_store_si512(dest, 23, zmm23);
+	mm512_store_si512(dest, 24, zmm24);
+	mm512_store_si512(dest, 25, zmm25);
+	mm512_store_si512(dest, 26, zmm26);
+	mm512_store_si512(dest, 27, zmm27);
+	mm512_store_si512(dest, 28, zmm28);
+	mm512_store_si512(dest, 29, zmm29);
+	mm512_store_si512(dest, 30, zmm30);
+	mm512_store_si512(dest, 31, zmm31);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -117,39 +129,39 @@ memmove_mov32x64b(char *dest, const char *src, flush64b_fn flush64b)
 static force_inline void
 memmove_mov16x64b(char *dest, const char *src, flush64b_fn flush64b)
 {
-	__m512i zmm0 = _mm512_loadu_si512((__m512i *)src + 0);
-	__m512i zmm1 = _mm512_loadu_si512((__m512i *)src + 1);
-	__m512i zmm2 = _mm512_loadu_si512((__m512i *)src + 2);
-	__m512i zmm3 = _mm512_loadu_si512((__m512i *)src + 3);
-	__m512i zmm4 = _mm512_loadu_si512((__m512i *)src + 4);
-	__m512i zmm5 = _mm512_loadu_si512((__m512i *)src + 5);
-	__m512i zmm6 = _mm512_loadu_si512((__m512i *)src + 6);
-	__m512i zmm7 = _mm512_loadu_si512((__m512i *)src + 7);
-	__m512i zmm8 = _mm512_loadu_si512((__m512i *)src + 8);
-	__m512i zmm9 = _mm512_loadu_si512((__m512i *)src + 9);
-	__m512i zmm10 = _mm512_loadu_si512((__m512i *)src + 10);
-	__m512i zmm11 = _mm512_loadu_si512((__m512i *)src + 11);
-	__m512i zmm12 = _mm512_loadu_si512((__m512i *)src + 12);
-	__m512i zmm13 = _mm512_loadu_si512((__m512i *)src + 13);
-	__m512i zmm14 = _mm512_loadu_si512((__m512i *)src + 14);
-	__m512i zmm15 = _mm512_loadu_si512((__m512i *)src + 15);
+	__m512i zmm0 = mm512_loadu_si512(src, 0);
+	__m512i zmm1 = mm512_loadu_si512(src, 1);
+	__m512i zmm2 = mm512_loadu_si512(src, 2);
+	__m512i zmm3 = mm512_loadu_si512(src, 3);
+	__m512i zmm4 = mm512_loadu_si512(src, 4);
+	__m512i zmm5 = mm512_loadu_si512(src, 5);
+	__m512i zmm6 = mm512_loadu_si512(src, 6);
+	__m512i zmm7 = mm512_loadu_si512(src, 7);
+	__m512i zmm8 = mm512_loadu_si512(src, 8);
+	__m512i zmm9 = mm512_loadu_si512(src, 9);
+	__m512i zmm10 = mm512_loadu_si512(src, 10);
+	__m512i zmm11 = mm512_loadu_si512(src, 11);
+	__m512i zmm12 = mm512_loadu_si512(src, 12);
+	__m512i zmm13 = mm512_loadu_si512(src, 13);
+	__m512i zmm14 = mm512_loadu_si512(src, 14);
+	__m512i zmm15 = mm512_loadu_si512(src, 15);
 
-	_mm512_store_si512((__m512i *)dest + 0, zmm0);
-	_mm512_store_si512((__m512i *)dest + 1, zmm1);
-	_mm512_store_si512((__m512i *)dest + 2, zmm2);
-	_mm512_store_si512((__m512i *)dest + 3, zmm3);
-	_mm512_store_si512((__m512i *)dest + 4, zmm4);
-	_mm512_store_si512((__m512i *)dest + 5, zmm5);
-	_mm512_store_si512((__m512i *)dest + 6, zmm6);
-	_mm512_store_si512((__m512i *)dest + 7, zmm7);
-	_mm512_store_si512((__m512i *)dest + 8, zmm8);
-	_mm512_store_si512((__m512i *)dest + 9, zmm9);
-	_mm512_store_si512((__m512i *)dest + 10, zmm10);
-	_mm512_store_si512((__m512i *)dest + 11, zmm11);
-	_mm512_store_si512((__m512i *)dest + 12, zmm12);
-	_mm512_store_si512((__m512i *)dest + 13, zmm13);
-	_mm512_store_si512((__m512i *)dest + 14, zmm14);
-	_mm512_store_si512((__m512i *)dest + 15, zmm15);
+	mm512_store_si512(dest, 0, zmm0);
+	mm512_store_si512(dest, 1, zmm1);
+	mm512_store_si512(dest, 2, zmm2);
+	mm512_store_si512(dest, 3, zmm3);
+	mm512_store_si512(dest, 4, zmm4);
+	mm512_store_si512(dest, 5, zmm5);
+	mm512_store_si512(dest, 6, zmm6);
+	mm512_store_si512(dest, 7, zmm7);
+	mm512_store_si512(dest, 8, zmm8);
+	mm512_store_si512(dest, 9, zmm9);
+	mm512_store_si512(dest, 10, zmm10);
+	mm512_store_si512(dest, 11, zmm11);
+	mm512_store_si512(dest, 12, zmm12);
+	mm512_store_si512(dest, 13, zmm13);
+	mm512_store_si512(dest, 14, zmm14);
+	mm512_store_si512(dest, 15, zmm15);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -172,23 +184,23 @@ memmove_mov16x64b(char *dest, const char *src, flush64b_fn flush64b)
 static force_inline void
 memmove_mov8x64b(char *dest, const char *src, flush64b_fn flush64b)
 {
-	__m512i zmm0 = _mm512_loadu_si512((__m512i *)src + 0);
-	__m512i zmm1 = _mm512_loadu_si512((__m512i *)src + 1);
-	__m512i zmm2 = _mm512_loadu_si512((__m512i *)src + 2);
-	__m512i zmm3 = _mm512_loadu_si512((__m512i *)src + 3);
-	__m512i zmm4 = _mm512_loadu_si512((__m512i *)src + 4);
-	__m512i zmm5 = _mm512_loadu_si512((__m512i *)src + 5);
-	__m512i zmm6 = _mm512_loadu_si512((__m512i *)src + 6);
-	__m512i zmm7 = _mm512_loadu_si512((__m512i *)src + 7);
+	__m512i zmm0 = mm512_loadu_si512(src, 0);
+	__m512i zmm1 = mm512_loadu_si512(src, 1);
+	__m512i zmm2 = mm512_loadu_si512(src, 2);
+	__m512i zmm3 = mm512_loadu_si512(src, 3);
+	__m512i zmm4 = mm512_loadu_si512(src, 4);
+	__m512i zmm5 = mm512_loadu_si512(src, 5);
+	__m512i zmm6 = mm512_loadu_si512(src, 6);
+	__m512i zmm7 = mm512_loadu_si512(src, 7);
 
-	_mm512_store_si512((__m512i *)dest + 0, zmm0);
-	_mm512_store_si512((__m512i *)dest + 1, zmm1);
-	_mm512_store_si512((__m512i *)dest + 2, zmm2);
-	_mm512_store_si512((__m512i *)dest + 3, zmm3);
-	_mm512_store_si512((__m512i *)dest + 4, zmm4);
-	_mm512_store_si512((__m512i *)dest + 5, zmm5);
-	_mm512_store_si512((__m512i *)dest + 6, zmm6);
-	_mm512_store_si512((__m512i *)dest + 7, zmm7);
+	mm512_store_si512(dest, 0, zmm0);
+	mm512_store_si512(dest, 1, zmm1);
+	mm512_store_si512(dest, 2, zmm2);
+	mm512_store_si512(dest, 3, zmm3);
+	mm512_store_si512(dest, 4, zmm4);
+	mm512_store_si512(dest, 5, zmm5);
+	mm512_store_si512(dest, 6, zmm6);
+	mm512_store_si512(dest, 7, zmm7);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -203,15 +215,15 @@ memmove_mov8x64b(char *dest, const char *src, flush64b_fn flush64b)
 static force_inline void
 memmove_mov4x64b(char *dest, const char *src, flush64b_fn flush64b)
 {
-	__m512i zmm0 = _mm512_loadu_si512((__m512i *)src + 0);
-	__m512i zmm1 = _mm512_loadu_si512((__m512i *)src + 1);
-	__m512i zmm2 = _mm512_loadu_si512((__m512i *)src + 2);
-	__m512i zmm3 = _mm512_loadu_si512((__m512i *)src + 3);
+	__m512i zmm0 = mm512_loadu_si512(src, 0);
+	__m512i zmm1 = mm512_loadu_si512(src, 1);
+	__m512i zmm2 = mm512_loadu_si512(src, 2);
+	__m512i zmm3 = mm512_loadu_si512(src, 3);
 
-	_mm512_store_si512((__m512i *)dest + 0, zmm0);
-	_mm512_store_si512((__m512i *)dest + 1, zmm1);
-	_mm512_store_si512((__m512i *)dest + 2, zmm2);
-	_mm512_store_si512((__m512i *)dest + 3, zmm3);
+	mm512_store_si512(dest, 0, zmm0);
+	mm512_store_si512(dest, 1, zmm1);
+	mm512_store_si512(dest, 2, zmm2);
+	mm512_store_si512(dest, 3, zmm3);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -222,11 +234,11 @@ memmove_mov4x64b(char *dest, const char *src, flush64b_fn flush64b)
 static force_inline void
 memmove_mov2x64b(char *dest, const char *src, flush64b_fn flush64b)
 {
-	__m512i zmm0 = _mm512_loadu_si512((__m512i *)src + 0);
-	__m512i zmm1 = _mm512_loadu_si512((__m512i *)src + 1);
+	__m512i zmm0 = mm512_loadu_si512(src, 0);
+	__m512i zmm1 = mm512_loadu_si512(src, 1);
 
-	_mm512_store_si512((__m512i *)dest + 0, zmm0);
-	_mm512_store_si512((__m512i *)dest + 1, zmm1);
+	mm512_store_si512(dest, 0, zmm0);
+	mm512_store_si512(dest, 1, zmm1);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -235,9 +247,9 @@ memmove_mov2x64b(char *dest, const char *src, flush64b_fn flush64b)
 static force_inline void
 memmove_mov1x64b(char *dest, const char *src, flush64b_fn flush64b)
 {
-	__m512i zmm0 = _mm512_loadu_si512((__m512i *)src + 0);
+	__m512i zmm0 = mm512_loadu_si512(src, 0);
 
-	_mm512_store_si512((__m512i *)dest + 0, zmm0);
+	mm512_store_si512(dest, 0, zmm0);
 
 	flush64b(dest + 0 * 64);
 }

--- a/src/libpmem2/x86_64/memcpy/memcpy_t_sse2.c
+++ b/src/libpmem2/x86_64/memcpy/memcpy_t_sse2.c
@@ -11,42 +11,54 @@
 #include "memcpy_sse2.h"
 #include "out.h"
 
+static force_inline __m128i
+mm_loadu_si128(const char *src, unsigned idx)
+{
+	return _mm_loadu_si128((const __m128i *)src + idx);
+}
+
+static force_inline void
+mm_store_si128(char *dest, unsigned idx, __m128i src)
+{
+	_mm_store_si128((__m128i *)dest + idx, src);
+}
+
 static force_inline void
 memmove_mov4x64b(char *dest, const char *src, flush64b_fn flush64b)
 {
-	__m128i xmm0 = _mm_loadu_si128((__m128i *)src + 0);
-	__m128i xmm1 = _mm_loadu_si128((__m128i *)src + 1);
-	__m128i xmm2 = _mm_loadu_si128((__m128i *)src + 2);
-	__m128i xmm3 = _mm_loadu_si128((__m128i *)src + 3);
-	__m128i xmm4 = _mm_loadu_si128((__m128i *)src + 4);
-	__m128i xmm5 = _mm_loadu_si128((__m128i *)src + 5);
-	__m128i xmm6 = _mm_loadu_si128((__m128i *)src + 6);
-	__m128i xmm7 = _mm_loadu_si128((__m128i *)src + 7);
-	__m128i xmm8 = _mm_loadu_si128((__m128i *)src + 8);
-	__m128i xmm9 = _mm_loadu_si128((__m128i *)src + 9);
-	__m128i xmm10 = _mm_loadu_si128((__m128i *)src + 10);
-	__m128i xmm11 = _mm_loadu_si128((__m128i *)src + 11);
-	__m128i xmm12 = _mm_loadu_si128((__m128i *)src + 12);
-	__m128i xmm13 = _mm_loadu_si128((__m128i *)src + 13);
-	__m128i xmm14 = _mm_loadu_si128((__m128i *)src + 14);
-	__m128i xmm15 = _mm_loadu_si128((__m128i *)src + 15);
+	__m128i xmm0 = mm_loadu_si128(src, 0);
+	__m128i xmm1 = mm_loadu_si128(src, 1);
+	__m128i xmm2 = mm_loadu_si128(src, 2);
+	__m128i xmm3 = mm_loadu_si128(src, 3);
+	__m128i xmm4 = mm_loadu_si128(src, 4);
+	__m128i xmm5 = mm_loadu_si128(src, 5);
+	__m128i xmm6 = mm_loadu_si128(src, 6);
+	__m128i xmm7 = mm_loadu_si128(src, 7);
+	__m128i xmm8 = mm_loadu_si128(src, 8);
+	__m128i xmm9 = mm_loadu_si128(src, 9);
+	__m128i xmm10 = mm_loadu_si128(src, 10);
+	__m128i xmm11 = mm_loadu_si128(src, 11);
+	__m128i xmm12 = mm_loadu_si128(src, 12);
+	__m128i xmm13 = mm_loadu_si128(src, 13);
+	__m128i xmm14 = mm_loadu_si128(src, 14);
+	__m128i xmm15 = mm_loadu_si128(src, 15);
 
-	_mm_store_si128((__m128i *)dest + 0, xmm0);
-	_mm_store_si128((__m128i *)dest + 1, xmm1);
-	_mm_store_si128((__m128i *)dest + 2, xmm2);
-	_mm_store_si128((__m128i *)dest + 3, xmm3);
-	_mm_store_si128((__m128i *)dest + 4, xmm4);
-	_mm_store_si128((__m128i *)dest + 5, xmm5);
-	_mm_store_si128((__m128i *)dest + 6, xmm6);
-	_mm_store_si128((__m128i *)dest + 7, xmm7);
-	_mm_store_si128((__m128i *)dest + 8, xmm8);
-	_mm_store_si128((__m128i *)dest + 9, xmm9);
-	_mm_store_si128((__m128i *)dest + 10, xmm10);
-	_mm_store_si128((__m128i *)dest + 11, xmm11);
-	_mm_store_si128((__m128i *)dest + 12, xmm12);
-	_mm_store_si128((__m128i *)dest + 13, xmm13);
-	_mm_store_si128((__m128i *)dest + 14, xmm14);
-	_mm_store_si128((__m128i *)dest + 15, xmm15);
+	mm_store_si128(dest, 0, xmm0);
+	mm_store_si128(dest, 1, xmm1);
+	mm_store_si128(dest, 2, xmm2);
+	mm_store_si128(dest, 3, xmm3);
+	mm_store_si128(dest, 4, xmm4);
+	mm_store_si128(dest, 5, xmm5);
+	mm_store_si128(dest, 6, xmm6);
+	mm_store_si128(dest, 7, xmm7);
+	mm_store_si128(dest, 8, xmm8);
+	mm_store_si128(dest, 9, xmm9);
+	mm_store_si128(dest, 10, xmm10);
+	mm_store_si128(dest, 11, xmm11);
+	mm_store_si128(dest, 12, xmm12);
+	mm_store_si128(dest, 13, xmm13);
+	mm_store_si128(dest, 14, xmm14);
+	mm_store_si128(dest, 15, xmm15);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -57,23 +69,23 @@ memmove_mov4x64b(char *dest, const char *src, flush64b_fn flush64b)
 static force_inline void
 memmove_mov2x64b(char *dest, const char *src, flush64b_fn flush64b)
 {
-	__m128i xmm0 = _mm_loadu_si128((__m128i *)src + 0);
-	__m128i xmm1 = _mm_loadu_si128((__m128i *)src + 1);
-	__m128i xmm2 = _mm_loadu_si128((__m128i *)src + 2);
-	__m128i xmm3 = _mm_loadu_si128((__m128i *)src + 3);
-	__m128i xmm4 = _mm_loadu_si128((__m128i *)src + 4);
-	__m128i xmm5 = _mm_loadu_si128((__m128i *)src + 5);
-	__m128i xmm6 = _mm_loadu_si128((__m128i *)src + 6);
-	__m128i xmm7 = _mm_loadu_si128((__m128i *)src + 7);
+	__m128i xmm0 = mm_loadu_si128(src, 0);
+	__m128i xmm1 = mm_loadu_si128(src, 1);
+	__m128i xmm2 = mm_loadu_si128(src, 2);
+	__m128i xmm3 = mm_loadu_si128(src, 3);
+	__m128i xmm4 = mm_loadu_si128(src, 4);
+	__m128i xmm5 = mm_loadu_si128(src, 5);
+	__m128i xmm6 = mm_loadu_si128(src, 6);
+	__m128i xmm7 = mm_loadu_si128(src, 7);
 
-	_mm_store_si128((__m128i *)dest + 0, xmm0);
-	_mm_store_si128((__m128i *)dest + 1, xmm1);
-	_mm_store_si128((__m128i *)dest + 2, xmm2);
-	_mm_store_si128((__m128i *)dest + 3, xmm3);
-	_mm_store_si128((__m128i *)dest + 4, xmm4);
-	_mm_store_si128((__m128i *)dest + 5, xmm5);
-	_mm_store_si128((__m128i *)dest + 6, xmm6);
-	_mm_store_si128((__m128i *)dest + 7, xmm7);
+	mm_store_si128(dest, 0, xmm0);
+	mm_store_si128(dest, 1, xmm1);
+	mm_store_si128(dest, 2, xmm2);
+	mm_store_si128(dest, 3, xmm3);
+	mm_store_si128(dest, 4, xmm4);
+	mm_store_si128(dest, 5, xmm5);
+	mm_store_si128(dest, 6, xmm6);
+	mm_store_si128(dest, 7, xmm7);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -82,15 +94,15 @@ memmove_mov2x64b(char *dest, const char *src, flush64b_fn flush64b)
 static force_inline void
 memmove_mov1x64b(char *dest, const char *src, flush64b_fn flush64b)
 {
-	__m128i xmm0 = _mm_loadu_si128((__m128i *)src + 0);
-	__m128i xmm1 = _mm_loadu_si128((__m128i *)src + 1);
-	__m128i xmm2 = _mm_loadu_si128((__m128i *)src + 2);
-	__m128i xmm3 = _mm_loadu_si128((__m128i *)src + 3);
+	__m128i xmm0 = mm_loadu_si128(src, 0);
+	__m128i xmm1 = mm_loadu_si128(src, 1);
+	__m128i xmm2 = mm_loadu_si128(src, 2);
+	__m128i xmm3 = mm_loadu_si128(src, 3);
 
-	_mm_store_si128((__m128i *)dest + 0, xmm0);
-	_mm_store_si128((__m128i *)dest + 1, xmm1);
-	_mm_store_si128((__m128i *)dest + 2, xmm2);
-	_mm_store_si128((__m128i *)dest + 3, xmm3);
+	mm_store_si128(dest, 0, xmm0);
+	mm_store_si128(dest, 1, xmm1);
+	mm_store_si128(dest, 2, xmm2);
+	mm_store_si128(dest, 3, xmm3);
 
 	flush64b(dest + 0 * 64);
 }

--- a/src/libpmem2/x86_64/memset/memset_nt_avx.c
+++ b/src/libpmem2/x86_64/memset/memset_nt_avx.c
@@ -17,6 +17,7 @@ static force_inline void
 mm256_stream_si256(char *dest, unsigned idx, __m256i src)
 {
 	_mm256_stream_si256((__m256i *)dest + idx, src);
+	barrier();
 }
 
 static force_inline void

--- a/src/libpmem2/x86_64/memset/memset_nt_avx.c
+++ b/src/libpmem2/x86_64/memset/memset_nt_avx.c
@@ -14,59 +14,65 @@
 #include "valgrind_internal.h"
 
 static force_inline void
+mm256_stream_si256(char *dest, unsigned idx, __m256i src)
+{
+	_mm256_stream_si256((__m256i *)dest + idx, src);
+}
+
+static force_inline void
 memset_movnt8x64b(char *dest, __m256i ymm)
 {
-	_mm256_stream_si256((__m256i *)dest + 0, ymm);
-	_mm256_stream_si256((__m256i *)dest + 1, ymm);
-	_mm256_stream_si256((__m256i *)dest + 2, ymm);
-	_mm256_stream_si256((__m256i *)dest + 3, ymm);
-	_mm256_stream_si256((__m256i *)dest + 4, ymm);
-	_mm256_stream_si256((__m256i *)dest + 5, ymm);
-	_mm256_stream_si256((__m256i *)dest + 6, ymm);
-	_mm256_stream_si256((__m256i *)dest + 7, ymm);
-	_mm256_stream_si256((__m256i *)dest + 8, ymm);
-	_mm256_stream_si256((__m256i *)dest + 9, ymm);
-	_mm256_stream_si256((__m256i *)dest + 10, ymm);
-	_mm256_stream_si256((__m256i *)dest + 11, ymm);
-	_mm256_stream_si256((__m256i *)dest + 12, ymm);
-	_mm256_stream_si256((__m256i *)dest + 13, ymm);
-	_mm256_stream_si256((__m256i *)dest + 14, ymm);
-	_mm256_stream_si256((__m256i *)dest + 15, ymm);
+	mm256_stream_si256(dest, 0, ymm);
+	mm256_stream_si256(dest, 1, ymm);
+	mm256_stream_si256(dest, 2, ymm);
+	mm256_stream_si256(dest, 3, ymm);
+	mm256_stream_si256(dest, 4, ymm);
+	mm256_stream_si256(dest, 5, ymm);
+	mm256_stream_si256(dest, 6, ymm);
+	mm256_stream_si256(dest, 7, ymm);
+	mm256_stream_si256(dest, 8, ymm);
+	mm256_stream_si256(dest, 9, ymm);
+	mm256_stream_si256(dest, 10, ymm);
+	mm256_stream_si256(dest, 11, ymm);
+	mm256_stream_si256(dest, 12, ymm);
+	mm256_stream_si256(dest, 13, ymm);
+	mm256_stream_si256(dest, 14, ymm);
+	mm256_stream_si256(dest, 15, ymm);
 }
 
 static force_inline void
 memset_movnt4x64b(char *dest, __m256i ymm)
 {
-	_mm256_stream_si256((__m256i *)dest + 0, ymm);
-	_mm256_stream_si256((__m256i *)dest + 1, ymm);
-	_mm256_stream_si256((__m256i *)dest + 2, ymm);
-	_mm256_stream_si256((__m256i *)dest + 3, ymm);
-	_mm256_stream_si256((__m256i *)dest + 4, ymm);
-	_mm256_stream_si256((__m256i *)dest + 5, ymm);
-	_mm256_stream_si256((__m256i *)dest + 6, ymm);
-	_mm256_stream_si256((__m256i *)dest + 7, ymm);
+	mm256_stream_si256(dest, 0, ymm);
+	mm256_stream_si256(dest, 1, ymm);
+	mm256_stream_si256(dest, 2, ymm);
+	mm256_stream_si256(dest, 3, ymm);
+	mm256_stream_si256(dest, 4, ymm);
+	mm256_stream_si256(dest, 5, ymm);
+	mm256_stream_si256(dest, 6, ymm);
+	mm256_stream_si256(dest, 7, ymm);
 }
 
 static force_inline void
 memset_movnt2x64b(char *dest, __m256i ymm)
 {
-	_mm256_stream_si256((__m256i *)dest + 0, ymm);
-	_mm256_stream_si256((__m256i *)dest + 1, ymm);
-	_mm256_stream_si256((__m256i *)dest + 2, ymm);
-	_mm256_stream_si256((__m256i *)dest + 3, ymm);
+	mm256_stream_si256(dest, 0, ymm);
+	mm256_stream_si256(dest, 1, ymm);
+	mm256_stream_si256(dest, 2, ymm);
+	mm256_stream_si256(dest, 3, ymm);
 }
 
 static force_inline void
 memset_movnt1x64b(char *dest, __m256i ymm)
 {
-	_mm256_stream_si256((__m256i *)dest + 0, ymm);
-	_mm256_stream_si256((__m256i *)dest + 1, ymm);
+	mm256_stream_si256(dest, 0, ymm);
+	mm256_stream_si256(dest, 1, ymm);
 }
 
 static force_inline void
 memset_movnt1x32b(char *dest, __m256i ymm)
 {
-	_mm256_stream_si256((__m256i *)dest, ymm);
+	mm256_stream_si256(dest, 0, ymm);
 }
 
 static force_inline void

--- a/src/libpmem2/x86_64/memset/memset_nt_avx512f.c
+++ b/src/libpmem2/x86_64/memset/memset_nt_avx512f.c
@@ -18,6 +18,7 @@ static force_inline void
 mm512_stream_si512(char *dest, unsigned idx, __m512i src)
 {
 	_mm512_stream_si512((__m512i *)dest + idx, src);
+	barrier();
 }
 
 static force_inline void

--- a/src/libpmem2/x86_64/memset/memset_nt_avx512f.c
+++ b/src/libpmem2/x86_64/memset/memset_nt_avx512f.c
@@ -15,96 +15,102 @@
 #include "valgrind_internal.h"
 
 static force_inline void
+mm512_stream_si512(char *dest, unsigned idx, __m512i src)
+{
+	_mm512_stream_si512((__m512i *)dest + idx, src);
+}
+
+static force_inline void
 memset_movnt32x64b(char *dest, __m512i zmm)
 {
-	_mm512_stream_si512((__m512i *)dest + 0, zmm);
-	_mm512_stream_si512((__m512i *)dest + 1, zmm);
-	_mm512_stream_si512((__m512i *)dest + 2, zmm);
-	_mm512_stream_si512((__m512i *)dest + 3, zmm);
-	_mm512_stream_si512((__m512i *)dest + 4, zmm);
-	_mm512_stream_si512((__m512i *)dest + 5, zmm);
-	_mm512_stream_si512((__m512i *)dest + 6, zmm);
-	_mm512_stream_si512((__m512i *)dest + 7, zmm);
-	_mm512_stream_si512((__m512i *)dest + 8, zmm);
-	_mm512_stream_si512((__m512i *)dest + 9, zmm);
-	_mm512_stream_si512((__m512i *)dest + 10, zmm);
-	_mm512_stream_si512((__m512i *)dest + 11, zmm);
-	_mm512_stream_si512((__m512i *)dest + 12, zmm);
-	_mm512_stream_si512((__m512i *)dest + 13, zmm);
-	_mm512_stream_si512((__m512i *)dest + 14, zmm);
-	_mm512_stream_si512((__m512i *)dest + 15, zmm);
-	_mm512_stream_si512((__m512i *)dest + 16, zmm);
-	_mm512_stream_si512((__m512i *)dest + 17, zmm);
-	_mm512_stream_si512((__m512i *)dest + 18, zmm);
-	_mm512_stream_si512((__m512i *)dest + 19, zmm);
-	_mm512_stream_si512((__m512i *)dest + 20, zmm);
-	_mm512_stream_si512((__m512i *)dest + 21, zmm);
-	_mm512_stream_si512((__m512i *)dest + 22, zmm);
-	_mm512_stream_si512((__m512i *)dest + 23, zmm);
-	_mm512_stream_si512((__m512i *)dest + 24, zmm);
-	_mm512_stream_si512((__m512i *)dest + 25, zmm);
-	_mm512_stream_si512((__m512i *)dest + 26, zmm);
-	_mm512_stream_si512((__m512i *)dest + 27, zmm);
-	_mm512_stream_si512((__m512i *)dest + 28, zmm);
-	_mm512_stream_si512((__m512i *)dest + 29, zmm);
-	_mm512_stream_si512((__m512i *)dest + 30, zmm);
-	_mm512_stream_si512((__m512i *)dest + 31, zmm);
+	mm512_stream_si512(dest, 0, zmm);
+	mm512_stream_si512(dest, 1, zmm);
+	mm512_stream_si512(dest, 2, zmm);
+	mm512_stream_si512(dest, 3, zmm);
+	mm512_stream_si512(dest, 4, zmm);
+	mm512_stream_si512(dest, 5, zmm);
+	mm512_stream_si512(dest, 6, zmm);
+	mm512_stream_si512(dest, 7, zmm);
+	mm512_stream_si512(dest, 8, zmm);
+	mm512_stream_si512(dest, 9, zmm);
+	mm512_stream_si512(dest, 10, zmm);
+	mm512_stream_si512(dest, 11, zmm);
+	mm512_stream_si512(dest, 12, zmm);
+	mm512_stream_si512(dest, 13, zmm);
+	mm512_stream_si512(dest, 14, zmm);
+	mm512_stream_si512(dest, 15, zmm);
+	mm512_stream_si512(dest, 16, zmm);
+	mm512_stream_si512(dest, 17, zmm);
+	mm512_stream_si512(dest, 18, zmm);
+	mm512_stream_si512(dest, 19, zmm);
+	mm512_stream_si512(dest, 20, zmm);
+	mm512_stream_si512(dest, 21, zmm);
+	mm512_stream_si512(dest, 22, zmm);
+	mm512_stream_si512(dest, 23, zmm);
+	mm512_stream_si512(dest, 24, zmm);
+	mm512_stream_si512(dest, 25, zmm);
+	mm512_stream_si512(dest, 26, zmm);
+	mm512_stream_si512(dest, 27, zmm);
+	mm512_stream_si512(dest, 28, zmm);
+	mm512_stream_si512(dest, 29, zmm);
+	mm512_stream_si512(dest, 30, zmm);
+	mm512_stream_si512(dest, 31, zmm);
 }
 
 static force_inline void
 memset_movnt16x64b(char *dest, __m512i zmm)
 {
-	_mm512_stream_si512((__m512i *)dest + 0, zmm);
-	_mm512_stream_si512((__m512i *)dest + 1, zmm);
-	_mm512_stream_si512((__m512i *)dest + 2, zmm);
-	_mm512_stream_si512((__m512i *)dest + 3, zmm);
-	_mm512_stream_si512((__m512i *)dest + 4, zmm);
-	_mm512_stream_si512((__m512i *)dest + 5, zmm);
-	_mm512_stream_si512((__m512i *)dest + 6, zmm);
-	_mm512_stream_si512((__m512i *)dest + 7, zmm);
-	_mm512_stream_si512((__m512i *)dest + 8, zmm);
-	_mm512_stream_si512((__m512i *)dest + 9, zmm);
-	_mm512_stream_si512((__m512i *)dest + 10, zmm);
-	_mm512_stream_si512((__m512i *)dest + 11, zmm);
-	_mm512_stream_si512((__m512i *)dest + 12, zmm);
-	_mm512_stream_si512((__m512i *)dest + 13, zmm);
-	_mm512_stream_si512((__m512i *)dest + 14, zmm);
-	_mm512_stream_si512((__m512i *)dest + 15, zmm);
+	mm512_stream_si512(dest, 0, zmm);
+	mm512_stream_si512(dest, 1, zmm);
+	mm512_stream_si512(dest, 2, zmm);
+	mm512_stream_si512(dest, 3, zmm);
+	mm512_stream_si512(dest, 4, zmm);
+	mm512_stream_si512(dest, 5, zmm);
+	mm512_stream_si512(dest, 6, zmm);
+	mm512_stream_si512(dest, 7, zmm);
+	mm512_stream_si512(dest, 8, zmm);
+	mm512_stream_si512(dest, 9, zmm);
+	mm512_stream_si512(dest, 10, zmm);
+	mm512_stream_si512(dest, 11, zmm);
+	mm512_stream_si512(dest, 12, zmm);
+	mm512_stream_si512(dest, 13, zmm);
+	mm512_stream_si512(dest, 14, zmm);
+	mm512_stream_si512(dest, 15, zmm);
 }
 
 static force_inline void
 memset_movnt8x64b(char *dest, __m512i zmm)
 {
-	_mm512_stream_si512((__m512i *)dest + 0, zmm);
-	_mm512_stream_si512((__m512i *)dest + 1, zmm);
-	_mm512_stream_si512((__m512i *)dest + 2, zmm);
-	_mm512_stream_si512((__m512i *)dest + 3, zmm);
-	_mm512_stream_si512((__m512i *)dest + 4, zmm);
-	_mm512_stream_si512((__m512i *)dest + 5, zmm);
-	_mm512_stream_si512((__m512i *)dest + 6, zmm);
-	_mm512_stream_si512((__m512i *)dest + 7, zmm);
+	mm512_stream_si512(dest, 0, zmm);
+	mm512_stream_si512(dest, 1, zmm);
+	mm512_stream_si512(dest, 2, zmm);
+	mm512_stream_si512(dest, 3, zmm);
+	mm512_stream_si512(dest, 4, zmm);
+	mm512_stream_si512(dest, 5, zmm);
+	mm512_stream_si512(dest, 6, zmm);
+	mm512_stream_si512(dest, 7, zmm);
 }
 
 static force_inline void
 memset_movnt4x64b(char *dest, __m512i zmm)
 {
-	_mm512_stream_si512((__m512i *)dest + 0, zmm);
-	_mm512_stream_si512((__m512i *)dest + 1, zmm);
-	_mm512_stream_si512((__m512i *)dest + 2, zmm);
-	_mm512_stream_si512((__m512i *)dest + 3, zmm);
+	mm512_stream_si512(dest, 0, zmm);
+	mm512_stream_si512(dest, 1, zmm);
+	mm512_stream_si512(dest, 2, zmm);
+	mm512_stream_si512(dest, 3, zmm);
 }
 
 static force_inline void
 memset_movnt2x64b(char *dest, __m512i zmm)
 {
-	_mm512_stream_si512((__m512i *)dest + 0, zmm);
-	_mm512_stream_si512((__m512i *)dest + 1, zmm);
+	mm512_stream_si512(dest, 0, zmm);
+	mm512_stream_si512(dest, 1, zmm);
 }
 
 static force_inline void
 memset_movnt1x64b(char *dest, __m512i zmm)
 {
-	_mm512_stream_si512((__m512i *)dest + 0, zmm);
+	mm512_stream_si512(dest, 0, zmm);
 }
 
 static force_inline void

--- a/src/libpmem2/x86_64/memset/memset_nt_sse2.c
+++ b/src/libpmem2/x86_64/memset/memset_nt_sse2.c
@@ -16,6 +16,7 @@ static force_inline void
 mm_stream_si128(char *dest, unsigned idx, __m128i src)
 {
 	_mm_stream_si128((__m128i *)dest + idx, src);
+	barrier();
 }
 
 static force_inline void

--- a/src/libpmem2/x86_64/memset/memset_nt_sse2.c
+++ b/src/libpmem2/x86_64/memset/memset_nt_sse2.c
@@ -13,53 +13,59 @@
 #include "valgrind_internal.h"
 
 static force_inline void
+mm_stream_si128(char *dest, unsigned idx, __m128i src)
+{
+	_mm_stream_si128((__m128i *)dest + idx, src);
+}
+
+static force_inline void
 memset_movnt4x64b(char *dest, __m128i xmm)
 {
-	_mm_stream_si128((__m128i *)dest + 0, xmm);
-	_mm_stream_si128((__m128i *)dest + 1, xmm);
-	_mm_stream_si128((__m128i *)dest + 2, xmm);
-	_mm_stream_si128((__m128i *)dest + 3, xmm);
-	_mm_stream_si128((__m128i *)dest + 4, xmm);
-	_mm_stream_si128((__m128i *)dest + 5, xmm);
-	_mm_stream_si128((__m128i *)dest + 6, xmm);
-	_mm_stream_si128((__m128i *)dest + 7, xmm);
-	_mm_stream_si128((__m128i *)dest + 8, xmm);
-	_mm_stream_si128((__m128i *)dest + 9, xmm);
-	_mm_stream_si128((__m128i *)dest + 10, xmm);
-	_mm_stream_si128((__m128i *)dest + 11, xmm);
-	_mm_stream_si128((__m128i *)dest + 12, xmm);
-	_mm_stream_si128((__m128i *)dest + 13, xmm);
-	_mm_stream_si128((__m128i *)dest + 14, xmm);
-	_mm_stream_si128((__m128i *)dest + 15, xmm);
+	mm_stream_si128(dest, 0, xmm);
+	mm_stream_si128(dest, 1, xmm);
+	mm_stream_si128(dest, 2, xmm);
+	mm_stream_si128(dest, 3, xmm);
+	mm_stream_si128(dest, 4, xmm);
+	mm_stream_si128(dest, 5, xmm);
+	mm_stream_si128(dest, 6, xmm);
+	mm_stream_si128(dest, 7, xmm);
+	mm_stream_si128(dest, 8, xmm);
+	mm_stream_si128(dest, 9, xmm);
+	mm_stream_si128(dest, 10, xmm);
+	mm_stream_si128(dest, 11, xmm);
+	mm_stream_si128(dest, 12, xmm);
+	mm_stream_si128(dest, 13, xmm);
+	mm_stream_si128(dest, 14, xmm);
+	mm_stream_si128(dest, 15, xmm);
 }
 
 static force_inline void
 memset_movnt2x64b(char *dest, __m128i xmm)
 {
-	_mm_stream_si128((__m128i *)dest + 0, xmm);
-	_mm_stream_si128((__m128i *)dest + 1, xmm);
-	_mm_stream_si128((__m128i *)dest + 2, xmm);
-	_mm_stream_si128((__m128i *)dest + 3, xmm);
-	_mm_stream_si128((__m128i *)dest + 4, xmm);
-	_mm_stream_si128((__m128i *)dest + 5, xmm);
-	_mm_stream_si128((__m128i *)dest + 6, xmm);
-	_mm_stream_si128((__m128i *)dest + 7, xmm);
+	mm_stream_si128(dest, 0, xmm);
+	mm_stream_si128(dest, 1, xmm);
+	mm_stream_si128(dest, 2, xmm);
+	mm_stream_si128(dest, 3, xmm);
+	mm_stream_si128(dest, 4, xmm);
+	mm_stream_si128(dest, 5, xmm);
+	mm_stream_si128(dest, 6, xmm);
+	mm_stream_si128(dest, 7, xmm);
 }
 
 static force_inline void
 memset_movnt1x64b(char *dest, __m128i xmm)
 {
-	_mm_stream_si128((__m128i *)dest + 0, xmm);
-	_mm_stream_si128((__m128i *)dest + 1, xmm);
-	_mm_stream_si128((__m128i *)dest + 2, xmm);
-	_mm_stream_si128((__m128i *)dest + 3, xmm);
+	mm_stream_si128(dest, 0, xmm);
+	mm_stream_si128(dest, 1, xmm);
+	mm_stream_si128(dest, 2, xmm);
+	mm_stream_si128(dest, 3, xmm);
 }
 
 static force_inline void
 memset_movnt1x32b(char *dest, __m128i xmm)
 {
-	_mm_stream_si128((__m128i *)dest + 0, xmm);
-	_mm_stream_si128((__m128i *)dest + 1, xmm);
+	mm_stream_si128(dest, 0, xmm);
+	mm_stream_si128(dest, 1, xmm);
 }
 
 static force_inline void

--- a/src/libpmem2/x86_64/memset/memset_t_avx.c
+++ b/src/libpmem2/x86_64/memset/memset_t_avx.c
@@ -12,24 +12,30 @@
 #include "memset_avx.h"
 
 static force_inline void
+mm256_store_si256(char *dest, unsigned idx, __m256i src)
+{
+	_mm256_store_si256((__m256i *)dest + idx, src);
+}
+
+static force_inline void
 memset_mov8x64b(char *dest, __m256i ymm, flush64b_fn flush64b)
 {
-	_mm256_store_si256((__m256i *)dest + 0, ymm);
-	_mm256_store_si256((__m256i *)dest + 1, ymm);
-	_mm256_store_si256((__m256i *)dest + 2, ymm);
-	_mm256_store_si256((__m256i *)dest + 3, ymm);
-	_mm256_store_si256((__m256i *)dest + 4, ymm);
-	_mm256_store_si256((__m256i *)dest + 5, ymm);
-	_mm256_store_si256((__m256i *)dest + 6, ymm);
-	_mm256_store_si256((__m256i *)dest + 7, ymm);
-	_mm256_store_si256((__m256i *)dest + 8, ymm);
-	_mm256_store_si256((__m256i *)dest + 9, ymm);
-	_mm256_store_si256((__m256i *)dest + 10, ymm);
-	_mm256_store_si256((__m256i *)dest + 11, ymm);
-	_mm256_store_si256((__m256i *)dest + 12, ymm);
-	_mm256_store_si256((__m256i *)dest + 13, ymm);
-	_mm256_store_si256((__m256i *)dest + 14, ymm);
-	_mm256_store_si256((__m256i *)dest + 15, ymm);
+	mm256_store_si256(dest, 0, ymm);
+	mm256_store_si256(dest, 1, ymm);
+	mm256_store_si256(dest, 2, ymm);
+	mm256_store_si256(dest, 3, ymm);
+	mm256_store_si256(dest, 4, ymm);
+	mm256_store_si256(dest, 5, ymm);
+	mm256_store_si256(dest, 6, ymm);
+	mm256_store_si256(dest, 7, ymm);
+	mm256_store_si256(dest, 8, ymm);
+	mm256_store_si256(dest, 9, ymm);
+	mm256_store_si256(dest, 10, ymm);
+	mm256_store_si256(dest, 11, ymm);
+	mm256_store_si256(dest, 12, ymm);
+	mm256_store_si256(dest, 13, ymm);
+	mm256_store_si256(dest, 14, ymm);
+	mm256_store_si256(dest, 15, ymm);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -44,14 +50,14 @@ memset_mov8x64b(char *dest, __m256i ymm, flush64b_fn flush64b)
 static force_inline void
 memset_mov4x64b(char *dest, __m256i ymm, flush64b_fn flush64b)
 {
-	_mm256_store_si256((__m256i *)dest + 0, ymm);
-	_mm256_store_si256((__m256i *)dest + 1, ymm);
-	_mm256_store_si256((__m256i *)dest + 2, ymm);
-	_mm256_store_si256((__m256i *)dest + 3, ymm);
-	_mm256_store_si256((__m256i *)dest + 4, ymm);
-	_mm256_store_si256((__m256i *)dest + 5, ymm);
-	_mm256_store_si256((__m256i *)dest + 6, ymm);
-	_mm256_store_si256((__m256i *)dest + 7, ymm);
+	mm256_store_si256(dest, 0, ymm);
+	mm256_store_si256(dest, 1, ymm);
+	mm256_store_si256(dest, 2, ymm);
+	mm256_store_si256(dest, 3, ymm);
+	mm256_store_si256(dest, 4, ymm);
+	mm256_store_si256(dest, 5, ymm);
+	mm256_store_si256(dest, 6, ymm);
+	mm256_store_si256(dest, 7, ymm);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -62,10 +68,10 @@ memset_mov4x64b(char *dest, __m256i ymm, flush64b_fn flush64b)
 static force_inline void
 memset_mov2x64b(char *dest, __m256i ymm, flush64b_fn flush64b)
 {
-	_mm256_store_si256((__m256i *)dest + 0, ymm);
-	_mm256_store_si256((__m256i *)dest + 1, ymm);
-	_mm256_store_si256((__m256i *)dest + 2, ymm);
-	_mm256_store_si256((__m256i *)dest + 3, ymm);
+	mm256_store_si256(dest, 0, ymm);
+	mm256_store_si256(dest, 1, ymm);
+	mm256_store_si256(dest, 2, ymm);
+	mm256_store_si256(dest, 3, ymm);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -74,8 +80,8 @@ memset_mov2x64b(char *dest, __m256i ymm, flush64b_fn flush64b)
 static force_inline void
 memset_mov1x64b(char *dest, __m256i ymm, flush64b_fn flush64b)
 {
-	_mm256_store_si256((__m256i *)dest + 0, ymm);
-	_mm256_store_si256((__m256i *)dest + 1, ymm);
+	mm256_store_si256(dest, 0, ymm);
+	mm256_store_si256(dest, 1, ymm);
 
 	flush64b(dest + 0 * 64);
 }

--- a/src/libpmem2/x86_64/memset/memset_t_avx512f.c
+++ b/src/libpmem2/x86_64/memset/memset_t_avx512f.c
@@ -12,40 +12,46 @@
 #include "memset_avx512f.h"
 
 static force_inline void
+mm512_store_si512(char *dest, unsigned idx, __m512i src)
+{
+	_mm512_store_si512((__m512i *)dest + idx, src);
+}
+
+static force_inline void
 memset_mov32x64b(char *dest, __m512i zmm, flush64b_fn flush64b)
 {
-	_mm512_store_si512((__m512i *)dest + 0, zmm);
-	_mm512_store_si512((__m512i *)dest + 1, zmm);
-	_mm512_store_si512((__m512i *)dest + 2, zmm);
-	_mm512_store_si512((__m512i *)dest + 3, zmm);
-	_mm512_store_si512((__m512i *)dest + 4, zmm);
-	_mm512_store_si512((__m512i *)dest + 5, zmm);
-	_mm512_store_si512((__m512i *)dest + 6, zmm);
-	_mm512_store_si512((__m512i *)dest + 7, zmm);
-	_mm512_store_si512((__m512i *)dest + 8, zmm);
-	_mm512_store_si512((__m512i *)dest + 9, zmm);
-	_mm512_store_si512((__m512i *)dest + 10, zmm);
-	_mm512_store_si512((__m512i *)dest + 11, zmm);
-	_mm512_store_si512((__m512i *)dest + 12, zmm);
-	_mm512_store_si512((__m512i *)dest + 13, zmm);
-	_mm512_store_si512((__m512i *)dest + 14, zmm);
-	_mm512_store_si512((__m512i *)dest + 15, zmm);
-	_mm512_store_si512((__m512i *)dest + 16, zmm);
-	_mm512_store_si512((__m512i *)dest + 17, zmm);
-	_mm512_store_si512((__m512i *)dest + 18, zmm);
-	_mm512_store_si512((__m512i *)dest + 19, zmm);
-	_mm512_store_si512((__m512i *)dest + 20, zmm);
-	_mm512_store_si512((__m512i *)dest + 21, zmm);
-	_mm512_store_si512((__m512i *)dest + 22, zmm);
-	_mm512_store_si512((__m512i *)dest + 23, zmm);
-	_mm512_store_si512((__m512i *)dest + 24, zmm);
-	_mm512_store_si512((__m512i *)dest + 25, zmm);
-	_mm512_store_si512((__m512i *)dest + 26, zmm);
-	_mm512_store_si512((__m512i *)dest + 27, zmm);
-	_mm512_store_si512((__m512i *)dest + 28, zmm);
-	_mm512_store_si512((__m512i *)dest + 29, zmm);
-	_mm512_store_si512((__m512i *)dest + 30, zmm);
-	_mm512_store_si512((__m512i *)dest + 31, zmm);
+	mm512_store_si512(dest, 0, zmm);
+	mm512_store_si512(dest, 1, zmm);
+	mm512_store_si512(dest, 2, zmm);
+	mm512_store_si512(dest, 3, zmm);
+	mm512_store_si512(dest, 4, zmm);
+	mm512_store_si512(dest, 5, zmm);
+	mm512_store_si512(dest, 6, zmm);
+	mm512_store_si512(dest, 7, zmm);
+	mm512_store_si512(dest, 8, zmm);
+	mm512_store_si512(dest, 9, zmm);
+	mm512_store_si512(dest, 10, zmm);
+	mm512_store_si512(dest, 11, zmm);
+	mm512_store_si512(dest, 12, zmm);
+	mm512_store_si512(dest, 13, zmm);
+	mm512_store_si512(dest, 14, zmm);
+	mm512_store_si512(dest, 15, zmm);
+	mm512_store_si512(dest, 16, zmm);
+	mm512_store_si512(dest, 17, zmm);
+	mm512_store_si512(dest, 18, zmm);
+	mm512_store_si512(dest, 19, zmm);
+	mm512_store_si512(dest, 20, zmm);
+	mm512_store_si512(dest, 21, zmm);
+	mm512_store_si512(dest, 22, zmm);
+	mm512_store_si512(dest, 23, zmm);
+	mm512_store_si512(dest, 24, zmm);
+	mm512_store_si512(dest, 25, zmm);
+	mm512_store_si512(dest, 26, zmm);
+	mm512_store_si512(dest, 27, zmm);
+	mm512_store_si512(dest, 28, zmm);
+	mm512_store_si512(dest, 29, zmm);
+	mm512_store_si512(dest, 30, zmm);
+	mm512_store_si512(dest, 31, zmm);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -84,22 +90,22 @@ memset_mov32x64b(char *dest, __m512i zmm, flush64b_fn flush64b)
 static force_inline void
 memset_mov16x64b(char *dest, __m512i zmm, flush64b_fn flush64b)
 {
-	_mm512_store_si512((__m512i *)dest + 0, zmm);
-	_mm512_store_si512((__m512i *)dest + 1, zmm);
-	_mm512_store_si512((__m512i *)dest + 2, zmm);
-	_mm512_store_si512((__m512i *)dest + 3, zmm);
-	_mm512_store_si512((__m512i *)dest + 4, zmm);
-	_mm512_store_si512((__m512i *)dest + 5, zmm);
-	_mm512_store_si512((__m512i *)dest + 6, zmm);
-	_mm512_store_si512((__m512i *)dest + 7, zmm);
-	_mm512_store_si512((__m512i *)dest + 8, zmm);
-	_mm512_store_si512((__m512i *)dest + 9, zmm);
-	_mm512_store_si512((__m512i *)dest + 10, zmm);
-	_mm512_store_si512((__m512i *)dest + 11, zmm);
-	_mm512_store_si512((__m512i *)dest + 12, zmm);
-	_mm512_store_si512((__m512i *)dest + 13, zmm);
-	_mm512_store_si512((__m512i *)dest + 14, zmm);
-	_mm512_store_si512((__m512i *)dest + 15, zmm);
+	mm512_store_si512(dest, 0, zmm);
+	mm512_store_si512(dest, 1, zmm);
+	mm512_store_si512(dest, 2, zmm);
+	mm512_store_si512(dest, 3, zmm);
+	mm512_store_si512(dest, 4, zmm);
+	mm512_store_si512(dest, 5, zmm);
+	mm512_store_si512(dest, 6, zmm);
+	mm512_store_si512(dest, 7, zmm);
+	mm512_store_si512(dest, 8, zmm);
+	mm512_store_si512(dest, 9, zmm);
+	mm512_store_si512(dest, 10, zmm);
+	mm512_store_si512(dest, 11, zmm);
+	mm512_store_si512(dest, 12, zmm);
+	mm512_store_si512(dest, 13, zmm);
+	mm512_store_si512(dest, 14, zmm);
+	mm512_store_si512(dest, 15, zmm);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -122,14 +128,14 @@ memset_mov16x64b(char *dest, __m512i zmm, flush64b_fn flush64b)
 static force_inline void
 memset_mov8x64b(char *dest, __m512i zmm, flush64b_fn flush64b)
 {
-	_mm512_store_si512((__m512i *)dest + 0, zmm);
-	_mm512_store_si512((__m512i *)dest + 1, zmm);
-	_mm512_store_si512((__m512i *)dest + 2, zmm);
-	_mm512_store_si512((__m512i *)dest + 3, zmm);
-	_mm512_store_si512((__m512i *)dest + 4, zmm);
-	_mm512_store_si512((__m512i *)dest + 5, zmm);
-	_mm512_store_si512((__m512i *)dest + 6, zmm);
-	_mm512_store_si512((__m512i *)dest + 7, zmm);
+	mm512_store_si512(dest, 0, zmm);
+	mm512_store_si512(dest, 1, zmm);
+	mm512_store_si512(dest, 2, zmm);
+	mm512_store_si512(dest, 3, zmm);
+	mm512_store_si512(dest, 4, zmm);
+	mm512_store_si512(dest, 5, zmm);
+	mm512_store_si512(dest, 6, zmm);
+	mm512_store_si512(dest, 7, zmm);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -144,10 +150,10 @@ memset_mov8x64b(char *dest, __m512i zmm, flush64b_fn flush64b)
 static force_inline void
 memset_mov4x64b(char *dest, __m512i zmm, flush64b_fn flush64b)
 {
-	_mm512_store_si512((__m512i *)dest + 0, zmm);
-	_mm512_store_si512((__m512i *)dest + 1, zmm);
-	_mm512_store_si512((__m512i *)dest + 2, zmm);
-	_mm512_store_si512((__m512i *)dest + 3, zmm);
+	mm512_store_si512(dest, 0, zmm);
+	mm512_store_si512(dest, 1, zmm);
+	mm512_store_si512(dest, 2, zmm);
+	mm512_store_si512(dest, 3, zmm);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -158,8 +164,8 @@ memset_mov4x64b(char *dest, __m512i zmm, flush64b_fn flush64b)
 static force_inline void
 memset_mov2x64b(char *dest, __m512i zmm, flush64b_fn flush64b)
 {
-	_mm512_store_si512((__m512i *)dest + 0, zmm);
-	_mm512_store_si512((__m512i *)dest + 1, zmm);
+	mm512_store_si512(dest, 0, zmm);
+	mm512_store_si512(dest, 1, zmm);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -168,7 +174,7 @@ memset_mov2x64b(char *dest, __m512i zmm, flush64b_fn flush64b)
 static force_inline void
 memset_mov1x64b(char *dest, __m512i zmm, flush64b_fn flush64b)
 {
-	_mm512_store_si512((__m512i *)dest + 0, zmm);
+	mm512_store_si512(dest, 0, zmm);
 
 	flush64b(dest + 0 * 64);
 }

--- a/src/libpmem2/x86_64/memset/memset_t_sse2.c
+++ b/src/libpmem2/x86_64/memset/memset_t_sse2.c
@@ -11,24 +11,30 @@
 #include "memset_sse2.h"
 
 static force_inline void
+mm_store_si128(char *dest, unsigned idx, __m128i src)
+{
+	_mm_store_si128((__m128i *)dest + idx, src);
+}
+
+static force_inline void
 memset_mov4x64b(char *dest, __m128i xmm, flush64b_fn flush64b)
 {
-	_mm_store_si128((__m128i *)dest + 0, xmm);
-	_mm_store_si128((__m128i *)dest + 1, xmm);
-	_mm_store_si128((__m128i *)dest + 2, xmm);
-	_mm_store_si128((__m128i *)dest + 3, xmm);
-	_mm_store_si128((__m128i *)dest + 4, xmm);
-	_mm_store_si128((__m128i *)dest + 5, xmm);
-	_mm_store_si128((__m128i *)dest + 6, xmm);
-	_mm_store_si128((__m128i *)dest + 7, xmm);
-	_mm_store_si128((__m128i *)dest + 8, xmm);
-	_mm_store_si128((__m128i *)dest + 9, xmm);
-	_mm_store_si128((__m128i *)dest + 10, xmm);
-	_mm_store_si128((__m128i *)dest + 11, xmm);
-	_mm_store_si128((__m128i *)dest + 12, xmm);
-	_mm_store_si128((__m128i *)dest + 13, xmm);
-	_mm_store_si128((__m128i *)dest + 14, xmm);
-	_mm_store_si128((__m128i *)dest + 15, xmm);
+	mm_store_si128(dest, 0, xmm);
+	mm_store_si128(dest, 1, xmm);
+	mm_store_si128(dest, 2, xmm);
+	mm_store_si128(dest, 3, xmm);
+	mm_store_si128(dest, 4, xmm);
+	mm_store_si128(dest, 5, xmm);
+	mm_store_si128(dest, 6, xmm);
+	mm_store_si128(dest, 7, xmm);
+	mm_store_si128(dest, 8, xmm);
+	mm_store_si128(dest, 9, xmm);
+	mm_store_si128(dest, 10, xmm);
+	mm_store_si128(dest, 11, xmm);
+	mm_store_si128(dest, 12, xmm);
+	mm_store_si128(dest, 13, xmm);
+	mm_store_si128(dest, 14, xmm);
+	mm_store_si128(dest, 15, xmm);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -39,14 +45,14 @@ memset_mov4x64b(char *dest, __m128i xmm, flush64b_fn flush64b)
 static force_inline void
 memset_mov2x64b(char *dest, __m128i xmm, flush64b_fn flush64b)
 {
-	_mm_store_si128((__m128i *)dest + 0, xmm);
-	_mm_store_si128((__m128i *)dest + 1, xmm);
-	_mm_store_si128((__m128i *)dest + 2, xmm);
-	_mm_store_si128((__m128i *)dest + 3, xmm);
-	_mm_store_si128((__m128i *)dest + 4, xmm);
-	_mm_store_si128((__m128i *)dest + 5, xmm);
-	_mm_store_si128((__m128i *)dest + 6, xmm);
-	_mm_store_si128((__m128i *)dest + 7, xmm);
+	mm_store_si128(dest, 0, xmm);
+	mm_store_si128(dest, 1, xmm);
+	mm_store_si128(dest, 2, xmm);
+	mm_store_si128(dest, 3, xmm);
+	mm_store_si128(dest, 4, xmm);
+	mm_store_si128(dest, 5, xmm);
+	mm_store_si128(dest, 6, xmm);
+	mm_store_si128(dest, 7, xmm);
 
 	flush64b(dest + 0 * 64);
 	flush64b(dest + 1 * 64);
@@ -55,10 +61,10 @@ memset_mov2x64b(char *dest, __m128i xmm, flush64b_fn flush64b)
 static force_inline void
 memset_mov1x64b(char *dest, __m128i xmm, flush64b_fn flush64b)
 {
-	_mm_store_si128((__m128i *)dest + 0, xmm);
-	_mm_store_si128((__m128i *)dest + 1, xmm);
-	_mm_store_si128((__m128i *)dest + 2, xmm);
-	_mm_store_si128((__m128i *)dest + 3, xmm);
+	mm_store_si128(dest, 0, xmm);
+	mm_store_si128(dest, 1, xmm);
+	mm_store_si128(dest, 2, xmm);
+	mm_store_si128(dest, 3, xmm);
 
 	flush64b(dest + 0 * 64);
 }


### PR DESCRIPTION
Some compilers do some silly reordering which sadly affects CPU
ability to use write-combining buffers.

---
The first patch is a cleanup and doesn't change any generated code.
The second patch is the actual change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4746)
<!-- Reviewable:end -->
