### PR TITLE
doc: fix too long line in the libpmem2.7 man

### DIFF
--- a/doc/libpmem2/libpmem2.7.md
+++ b/doc/libpmem2/libpmem2.7.md
@@ -109,7 +109,7 @@ To read or clear badblocks, the following functions are provided:
 To handle unsafe shutdown in the application, the following functions are provided:
 **pmem2_source_device_id**(3), **pmem2_source_device_usc**(3).
 More detailed information about unsafe shutdown detection and unsafe shutdown count
-and can be found in the [libpmem2_unsafe_shutdown](https://pmem.io/pmdk/manpages/linux/master/libpmem2/libpmem2_unsafe_shutdown.7.html) man page.
+and can be found in the **libpmem2_unsafe_shutdown**(7) man page.
 
 # GRANULARITY #
 
@@ -299,5 +299,5 @@ by the SNIA NVM Programming Technical Work Group:
 **pmem2_get_persist_fn**(3),**pmem2_map_get_store_granularity**(3),
 **pmem2_map_new**(3), **pmem2_source_from_anon**(3),
 **pmem2_source_from_fd**(3), **pmem2_source_from_handle**(3),
-**libpmemblk**(7), **libpmemlog**(7), **libpmemobj**(7)
-and **<https://pmem.io>**
+**libpmem2_unsafe_shutdown**(7), **libpmemblk**(7),
+**libpmemlog**(7), **libpmemobj**(7) and **<https://pmem.io>**


### PR DESCRIPTION
This is the easiest way to fix:
10:32:09,450 WARN  - libpmem2.7: <standard input>:109: warning [p 2, 4.3i]: can't break line
10:32:09,735 WARN  - make: *** [check-doc] Error 123

In fact, we do not use full page links anywhere in .md files. It was the only place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4919)
<!-- Reviewable:end -->
