### PR TITLE
pmem2: remove redundant NULL-check

### DIFF
--- a/src/libpmem2/extent_linux.c
+++ b/src/libpmem2/extent_linux.c
@@ -139,10 +139,8 @@ pmem2_extents_create_get(int fd, struct extents **exts)
 	return 0;
 
 error_free:
-	if (pexts) {
-		Free(pexts->extents);
-		Free(pexts);
-	}
+	Free(pexts->extents);
+	Free(pexts);
 	Free(fmap);
 
 	return ret;


### PR DESCRIPTION
This redundant NULL-check misleads readers and static code analyzers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4762)
<!-- Reviewable:end -->
