### PR TITLE
pmem2: Fix check ndctl_dimm_get_unique_id return before using it

### DIFF
--- a/src/libpmem2/usc_ndctl.c
+++ b/src/libpmem2/usc_ndctl.c
@@ -82,6 +82,7 @@ pmem2_source_device_id(const struct pmem2_source *src, char *id, size_t *len)
 	struct ndctl_dimm *dimm;
 	int ret;
 	struct ndctl_region *region = NULL;
+	const char *dimm_uid;
 
 	if (src->type == PMEM2_SOURCE_ANON) {
 		ERR("Anonymous source does not have device id");
@@ -110,6 +111,11 @@ pmem2_source_device_id(const struct pmem2_source *src, char *id, size_t *len)
 
 	if (id == NULL) {
 		ndctl_dimm_foreach_in_region(region, dimm) {
+			dimm_uid = ndctl_dimm_get_unique_id(dimm);
+			if (dimm_uid == NULL) {
+				ret = PMEM2_E_NOSUPP;
+				goto err;
+			}
 			len_base += strlen(ndctl_dimm_get_unique_id(dimm));
 		}
 		goto end;
@@ -117,7 +123,11 @@ pmem2_source_device_id(const struct pmem2_source *src, char *id, size_t *len)
 
 	size_t count = 1;
 	ndctl_dimm_foreach_in_region(region, dimm) {
-		const char *dimm_uid = ndctl_dimm_get_unique_id(dimm);
+		dimm_uid = ndctl_dimm_get_unique_id(dimm);
+		if (dimm_uid == NULL) {
+			ret = PMEM2_E_NOSUPP;
+			goto err;
+		}
 		count += strlen(dimm_uid);
 		if (count > *len) {
 			ret = PMEM2_E_BUFFER_TOO_SMALL;


### PR DESCRIPTION
For PAPR devices ndctl_dimm_get_unique_id returns NULL which causes
strlen to trigger a SIGSEGV.

Signed-off-by: Lucas A. M. Magalhaes <lamm@linux.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5029)
<!-- Reviewable:end -->
