### PR TITLE
pmem2: fix error handling of ndctl new()

### DIFF
--- a/src/libpmem2/badblocks_ndctl.c
+++ b/src/libpmem2/badblocks_ndctl.c
@@ -263,7 +263,8 @@ pmem2_badblock_context_new(const struct pmem2_source *src,
 
 	*bbctx = NULL;
 
-	if (ndctl_new(&ctx)) {
+	errno = ndctl_new(&ctx) * (-1);
+	if (errno) {
 		ERR("!ndctl_new");
 		return PMEM2_E_ERRNO;
 	}

--- a/src/libpmem2/region_namespace_ndctl.c
+++ b/src/libpmem2/region_namespace_ndctl.c
@@ -234,7 +234,8 @@ pmem2_get_region_id(const os_stat_t *st, unsigned *region_id)
 	struct ndctl_namespace *ndns;
 	struct ndctl_ctx *ctx;
 
-	if (ndctl_new(&ctx)) {
+	errno = ndctl_new(&ctx) * (-1);
+	if (errno) {
 		ERR("!ndctl_new");
 		return PMEM2_E_ERRNO;
 	}

--- a/src/libpmem2/usc_ndctl.c
+++ b/src/libpmem2/usc_ndctl.c
@@ -51,7 +51,8 @@ pmem2_source_device_usc(const struct pmem2_source *src, uint64_t *usc)
 		return PMEM2_E_ERRNO;
 	}
 
-	if (ndctl_new(&ctx)) {
+	errno = ndctl_new(&ctx) * (-1);
+	if (errno) {
 		ERR("!ndctl_new");
 		return PMEM2_E_ERRNO;
 	}
@@ -95,7 +96,8 @@ pmem2_source_device_id(const struct pmem2_source *src, char *id, size_t *len)
 		return PMEM2_E_ERRNO;
 	}
 
-	if (ndctl_new(&ctx)) {
+	errno = ndctl_new(&ctx) * (-1);
+	if (errno) {
 		ERR("!ndctl_new");
 		return PMEM2_E_ERRNO;
 	}


### PR DESCRIPTION
ndctl_new() does not set errno, it returns it.

---
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4808)
<!-- Reviewable:end -->
