### PR TITLE
pmem2: deregister valgrind mapping prior to unmap

### DIFF
--- a/src/libpmem2/map_posix.c
+++ b/src/libpmem2/map_posix.c
@@ -502,11 +502,11 @@ pmem2_map_delete(struct pmem2_map **map_ptr)
 	if (ret)
 		return ret;
 
+	VALGRIND_REMOVE_PMEM_MAPPING(map->addr, map->content_length);
+
 	ret = unmap(map->addr, map->reserved_length);
 	if (ret)
 		return ret;
-
-	VALGRIND_REMOVE_PMEM_MAPPING(map->addr, map->content_length);
 
 	Free(map);
 	*map_ptr = NULL;


### PR DESCRIPTION
This was raported by coverity as use-after-free, but I think
it's unlikely to be a real problem. But the fix is simple enough...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4909)
<!-- Reviewable:end -->
