### PR TITLE
update valgrind suppressions for new glibc

### DIFF
--- a/src/test/drd-log.supp
+++ b/src/test/drd-log.supp
@@ -1,7 +1,7 @@
 {
     <debug_log_suppress>
     drd:ConflictingAccess
-    fun:*mempcpy
+    fun:*mem*cpy
     ...
     fun:_IO_file_xsputn@@GLIBC*
     fun:fputs
@@ -22,7 +22,7 @@
 {
     <ut_log_suppress>
     drd:ConflictingAccess
-    fun:*mempcpy
+    fun:*mem*cpy
     fun:_IO_file_xsputn@@GLIBC*
     fun:fputs
     ...

--- a/src/test/helgrind-log.supp
+++ b/src/test/helgrind-log.supp
@@ -1,7 +1,7 @@
 {
     <debug_log_suppress>
     Helgrind:Race
-    fun:*mempcpy
+    fun:*mem*cpy
     ...
     fun:_IO_file_xsputn@@GLIBC*
     fun:fputs
@@ -22,7 +22,7 @@
 {
     <ut_log_suppress>
     Helgrind:Race
-    fun:*mempcpy
+    fun:*mem*cpy
     fun:_IO_file_xsputn@@GLIBC*
     fun:fputs
     ...

--- a/src/test/helgrind-log.supp
+++ b/src/test/helgrind-log.supp
@@ -20,6 +20,18 @@
     fun:out_log
 }
 {
+    <debug_err_suppress>
+    Helgrind:Race
+    fun:*mem*cpy
+    ...
+    fun:_IO_file_xsputn@@GLIBC*
+    fun:fputs
+    fun:out_print_func
+    fun:out_error
+    fun:out_err
+}
+
+{
     <ut_log_suppress>
     Helgrind:Race
     fun:*mem*cpy


### PR DESCRIPTION
Fixes fails on arm64 and ppc64.

The mem*cpy part is obvious; I don't fully understand why out_err is needed — somehow valgrind requires both sides to be suppressed.

Closes #4926

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4931)
<!-- Reviewable:end -->
