### PR TITLE
pmem2: fix possible NULL-pointer dereference

### DIFF
--- a/src/libpmem2/badblocks_ndctl.c
+++ b/src/libpmem2/badblocks_ndctl.c
@@ -590,6 +590,9 @@ pmem2_badblock_context_delete(struct pmem2_badblock_context **bbctx)
 
 	ASSERTne(bbctx, NULL);
 
+	if (*bbctx == NULL)
+		return;
+
 	struct pmem2_badblock_context *tbbctx = *bbctx;
 
 	pmem2_extents_destroy(&tbbctx->exts);


### PR DESCRIPTION
It fixes possible NULL-pointer dereference
in pmem2_badblock_context_delete().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4784)
<!-- Reviewable:end -->
