### PR TITLE
pmem2: fix munmap when file mapping fails (posix)

### DIFF
--- a/src/libpmem2/map_posix.c
+++ b/src/libpmem2/map_posix.c
@@ -488,8 +488,13 @@ pmem2_map_new(struct pmem2_map **map_ptr, const struct pmem2_config *cfg,
 	ret = file_map(reserv, content_length, proto, flags, map_fd, off,
 			&map_sync, &addr);
 	if (ret) {
-		/* unmap the reservation mapping */
-		munmap(reserv, reserved_length);
+		/*
+		 * unmap the reservation mapping only
+		 * if it wasn't provided by the config
+		 */
+		if (!cfg->reserv)
+			munmap(reserv, reserved_length);
+
 		if (ret == -EACCES)
 			ret = PMEM2_E_NO_ACCESS;
 		else if (ret == -ENOTSUP)


### PR DESCRIPTION
Reservation region should be unmapped only when it wasn't provided
by the config, otherwise the job of cleaning up the reservation is
up to the invoking layer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4940)
<!-- Reviewable:end -->
