### PR TITLE
endif clause in rpm spec file shouldn't have any inline comments

### DIFF
--- a/utils/pmdk.spec.in
+++ b/utils/pmdk.spec.in
@@ -157,7 +157,9 @@ debug version is to set the environment variable LD_LIBRARY_PATH to
 %{_libdir}/pmdk_debug/libpmem2.so.*
 %license LICENSE
 %doc ChangeLog CONTRIBUTING.md README.md
-%endif #_pmem2_install
+
+# end of "if _pmem2_install"
+%endif
 
 
 %package -n libpmem__PKG_NAME_SUFFIX__
@@ -567,7 +569,8 @@ and facilitates access to persistent memory over RDMA.
 %{_bindir}/rpmemd
 %{_mandir}/man1/rpmemd.1.gz
 
-%endif # _with_fabric
+# end of "if _with_fabric"
+%endif
 
 %package -n pmempool
 Summary: Utilities for Persistent Memory
@@ -631,7 +634,8 @@ a device.
 %license LICENSE
 %doc ChangeLog CONTRIBUTING.md README.md
 
-%endif # _with_ndctl
+# end of "if _with_ndctl"
+%endif
 
 %prep
 %setup -q -n %{name}-%{version}


### PR DESCRIPTION
while building rpm packages for PMDK 1.9 on Fedora rawhide I encountered:

```
RPM build errors:
[91m    extra tokens at the end of %endif directive in line 160:  %endif #_pmem2_install

    extra tokens at the end of %endif directive in line 570:  %endif # _with_fabric

    extra tokens at the end of %endif directive in line 634:  %endif # _with_ndctl

    Bad exit status from /var/tmp/rpm-tmp.dIyVYY (%build)
```

In other OSes it's treated just as warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4937)
<!-- Reviewable:end -->
