### PR TITLE
common: fix GIT_VERSION string

### DIFF
--- a/GIT_VERSION
+++ b/GIT_VERSION
@@ -1,1 +1,1 @@
-$Format:%h %d$
+$Format:%h$


### PR DESCRIPTION
I messed up restoring GIT_VERSION after a release...

I'm doing this through a PR so that I can be sure that CI builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4879)
<!-- Reviewable:end -->
