### PR TITLE
pmem2: always translate PMEM2_E_NOSUPP into ENOTSUP

### DIFF
--- a/src/libpmem2/pmem2_utils.c
+++ b/src/libpmem2/pmem2_utils.c
@@ -69,6 +69,9 @@ pmem2_err_to_errno(int err)
 	if (err > 0)
 		FATAL("positive error code is a bug in libpmem2");
 
+	if (err == PMEM2_E_NOSUPP)
+		return ENOTSUP;
+
 	if (err <= PMEM2_E_UNKNOWN)
 		return EINVAL;
 

--- a/src/test/pmem2_perror/pmem2_perror.c
+++ b/src/test/pmem2_perror/pmem2_perror.c
@@ -143,7 +143,7 @@ test_simple_err_to_errno_check(const struct test_case *tc,
 		int argc, char *argv[])
 {
 	int ret_errno = pmem2_err_to_errno(PMEM2_E_NOSUPP);
-	UT_ASSERTeq(ret_errno, EINVAL);
+	UT_ASSERTeq(ret_errno, ENOTSUP);
 
 	ret_errno = pmem2_err_to_errno(PMEM2_E_UNKNOWN);
 	UT_ASSERTeq(ret_errno, EINVAL);


### PR DESCRIPTION
Translate always the PMEM2_E_NOSUPP error into the ENOTSUP errno.
It will help handle this error on OSes, where some features
are not supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4827)
<!-- Reviewable:end -->
