### PR TITLE
pmem2: fix regression in badblocks_get()

### DIFF
--- a/src/libpmem2/badblocks_ndctl.c
+++ b/src/libpmem2/badblocks_ndctl.c
@@ -552,7 +552,7 @@ badblocks_get(const char *file, struct badblocks *bbs)
 				bbs->bbv[b].length);
 		}
 
-		goto exit_free_all;
+		goto exit_free_exts;
 	}
 
 	bb_found = 0;
@@ -623,8 +623,6 @@ error_free_all:
 	bbs->bb_cnt = 0;
 
 exit_free_all:
-	pmem2_extents_destroy(&exts);
-
 	if (bb_found > 0) {
 		bbs->bbv = VEC_ARR(&bbv);
 		bbs->bb_cnt = (unsigned)VEC_SIZE(&bbv);
@@ -634,6 +632,9 @@ exit_free_all:
 		/* sanity check */
 		ASSERTeq((unsigned)bb_found, bbs->bb_cnt);
 	}
+
+exit_free_exts:
+	pmem2_extents_destroy(&exts);
 
 	if (fd != -1)
 		close(fd);


### PR DESCRIPTION
Fix regression in badblocks_get() introduced by the commit 831d125.

Now (b773100) the condition in the line no. 628 looks like:
```
   if (bb_found > 0) {
```
Earlier, before the commit 831d125, it looked like:
```
   if (extents > 0 && bb_found > 0) {
```
so it was false for DAX devices (which have no extents).

Now the array of bad blocks in a DAX device (bbs) is cleared
and zeroed in the above 'if' condition (lines no. 629-630)
by being assigned to the empty in this case 'bbv' vector.

This patch adds the new `exit_free_exts` label,
so this 'if' condition is skipped for DAX devices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4764)
<!-- Reviewable:end -->
