### PR TITLE
test: change valgrind version for PPC64LE

### DIFF
--- a/utils/docker/images/install-valgrind.sh
+++ b/utils/docker/images/install-valgrind.sh
@@ -18,6 +18,19 @@ install_upstream_from_distro() {
   esac
 }
 
+install_upstream_3_16_1() {
+  git clone git://sourceware.org/git/valgrind.git
+  cd valgrind
+  # valgrind v3.16.1 upstream
+  git checkout VALGRIND_3_16_BRANCH
+  ./autogen.sh
+  ./configure
+  make -j$(nproc)
+  make -j$(nproc) install
+  cd ..
+  rm -rf valgrind
+}
+
 install_custom-pmem_from_source() {
   git clone https://github.com/pmem/valgrind.git
   cd valgrind
@@ -34,6 +47,6 @@ install_custom-pmem_from_source() {
 
 ARCH=$(uname -m)
 case "$ARCH" in
-  ppc64le) install_upstream_from_distro ;;
+  ppc64le) install_upstream_3_16_1 ;;
   *) install_custom-pmem_from_source ;;
 esac


### PR DESCRIPTION
The recent change on flush instructions on power triggers a bug on
valgrind. The newest valgrind version 3.16.1 already have a patch for
this so, for now, we are changing to use it.

Signed-off-by: Lucas A. M. Magalhaes <lamm@linux.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4876)
<!-- Reviewable:end -->
