### PR TITLE
doc: remove a false sentence from pmem2_config_new(3) manual

### DIFF
--- a/doc/libpmem2/pmem2_config_new.3.md
+++ b/doc/libpmem2/pmem2_config_new.3.md
@@ -49,8 +49,6 @@ The **pmem2_config_new**() function returns 0 on success or a negative error cod
 
 The **pmem2_config_delete**() function returns 0.
 
-Please see **libpmem2**(7) for detailed description of libpmem2 error codes.
-
 # ERRORS #
 **pmem2_config_new**() can fail with the following error:
 - **-ENOMEM** - out of memory


### PR DESCRIPTION
There is no description of libpmem2 error codes in libpmem2(7) manual.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4807)
<!-- Reviewable:end -->
