### PR TITLE
pmem2: don't force smaller alignment for fsdax mappings

### DIFF
--- a/src/test/pmem2_map/TESTS.py
+++ b/src/test/pmem2_map/TESTS.py
@@ -1,6 +1,6 @@
 #!../env.py
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2019-2020, Intel Corporation
+# Copyright 2019-2021, Intel Corporation
 #
 
 import os
@@ -216,3 +216,19 @@ class TEST28(PMEM2_MAP_DEVDAX):
     """DevDax file with PMEM2_PRIVATE sharing"""
     test_case = "test_map_sharing_private_devdax"
     with_size = False
+
+
+@t.linux_only
+@t.require_architectures('x86_64')
+class TEST29(PMEM2_MAP):
+    """map alignment test for huge pages"""
+    test_case = "test_map_huge_alignment"
+    filesize = 16 * t.MiB
+
+
+@t.linux_only
+@t.require_architectures('x86_64')
+class TEST30(PMEM2_MAP):
+    """map alignment test for small pages"""
+    test_case = "test_map_huge_alignment"
+    filesize = 16 * t.KiB

--- a/src/test/pmem2_map/pmem2_map.c
+++ b/src/test/pmem2_map/pmem2_map.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2019-2020, Intel Corporation */
+/* Copyright 2019-2021, Intel Corporation */
 
 /*
  * pmem2_map.c -- pmem2_map unittests
@@ -832,6 +832,49 @@ test_map_sharing_private_devdax(const struct test_case *tc, int argc,
 }
 
 /*
+ * test_map_huge_alignment - tests whether pmem2_map correctly utilizes
+ * huge pages where possible.
+ */
+static int
+test_map_huge_alignment(const struct test_case *tc, int argc,
+					char *argv[])
+{
+	if (argc < 2)
+		UT_FATAL("usage: test_map_huge_alignment <file> <filesize>");
+
+	char *file = argv[0];
+	size_t size = ATOUL(argv[1]);
+
+	struct pmem2_config cfg;
+	struct pmem2_source *src;
+	struct FHandle *fh;
+	ut_pmem2_prepare_config(&cfg, &src, &fh, FH_FD, file, size, 0, FH_RDWR);
+
+	struct pmem2_map *map;
+	int ret = pmem2_map_new(&map, &cfg, src);
+	UT_PMEM2_EXPECT_RETURN(ret, 0);
+
+#define PAGESIZE_HUGE ((1 << 20) * 2)
+
+	void *addr = pmem2_map_get_address(map);
+	uintptr_t addru = (uintptr_t)addr;
+	if (pmem2_map_get_size(map) >= PAGESIZE_HUGE) {
+		UT_ASSERTeq(addru % PAGESIZE_HUGE, 0);
+	} else {
+		UT_ASSERTeq(addru % Pagesize, 0);
+	}
+
+#undef PAGESIZE_HUGE
+
+	unmap_map(map);
+	FREE(map);
+	PMEM2_SOURCE_DELETE(&src);
+	UT_FH_CLOSE(fh);
+
+	return 2;
+}
+
+/*
  * test_cases -- available test cases
  */
 static struct test_case test_cases[] = {
@@ -856,6 +899,7 @@ static struct test_case test_cases[] = {
 	TEST_CASE(test_map_sharing_private_with_reopened_fd),
 	TEST_CASE(test_map_sharing_private_rdonly_file),
 	TEST_CASE(test_map_sharing_private_devdax),
+	TEST_CASE(test_map_huge_alignment),
 };
 
 #define NTESTS (sizeof(test_cases) / sizeof(test_cases[0]))


### PR DESCRIPTION
We should ideally always try to align mappings to the largest possible
page size while taking into account the limitations of the
underlying source (e.g., devdax alignment)...

But instead of doing that, the existing code always forced
the smallest possible alignment for the source - unconditionally.

This patch fixes that by restoring the intended behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5143)
<!-- Reviewable:end -->
