### PR TITLE
The function btree_map_clear_node is missing a null check.  An entry …

### DIFF
--- a/src/examples/libpmemobj/tree_map/btree_map.c
+++ b/src/examples/libpmemobj/tree_map/btree_map.c
@@ -64,6 +64,8 @@ btree_map_create(PMEMobjpool *pop, TOID(struct btree_map) *map, void *arg)
 static void
 btree_map_clear_node(TOID(struct tree_map_node) node)
 {
+	if (TOID_IS_NULL(node))
+		return;
 	for (int i = 0; i < D_RO(node)->n; ++i) {
 		btree_map_clear_node(D_RO(node)->slots[i]);
 	}


### PR DESCRIPTION
…in the slots array can be empty as an item can be in the items array without a child tree_map_node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5026)
<!-- Reviewable:end -->
