### PR TITLE
pmem: Fix ppc64le build

### DIFF
--- a/src/libpmem/ppc64/platform_generic.c
+++ b/src/libpmem/ppc64/platform_generic.c
@@ -135,9 +135,9 @@ platform_init(struct pmem_funcs *funcs)
 
 	/* XXX: valgrind does not recognize powerpc fence instruction */
 	if (On_valgrind) {
-		pcc_pmem_funcs.predrain_fence = ppc_predrain_fence_empty;
-		pcc_pmem_funcs.flush = ppc_flush_msync;
-		pcc_pmem_funcs.deep_flush = ppc_flush_msync;
+		ppc_pmem_funcs.predrain_fence = ppc_predrain_fence_empty;
+		ppc_pmem_funcs.flush = ppc_flush_msync;
+		ppc_pmem_funcs.deep_flush = ppc_flush_msync;
 	}
 
 	*funcs = ppc_pmem_funcs;


### PR DESCRIPTION
Typo broke ppc64le build.
Fix commit 28050429877321d0982a996ffe187f3f0f0a2fc5

Signed-off-by: Lucas A. M. Magalhaes <lamm@linux.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4956)
<!-- Reviewable:end -->
