### PR TITLE
test: fix UT_ASSERTinfo_rt() macro

### DIFF
--- a/src/test/unittest/unittest.h
+++ b/src/test/unittest/unittest.h
@@ -201,7 +201,7 @@ void ut_err(const char *file, int line, const char *func,
 /* assertion with extra info printed if assertion fails at runtime */
 #define UT_ASSERTinfo_rt(cnd, info) \
 	((void)((cnd) || (ut_fatal(__FILE__, __LINE__, __func__,\
-	"assertion failure: %s (%s = %s)", #cnd, #info, info), 0)))
+	"assertion failure: %s (%s)", #cnd, info), 0)))
 
 /* assert two integer values are equal at runtime */
 #define UT_ASSERTeq_rt(lhs, rhs)\


### PR DESCRIPTION
The command:
```
UT_ASSERTinfo_rt(0 == 1, "text");
```
prints out two messages now:
```
Error: assertion failure: 0 == 1 ("text" = text)
```
and with this patch only one:
```
Error: assertion failure: 0 == 1 (text)
```

---
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4752)
<!-- Reviewable:end -->
