### PR TITLE
core: fix _On_drd_or_hg in util_init()

### DIFF
--- a/src/core/util.c
+++ b/src/core/util.c
@@ -348,7 +348,7 @@ util_init(void)
 #endif
 
 #if VG_DRD_ENABLED || VG_HELGRIND_ENABLED
-	_On_drd_or_hg = _On_helgrind + _On_drd;
+	_On_drd_or_hg = (unsigned)(On_helgrind + On_drd);
 #endif
 
 #if VG_PMEMCHECK_ENABLED


### PR DESCRIPTION
_On_drd is defined only if VG_DRD_ENABLED is defined and
_On_helgrind is defined only if VG_HELGRIND_ENABLED is defined.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4834)
<!-- Reviewable:end -->
