### PR TITLE
test: util_badblock: don't pass uninitialized attr

### DIFF
--- a/src/test/util_badblock/util_badblock.c
+++ b/src/test/util_badblock/util_badblock.c
@@ -104,11 +104,10 @@ static void
 do_open(const char *path)
 {
 	struct pool_set *set;
-	const struct pool_attr attr;
 	unsigned nlanes = 1;
 
 	if (util_pool_open(&set, path, MIN_PART,
-				&attr, &nlanes, NULL, 0) != 0) {
+				NULL, &nlanes, NULL, 0) != 0) {
 		UT_FATAL("!util_pool_open: %s", path);
 	}
 


### PR DESCRIPTION
Otherwise, it fails on new toolchain (as in current Fedora rawhide).

Uninitialized const struct don't make any sense.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5081)
<!-- Reviewable:end -->
