### PR TITLE
common: use special environment var in GHA for Windows' PATH

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -67,8 +67,8 @@ jobs:
     steps:
        - name: Update Path
          run: |
-           echo "::add-path::$Env:msbuild"
-           echo "::add-path::$Env:perl"
+           echo "${env:msbuild}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+           echo "${env:perl}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
        - name: Clone the git repo
          uses: actions/checkout@v2


### PR DESCRIPTION
The old 'addPath' is depreciated now. For more details see:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5054)
<!-- Reviewable:end -->
