### PR TITLE
[gh-pages] fix release tag for 1.10

### DIFF
--- a/_data/releases_linux.yml
+++ b/_data/releases_linux.yml
@@ -412,7 +412,7 @@
         pmemset_source_from_file.3
         pmemset_source_from_pmem2.3
 
-- tag: 1.10
+- tag: "1.10"
   libs:
     daxio
     libpmem

--- a/_data/releases_windows.yml
+++ b/_data/releases_windows.yml
@@ -394,7 +394,7 @@
         pmemset_source_from_file.3
         pmemset_source_from_pmem2.3
 
-- tag: 1.10
+- tag: "1.10"
   libs:
     libpmem
     libpmem2


### PR DESCRIPTION
it seems Jekyll/JSON(?) treats 1.10 as it would have a trailing zero.


before: https://pmem.io/pmdk/manpages/linux/master/libpmem/libpmem.7.html
after: https://lukaszstolarczuk.github.io/pmdk/manpages/linux/master/libpmem/libpmem.7.html
(spot one difference ;) hint: look in the "shortcut" menu on the right-hand side)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5110)
<!-- Reviewable:end -->
