### PR TITLE
test: store logs in separate folders

### DIFF
--- a/src/test/README
+++ b/src/test/README
@@ -189,13 +189,14 @@ test run, it can use this line:
 
 Using the unittest library, the C programs run during unit testing get their
 output and tracing information logged to various files.  These are named with
-the test number embedded in them, so a script called TEST0 would commonly
+the test number embedded in them and stored inside folders for each build type,
+so a script called TEST0 run with (check/none/debug) build type would commonly
 produce:
 
-	err0.log	log of stderr
-	out0.log	log of stdout
-	trace0.log	trace points from unittest library
-	pmem0.log	trace from libpmem (PMEM_LOG_FILE points here)
+	logs/check/none/debug/err0.log	log of stderr
+	logs/check/none/debug/out0.log	log of stdout
+	logs/check/none/debug/trace0.log	trace points from unittest library
+	logs/check/none/debug/pmem0.log	trace from libpmem (PMEM_LOG_FILE points here)
 
 Although the above log files are the common case, the TEST* scripts are free to
 create any files.  It is recommended, however, that the script creates files

--- a/src/test/unittest/unittest.ps1
+++ b/src/test/unittest/unittest.ps1
@@ -640,6 +640,16 @@ function check {
     if ($listing) {
 		match $listing
     }
+
+    # Move logs to build folder
+    $LOGS_DIR="logs\$Env:TYPE\$Global:REAL_FS\$Env:BUILD"
+    If(!(test-path $LOGS_DIR))
+    {
+        [void](New-Item -path $LOGS_DIR -ItemType Directory)
+    }
+    foreach ($f in $(get_files "[a-zA-Z_]*${Env:UNITTEST_NUM}\.log$")) {
+        Move-Item $f $LOGS_DIR\$f -force
+    }
 }
 
 #

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -2831,6 +2831,12 @@ function check() {
 			match $option $FILES
 		fi
 	fi
+	# Move logs to build folder
+	LOG_DIR=logs/$TEST/$REAL_FS/$BUILD$MCSTR$PROV$PM
+	if [ ! -d $LOG_DIR ]; then mkdir --parents $LOG_DIR; fi
+	for f in $(get_files ".*[a-zA-Z_]${UNITTEST_NUM}\.log"); do
+		mv -f $f $LOG_DIR/$f
+	done
 }
 
 #


### PR DESCRIPTION
Signed-off-by: Michal Papinski <michalx.papinski@intel.com>

Issue:
At current version when we run tests for multiple build types, the logs will get overwritten. 

Solution:
To avoid loosing the log files I implemented feature to create directory tree for each specific build type inside the test group folder. When all the tests from specific group with specific build type will finish running, the logs will be moved to the proper folder.

Example logs:
https://github.com/pmem/pmdk/issues/4825
https://github.com/pmem/pmdk/issues/4715

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4895)
<!-- Reviewable:end -->
