### PR TITLE
core: fix Last_errormsg_get when NO_LIBPTHREAD is defined

### DIFF
--- a/src/core/out.c
+++ b/src/core/out.c
@@ -127,7 +127,7 @@ Last_errormsg_fini(void)
 static inline const struct errormsg *
 Last_errormsg_get(void)
 {
-	return &Last_errormsg.msg[0];
+	return &Last_errormsg;
 }
 
 #endif /* NO_LIBPTHREAD */


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4833)
<!-- Reviewable:end -->
