### PR TITLE
obj: fix failure atomicity bug in huge allocs

### DIFF
--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -953,10 +953,10 @@ heap_split_block(struct palloc_heap *heap, struct bucket *b,
 		uint32_t new_chunk_id = m->chunk_id + units;
 		uint32_t new_size_idx = m->size_idx - units;
 
-		*m = memblock_huge_init(heap, m->chunk_id, m->zone_id, units);
-
 		struct memory_block n = memblock_huge_init(heap,
 			new_chunk_id, m->zone_id, new_size_idx);
+
+		*m = memblock_huge_init(heap, m->chunk_id, m->zone_id, units);
 
 		if (bucket_insert_block(b, &n) != 0)
 			LOG(2,


### PR DESCRIPTION


This is a regression introduced in 5e137e0. That patch accidentally
modified the order in which huge chunk headers are updated, leading
to possible issue with failure atomicity where the chunk headers could
be inconsistent if a crash happened in between two header updates.

Closes #4945

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4946)
<!-- Reviewable:end -->
