### PR TITLE
pmem2: separate ravl map module and map.c

### DIFF
--- a/src/common/ravl.c
+++ b/src/common/ravl.c
@@ -515,7 +515,7 @@ ravl_predicate_holds(struct ravl *ravl, int result, struct ravl_node **ret,
 }
 
 /*
- * ravl_find -- searches for the node in the free
+ * ravl_find -- searches for the node in the tree
  */
 struct ravl_node *
 ravl_find(struct ravl *ravl, const void *data, enum ravl_predicate flags)

--- a/src/libpmem2/Makefile
+++ b/src/libpmem2/Makefile
@@ -27,7 +27,8 @@ SOURCE =\
 	usc_$(OS_DIMM).c\
 	source.c\
 	source_posix.c\
-	vm_reservation.c
+	vm_reservation.c\
+	ravl_interval.c
 
 ifeq ($(OS_KERNEL_NAME),Linux)
 SOURCE +=\

--- a/src/libpmem2/libpmem2.vcxproj
+++ b/src/libpmem2/libpmem2.vcxproj
@@ -33,6 +33,7 @@
     <ClCompile Include="persist_windows.c" />
     <ClCompile Include="pmem2_utils.c" />
     <ClCompile Include="pmem2_utils_other.c" />
+    <ClCompile Include="ravl_interval.c" />
     <ClCompile Include="source.c" />
     <ClCompile Include="source_windows.c" />
     <ClCompile Include="usc_windows.c" />
@@ -72,6 +73,7 @@
     <ClInclude Include="pmem2.h" />
     <ClInclude Include="pmem2_arch.h" />
     <ClInclude Include="pmem2_utils.h" />
+    <ClInclude Include="ravl_interval.h" />
     <ClInclude Include="source.h" />
     <ClInclude Include="x86_64\cpu.h" />
     <ClInclude Include="x86_64\avx.h" />

--- a/src/libpmem2/libpmem2.vcxproj.filters
+++ b/src/libpmem2/libpmem2.vcxproj.filters
@@ -129,6 +129,9 @@
     <ClCompile Include="vm_reservation.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ravl_interval.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\core\os_thread.h">
@@ -195,6 +198,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="config.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ravl_interval.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/libpmem2/ravl_interval.c
+++ b/src/libpmem2/ravl_interval.c
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2020, Intel Corporation */
+
+/*
+ * ravl_interval.c -- ravl_interval implementation
+ */
+
+#include "alloc.h"
+#include "map.h"
+#include "ravl_interval.h"
+#include "pmem2_utils.h"
+#include "sys_util.h"
+#include "os_thread.h"
+#include "ravl.h"
+
+/*
+ * ravl_interval - structure representing two points
+ *                 on the number line
+ */
+struct ravl_interval {
+	struct ravl *tree;
+	ravl_interval_min *get_min;
+	ravl_interval_max *get_max;
+};
+
+/*
+ * ravl_interval_node - structure holding min, max functions and address
+ */
+struct ravl_interval_node {
+	void *addr;
+	ravl_interval_min *get_min;
+	ravl_interval_max *get_max;
+};
+
+/*
+ * ravl_interval_compare -- compare intervals by its boundaries,
+ *                          no overlapping allowed
+ */
+static int
+ravl_interval_compare(const void *lhs, const void *rhs)
+{
+	const struct ravl_interval_node *left = lhs;
+	const struct ravl_interval_node *right = rhs;
+
+	if (left->get_min(left->addr) < right->get_min(right->addr) &&
+		left->get_max(left->addr) <= right->get_min(right->addr))
+		return -1;
+	if (left->get_min(left->addr) > right->get_min(right->addr) &&
+		left->get_max(left->addr) >= right->get_min(right->addr))
+		return 1;
+	return 0;
+}
+
+/*
+ * ravl_interval_delete - finalize the ravl interval module
+ */
+void
+ravl_interval_delete(struct ravl_interval *ri)
+{
+	ravl_delete(ri->tree);
+	ri->tree = NULL;
+	Free(ri);
+}
+
+/*
+ * ravl_interval_new -- initialize the ravl interval module
+ */
+struct ravl_interval *
+ravl_interval_new(ravl_interval_min *get_min, ravl_interval_max *get_max)
+{
+	int ret;
+	struct ravl_interval *interval = pmem2_malloc(sizeof(*interval), &ret);
+	if (ret)
+		goto ret_null;
+
+	interval->tree = ravl_new_sized(ravl_interval_compare,
+			sizeof(struct ravl_interval_node));
+	if (!(interval->tree))
+		goto free_alloc;
+
+	interval->get_min = get_min;
+	interval->get_max = get_max;
+
+	return interval;
+
+free_alloc:
+	Free(interval);
+ret_null:
+	return NULL;
+}
+
+/*
+ * ravl_interval_insert -- insert interval entry into the tree
+ */
+int
+ravl_interval_insert(struct ravl_interval *ri, void *addr)
+{
+	struct ravl_interval_node rin;
+	rin.addr = addr;
+	rin.get_min = ri->get_min;
+	rin.get_max = ri->get_max;
+
+	if (ravl_emplace_copy(ri->tree, &rin))
+		return PMEM2_E_ERRNO;
+
+	return 0;
+}
+
+/*
+ * ravl_interval_remove -- remove interval entry from the tree
+ */
+int
+ravl_interval_remove(struct ravl_interval *ri, struct ravl_interval_node *rin)
+{
+	struct ravl_node *node = ravl_find(ri->tree, rin,
+			RAVL_PREDICATE_EQUAL);
+	if (!node)
+		return PMEM2_E_MAPPING_NOT_FOUND;
+
+	ravl_remove(ri->tree, node);
+
+	return 0;
+}
+
+/*
+ * ravl_interval_find_prior_or_eq -- find overlapping interval starting prior to
+ *                                   the current one or at the same place
+ */
+static struct ravl_interval_node *
+ravl_interval_find_prior_or_eq(struct ravl *tree,
+		struct ravl_interval_node *rin)
+{
+	struct ravl_node *node;
+	struct ravl_interval_node *cur;
+
+	node = ravl_find(tree, rin, RAVL_PREDICATE_LESS_EQUAL);
+	if (!node)
+		return NULL;
+
+	cur = ravl_data(node);
+	/*
+	 * If the end of the found interval is below the searched boundary, then
+	 * this is not our interval.
+	 */
+	if (cur->get_max(cur->addr) <= rin->get_min(rin->addr))
+		return NULL;
+
+	return cur;
+}
+
+/*
+ * ravl_interval_find_later -- find overlapping interval starting later than
+ *                             the current one
+ */
+static struct ravl_interval_node *
+ravl_interval_find_later(struct ravl *tree, struct ravl_interval_node *rin)
+{
+	struct ravl_node *node;
+	struct ravl_interval_node *cur;
+
+	node = ravl_find(tree, rin, RAVL_PREDICATE_GREATER);
+	if (!node)
+		return NULL;
+
+	cur = ravl_data(node);
+
+	/*
+	 * If the beginning of the found interval is above the end of
+	 * the searched range, then this is not our interval.
+	 */
+	if (cur->get_min(cur->addr) >= rin->get_max(rin->addr))
+		return NULL;
+
+	return cur;
+}
+
+/*
+ * ravl_interval_find_equal -- find the interval with exact (min, max) range
+ */
+struct ravl_interval_node *
+ravl_interval_find_equal(struct ravl_interval *ri, void *addr)
+{
+	struct ravl_interval_node range;
+	range.addr = addr;
+	range.get_min = ri->get_min;
+	range.get_max = ri->get_max;
+
+	struct ravl_node *node;
+	node = ravl_find(ri->tree, &range, RAVL_PREDICATE_EQUAL);
+	if (!node)
+		return NULL;
+
+	return ravl_data(node);
+}
+
+/*
+ * ravl_interval_find -- find the earliest interval within (min, max) range
+ */
+struct ravl_interval_node *
+ravl_interval_find(struct ravl_interval *ri, void *addr)
+{
+	struct ravl_interval_node range;
+	range.addr = addr;
+	range.get_min = ri->get_min;
+	range.get_max = ri->get_max;
+
+	struct ravl_interval_node *cur;
+	cur = ravl_interval_find_prior_or_eq(ri->tree, &range);
+	if (!cur)
+		cur = ravl_interval_find_later(ri->tree, &range);
+
+	return cur;
+}
+
+/*
+ * ravl_interval_data -- returns the data contained within interval node
+ */
+void *
+ravl_interval_data(struct ravl_interval_node *rin)
+{
+	return (void *)rin->addr;
+}

--- a/src/libpmem2/ravl_interval.h
+++ b/src/libpmem2/ravl_interval.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2020, Intel Corporation */
+
+/*
+ * ravl_interval.h -- internal definitions for ravl_interval
+ */
+
+#ifndef RAVL_INTERVAL_H
+#define RAVL_INTERVAL_H
+
+#include "libpmem2.h"
+#include "os_thread.h"
+#include "ravl.h"
+
+struct ravl_interval;
+struct ravl_interval_node;
+
+typedef size_t ravl_interval_min(void *addr);
+typedef size_t ravl_interval_max(void *addr);
+
+struct ravl_interval *ravl_interval_new(ravl_interval_min *min,
+		ravl_interval_min *max);
+void  ravl_interval_delete(struct ravl_interval *ri);
+int ravl_interval_insert(struct ravl_interval *ri, void *addr);
+int ravl_interval_remove(struct ravl_interval *ri,
+		struct ravl_interval_node *rin);
+struct ravl_interval_node *ravl_interval_find_equal(struct ravl_interval *ri,
+		void *addr);
+struct ravl_interval_node *ravl_interval_find(struct ravl_interval *ri,
+		void *addr);
+void *ravl_interval_data(struct ravl_interval_node *rin);
+#endif

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -175,7 +175,8 @@ OBJS +=\
 	$(TOP)/src/debug/libpmem2/source.o\
 	$(TOP)/src/debug/libpmem2/source_posix.o\
 	$(TOP)/src/debug/libpmem2/usc_$(OS_DIMM).o\
-	$(TOP)/src/debug/libpmem2/vm_reservation.o
+	$(TOP)/src/debug/libpmem2/vm_reservation.o\
+	$(TOP)/src/debug/libpmem2/ravl_interval.o
 
 ifeq ($(OS_KERNEL_NAME),Linux)
 OBJS +=\
@@ -226,6 +227,7 @@ OBJS +=\
 	$(TOP)/src/nondebug/libpmem2/ravl.o\
 	$(TOP)/src/nondebug/libpmem2/usc_$(OS_DIMM).o\
 	$(TOP)/src/nondebug/libpmem2/vm_reservation.o
+	$(TOP)/src/nondebug/libpmem2/ravl_interval.o
 
 ifeq ($(OS_KERNEL_NAME),Linux)
 OBJS +=\

--- a/src/test/pmem2_granularity/pmem2_granularity.vcxproj
+++ b/src/test/pmem2_granularity/pmem2_granularity.vcxproj
@@ -86,6 +86,7 @@
     <ClCompile Include="..\..\libpmem2\memops_generic.c" />
     <ClCompile Include="..\..\libpmem2\persist.c" />
     <ClCompile Include="..\..\libpmem2\persist_windows.c" />
+    <ClCompile Include="..\..\libpmem2\ravl_interval.c" />
     <ClCompile Include="..\..\libpmem2\x86_64\cpu.c" />
     <ClCompile Include="..\..\libpmem2\x86_64\init.c" />
     <ClCompile Include="..\pmem_has_auto_flush_win\mocks_windows.c">
@@ -102,6 +103,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\libpmem2\config.h" />
     <ClInclude Include="..\..\libpmem2\map.h" />
+    <ClInclude Include="..\..\libpmem2\ravl_interval.h" />
     <ClInclude Include="..\pmem_has_auto_flush_win\mocks_windows.h" />
     <ClInclude Include="..\unittest\unittest.h" />
     <ClInclude Include="..\unittest\ut_pmem2_utils.h" />

--- a/src/test/pmem2_granularity/pmem2_granularity.vcxproj.filters
+++ b/src/test/pmem2_granularity/pmem2_granularity.vcxproj.filters
@@ -65,6 +65,9 @@
     <ClCompile Include="..\..\libpmem2\deep_flush_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\libpmem2\ravl_interval.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\unittest\ut_pmem2_utils.h">
@@ -86,6 +89,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="pmem2_granularity.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libpmem2\ravl_interval.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/test/pmem2_map/pmem2_map.vcxproj
+++ b/src/test/pmem2_map/pmem2_map.vcxproj
@@ -88,6 +88,7 @@
     <ClCompile Include="..\..\libpmem2\persist.c" />
     <ClCompile Include="..\..\libpmem2\persist_windows.c" />
     <ClCompile Include="..\..\libpmem2\pmem2_utils.c" />
+    <ClCompile Include="..\..\libpmem2\ravl_interval.c" />
     <ClCompile Include="..\..\libpmem2\x86_64\cpu.c" />
     <ClCompile Include="..\..\libpmem2\x86_64\init.c" />
     <ClCompile Include="..\unittest\ut_pmem2_setup.c" />
@@ -100,6 +101,7 @@
     <ClInclude Include="..\..\libpmem2\map.h" />
     <ClInclude Include="..\..\libpmem2\pmem2.h" />
     <ClInclude Include="..\..\libpmem2\pmem2_utils.h" />
+    <ClInclude Include="..\..\libpmem2\ravl_interval.h" />
     <ClInclude Include="..\unittest\ut_pmem2.h" />
   </ItemGroup>
   <ItemGroup>

--- a/src/test/pmem2_map/pmem2_map.vcxproj.filters
+++ b/src/test/pmem2_map/pmem2_map.vcxproj.filters
@@ -65,6 +65,9 @@
     <ClCompile Include="..\unittest\ut_pmem2_setup.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\libpmem2\ravl_interval.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\libpmem2\config.h">
@@ -80,6 +83,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\unittest\ut_pmem2.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libpmem2\ravl_interval.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/test/pmem2_map_prot/pmem2_map_prot.vcxproj
+++ b/src/test/pmem2_map_prot/pmem2_map_prot.vcxproj
@@ -88,6 +88,7 @@
     <ClCompile Include="..\..\libpmem2\persist.c" />
     <ClCompile Include="..\..\libpmem2\persist_windows.c" />
     <ClCompile Include="..\..\libpmem2\pmem2_utils.c" />
+    <ClCompile Include="..\..\libpmem2\ravl_interval.c" />
     <ClCompile Include="..\..\libpmem2\x86_64\cpu.c" />
     <ClCompile Include="..\..\libpmem2\x86_64\init.c" />
     <ClCompile Include="..\unittest\ut_pmem2_config.c" />
@@ -101,6 +102,7 @@
     <ClInclude Include="..\..\libpmem2\map.h" />
     <ClInclude Include="..\..\libpmem2\pmem2.h" />
     <ClInclude Include="..\..\libpmem2\pmem2_utils.h" />
+    <ClInclude Include="..\..\libpmem2\ravl_interval.h" />
     <ClInclude Include="..\unittest\ut_pmem2.h" />
   </ItemGroup>
   <ItemGroup>

--- a/src/test/pmem2_map_prot/pmem2_map_prot.vcxproj.filters
+++ b/src/test/pmem2_map_prot/pmem2_map_prot.vcxproj.filters
@@ -68,6 +68,9 @@
     <ClCompile Include="..\unittest\ut_pmem2_setup.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\libpmem2\ravl_interval.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\libpmem2\config.h">
@@ -83,6 +86,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\unittest\ut_pmem2.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\libpmem2\ravl_interval.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/test/util_sds/util_sds.vcxproj
+++ b/src/test/util_sds/util_sds.vcxproj
@@ -76,6 +76,7 @@
     <ClCompile Include="..\..\libpmem2\persist.c" />
     <ClCompile Include="..\..\libpmem2\persist_windows.c" />
     <ClCompile Include="..\..\libpmem2\pmem2_utils.c" />
+    <ClCompile Include="..\..\libpmem2\ravl_interval.c" />
     <ClCompile Include="..\..\libpmem2\usc_windows.c">
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">PMDK_UTF8_API;SDS_ENABLED;NTDDI_VERSION=NTDDI_WIN10_RS1;WRAP_REAL;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">PMDK_UTF8_API;SDS_ENABLED;NTDDI_VERSION=NTDDI_WIN10_RS1;WRAP_REAL;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/test/util_sds/util_sds.vcxproj.filters
+++ b/src/test/util_sds/util_sds.vcxproj.filters
@@ -109,6 +109,9 @@
     <ClCompile Include="..\..\libpmem2\deep_flush_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\libpmem2\ravl_interval.c">
+      <Filter>Source Files\pmem2</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mocks_windows.h">


### PR DESCRIPTION
Move ravl map module implementation from map.c into separate files
map_ravl.c and map_ravl.h. Effectively map.c uses map_ravl structure
to keep track of the mappings in the ravl tree.
The reason for the separation is that the pmem2_vm_reservation feature
will be using ravl tree in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4813)
<!-- Reviewable:end -->
