### PR TITLE
Fix data cache flush on ppc64

### DIFF
--- a/src/libpmem/ppc64/.cstyleignore
+++ b/src/libpmem/ppc64/.cstyleignore
@@ -1,0 +1,1 @@
+platform_generic.c


### PR DESCRIPTION
The dcbst instruction doesn't flush a cache block correctly because it
doesn't mark that block as clean on Power 9, see Manual "POWER9
Processor User’s Manual" page 66.
Replace dcbst with dcbf in order to fix this issue. This change requires
to replace lwsync with a hwsync too in order to cover for the usage of dcbf.

Adopt the best practices according to the POWER ISA 3.1.

Fix #4843 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4844)
<!-- Reviewable:end -->
