### PR TITLE
test: fix run_tests() in RUNTESTS.py

### DIFF
--- a/src/test/RUNTESTS.py
+++ b/src/test/RUNTESTS.py
@@ -68,6 +68,12 @@ class TestRunner:
 
             cf = CtxFilter(self.config, tc)
 
+            # The 'c' context has to be initilized before the 'for' loop,
+            # because cf.get_contexts() can return no value ([])
+            # and in case of the 'futils.Fail' exception
+            # self._test_failed(tc, c, f) will be called
+            # with uninitilized value of the 'c' context.
+            c = None
             try:
                 for c in cf.get_contexts():
                     try:


### PR DESCRIPTION
The 'c' context has to be initilized before the 'for' loop,
because cf.get_contexts() can return no value ([])
and in case of the 'futils.Fail' exception
self._test_failed(tc, c, f) will be called
with uninitilized value of the 'c' context:
```
[...]
    raise futils.Fail('Error: ...')
futils.Fail: Error: ...

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./RUNTESTS.py", line 172, in <module>
    main()
  File "./RUNTESTS.py", line 168, in main
    sys.exit(runner.run_tests())
  File "./RUNTESTS.py", line 110, in run_tests
    self._test_failed(tc, c, f)
UnboundLocalError: local variable 'c' referenced before assignment
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4819)
<!-- Reviewable:end -->
