### PR TITLE
pmem: remove SDS support for PPC64LE

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -88,7 +88,9 @@ CFLAGS += -pthread
 CFLAGS += -DSRCVERSION=\"$(SRCVERSION)\"
 
 ifeq ($(OS_DIMM),ndctl)
+ifneq ($(ARCH), ppc64)
 CFLAGS += -DSDS_ENABLED
+endif
 CFLAGS += $(OS_DIMM_CFLAG)
 endif
 

--- a/src/libpmem2/ppc64/init.c
+++ b/src/libpmem2/ppc64/init.c
@@ -103,6 +103,7 @@ void
 pmem2_arch_init(struct pmem2_arch_info *info)
 {
 	LOG(3, "libpmem*: PPC64 support");
+	LOG(3, "PPC64 PMDK does not support SDS");
 
 	if (On_valgrind) {
 		info->fence = ppc_fence_empty;


### PR DESCRIPTION
PPC64LE doesn't have NFIT support on Linux Kernel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4889)
<!-- Reviewable:end -->
