### PR TITLE
pmem/pmem2: optimize NT mem[cpy|set] for SSE2 and AVX

### DIFF
--- a/src/libpmem2/x86_64/cpu.c
+++ b/src/libpmem2/x86_64/cpu.c
@@ -88,6 +88,32 @@ is_cpu_feature_present(unsigned func, unsigned reg, unsigned bit)
 }
 
 /*
+ * is_cpu_genuine_intel -- checks for genuine Intel CPU
+ */
+int
+is_cpu_genuine_intel(void)
+{
+	unsigned cpuinfo[4] = { 0 };
+
+	union {
+		char name[0x20];
+		unsigned cpuinfo[3];
+	} vendor;
+
+	memset(&vendor, 0, sizeof(vendor));
+
+	cpuid(0x0, 0x0, cpuinfo);
+
+	vendor.cpuinfo[0] = cpuinfo[EBX_IDX];
+	vendor.cpuinfo[1] = cpuinfo[EDX_IDX];
+	vendor.cpuinfo[2] = cpuinfo[ECX_IDX];
+
+	LOG(4, "CPU vendor: %s", vendor.name);
+	return (strncmp(vendor.name, "GenuineIntel",
+				sizeof(vendor.name))) == 0;
+}
+
+/*
  * is_cpu_clflush_present -- checks if CLFLUSH instruction is supported
  */
 int

--- a/src/libpmem2/x86_64/cpu.h
+++ b/src/libpmem2/x86_64/cpu.h
@@ -8,6 +8,7 @@
  * cpu.h -- definitions for "cpu" module
  */
 
+int is_cpu_genuine_intel(void);
 int is_cpu_clflush_present(void);
 int is_cpu_clflushopt_present(void);
 int is_cpu_clwb_present(void);

--- a/src/libpmem2/x86_64/memcpy/memcpy_nt_avx.c
+++ b/src/libpmem2/x86_64/memcpy/memcpy_nt_avx.c
@@ -336,8 +336,56 @@ memmove_movnt_avx(char *dest, const char *src, size_t len, flush_fn flush,
 	VALGRIND_DO_FLUSH(dest, len);
 }
 
+/* variants without perf_barrier */
+
 void
-memmove_movnt_avx_noflush(char *dest, const char *src, size_t len)
+memmove_movnt_avx_noflush_nobarrier(char *dest, const char *src, size_t len)
+{
+	LOG(15, "dest %p src %p len %zu", dest, src, len);
+
+	memmove_movnt_avx(dest, src, len, noflush, barrier_after_ntstores,
+			no_barrier);
+}
+
+void
+memmove_movnt_avx_empty_nobarrier(char *dest, const char *src, size_t len)
+{
+	LOG(15, "dest %p src %p len %zu", dest, src, len);
+
+	memmove_movnt_avx(dest, src, len, flush_empty_nolog,
+			barrier_after_ntstores, no_barrier);
+}
+void
+memmove_movnt_avx_clflush_nobarrier(char *dest, const char *src, size_t len)
+{
+	LOG(15, "dest %p src %p len %zu", dest, src, len);
+
+	memmove_movnt_avx(dest, src, len, flush_clflush_nolog,
+			barrier_after_ntstores, no_barrier);
+}
+
+void
+memmove_movnt_avx_clflushopt_nobarrier(char *dest, const char *src, size_t len)
+{
+	LOG(15, "dest %p src %p len %zu", dest, src, len);
+
+	memmove_movnt_avx(dest, src, len, flush_clflushopt_nolog,
+			no_barrier_after_ntstores, no_barrier);
+}
+
+void
+memmove_movnt_avx_clwb_nobarrier(char *dest, const char *src, size_t len)
+{
+	LOG(15, "dest %p src %p len %zu", dest, src, len);
+
+	memmove_movnt_avx(dest, src, len, flush_clwb_nolog,
+			no_barrier_after_ntstores, no_barrier);
+}
+
+/* variants with perf_barrier */
+
+void
+memmove_movnt_avx_noflush_wcbarrier(char *dest, const char *src, size_t len)
 {
 	LOG(15, "dest %p src %p len %zu", dest, src, len);
 
@@ -346,7 +394,7 @@ memmove_movnt_avx_noflush(char *dest, const char *src, size_t len)
 }
 
 void
-memmove_movnt_avx_empty(char *dest, const char *src, size_t len)
+memmove_movnt_avx_empty_wcbarrier(char *dest, const char *src, size_t len)
 {
 	LOG(15, "dest %p src %p len %zu", dest, src, len);
 
@@ -354,7 +402,7 @@ memmove_movnt_avx_empty(char *dest, const char *src, size_t len)
 			barrier_after_ntstores, wc_barrier);
 }
 void
-memmove_movnt_avx_clflush(char *dest, const char *src, size_t len)
+memmove_movnt_avx_clflush_wcbarrier(char *dest, const char *src, size_t len)
 {
 	LOG(15, "dest %p src %p len %zu", dest, src, len);
 
@@ -363,7 +411,7 @@ memmove_movnt_avx_clflush(char *dest, const char *src, size_t len)
 }
 
 void
-memmove_movnt_avx_clflushopt(char *dest, const char *src, size_t len)
+memmove_movnt_avx_clflushopt_wcbarrier(char *dest, const char *src, size_t len)
 {
 	LOG(15, "dest %p src %p len %zu", dest, src, len);
 
@@ -372,7 +420,7 @@ memmove_movnt_avx_clflushopt(char *dest, const char *src, size_t len)
 }
 
 void
-memmove_movnt_avx_clwb(char *dest, const char *src, size_t len)
+memmove_movnt_avx_clwb_wcbarrier(char *dest, const char *src, size_t len)
 {
 	LOG(15, "dest %p src %p len %zu", dest, src, len);
 

--- a/src/libpmem2/x86_64/memcpy/memcpy_nt_sse2.c
+++ b/src/libpmem2/x86_64/memcpy/memcpy_nt_sse2.c
@@ -319,8 +319,57 @@ memmove_movnt_sse2(char *dest, const char *src, size_t len, flush_fn flush,
 	VALGRIND_DO_FLUSH(dest, len);
 }
 
+/* variants without perf_barrier */
+
 void
-memmove_movnt_sse2_noflush(char *dest, const char *src, size_t len)
+memmove_movnt_sse2_noflush_nobarrier(char *dest, const char *src, size_t len)
+{
+	LOG(15, "dest %p src %p len %zu", dest, src, len);
+
+	memmove_movnt_sse2(dest, src, len, noflush, barrier_after_ntstores,
+			no_barrier);
+}
+
+void
+memmove_movnt_sse2_empty_nobarrier(char *dest, const char *src, size_t len)
+{
+	LOG(15, "dest %p src %p len %zu", dest, src, len);
+
+	memmove_movnt_sse2(dest, src, len, flush_empty_nolog,
+			barrier_after_ntstores, no_barrier);
+}
+
+void
+memmove_movnt_sse2_clflush_nobarrier(char *dest, const char *src, size_t len)
+{
+	LOG(15, "dest %p src %p len %zu", dest, src, len);
+
+	memmove_movnt_sse2(dest, src, len, flush_clflush_nolog,
+			barrier_after_ntstores, no_barrier);
+}
+
+void
+memmove_movnt_sse2_clflushopt_nobarrier(char *dest, const char *src, size_t len)
+{
+	LOG(15, "dest %p src %p len %zu", dest, src, len);
+
+	memmove_movnt_sse2(dest, src, len, flush_clflushopt_nolog,
+			no_barrier_after_ntstores, no_barrier);
+}
+
+void
+memmove_movnt_sse2_clwb_nobarrier(char *dest, const char *src, size_t len)
+{
+	LOG(15, "dest %p src %p len %zu", dest, src, len);
+
+	memmove_movnt_sse2(dest, src, len, flush_clwb_nolog,
+			no_barrier_after_ntstores, no_barrier);
+}
+
+/* variants with perf_barrier */
+
+void
+memmove_movnt_sse2_noflush_wcbarrier(char *dest, const char *src, size_t len)
 {
 	LOG(15, "dest %p src %p len %zu", dest, src, len);
 
@@ -329,7 +378,7 @@ memmove_movnt_sse2_noflush(char *dest, const char *src, size_t len)
 }
 
 void
-memmove_movnt_sse2_empty(char *dest, const char *src, size_t len)
+memmove_movnt_sse2_empty_wcbarrier(char *dest, const char *src, size_t len)
 {
 	LOG(15, "dest %p src %p len %zu", dest, src, len);
 
@@ -338,7 +387,7 @@ memmove_movnt_sse2_empty(char *dest, const char *src, size_t len)
 }
 
 void
-memmove_movnt_sse2_clflush(char *dest, const char *src, size_t len)
+memmove_movnt_sse2_clflush_wcbarrier(char *dest, const char *src, size_t len)
 {
 	LOG(15, "dest %p src %p len %zu", dest, src, len);
 
@@ -347,7 +396,7 @@ memmove_movnt_sse2_clflush(char *dest, const char *src, size_t len)
 }
 
 void
-memmove_movnt_sse2_clflushopt(char *dest, const char *src, size_t len)
+memmove_movnt_sse2_clflushopt_wcbarrier(char *dest, const char *src, size_t len)
 {
 	LOG(15, "dest %p src %p len %zu", dest, src, len);
 
@@ -356,7 +405,7 @@ memmove_movnt_sse2_clflushopt(char *dest, const char *src, size_t len)
 }
 
 void
-memmove_movnt_sse2_clwb(char *dest, const char *src, size_t len)
+memmove_movnt_sse2_clwb_wcbarrier(char *dest, const char *src, size_t len)
 {
 	LOG(15, "dest %p src %p len %zu", dest, src, len);
 

--- a/src/libpmem2/x86_64/memcpy_memset.h
+++ b/src/libpmem2/x86_64/memcpy_memset.h
@@ -60,6 +60,11 @@ wc_barrier(void)
 	_mm_sfence();
 }
 
+static force_inline void
+no_barrier(void)
+{
+}
+
 #ifndef AVX512F_AVAILABLE
 /*
  * XXX not supported in MSVC version we currently use.
@@ -87,21 +92,46 @@ void memmove_mov_sse2_clflushopt(char *dest, const char *src, size_t len);
 void memmove_mov_sse2_clwb(char *dest, const char *src, size_t len);
 void memmove_mov_sse2_empty(char *dest, const char *src, size_t len);
 void memmove_mov_sse2_noflush(char *dest, const char *src, size_t len);
-void memmove_movnt_sse2_clflush(char *dest, const char *src, size_t len);
-void memmove_movnt_sse2_clflushopt(char *dest, const char *src, size_t len);
-void memmove_movnt_sse2_clwb(char *dest, const char *src, size_t len);
-void memmove_movnt_sse2_empty(char *dest, const char *src, size_t len);
-void memmove_movnt_sse2_noflush(char *dest, const char *src, size_t len);
+
+void memmove_movnt_sse2_clflush_nobarrier(char *dest, const char *src,
+		size_t len);
+void memmove_movnt_sse2_clflushopt_nobarrier(char *dest, const char *src,
+		size_t len);
+void memmove_movnt_sse2_clwb_nobarrier(char *dest, const char *src,
+		size_t len);
+void memmove_movnt_sse2_empty_nobarrier(char *dest, const char *src,
+		size_t len);
+void memmove_movnt_sse2_noflush_nobarrier(char *dest, const char *src,
+		size_t len);
+
+void memmove_movnt_sse2_clflush_wcbarrier(char *dest, const char *src,
+		size_t len);
+void memmove_movnt_sse2_clflushopt_wcbarrier(char *dest, const char *src,
+		size_t len);
+void memmove_movnt_sse2_clwb_wcbarrier(char *dest, const char *src,
+		size_t len);
+void memmove_movnt_sse2_empty_wcbarrier(char *dest, const char *src,
+		size_t len);
+void memmove_movnt_sse2_noflush_wcbarrier(char *dest, const char *src,
+		size_t len);
+
 void memset_mov_sse2_clflush(char *dest, int c, size_t len);
 void memset_mov_sse2_clflushopt(char *dest, int c, size_t len);
 void memset_mov_sse2_clwb(char *dest, int c, size_t len);
 void memset_mov_sse2_empty(char *dest, int c, size_t len);
 void memset_mov_sse2_noflush(char *dest, int c, size_t len);
-void memset_movnt_sse2_clflush(char *dest, int c, size_t len);
-void memset_movnt_sse2_clflushopt(char *dest, int c, size_t len);
-void memset_movnt_sse2_clwb(char *dest, int c, size_t len);
-void memset_movnt_sse2_empty(char *dest, int c, size_t len);
-void memset_movnt_sse2_noflush(char *dest, int c, size_t len);
+
+void memset_movnt_sse2_clflush_nobarrier(char *dest, int c, size_t len);
+void memset_movnt_sse2_clflushopt_nobarrier(char *dest, int c, size_t len);
+void memset_movnt_sse2_clwb_nobarrier(char *dest, int c, size_t len);
+void memset_movnt_sse2_empty_nobarrier(char *dest, int c, size_t len);
+void memset_movnt_sse2_noflush_nobarrier(char *dest, int c, size_t len);
+
+void memset_movnt_sse2_clflush_wcbarrier(char *dest, int c, size_t len);
+void memset_movnt_sse2_clflushopt_wcbarrier(char *dest, int c, size_t len);
+void memset_movnt_sse2_clwb_wcbarrier(char *dest, int c, size_t len);
+void memset_movnt_sse2_empty_wcbarrier(char *dest, int c, size_t len);
+void memset_movnt_sse2_noflush_wcbarrier(char *dest, int c, size_t len);
 #endif
 
 #if AVX_AVAILABLE
@@ -110,21 +140,46 @@ void memmove_mov_avx_clflushopt(char *dest, const char *src, size_t len);
 void memmove_mov_avx_clwb(char *dest, const char *src, size_t len);
 void memmove_mov_avx_empty(char *dest, const char *src, size_t len);
 void memmove_mov_avx_noflush(char *dest, const char *src, size_t len);
-void memmove_movnt_avx_clflush(char *dest, const char *src, size_t len);
-void memmove_movnt_avx_clflushopt(char *dest, const char *src, size_t len);
-void memmove_movnt_avx_clwb(char *dest, const char *src, size_t len);
-void memmove_movnt_avx_empty(char *dest, const char *src, size_t len);
-void memmove_movnt_avx_noflush(char *dest, const char *src, size_t len);
+
+void memmove_movnt_avx_clflush_nobarrier(char *dest, const char *src,
+		size_t len);
+void memmove_movnt_avx_clflushopt_nobarrier(char *dest, const char *src,
+		size_t len);
+void memmove_movnt_avx_clwb_nobarrier(char *dest, const char *src,
+		size_t len);
+void memmove_movnt_avx_empty_nobarrier(char *dest, const char *src,
+		size_t len);
+void memmove_movnt_avx_noflush_nobarrier(char *dest, const char *src,
+		size_t len);
+
+void memmove_movnt_avx_clflush_wcbarrier(char *dest, const char *src,
+		size_t len);
+void memmove_movnt_avx_clflushopt_wcbarrier(char *dest, const char *src,
+		size_t len);
+void memmove_movnt_avx_clwb_wcbarrier(char *dest, const char *src,
+		size_t len);
+void memmove_movnt_avx_empty_wcbarrier(char *dest, const char *src,
+		size_t len);
+void memmove_movnt_avx_noflush_wcbarrier(char *dest, const char *src,
+		size_t len);
+
 void memset_mov_avx_clflush(char *dest, int c, size_t len);
 void memset_mov_avx_clflushopt(char *dest, int c, size_t len);
 void memset_mov_avx_clwb(char *dest, int c, size_t len);
 void memset_mov_avx_empty(char *dest, int c, size_t len);
 void memset_mov_avx_noflush(char *dest, int c, size_t len);
-void memset_movnt_avx_clflush(char *dest, int c, size_t len);
-void memset_movnt_avx_clflushopt(char *dest, int c, size_t len);
-void memset_movnt_avx_clwb(char *dest, int c, size_t len);
-void memset_movnt_avx_empty(char *dest, int c, size_t len);
-void memset_movnt_avx_noflush(char *dest, int c, size_t len);
+
+void memset_movnt_avx_clflush_nobarrier(char *dest, int c, size_t len);
+void memset_movnt_avx_clflushopt_nobarrier(char *dest, int c, size_t len);
+void memset_movnt_avx_clwb_nobarrier(char *dest, int c, size_t len);
+void memset_movnt_avx_empty_nobarrier(char *dest, int c, size_t len);
+void memset_movnt_avx_noflush_nobarrier(char *dest, int c, size_t len);
+
+void memset_movnt_avx_clflush_wcbarrier(char *dest, int c, size_t len);
+void memset_movnt_avx_clflushopt_wcbarrier(char *dest, int c, size_t len);
+void memset_movnt_avx_clwb_wcbarrier(char *dest, int c, size_t len);
+void memset_movnt_avx_empty_wcbarrier(char *dest, int c, size_t len);
+void memset_movnt_avx_noflush_wcbarrier(char *dest, int c, size_t len);
 #endif
 
 #if AVX512F_AVAILABLE

--- a/src/libpmem2/x86_64/memcpy_memset.h
+++ b/src/libpmem2/x86_64/memcpy_memset.h
@@ -42,6 +42,24 @@ noflush64b(const void *addr)
 	/* NOP, not even pmemcheck annotation */
 }
 
+typedef void perf_barrier_fn(void);
+
+static force_inline void
+wc_barrier(void)
+{
+	/*
+	 * Currently, for SSE2 and AVX code paths, use of non-temporal stores
+	 * on all generations of CPUs must be limited to the number of
+	 * write-combining buffers (12) because otherwise, suboptimal eviction
+	 * policy might impact performance when writing more data than WC
+	 * buffers can simultaneously hold.
+	 *
+	 * The AVX512 code path is not affected, probably because we are
+	 * overwriting whole cache lines.
+	 */
+	_mm_sfence();
+}
+
 #ifndef AVX512F_AVAILABLE
 /*
  * XXX not supported in MSVC version we currently use.

--- a/src/libpmem2/x86_64/memset/memset_nt_avx.c
+++ b/src/libpmem2/x86_64/memset/memset_nt_avx.c
@@ -122,7 +122,7 @@ memset_movnt_avx(char *dest, int c, size_t len, flush_fn flush,
 		len -= cnt;
 	}
 
-	while (len >= 12 * 64) {
+	while (len >= PERF_BARRIER_SIZE) {
 		memset_movnt8x64b(dest, ymm);
 		dest += 8 * 64;
 		len -= 8 * 64;
@@ -130,6 +130,8 @@ memset_movnt_avx(char *dest, int c, size_t len, flush_fn flush,
 		memset_movnt4x64b(dest, ymm);
 		dest += 4 * 64;
 		len -= 4 * 64;
+
+		COMPILE_ERROR_ON(PERF_BARRIER_SIZE != (8 + 4) * 64);
 
 		if (len)
 			perf_barrier();

--- a/src/libpmem2/x86_64/memset/memset_nt_avx.c
+++ b/src/libpmem2/x86_64/memset/memset_nt_avx.c
@@ -189,8 +189,57 @@ end:
 	VALGRIND_DO_FLUSH(orig_dest, orig_len);
 }
 
+/* variants without perf_barrier */
+
 void
-memset_movnt_avx_noflush(char *dest, int c, size_t len)
+memset_movnt_avx_noflush_nobarrier(char *dest, int c, size_t len)
+{
+	LOG(15, "dest %p c %d len %zu", dest, c, len);
+
+	memset_movnt_avx(dest, c, len, noflush, barrier_after_ntstores,
+			no_barrier);
+}
+
+void
+memset_movnt_avx_empty_nobarrier(char *dest, int c, size_t len)
+{
+	LOG(15, "dest %p c %d len %zu", dest, c, len);
+
+	memset_movnt_avx(dest, c, len, flush_empty_nolog,
+			barrier_after_ntstores, no_barrier);
+}
+
+void
+memset_movnt_avx_clflush_nobarrier(char *dest, int c, size_t len)
+{
+	LOG(15, "dest %p c %d len %zu", dest, c, len);
+
+	memset_movnt_avx(dest, c, len, flush_clflush_nolog,
+			barrier_after_ntstores, no_barrier);
+}
+
+void
+memset_movnt_avx_clflushopt_nobarrier(char *dest, int c, size_t len)
+{
+	LOG(15, "dest %p c %d len %zu", dest, c, len);
+
+	memset_movnt_avx(dest, c, len, flush_clflushopt_nolog,
+			no_barrier_after_ntstores, no_barrier);
+}
+
+void
+memset_movnt_avx_clwb_nobarrier(char *dest, int c, size_t len)
+{
+	LOG(15, "dest %p c %d len %zu", dest, c, len);
+
+	memset_movnt_avx(dest, c, len, flush_clwb_nolog,
+			no_barrier_after_ntstores, no_barrier);
+}
+
+/* variants with perf_barrier */
+
+void
+memset_movnt_avx_noflush_wcbarrier(char *dest, int c, size_t len)
 {
 	LOG(15, "dest %p c %d len %zu", dest, c, len);
 
@@ -199,7 +248,7 @@ memset_movnt_avx_noflush(char *dest, int c, size_t len)
 }
 
 void
-memset_movnt_avx_empty(char *dest, int c, size_t len)
+memset_movnt_avx_empty_wcbarrier(char *dest, int c, size_t len)
 {
 	LOG(15, "dest %p c %d len %zu", dest, c, len);
 
@@ -208,7 +257,7 @@ memset_movnt_avx_empty(char *dest, int c, size_t len)
 }
 
 void
-memset_movnt_avx_clflush(char *dest, int c, size_t len)
+memset_movnt_avx_clflush_wcbarrier(char *dest, int c, size_t len)
 {
 	LOG(15, "dest %p c %d len %zu", dest, c, len);
 
@@ -217,7 +266,7 @@ memset_movnt_avx_clflush(char *dest, int c, size_t len)
 }
 
 void
-memset_movnt_avx_clflushopt(char *dest, int c, size_t len)
+memset_movnt_avx_clflushopt_wcbarrier(char *dest, int c, size_t len)
 {
 	LOG(15, "dest %p c %d len %zu", dest, c, len);
 
@@ -226,7 +275,7 @@ memset_movnt_avx_clflushopt(char *dest, int c, size_t len)
 }
 
 void
-memset_movnt_avx_clwb(char *dest, int c, size_t len)
+memset_movnt_avx_clwb_wcbarrier(char *dest, int c, size_t len)
 {
 	LOG(15, "dest %p c %d len %zu", dest, c, len);
 

--- a/src/libpmem2/x86_64/memset/memset_nt_sse2.c
+++ b/src/libpmem2/x86_64/memset/memset_nt_sse2.c
@@ -113,7 +113,7 @@ memset_movnt_sse2(char *dest, int c, size_t len, flush_fn flush,
 		len -= cnt;
 	}
 
-	while (len >= 12 * 64) {
+	while (len >= PERF_BARRIER_SIZE) {
 		memset_movnt4x64b(dest, xmm);
 		dest += 4 * 64;
 		len -= 4 * 64;
@@ -125,6 +125,8 @@ memset_movnt_sse2(char *dest, int c, size_t len, flush_fn flush,
 		memset_movnt4x64b(dest, xmm);
 		dest += 4 * 64;
 		len -= 4 * 64;
+
+		COMPILE_ERROR_ON(PERF_BARRIER_SIZE != (4 + 4 + 4) * 64);
 
 		if (len)
 			perf_barrier();

--- a/src/libpmem2/x86_64/memset/memset_nt_sse2.c
+++ b/src/libpmem2/x86_64/memset/memset_nt_sse2.c
@@ -176,8 +176,57 @@ end:
 	VALGRIND_DO_FLUSH(orig_dest, orig_len);
 }
 
+/* variants without perf_barrier */
+
 void
-memset_movnt_sse2_noflush(char *dest, int c, size_t len)
+memset_movnt_sse2_noflush_nobarrier(char *dest, int c, size_t len)
+{
+	LOG(15, "dest %p c %d len %zu", dest, c, len);
+
+	memset_movnt_sse2(dest, c, len, noflush, barrier_after_ntstores,
+			no_barrier);
+}
+
+void
+memset_movnt_sse2_empty_nobarrier(char *dest, int c, size_t len)
+{
+	LOG(15, "dest %p c %d len %zu", dest, c, len);
+
+	memset_movnt_sse2(dest, c, len, flush_empty_nolog,
+			barrier_after_ntstores, no_barrier);
+}
+
+void
+memset_movnt_sse2_clflush_nobarrier(char *dest, int c, size_t len)
+{
+	LOG(15, "dest %p c %d len %zu", dest, c, len);
+
+	memset_movnt_sse2(dest, c, len, flush_clflush_nolog,
+			barrier_after_ntstores, no_barrier);
+}
+
+void
+memset_movnt_sse2_clflushopt_nobarrier(char *dest, int c, size_t len)
+{
+	LOG(15, "dest %p c %d len %zu", dest, c, len);
+
+	memset_movnt_sse2(dest, c, len, flush_clflushopt_nolog,
+			no_barrier_after_ntstores, no_barrier);
+}
+
+void
+memset_movnt_sse2_clwb_nobarrier(char *dest, int c, size_t len)
+{
+	LOG(15, "dest %p c %d len %zu", dest, c, len);
+
+	memset_movnt_sse2(dest, c, len, flush_clwb_nolog,
+			no_barrier_after_ntstores, no_barrier);
+}
+
+/* variants with perf_barrier */
+
+void
+memset_movnt_sse2_noflush_wcbarrier(char *dest, int c, size_t len)
 {
 	LOG(15, "dest %p c %d len %zu", dest, c, len);
 
@@ -186,7 +235,7 @@ memset_movnt_sse2_noflush(char *dest, int c, size_t len)
 }
 
 void
-memset_movnt_sse2_empty(char *dest, int c, size_t len)
+memset_movnt_sse2_empty_wcbarrier(char *dest, int c, size_t len)
 {
 	LOG(15, "dest %p c %d len %zu", dest, c, len);
 
@@ -195,7 +244,7 @@ memset_movnt_sse2_empty(char *dest, int c, size_t len)
 }
 
 void
-memset_movnt_sse2_clflush(char *dest, int c, size_t len)
+memset_movnt_sse2_clflush_wcbarrier(char *dest, int c, size_t len)
 {
 	LOG(15, "dest %p c %d len %zu", dest, c, len);
 
@@ -204,7 +253,7 @@ memset_movnt_sse2_clflush(char *dest, int c, size_t len)
 }
 
 void
-memset_movnt_sse2_clflushopt(char *dest, int c, size_t len)
+memset_movnt_sse2_clflushopt_wcbarrier(char *dest, int c, size_t len)
 {
 	LOG(15, "dest %p c %d len %zu", dest, c, len);
 
@@ -213,7 +262,7 @@ memset_movnt_sse2_clflushopt(char *dest, int c, size_t len)
 }
 
 void
-memset_movnt_sse2_clwb(char *dest, int c, size_t len)
+memset_movnt_sse2_clwb_wcbarrier(char *dest, int c, size_t len)
 {
 	LOG(15, "dest %p c %d len %zu", dest, c, len);
 

--- a/src/test/pmem2_mem_ext/TESTS.py
+++ b/src/test/pmem2_mem_ext/TESTS.py
@@ -186,6 +186,11 @@ class Pmem2MemExt(t.Test):
         ctx.env['PMEM2_LOG_FILE'] = self.pmem2_log
         ctx.env['PMEM2_LOG_LEVEL'] = '15'
 
+        if ctx.wc_workaround() == 'on':
+            ctx.env['PMEM_WC_WORKAROUND'] = '1'
+        elif ctx.wc_workaround() == 'off':
+            ctx.env['PMEM_WC_WORKAROUND'] = '0'
+
         if ctx.variant() == VARIANT_LIBC:
             ctx.env['PMEM_NO_MOVNT'] = '1'
             ctx.env['PMEM_NO_GENERIC_MEMCPY'] = '1'
@@ -214,29 +219,34 @@ class Pmem2MemExt(t.Test):
 
 
 @t.add_params('variant', [VARIANT_LIBC, VARIANT_GENERIC])
+@t.add_params('wc_workaround', ['default'])
 class TEST0(Pmem2MemExt):
     test_case = [(NO_FLAGS, 1024, "")]
 
 
 @g.require_granularity(g.PAGE, g.CACHELINE)
 @t.add_params('variant', [VARIANT_SSE2, VARIANT_AVX, VARIANT_AVX512F])
+@t.add_params('wc_workaround', ['on', 'off', 'default'])
 class TEST1(Pmem2MemExt):
     test_case = MATCH_PAGE_CACHELINE_SMALL
 
 
 @g.require_granularity(g.BYTE)
 @t.add_params('variant', [VARIANT_SSE2, VARIANT_AVX, VARIANT_AVX512F])
+@t.add_params('wc_workaround', ['on', 'off', 'default'])
 class TEST2(Pmem2MemExt):
     test_case = MATCH_BYTE_SMALL
 
 
 @g.require_granularity(g.PAGE, g.CACHELINE)
 @t.add_params('variant', [VARIANT_SSE2, VARIANT_AVX, VARIANT_AVX512F])
+@t.add_params('wc_workaround', ['on', 'off', 'default'])
 class TEST3(Pmem2MemExt):
     test_case = MATCH_PAGE_CACHELINE_BIG
 
 
 @g.require_granularity(g.BYTE)
 @t.add_params('variant', [VARIANT_SSE2, VARIANT_AVX, VARIANT_AVX512F])
+@t.add_params('wc_workaround', ['on', 'off', 'default'])
 class TEST4(Pmem2MemExt):
     test_case = MATCH_BYTE_BIG

--- a/src/test/pmem2_memcpy/TESTS.py
+++ b/src/test/pmem2_memcpy/TESTS.py
@@ -32,29 +32,40 @@ class Pmem2Memcpy(t.Test):
     def run(self, ctx):
         for env in self.envs:
             ctx.env[env] = '1'
+
+        if ctx.wc_workaround() == 'on':
+            ctx.env['PMEM_WC_WORKAROUND'] = '1'
+        elif ctx.wc_workaround() == 'off':
+            ctx.env['PMEM_WC_WORKAROUND'] = '0'
+
         for tc in self.test_cases:
             filepath = ctx.create_holey_file(self.filesize, 'testfile',)
             ctx.exec('pmem2_memcpy', filepath,
                      tc.dest, tc.src, tc.length)
 
 
+@t.add_params('wc_workaround', ['on', 'off', 'default'])
 class TEST0(Pmem2Memcpy):
     pass
 
 
 @t.require_architectures('x86_64')
+@t.add_params('wc_workaround', ['on', 'off', 'default'])
 class TEST1(Pmem2Memcpy):
     envs = ("PMEM_AVX512F",)
 
 
 @t.require_architectures('x86_64')
+@t.add_params('wc_workaround', ['on', 'off', 'default'])
 class TEST2(Pmem2Memcpy):
     envs = ("PMEM_AVX",)
 
 
+@t.add_params('wc_workaround', ['default'])
 class TEST3(Pmem2Memcpy):
     envs = ("PMEM_NO_MOVNT",)
 
 
+@t.add_params('wc_workaround', ['default'])
 class TEST4(Pmem2Memcpy):
     envs = ("PMEM_NO_MOVNT", "PMEM_NO_GENERIC_MEMCPY")

--- a/src/test/pmem2_memset/TESTS.py
+++ b/src/test/pmem2_memset/TESTS.py
@@ -23,28 +23,39 @@ class Pmem2Memset(t.Test):
     def run(self, ctx):
         for env in self.envs:
             ctx.env[env] = '1'
+
+        if ctx.wc_workaround() == 'on':
+            ctx.env['PMEM_WC_WORKAROUND'] = '1'
+        elif ctx.wc_workaround() == 'off':
+            ctx.env['PMEM_WC_WORKAROUND'] = '0'
+
         for tc in self.test_cases:
             filepath = ctx.create_holey_file(self.filesize, 'testfile',)
             ctx.exec('pmem2_memset', filepath, tc.offset, tc.length)
 
 
+@t.add_params('wc_workaround', ['on', 'off', 'default'])
 class TEST0(Pmem2Memset):
     pass
 
 
 @t.require_architectures('x86_64')
+@t.add_params('wc_workaround', ['on', 'off', 'default'])
 class TEST1(Pmem2Memset):
     envs = ("PMEM_AVX512F",)
 
 
 @t.require_architectures('x86_64')
+@t.add_params('wc_workaround', ['on', 'off', 'default'])
 class TEST2(Pmem2Memset):
     envs = ("PMEM_AVX",)
 
 
+@t.add_params('wc_workaround', ['default'])
 class TEST3(Pmem2Memset):
     envs = ("PMEM_NO_MOVNT",)
 
 
+@t.add_params('wc_workaround', ['default'])
 class TEST4(Pmem2Memset):
     envs = ("PMEM_NO_MOVNT", "PMEM_NO_GENERIC_MEMCPY")


### PR DESCRIPTION
I recommend looking at each patch individually to get the overall idea. The second patch ("pmem: (+pmem2) make WC issue workaround optional") is the messiest, but the least interesting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4774)
<!-- Reviewable:end -->
