### PR TITLE
benchmark: fix memset scenario name

### DIFF
--- a/src/benchmarks/pmembench_memset.cfg
+++ b/src/benchmarks/pmembench_memset.cfg
@@ -86,7 +86,7 @@ mem-mode = seq
 # from 64 to 8k bytes
 # mode sequential
 # memset followed by pmem_msync()
-[pmem_memset_libc_memset_persist]
+[pmem_memset_libc_memset_msync]
 bench = pmem_memset
 threads = 1
 data-size = 64:*2:8192


### PR DESCRIPTION
Fix test name from pmem_memset_libc_memset_persist to pmem_memset_libc_memset_msync.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4893)
<!-- Reviewable:end -->
