### PR TITLE
examples:Increase the print decimal length

### DIFF
--- a/src/examples/libpmemobj/pi.c
+++ b/src/examples/libpmemobj/pi.c
@@ -211,12 +211,12 @@ main(int argc, char *argv[])
 				pi_val += D_RO(iter)->proto.result;
 			}
 
-			printf("pi: %Lf\n", pi_val * 4);
+			printf("pi: %.10Lf\n", pi_val * 4);
 		} break;
 		case 'd': { /* print done list */
 			TOID(struct pi_task) iter;
 			POBJ_LIST_FOREACH(iter, &D_RO(pi)->done, done) {
-				printf("(%" PRIu64 " - %" PRIu64 ") = %Lf\n",
+				printf("(%" PRIu64 " - %" PRIu64 ") = %.10Lf\n",
 					D_RO(iter)->proto.start,
 					D_RO(iter)->proto.stop,
 					D_RO(iter)->proto.result);
@@ -225,7 +225,7 @@ main(int argc, char *argv[])
 		case 't': { /* print to-do list */
 			TOID(struct pi_task) iter;
 			POBJ_LIST_FOREACH(iter, &D_RO(pi)->todo, todo) {
-				printf("(%" PRIu64 " - %" PRIu64 ") = %Lf\n",
+				printf("(%" PRIu64 " - %" PRIu64 ") = %.10Lf\n",
 					D_RO(iter)->proto.start,
 					D_RO(iter)->proto.stop,
 					D_RO(iter)->proto.result);


### PR DESCRIPTION
Increases the print length of PI and its intermediate results.PI is about 3.1415926 as we all know，But now we're only printing 6 after the decimal point.This does not facilitate checking the accuracy of the π results.
When it comes to printing done lists, it's even more confusing to print "0.000000".（At one point it was thought that no calculation had been made！）
I think it would be kinder to modify the print length.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5053)
<!-- Reviewable:end -->
