### PR TITLE
pmreorder: fix a cstyle error

### DIFF
--- a/src/tools/pmreorder/loggingfacility.py
+++ b/src/tools/pmreorder/loggingfacility.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2020, Intel Corporation
 
 import logging
 
@@ -68,7 +68,7 @@ def get_logger(log_output, log_level=None):
     log_level = "warning" if log_level is None else log_level
     numeric_level = getattr(logging, log_level.upper())
     if not isinstance(numeric_level, int):
-        raise ValueError('Invalid log level: %s'.format(log_level.upper()))
+        raise ValueError('Invalid log level: {}'.format(log_level.upper()))
 
     if log_output is None:
         logger = DefaultPrintLogger()


### PR DESCRIPTION
It fixes the following 'make cstyle' error:
```
loggingfacility.py:71:26: F999 '...'.format(...) has unused arguments at position(s): 0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4782)
<!-- Reviewable:end -->
