### PR TITLE
obj: cache run bitmap data for use during allocation

### DIFF
--- a/src/libpmemobj/alloc_class.h
+++ b/src/libpmemobj/alloc_class.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2016-2019, Intel Corporation */
+/* Copyright 2016-2020, Intel Corporation */
 
 /*
  * alloc_class.h -- internal definitions for allocation classes
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include <sys/types.h>
 #include "heap_layout.h"
+#include "memblock.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,11 +42,7 @@ struct alloc_class {
 	enum alloc_class_type type;
 
 	/* run-specific data */
-	struct {
-		uint32_t size_idx; /* size index of a single run instance */
-		size_t alignment; /* required alignment of objects */
-		unsigned nallocs; /* number of allocs per run */
-	} run;
+	struct run_descriptor rdsc;
 };
 
 struct alloc_class_collection *alloc_class_collection_new(void);

--- a/src/libpmemobj/pmalloc.c
+++ b/src/libpmemobj/pmalloc.c
@@ -305,7 +305,7 @@ CTL_WRITE_HANDLER(desc)(void *ctx,
 	}
 
 	p->class_id = c->id;
-	p->units_per_block = c->run.nallocs;
+	p->units_per_block = c->rdsc.nallocs;
 
 	return 0;
 }
@@ -382,11 +382,11 @@ CTL_READ_HANDLER(desc)(void *ctx,
 	}
 
 	struct pobj_alloc_class_desc *p = arg;
-	p->units_per_block = c->type == CLASS_HUGE ? 0 : c->run.nallocs;
+	p->units_per_block = c->type == CLASS_HUGE ? 0 : c->rdsc.nallocs;
 	p->header_type = user_htype;
 	p->unit_size = c->unit_size;
 	p->class_id = c->id;
-	p->alignment = c->flags & CHUNK_FLAG_ALIGNED ? c->run.alignment : 0;
+	p->alignment = c->flags & CHUNK_FLAG_ALIGNED ? c->rdsc.alignment : 0;
 
 	return 0;
 }


### PR DESCRIPTION
Recalculating bitmap information was one of the most costly
operations performed during allocation. This patch eliminates
that cost by caching the bitmap data in the allocation class
instance, eliminating the need for costly computations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4773)
<!-- Reviewable:end -->
