### PR TITLE
common: error out on extra space before or after ++/-- operators

### DIFF
--- a/src/libpmempool/sync.c
+++ b/src/libpmempool/sync.c
@@ -1328,7 +1328,7 @@ static int
 update_remote_headers(struct pool_set *set)
 {
 	LOG(3, "set %p", set);
-	for (unsigned r = 0; r < set->nreplicas; ++ r) {
+	for (unsigned r = 0; r < set->nreplicas; ++r) {
 		/* skip local or just created replicas */
 		if (REP(set, r)->remote == NULL ||
 				PART(REP(set, r), 0)->created == 1)

--- a/utils/cstyle
+++ b/utils/cstyle
@@ -554,6 +554,12 @@ line: while (<$filehandle>) {
 	if (/(return|case|=|\?|:|,|\[)[ \t]+\-[ \t]/ || /[\(\[]\-[ \t]/) {
 		err("extra space after - operator");
 	}
+	if (/[ \t]\+\+ /) {
+		err("extra space before or after ++ operator");
+	}
+	if (/[ \t]\-\- /) {
+		err("extra space before or after -- operator");
+	}
 	if (/[^ \t]\-=/ || /\-=[^ ]/) {
 		err("missing space around -= operator");
 	}


### PR DESCRIPTION
Make cstyle error out on extra space before or after ++/-- operators.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4887)
<!-- Reviewable:end -->
