### PR TITLE
fix build with -Og on some platforms

### DIFF
--- a/src/libpmem2/badblocks_ndctl.c
+++ b/src/libpmem2/badblocks_ndctl.c
@@ -538,8 +538,8 @@ pmem2_badblock_next(struct pmem2_badblock_context *bbctx,
 	unsigned long long bb_end;
 	unsigned long long bb_len;
 	unsigned long long bb_off;
-	unsigned long long ext_beg;
-	unsigned long long ext_end;
+	unsigned long long ext_beg = 0; /* placate compiler warnings */
+	unsigned long long ext_end = -1ULL;
 	unsigned e;
 	int ret;
 


### PR DESCRIPTION
-Og enables some basic flow tracking, so this warning is enabled, yet the flow tracking is not yet deep enough to notice this can't actually happen.  Then, -Werror makes the build fail.

Got this on arm64 Debian unstable, doesn't repro on x86.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4928)
<!-- Reviewable:end -->
