### PR TITLE
pmem2: fix vm_reservation TEST29 bugs

### DIFF
--- a/doc/libpmem2/pmem2_map_new.3.md
+++ b/doc/libpmem2/pmem2_map_new.3.md
@@ -41,6 +41,9 @@ The **pmem2_map_new**() function creates a new mapping in the virtual address sp
 of the calling process. This function requires a configuration
 *config* of the mapping and the data source *source*.
 
+Optionally, the mapping can be created at the offset of the virtual memory reservation
+set in the configuration *config*. See **pmem2_config_set_vm_reservation**(3) for details.
+
 For a mapping to succeed, the *config* structure must have the granularity
 parameter set to the appropriate level. See **pmem2_config_set_required_store_granularity**(3)
 and **libpmem2**(7) for more details.
@@ -95,6 +98,9 @@ the alignment required for specific *\*source*. Please see
 and the base mapping address (reservation address + reservation offset) is not aligned
 to the device DAX granularity. Please see **pmem2_config_set_vm_reservation**(3). (Linux only)
 
+* **PMEM2_E_ADDRESS_UNALIGNED** - when mapping to a virtual memory reservation and the region
+for the mapping exceeds reservation size. Please see **pmem2_config_set_vm_reservation**(3).
+
 * **PMEM2_E_NOSUPP** - when config-provided protection flags combination is not supported.
 
 * **PMEM2_E_NO_ACCESS** - there is a conflict between mapping protection and file opening mode.
@@ -115,4 +121,5 @@ It can also return all errors from the underlying
 **pmem2_config_set_required_store_granularity**(3),
 **pmem2_source_alignment**(3), **pmem2_source_from_fd**(3),
 **pmem2_source_size**(3), **pmem2_map_delete**(3),
+**pmem2_config_set_vm_reservation**(3),
 **libpmem2**(7) and **<http://pmem.io>**

--- a/src/libpmem2/map.h
+++ b/src/libpmem2/map.h
@@ -45,10 +45,6 @@ struct pmem2_map {
 	struct pmem2_vm_reservation *reserv;
 };
 
-#ifdef _WIN32
-os_rwlock_t split_merge_lock;
-#endif
-
 enum pmem2_granularity get_min_granularity(bool eADR, bool is_pmem,
 					enum pmem2_sharing_type sharing);
 struct pmem2_map *pmem2_map_find(const void *addr, size_t len);

--- a/src/libpmem2/vm_reservation.h
+++ b/src/libpmem2/vm_reservation.h
@@ -16,11 +16,15 @@ struct pmem2_vm_reservation {
 	os_rwlock_t lock;
 };
 
-int vm_reservation_map_register(struct pmem2_vm_reservation *rsv,
+int vm_reservation_map_register_release(struct pmem2_vm_reservation *rsv,
 		struct pmem2_map *map);
-int vm_reservation_map_unregister(struct pmem2_vm_reservation *rsv,
+int vm_reservation_map_unregister_release(struct pmem2_vm_reservation *rsv,
 		struct pmem2_map *map);
 struct pmem2_map *vm_reservation_map_find(struct pmem2_vm_reservation *rsv,
 		size_t reserv_offset, size_t len);
+struct pmem2_map *vm_reservation_map_find_acquire(
+		struct pmem2_vm_reservation *rsv, size_t reserv_offset,
+		size_t len);
+void vm_reservation_release(struct pmem2_vm_reservation *rsv);
 
 #endif /* vm_reservation.h */

--- a/src/libpmem2/vm_reservation_posix.c
+++ b/src/libpmem2/vm_reservation_posix.c
@@ -32,8 +32,6 @@ vm_reservation_reserve_memory(void *addr, size_t size, void **raddr,
  */
 #ifdef MAP_FIXED_NOREPLACE
 		map_flag = MAP_FIXED_NOREPLACE;
-#else
-		map_flag = 0;
 #endif
 	}
 

--- a/src/libpmem2/vm_reservation_windows.c
+++ b/src/libpmem2/vm_reservation_windows.c
@@ -84,9 +84,7 @@ vm_reservation_map_find_closest_prior(struct pmem2_vm_reservation *rsv,
 
 	struct ravl_interval_node *node;
 
-	util_rwlock_rdlock(&rsv->lock);
 	node = ravl_interval_find_closest_prior(rsv->itree, &map);
-	util_rwlock_unlock(&rsv->lock);
 
 	if (!node)
 		return NULL;
@@ -108,9 +106,7 @@ vm_reservation_map_find_closest_later(struct pmem2_vm_reservation *rsv,
 
 	struct ravl_interval_node *node;
 
-	util_rwlock_rdlock(&rsv->lock);
 	node = ravl_interval_find_closest_later(rsv->itree, &map);
-	util_rwlock_unlock(&rsv->lock);
 
 	if (!node)
 		return NULL;

--- a/src/test/pmem2_vm_reservation/TESTS.py
+++ b/src/test/pmem2_vm_reservation/TESTS.py
@@ -311,7 +311,7 @@ class TEST35(PMEM2_VM_RESERVATION_ASYNC):
     """
     test_case = "test_vm_reserv_async_map_unmap_multiple_files"
     threads = 32
-    ops_per_thread = 10000
+    ops_per_thread = 1000
 
 
 class TEST36(PMEM2_VM_RESERVATION_ASYNC_DEVDAX):


### PR DESCRIPTION
Due to possible races and bugs when mapping asynchronously to the
virtual memory reservation, rw_locks were added in the
pmem2_map_new/delete functions. Locks are invoked only when the
reservation is set in the config structure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4965)
<!-- Reviewable:end -->
