### PR TITLE
common: fix LIBFABRIC flags

### DIFF
--- a/src/common.inc
+++ b/src/common.inc
@@ -311,6 +311,7 @@ LIBFABRIC_MIN_VERSION := 1.4.2
 # utils/docker/images/install-libfabric.sh.
 ifeq ($(BUILD_RPMEM),)
 BUILD_RPMEM := $(call check_package, libfabric --atleast-version=$(LIBFABRIC_MIN_VERSION))
+endif
 ifneq ($(BUILD_RPMEM),y)
 export BUILD_RPMEM_INFO := libfabric (version >= $(LIBFABRIC_MIN_VERSION)) is missing -- \
 see src/librpmem/README for details
@@ -319,7 +320,6 @@ LIBFABRIC_CFLAGS := $(shell $(PKG_CONFIG) --cflags libfabric)
 LIBFABRIC_LD_LIBRARY_PATHS := $(shell $(PKG_CONFIG) --variable=libdir libfabric)
 LIBFABRIC_LIBS := $(shell $(PKG_CONFIG) --libs libfabric)
 LIBFABRIC_PATH := $(shell $(PKG_CONFIG) --variable=exec_prefix libfabric)/bin
-endif
 endif
 export BUILD_RPMEM
 export LIBFABRIC_CFLAGS


### PR DESCRIPTION
If BUILD_RPMEM is set, LIBFABRIC_* are not set up by common.inc and cause rpmemd to fail building

Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4912)
<!-- Reviewable:end -->
