### PR TITLE
pmem2: fix non-page-aligned deep flushes

### DIFF
--- a/src/test/pmem2_integration/TESTS.py
+++ b/src/test/pmem2_integration/TESTS.py
@@ -282,3 +282,8 @@ class TEST36(PMEM2_INTEGRATION_DEV_DAXES):
 class TEST37(PMEM2_INTEGRATION_DEV_DAXES):
     """test deep flush with overlaping part"""
     test_case = "test_deep_flush_overlap"
+
+
+class TEST38(PMEM2_INTEGRATION):
+    """test for unaligned persists"""
+    test_case = "test_unaligned_persist"


### PR DESCRIPTION
Deep flushing uses msync, which requires address
to be page aligned. In our API, we usually round
down the address and increase the flushing length.
This wasn't done for deep flush, which caused failures
on unaligned deep flushes.

This patch simply copies the alignment mechanism from the
same functionality used in the persist.c file. Ideally,
we'd abstract this into its own method that then calls
msync. But the code is simple enough, and I decided not
to introduce extra complexity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4891)
<!-- Reviewable:end -->
