### PR TITLE
doc: Fix the document of pmem_is_pmem(). It can be used for filesystem dax.

### DIFF
--- a/doc/libpmem/pmem_is_pmem.3.md
+++ b/doc/libpmem/pmem_is_pmem.3.md
@@ -138,11 +138,10 @@ On success, **pmem_unmap**() returns 0. On error, it returns -1 and sets
 
 # NOTES #
 
-On Linux, **pmem_is_pmem**() returns true only if the entire range
-is mapped directly from Device DAX (/dev/daxX.Y) without an intervening
-file system.  In the future, as file systems become available that support
-flushing with **pmem_persist**(3), **pmem_is_pmem**() will return true
-as appropriate.
+On Linux, **pmem_is_pmem**() returned true if the entire range
+was mapped directly from Device DAX (/dev/daxX.Y) without an intervening
+file system, or **MAP_SYNC** flag of **mmap(3)** is supported by the
+file system on Filesystem DAX.
 
 # CAVEATS #
 


### PR DESCRIPTION
Since MAP_SYNC flag is already supported by XFS and EXT4, pmem_is_pmem() can return true even if you use filesystem-dax.
So, we can fix the old description of its manual.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5087)
<!-- Reviewable:end -->
