### PR TITLE
common: change appveyor image version to 2019 and delete sln sort check

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 1.4.{build}
-os: Visual Studio 2017
+os: Visual Studio 2019
 platform: x64
 
 install:
@@ -29,10 +29,6 @@ before_build:
                 exit 1
         }
         utils/ps_analyze.ps1
-        if ($LASTEXITCODE -ne 0) {
-                exit 1
-        }
-        perl utils/sort_solution check
         if ($LASTEXITCODE -ne 0) {
                 exit 1
         }


### PR DESCRIPTION
Image version change is needed for VirtualAlloc2 function. Sort check is done on gh actions. Appveyor with image 2019 has a problem with our sorting perl script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4747)
<!-- Reviewable:end -->
