### PR TITLE
test: fix flake8 v3.8.1 errors in valgrind.py

### DIFF
--- a/src/test/unittest/valgrind.py
+++ b/src/test/unittest/valgrind.py
@@ -227,7 +227,7 @@ class Valgrind:
         no_ignored = []
         # remove ignored warnings from log file
         with open(self.log_file, 'r+') as f:
-            no_ignored = [l for l in f if not any(w in l for w in _IGNORED)]
+            no_ignored = [ln for ln in f if not any(w in ln for w in _IGNORED)]
             f.seek(0)
             f.writelines(no_ignored)
             f.truncate()
@@ -238,8 +238,8 @@ class Valgrind:
             return
 
         non_zero_errors = 'ERROR SUMMARY: [^0]'
-        errors_found = any(re.search(non_zero_errors, l) for l in no_ignored)
-        if any('Bad pmempool' in l for l in no_ignored) or errors_found:
+        errors_found = any(re.search(non_zero_errors, ln) for ln in no_ignored)
+        if any('Bad pmempool' in ln for ln in no_ignored) or errors_found:
             raise futils.Fail('Valgrind log validation failed')
 
     def verify(self):


### PR DESCRIPTION
Fix the following flake8 v3.8.1 errors:
./valgrind.py:230:33: E741 ambiguous variable name 'l'
./valgrind.py:241:62: E741 ambiguous variable name 'l'
./valgrind.py:242:40: E741 ambiguous variable name 'l'

They occurred after the last update of flake8 to v3.8.1
(mccabe: 0.6.1, pycodestyle: 2.6.0, pyflakes: 2.2.0)
CPython 3.8.2 on Linux

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4815)
<!-- Reviewable:end -->
