### PR TITLE
pmem2: (+pmem) revert ppc64 workaround for valgrind

### DIFF
--- a/src/libpmem2/ppc64/init.c
+++ b/src/libpmem2/ppc64/init.c
@@ -35,12 +35,6 @@ ppc_fence(void)
 }
 
 static void
-ppc_fence_empty(void)
-{
-	LOG(15, NULL);
-}
-
-static void
 ppc_flush(const void *addr, size_t size)
 {
 	LOG(15, "addr %p size %zu", addr, size);
@@ -62,53 +56,11 @@ ppc_flush(const void *addr, size_t size)
 	}
 }
 
-static void
-ppc_flush_msync(const void *addr, size_t len)
-{
-	LOG(15, "addr %p len %zu", addr, len);
-	/* this implementation is copy of pmem_msync */
-
-	VALGRIND_DO_CHECK_MEM_IS_ADDRESSABLE(addr, len);
-
-	/*
-	 * msync requires addr to be a multiple of pagesize but there are no
-	 * requirements for len. Align addr down and change len so that
-	 * [addr, addr + len) still contains initial range.
-	 */
-
-	/* increase len by the amount we gain when we round addr down */
-	len += (uintptr_t)addr & (Pagesize - 1);
-
-	/* round addr down to page boundary */
-	uintptr_t uptr = (uintptr_t)addr & ~((uintptr_t)Pagesize - 1);
-
-	/*
-	 * msync accepts addresses aligned to page boundary, so we may sync
-	 * more and part of it may have been marked as undefined/inaccessible
-	 * Msyncing such memory is not a bug, so as a workaround temporarily
-	 * disable error reporting.
-	 */
-	VALGRIND_DO_DISABLE_ERROR_REPORTING;
-
-	if (msync((void *)uptr, len, MS_SYNC) < 0)
-		ERR("!msync");
-
-	VALGRIND_DO_ENABLE_ERROR_REPORTING;
-
-	/* full flush */
-	VALGRIND_DO_PERSIST(uptr, len);
-}
-
 void
 pmem2_arch_init(struct pmem2_arch_info *info)
 {
 	LOG(3, "libpmem*: PPC64 support");
 
-	if (On_valgrind) {
-		info->fence = ppc_fence_empty;
-		info->flush = ppc_flush_msync;
-	} else {
-		info->fence = ppc_fence;
-		info->flush = ppc_flush;
-	}
+	info->fence = ppc_fence;
+	info->flush = ppc_flush;
 }


### PR DESCRIPTION
This caused more issues then it solved... The CI environment simply
has to have a new enough valgrind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4875)
<!-- Reviewable:end -->
