### PR TITLE
obj: disable obj_ctl_arenas on PPC

### DIFF
--- a/utils/docker/ppc64le.blacklist
+++ b/utils/docker/ppc64le.blacklist
@@ -4,6 +4,7 @@ ex_librpmem_manpage
 libpmempool_rm_remote
 obj_basic_integration
 obj_check_remote
+obj_ctl_arenas
 obj_ctl_debug
 obj_mem
 obj_memcheck_register


### PR DESCRIPTION
There's an unexplained issue with the above test when
run under drd on PPC. It just started happening recently,
without any changes in the library - so the problem has
surfaced due to some change in the platform.

The same problem cannot be reproduced on x86, and all
reported code paths use regular locking for synchronization,
so this isn't an issue with incorrect use of atomics.

This needs to be investigated fully, but for now, the
test is added to PPC blacklist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4873)
<!-- Reviewable:end -->
