### PR TITLE
make pmemobj_open/create/close thread-safe

### DIFF
--- a/doc/libpmemobj/pmemobj_open.3.md
+++ b/doc/libpmemobj/pmemobj_open.3.md
@@ -8,7 +8,7 @@ date: pmemobj API version 2.3
 ...
 
 [comment]: <> (SPDX-License-Identifier: BSD-3-Clause)
-[comment]: <> (Copyright 2017-2018, Intel Corporation)
+[comment]: <> (Copyright 2017-2020, Intel Corporation)
 
 [comment]: <> (pmemobj_open.3 -- man page for most commonly used functions from libpmemobj library)
 
@@ -50,10 +50,8 @@ To use the pmem-resident transactional object store provided by
 with the _UW(pmemobj_create) function described below. Existing pools
 may be opened with the _UW(pmemobj_open) function.
 
-None of the three functions described below are thread-safe with respect
-to any other **libpmemobj**(7) function. In other words, when creating,
-opening or deleting a pool, nothing else in the library can happen in parallel,
-and therefore these functions should be called from the main thread.
+As of **libpmemobj** **1.11**, these functions are thread-safe; be careful
+if you have to use earlier versions of the library.
 
 Once created, the memory pool is represented by an opaque handle,
 of type *PMEMobjpool\**, which is passed to most of the other **libpmemobj**(7)

--- a/src/benchmarks/pmembench_obj_gen.cfg
+++ b/src/benchmarks/pmembench_obj_gen.cfg
@@ -19,14 +19,13 @@ data-size = 1024
 objects = 1:*10:100000
 type-number = rand
 
-# pmemobj_open/close are not yet thread-safe
-#[obj_open_threads]
-#bench = obj_open
-#threads = 1:+1:10
-#data-size = 1024
-#min-size = 1
-#objects = 1000
-#type-number = rand
+[obj_open_threads]
+bench = obj_open
+threads = 1:+1:10
+data-size = 1024
+min-size = 1
+objects = 1000
+type-number = rand
 
 [obj_direct_threads_one_pool]
 bench = obj_direct

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -64,6 +64,7 @@ static struct critnib *pools_ht; /* hash table used for searching by UUID */
 static struct critnib *pools_tree; /* tree used for searching by address */
 
 int _pobj_cache_invalidate;
+static os_mutex_t pools_mutex;
 
 #ifndef _WIN32
 
@@ -267,6 +268,8 @@ obj_init(void)
 
 	COMPILE_ERROR_ON(PMEMOBJ_F_MEM_NOFLUSH != PMEM_F_MEM_NOFLUSH);
 
+	os_mutex_init(&pools_mutex);
+
 #ifdef _WIN32
 	/* XXX - temporary implementation (see above) */
 	os_once(&Cached_pool_key_once, _Cached_pool_key_alloc);
@@ -301,6 +304,8 @@ obj_fini(void)
 		critnib_delete(pools_tree);
 	lane_info_destroy();
 	util_remote_fini();
+
+	os_mutex_destroy(&pools_mutex);
 
 #ifdef _WIN32
 	(void) os_tls_key_delete(Cached_pool_key);
@@ -1323,6 +1328,8 @@ pmemobj_createU(const char *path, const char *layout,
 		return NULL;
 	}
 
+	os_mutex_lock(&pools_mutex);
+
 	/*
 	 * A number of lanes available at runtime equals the lowest value
 	 * from all reported by remote replicas hosts. In the single host mode
@@ -1344,6 +1351,7 @@ pmemobj_createU(const char *path, const char *layout,
 			PMEMOBJ_MIN_PART, &adj_pool_attr, &runtime_nlanes,
 			REPLICAS_ENABLED) != 0) {
 		LOG(2, "cannot create pool or pool set");
+		os_mutex_unlock(&pools_mutex);
 		return NULL;
 	}
 
@@ -1397,6 +1405,7 @@ pmemobj_createU(const char *path, const char *layout,
 	util_poolset_fdclose(set);
 
 	LOG(3, "pop %p", pop);
+	os_mutex_unlock(&pools_mutex);
 
 	return pop;
 
@@ -1406,6 +1415,7 @@ err:
 	if (set->remote)
 		obj_cleanup_remote(pop);
 	util_poolset_close(set, DELETE_CREATED_PARTS);
+	os_mutex_unlock(&pools_mutex);
 	errno = oerrno;
 	return NULL;
 }
@@ -1707,6 +1717,8 @@ obj_open_common(const char *path, const char *layout, unsigned flags, int boot)
 	PMEMobjpool *pop = NULL;
 	struct pool_set *set;
 
+	os_mutex_lock(&pools_mutex);
+
 	/*
 	 * A number of lanes available at runtime equals the lowest value
 	 * from all reported by remote replicas hosts. In the single host mode
@@ -1715,8 +1727,10 @@ obj_open_common(const char *path, const char *layout, unsigned flags, int boot)
 	 * environment variable whichever is lower.
 	 */
 	unsigned runtime_nlanes = obj_get_nlanes();
-	if (obj_pool_open(&set, path, flags, &runtime_nlanes))
+	if (obj_pool_open(&set, path, flags, &runtime_nlanes)) {
+		os_mutex_unlock(&pools_mutex);
 		return NULL;
+	}
 
 	/* pop is master replica from now on */
 	pop = set->replica[0]->part[0].addr;
@@ -1769,6 +1783,7 @@ obj_open_common(const char *path, const char *layout, unsigned flags, int boot)
 #endif
 
 	util_poolset_fdclose(set);
+	os_mutex_unlock(&pools_mutex);
 
 	LOG(3, "pop %p", pop);
 
@@ -1781,6 +1796,7 @@ err_descr_check:
 	obj_replicas_fini(set);
 replicas_init:
 	obj_pool_close(set);
+	os_mutex_unlock(&pools_mutex);
 	return NULL;
 }
 
@@ -1941,6 +1957,7 @@ pmemobj_close(PMEMobjpool *pop)
 	LOG(3, "pop %p", pop);
 	PMEMOBJ_API_START();
 
+	os_mutex_lock(&pools_mutex);
 	_pobj_cache_invalidate++;
 
 	if (critnib_remove(pools_ht, pop->uuid_lo) != pop) {
@@ -1970,6 +1987,7 @@ pmemobj_close(PMEMobjpool *pop)
 #endif /* _WIN32 */
 
 	obj_pool_cleanup(pop);
+	os_mutex_unlock(&pools_mutex);
 	PMEMOBJ_API_END();
 }
 

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1958,7 +1958,6 @@ pmemobj_close(PMEMobjpool *pop)
 	PMEMOBJ_API_START();
 
 	os_mutex_lock(&pools_mutex);
-	_pobj_cache_invalidate++;
 
 	if (critnib_remove(pools_ht, pop->uuid_lo) != pop) {
 		ERR("critnib_remove for pools_ht");
@@ -1985,6 +1984,10 @@ pmemobj_close(PMEMobjpool *pop)
 	}
 
 #endif /* _WIN32 */
+
+	VALGRIND_HG_DRD_DISABLE_CHECKING(&_pobj_cache_invalidate,
+		sizeof(_pobj_cache_invalidate));
+	_pobj_cache_invalidate++;
 
 	obj_pool_cleanup(pop);
 	os_mutex_unlock(&pools_mutex);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -96,6 +96,7 @@ OBJ_TESTS = \
 	obj_pool\
 	obj_pool_lock\
 	obj_pool_lookup\
+	obj_pool_open_mt\
 	obj_recovery\
 	obj_recreate\
 	obj_root\

--- a/src/test/obj_pool_open_mt/.gitignore
+++ b/src/test/obj_pool_open_mt/.gitignore
@@ -1,0 +1,1 @@
+obj_pool_open_mt

--- a/src/test/obj_pool_open_mt/Makefile
+++ b/src/test/obj_pool_open_mt/Makefile
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2019, Intel Corporation
+
+#
+# src/test/obj_obj_pool_mt/Makefile -- build obj_obj_pool_mt unit test
+#
+TARGET = obj_pool_open_mt
+OBJS = obj_pool_open_mt.o
+
+LIBPMEMOBJ=y
+
+include ../Makefile.inc

--- a/src/test/obj_pool_open_mt/TEST0
+++ b/src/test/obj_pool_open_mt/TEST0
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2019, Intel Corporation
+
+#
+# src/test/obj_pool_open_mt/TEST0 -- unit test for concurrent pool opens/closes
+#
+
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+
+setup
+
+expect_normal_exit ./obj_pool_open_mt$EXESUFFIX $DIR 8
+
+pass

--- a/src/test/obj_pool_open_mt/TEST0.PS1
+++ b/src/test/obj_pool_open_mt/TEST0.PS1
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2019-2020, Intel Corporation
+#
+# src/test/obj_pool_opem_mt/TEST0 -- unit test for pmemobj_pool
+#
+
+. ..\unittest\unittest.ps1
+
+require_test_type medium
+require_fs_type any
+
+setup
+
+expect_normal_exit $Env:EXE_DIR\obj_pool_open_mt$Env:EXESUFFIX $DIR 8
+
+pass

--- a/src/test/obj_pool_open_mt/TEST1
+++ b/src/test/obj_pool_open_mt/TEST1
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2019, Intel Corporation
+
+#
+# src/test/obj_pool_open_mt/TEST1 -- multithreaded test for pool_open
+#
+
+. ../unittest/unittest.sh
+
+require_test_type medium
+require_fs_type any
+configure_valgrind helgrind force-enable
+
+setup
+
+expect_normal_exit ./obj_pool_open_mt$EXESUFFIX $DIR 2
+
+pass

--- a/src/test/obj_pool_open_mt/obj_pool_open_mt.c
+++ b/src/test/obj_pool_open_mt/obj_pool_open_mt.c
@@ -27,6 +27,14 @@ thread_oc(void *arg)
 
 	PMEMobjpool *p = pmemobj_create(pname, "", POOLSIZE, 0666);
 	UT_ASSERT(p);
+
+	/* use the new pool */
+	PMEMoid o;
+	UT_ASSERT(!pmemobj_zalloc(p, &o, 64, 0));
+	int *ptr = pmemobj_direct(o);
+	UT_ASSERT(ptr);
+	UT_ASSERT(! *ptr);
+
 	pmemobj_close(p);
 
 	for (uint64_t count = 0; count < niter; count++) {

--- a/src/test/obj_pool_open_mt/obj_pool_open_mt.c
+++ b/src/test/obj_pool_open_mt/obj_pool_open_mt.c
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2019, Intel Corporation */
+
+/*
+ * obj_pool_open_mt.c -- multithreaded unit test for pool_open
+ */
+
+#include <errno.h>
+
+#include "unittest.h"
+
+/* more concurrency = good */
+#define NTHREADS 16
+
+#define POOLSIZE (16 * 1048576)
+
+static unsigned long niter;
+static const char *path;
+
+static void *
+thread_oc(void *arg)
+{
+	unsigned tid = (unsigned)(uint64_t)arg;
+
+	char pname[PATH_MAX];
+	snprintf(pname, sizeof(pname), "%s/open_mt_%02u", path, tid);
+
+	PMEMobjpool *p = pmemobj_create(pname, "", POOLSIZE, 0666);
+	UT_ASSERT(p);
+	pmemobj_close(p);
+
+	for (uint64_t count = 0; count < niter; count++) {
+		p = pmemobj_open(pname, "");
+		UT_ASSERT(p);
+		pmemobj_close(p);
+	}
+
+	UNLINK(pname);
+
+	return NULL;
+}
+
+static void
+test()
+{
+	os_thread_t th[NTHREADS];
+
+	for (int i = 0; i < NTHREADS; i++)
+		THREAD_CREATE(&th[i], 0, thread_oc, (void *)(uint64_t)i);
+
+	/* The threads work here... */
+
+	for (int i = 0; i < NTHREADS; i++) {
+		void *retval;
+		THREAD_JOIN(&th[i], &retval);
+	}
+}
+
+int
+main(int argc, char *argv[])
+{
+	START(argc, argv, "obj_pool_open_mt");
+
+	if (argc != 3)
+		UT_FATAL("usage: %s path niter", argv[0]);
+
+	path = argv[1];
+	niter = ATOUL(argv[2]);
+	if (!niter || niter == ULONG_MAX)
+		UT_FATAL("%s: bad iteration count '%s'", argv[0], argv[2]);
+
+	test();
+
+	DONE(NULL);
+}


### PR DESCRIPTION
We had been close to getting this done in a fully concurrent way for 1½ years, yet this has never materialized.  Thus, let's at least use a mutex to serialize pool opens so it's safe to use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4941)
<!-- Reviewable:end -->
