### PR TITLE
pool: remove sds extraneous

### DIFF
--- a/src/libpmempool/check_sds.c
+++ b/src/libpmempool/check_sds.c
@@ -26,7 +26,6 @@ enum question {
 #define SDS_CHECK_STR	"checking shutdown state"
 #define SDS_OK_STR	"shutdown state correct"
 #define SDS_DIRTY_STR	"shutdown state is dirty"
-#define SDS_NOT_SUPP	"shutdown state not supported"
 
 #define ADR_FAILURE_STR \
 	"an ADR failure was detected - your pool might be corrupted"
@@ -46,22 +45,6 @@ enum question {
 	IGNORE_SDS(hdrp) \
 		? SDS_DIRTY_STR ".|" ZERO_SDS_STR \
 		: ADR_FAILURE_STR ".|" RESET_SDS_STR
-
-/*
- *
- */
-static int
-sds_is_supported(location *loc)
-{
-	LOG(3, NULL);
-
-	ASSERTne(loc, NULL);
-	struct pool_replica *rep = REP(loc->set, 0);
-	ASSERTne(rep, NULL);
-	ASSERTne(PART(rep, 0)->fd, 0);
-
-	return shutdown_state_is_supported(PART(rep, 0)->fd);
-}
 
 /*
  * sds_check_replica -- (internal) check if replica is healthy
@@ -105,13 +88,6 @@ sds_check(PMEMpoolcheck *ppc, location *loc)
 	LOG(3, NULL);
 
 	CHECK_INFO(ppc, "%s" SDS_CHECK_STR, loc->prefix);
-
-	/* shutdown state is supported */
-	if (sds_is_supported(loc)) {
-		CHECK_INFO(ppc, "%s" SDS_NOT_SUPP, loc->prefix);
-		loc->step = CHECK_STEP_COMPLETE;
-		return 0;
-	}
 
 	/* shutdown state is valid */
 	if (!sds_check_replica(loc)) {
@@ -276,12 +252,6 @@ check_sds(PMEMpoolcheck *ppc)
 	/* initialize replica 0 for sds check */
 	loc->replica = 0;
 	init_location_data(ppc, loc);
-	if (!sds_is_supported(loc)) {
-		CHECK_INFO(ppc, "%s" SDS_CHECK_STR,
-				loc->prefix);
-		CHECK_INFO(ppc, "%s" SDS_NOT_SUPP, loc->prefix);
-		return;
-	}
 
 	if (!loc->init_done) {
 		sds_get_healthy_replicas_num(ppc, loc);

--- a/src/test/pmempool_check/TEST1.PS1
+++ b/src/test/pmempool_check/TEST1.PS1
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2014-2019, Intel Corporation
+# Copyright 2014-2020, Intel Corporation
 #
 #
 # pmempool_check/TEST1 -- test for checking pools
@@ -20,7 +20,7 @@ echo "PMEMLOG: pool_hdr" > $LOG
 expect_normal_exit $PMEMPOOL create log $POOL
 check_file $POOL
 
-Invoke-Expression "$PMEMSPOIL -v $POOL pool_hdr.major=0x0 pool_hdr.features.compat=0xfe pool_hdr.features.incompat=0xfe pool_hdr.features.ro_compat=0xfb pool_hdr.shutdown_state.usc=0 pool_hdr.shutdown_state.uuid=0 'pool_hdr.shutdown_state.f:checksum_gen' pool_hdr.unused=ERROR >> $LOG"
+Invoke-Expression "$PMEMSPOIL -v $POOL pool_hdr.major=0x0 pool_hdr.features.compat=0xfe pool_hdr.features.incompat=0xfb pool_hdr.features.ro_compat=0xff pool_hdr.shutdown_state.usc=0 pool_hdr.shutdown_state.uuid=0 'pool_hdr.shutdown_state.f:checksum_gen' pool_hdr.unused=ERROR >> $LOG"
 expect_normal_exit $PMEMPOOL check -vry $POOL >> $LOG
 
 echo "PMEMLOG: pmemlog" >> $LOG

--- a/src/test/pmempool_check/TEST9.PS1
+++ b/src/test/pmempool_check/TEST9.PS1
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2017-2019, Intel Corporation
+# Copyright 2017-2020, Intel Corporation
 #
 # pmempool_check/TEST9 -- test for checking pmemobj pool
 #
@@ -23,7 +23,7 @@ expect_normal_exit $PMEMPOOL check -vyr $POOL >> $LOG
 &$PMEMSPOIL -v $POOL `
 	pool_hdr.major=0x0 `
 	pool_hdr.features.compat=0xfe `
-	pool_hdr.features.incompat=0xfe `
+	pool_hdr.features.incompat=0xfb `
 	pool_hdr.features.ro_compat=0xff `
 	pool_hdr.shutdown_state.usc=0 `
 	pool_hdr.shutdown_state.uuid=0 `


### PR DESCRIPTION
It seems like these checks are not necessary, and would prevent SDS from functioning in a situation where the pool was created with SDS enabled, but moved to a device without it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/4996)
<!-- Reviewable:end -->
