### PR TITLE
test: compile and run pmem2_badblock_mocks only if ndctl is enabled and installed

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -197,7 +197,6 @@ PMEM_TESTS = \
 
 PMEM2_TESTS = \
 	pmem2_api\
-	pmem2_badblock_mocks\
 	pmem2_compat\
 	pmem2_config\
 	pmem2_source\
@@ -218,6 +217,13 @@ PMEM2_TESTS = \
 	pmem2_movnt_align\
 	pmem2_mem_ext\
 	pmem2_deep_flush
+
+ifeq ($(OS_DIMM),ndctl)
+PMEM2_TESTS += \
+	pmem2_badblock_mocks
+else
+$(info NOTE: Skipping pmem2_badblock_mocks test because libndctl is disabled (see NDCTL_ENABLE))
+endif
 
 PMEMPOOL_TESTS = \
 	pmempool_check\

--- a/src/test/pmem2_badblock_mocks/TESTS.py
+++ b/src/test/pmem2_badblock_mocks/TESTS.py
@@ -7,6 +7,7 @@ import testframework as t
 
 
 @t.linux_only
+@t.require_ndctl
 class BB_MOCKS_BASIC(t.Test):
     """PART #1 - basic tests"""
     def run(self, ctx):
@@ -37,6 +38,7 @@ class TEST2(BB_MOCKS_BASIC):
 
 
 @t.linux_only
+@t.require_ndctl
 class BB_MOCKS_READ_CLEAR(t.Test):
     """PART #2 - test reading and clearing bad blocks"""
     def run(self, ctx):

--- a/src/test/testframework.py
+++ b/src/test/testframework.py
@@ -23,4 +23,5 @@ from poolset import *  # noqa: E402, F401, F403
 from builds import *  # noqa: E402, F401, F403
 from devdax import *  # noqa: E402, F401, F403
 from test_types import *  # noqa: E402, F401, F403
+from requirements import *  # noqa: E402, F401, F403
 import granularity  # noqa: E402, F401

--- a/src/test/unittest/ctx_filter.py
+++ b/src/test/unittest/ctx_filter.py
@@ -16,6 +16,7 @@ import devdax
 
 import context as ctx
 import valgrind as vg
+import requirements as req
 
 if sys.platform != 'win32':
     CTX_TYPES = (vg.Valgrind, granularity.Granularity, devdax.DevDaxes)
@@ -42,6 +43,9 @@ class CtxFilter:
         Generate a list of context based on configuration and
         test requirements
         """
+        reqs = req.Requirements()
+        if not reqs.check_if_all_requirements_are_met(self.tc):
+            return []
         conf_params = self._get_configured_params()
         common_params = self._get_common_params()
         ctx_arg_keys = list(conf_params.keys()) + list(common_params.keys())

--- a/src/test/unittest/requirements.py
+++ b/src/test/unittest/requirements.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2020, Intel Corporation
+#
+"""Various requirements"""
+
+
+import subprocess as sp
+import os
+
+import context as ctx
+import futils
+
+
+NDCTL_MIN_VERSION = '63'
+
+
+class Requirements:
+    """Various requirements"""
+    def _check_pkgconfig(self, pkg, min_ver):
+        """
+        Run pkg-config to check if a package is installed
+        """
+        proc = sp.run(['pkg-config', pkg, '--atleast-version', min_ver],
+                      stdout=sp.PIPE, stderr=sp.STDOUT)
+        return proc.returncode == 0
+
+    def _check_ndctl_req_is_met(self, tc):
+        """
+        Check if all conditions for the ndctl requirement are met
+        """
+        require_ndctl, _ = ctx.get_requirement(tc, 'require_ndctl', ())
+        if not require_ndctl:
+            return True
+
+        ndctl_enable = os.environ.get('NDCTL_ENABLE')
+        if ndctl_enable == 'n':
+            raise futils.Skip('libndctl is disabled (NDCTL_ENABLE == \'n\')')
+
+        is_ndctl = self._check_pkgconfig('libndctl', NDCTL_MIN_VERSION)
+        if not is_ndctl:
+            raise futils.Skip('libndctl (>=v{}) is not installed'
+                              .format(NDCTL_MIN_VERSION))
+        return True
+
+    def check_if_all_requirements_are_met(self, tc):
+        if not self._check_ndctl_req_is_met(tc):
+            return False
+        """More requirements can be checked here"""
+        return True
+
+
+def require_ndctl(tc):
+    """Enable test only if ndctl is installed"""
+    ctx.add_requirement(tc, 'require_ndctl', True)
+    return tc


### PR DESCRIPTION
The pmem2_badblock_mocks test includes 'ndctl/libndctl.h',
so it requires libndctl to be enabled and installed in OS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4806)
<!-- Reviewable:end -->
