### PR TITLE
Fix various issues reported by PVS-Studio analysis

### DIFF
--- a/src/benchmarks/clo.cpp
+++ b/src/benchmarks/clo.cpp
@@ -202,7 +202,7 @@ clo_parse_single_uint(struct benchmark_clo *clo, const char *arg, void *ptr)
 		return -1;
 	}
 
-	uint64_t tmax = ~0 >> (64 - 8 * clo->type_uint.size);
+	uint64_t tmax = ~0ULL >> (64 - 8 * clo->type_uint.size);
 	uint64_t tmin = 0;
 
 	tmax = min(tmax, clo->type_uint.max);

--- a/src/core/os_thread_windows.c
+++ b/src/core/os_thread_windows.c
@@ -354,9 +354,7 @@ get_rel_wait(const struct timespec *abstime)
 	time_t ms = (time_t)(abstime->tv_sec * 1000 +
 		abstime->tv_nsec / 1000000);
 
-	DWORD rel_wait = (DWORD)(ms - now_ms);
-
-	return rel_wait < 0 ? 0 : rel_wait;
+	return (DWORD)(ms - now_ms);
 }
 
 /*

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -1051,7 +1051,7 @@ heap_coalesce(struct palloc_heap *heap,
 		if (blocks[i] == NULL)
 			continue;
 		b = b ? b : blocks[i];
-		ret.size_idx += blocks[i] ? blocks[i]->size_idx : 0;
+		ret.size_idx += blocks[i]->size_idx;
 	}
 
 	ASSERTne(b, NULL);

--- a/src/test/pmem2_map_prot/pmem2_map_prot.c
+++ b/src/test/pmem2_map_prot/pmem2_map_prot.c
@@ -485,7 +485,7 @@ test_rw_mode_rw_prot_do_execute(const struct test_case *tc,
 	return 2;
 }
 
-static const char *initial_state = "No code.";
+static const char initial_state[] = "No code.";
 
 /*
  * test_rwx_prot_map_priv_do_execute -- copy string with the program to

--- a/src/test/pmem2_memcpy/memcpy_common.c
+++ b/src/test/pmem2_memcpy/memcpy_common.c
@@ -59,7 +59,7 @@ do_memcpy(int fd, char *dest, int dest_off, char *src, int src_off,
 			file_name, bytes / 2);
 
 	/* Now validate the contents of the file */
-	LSEEK(fd, (os_off_t)(dest_off + (int)(mapped_len / 2)), SEEK_SET);
+	LSEEK(fd, dest_off + (os_off_t)(mapped_len) / 2, SEEK_SET);
 	if (READ(fd, buf, bytes / 2) == bytes / 2) {
 		if (memcmp(src + src_off, buf, bytes / 2))
 			UT_FATAL("%s: first %zu bytes do not match",

--- a/src/test/tools/bttcreate/bttcreate.c
+++ b/src/test/tools/bttcreate/bttcreate.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2016-2019, Intel Corporation */
+/* Copyright 2016-2020, Intel Corporation */
 /*
  * bttcreate.c -- tool for generating BTT layout
  */
@@ -24,7 +24,7 @@
 #include "util.h"
 #include "page_size.h"
 
-#define BTT_CREATE_DEF_SIZE	(20 * 1UL << 20) /* 20 MB */
+#define BTT_CREATE_DEF_SIZE	(20 * (1UL << 20)) /* 20 MB */
 #define BTT_CREATE_DEF_BLK_SIZE	512UL
 #define BTT_CREATE_DEF_OFFSET_SIZE	PMEM_PAGESIZE
 

--- a/src/test/tools/pmemobjcli/pmemobjcli.c
+++ b/src/test/tools/pmemobjcli/pmemobjcli.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2014-2019, Intel Corporation */
+/* Copyright 2014-2020, Intel Corporation */
 /*
  * pmemobjcli.c -- CLI interface for pmemobj API
  */
@@ -234,18 +234,17 @@ pocli_args_obj_root(struct pocli_ctx *ctx, char *in, PMEMoid **oidp)
 	if (!input)
 		return POCLI_ERR_MALLOC;
 
+	enum pocli_ret ret = POCLI_ERR_PARS;
+
 	if (!oidp)
-		return POCLI_ERR_PARS;
+		goto out_input;
 
 	struct pocli_args *args = pocli_args_alloc(NULL, input, ".");
 	if (!args)
-		return POCLI_ERR_PARS;
-	enum pocli_ret ret = POCLI_RET_OK;
+		goto out_input;
 
-	if (strcmp(args->argv[0], "r") != 0) {
-		ret = POCLI_ERR_PARS;
+	if (strcmp(args->argv[0], "r") != 0)
 		goto out;
-	}
 
 	PMEMoid *oid = &ctx->root;
 	size_t size = pmemobj_root_size(ctx->pop);
@@ -254,27 +253,26 @@ pocli_args_obj_root(struct pocli_ctx *ctx, char *in, PMEMoid **oidp)
 		unsigned ind;
 		char c;
 		int n = sscanf(args->argv[i], "%u%c", &ind, &c);
-		if (n != 1) {
-			ret = POCLI_ERR_PARS;
+		if (n != 1)
 			goto out;
-		}
 
 		size_t max_ind = size / sizeof(PMEMoid);
-		if (!max_ind || ind >= max_ind) {
-			ret = POCLI_ERR_PARS;
+		if (!max_ind || ind >= max_ind)
 			goto out;
-		}
 
 		PMEMoid *oids = (PMEMoid *)pmemobj_direct(*oid);
 		oid = &oids[ind];
 		size = pmemobj_alloc_usable_size(*oid);
 	}
 
+	ret = POCLI_RET_OK;
+
 	*oidp = oid;
 
 out:
-	free(input);
 	free(args);
+out_input:
+	free(input);
 	return ret;
 }
 

--- a/src/test/unittest/ut.c
+++ b/src/test/unittest/ut.c
@@ -640,8 +640,8 @@ enum_handles(int op)
 	NTSTATUS status;
 	while ((status = NtQuerySystemInformation(
 			SystemExtendedHandleInformation,
-			hndl_info, hi_size, &req_size)
-				== STATUS_INFO_LENGTH_MISMATCH)) {
+			hndl_info, hi_size, &req_size))
+				== STATUS_INFO_LENGTH_MISMATCH) {
 		hi_size = req_size + 4096;
 		hndl_info = (PSYSTEM_HANDLE_INFORMATION_EX)REALLOC(hndl_info,
 				hi_size);

--- a/src/test/util_ctl/util_ctl.c
+++ b/src/test/util_ctl/util_ctl.c
@@ -714,24 +714,23 @@ main(int argc, char *argv[])
 
 	test_ctl_global_namespace(NULL);
 
-	struct pool *pop = malloc(sizeof(pop));
+	struct pool pop;
 
-	pop->ctl = ctl_new();
+	pop.ctl = ctl_new();
 
 	test_ctl_global_namespace(NULL);
 
-	CTL_REGISTER_MODULE(pop->ctl, debug);
+	CTL_REGISTER_MODULE(pop.ctl, debug);
 
-	test_ctl_global_namespace(pop);
+	test_ctl_global_namespace(&pop);
 
-	test_fault_injection(pop);
-	test_ctl_parser(pop);
-	test_string_config(pop);
-	test_file_config(pop);
+	test_fault_injection(&pop);
+	test_ctl_parser(&pop);
+	test_string_config(&pop);
+	test_file_config(&pop);
 	test_ctl_arg_parsers();
 
-	ctl_delete(pop->ctl);
-	free(pop);
+	ctl_delete(pop.ctl);
 
 	common_fini();
 


### PR DESCRIPTION
Thanks to Andrey Karpov and PVS-Studio for doing a thorough analysis of PMDK:
https://viva64.com/en/b/0756/

Even though we run two different static analysis tools and many runtime checkers, PVS-Studio managed to catch a couple of issues. The good news is that most of the problems were in tests or examples.

I didn't address the missing memory allocation error handling because while I 100% agree that library code should definitely handle all possible recoverable errors correctly, we usually omi extraneous error handling in tools/tests or benchmarks for the sake of brevity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4942)
<!-- Reviewable:end -->
