### PR TITLE
doc: fix an inaccuracy in libpmem docs

### DIFF
--- a/libpmem/index.md
+++ b/libpmem/index.md
@@ -180,7 +180,7 @@ by calling `pmem_flush()` for the first step and `pmem_drain()`
 for the second.  Note that either of these steps may be
 unnecessary on a given platform, and the library knows how
 to check for that and do the right thing.  For example, on
-Intel platforms, `pmem_drain()` is an empty function.
+Intel platforms with eADR, `pmem_flush()` is an empty function.
 
 When does it make sense to break flushing into steps?  This example,
 called *full_copy* illustrates one reason you might do this.  Since


### PR DESCRIPTION
pmem_drain() is almost always an sfence...

Reported-by: Steve Heller <steve@steveheller.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4877)
<!-- Reviewable:end -->
