### PR TITLE
pmem2: remove experimental message from ppc64le port

### DIFF
--- a/src/libpmem2/ppc64/init.c
+++ b/src/libpmem2/ppc64/init.c
@@ -103,8 +103,7 @@ void
 pmem2_arch_init(struct pmem2_arch_info *info)
 {
 	LOG(3, "libpmem*: PPC64 support");
-	LOG(3, "PMDK PPC64 support is currently experimental");
-	LOG(3, "Please don't use this library in production environment");
+
 	if (On_valgrind) {
 		info->fence = ppc_fence_empty;
 		info->flush = ppc_flush_msync;


### PR DESCRIPTION
The ppc64le port should no longer be considered experimental.

Signed-off-by: Lucas A. M. Magalhaes <lamm@linux.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4863)
<!-- Reviewable:end -->
