### PR TITLE
pmem: remove SDS support for PPC64LE

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -109,7 +109,9 @@ CFLAGS += -pthread
 CFLAGS += -DSRCVERSION=\"$(SRCVERSION)\"
 
 ifeq ($(OS_DIMM),ndctl)
+ifneq ($(ARCH), ppc64)
 CFLAGS += -DSDS_ENABLED
+endif
 CFLAGS += $(OS_DIMM_CFLAG)
 endif
 

--- a/src/libpmem/ppc64/init.c
+++ b/src/libpmem/ppc64/init.c
@@ -47,6 +47,7 @@ pmem_init_funcs(struct pmem_funcs *funcs)
 {
 
 	LOG(3, "libpmem: PPC64 support");
+	LOG(3, "PPC64 PMDK does not support SDS");
 	LOG(3, "PMDK PPC64 support is currently experimental");
 	LOG(3, "Please dont use this library in production environment");
 


### PR DESCRIPTION
PPC64LE doesn't have NFIT support on Linux Kernel.

Signed-off-by: Lucas A. M. Magalhaes <lamm@linux.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4888)
<!-- Reviewable:end -->
