### PR TITLE
examples: Initialize child_idx

### DIFF
--- a/src/examples/libpmemobj/tree_map/rtree_map.c
+++ b/src/examples/libpmemobj/tree_map/rtree_map.c
@@ -8,6 +8,7 @@
 #include <ex_common.h>
 #include <assert.h>
 #include <errno.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <stdbool.h>
 
@@ -320,12 +321,13 @@ has_only_one_child(TOID(struct tree_map_node) node, unsigned *child_idx)
 static void
 remove_extra_node(TOID(struct tree_map_node) *node)
 {
-	unsigned child_idx;
+	unsigned child_idx = UINT_MAX;
 	TOID(struct tree_map_node) tmp, tmp_child;
 
 	/* Our node has child with only one child. */
 	tmp = *node;
 	has_only_one_child(tmp, &child_idx);
+	assert(child_idx != UINT_MAX);
 	tmp_child = D_RO(tmp)->slots[child_idx];
 
 	/*


### PR DESCRIPTION
Fixes warning
rtree_map.c:358:12: error: 'child_idx' may be used uninitialized in this function [-Werror=maybe-uninitialized]

Signed-off-by: Khem Raj <raj.khem@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4802)
<!-- Reviewable:end -->
