### PR TITLE
common: exclude envconfig.py from style checking

### DIFF
--- a/utils/style_check.sh
+++ b/utils/style_check.sh
@@ -86,7 +86,7 @@ function run_flake8() {
 	if [ $# -eq 0 ]; then
 		return
 	fi
-	${flake8_bin} --exclude=testconfig.py $@
+	${flake8_bin} --exclude=testconfig.py,envconfig.py $@
 }
 
 for ((i=1; i<$#; i++)) {


### PR DESCRIPTION
envconfig.py is an autogenerated file and it can have
too long lines inside:
```
envconfig.py:6:80: E501 line too long (104 > 79 characters)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4771)
<!-- Reviewable:end -->
