### PR TITLE
core: fix ravl_interval_find function

### DIFF
--- a/src/core/ravl_interval.c
+++ b/src/core/ravl_interval.c
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * ravl_interval.c -- ravl_interval implementation
  */
+
+#include <stdbool.h>
 
 #include "alloc.h"
 #include "ravl_interval.h"
@@ -28,11 +30,11 @@ struct ravl_interval_node {
 	void *addr;
 	ravl_interval_min *get_min;
 	ravl_interval_max *get_max;
+	bool overlap;
 };
 
 /*
- * ravl_interval_compare -- compare intervals by its boundaries,
- *                          no overlapping allowed
+ * ravl_interval_compare -- compare intervals by its boundaries
  */
 static int
 ravl_interval_compare(const void *lhs, const void *rhs)
@@ -40,10 +42,23 @@ ravl_interval_compare(const void *lhs, const void *rhs)
 	const struct ravl_interval_node *left = lhs;
 	const struct ravl_interval_node *right = rhs;
 
-	if (left->get_max(left->addr) <= right->get_min(right->addr))
+	/*
+	 * when searching, comparing should return the
+	 * earliest overlapped record
+	 */
+	if (left->overlap) {
+		if (left->get_min(left->addr) >= right->get_max(right->addr))
+			return 1;
+		if (left->get_min(left->addr) == right->get_min(right->addr))
+			return 0;
 		return -1;
+	}
+
+	/* when inserting, comparing shouldn't allow overlapping intervals */
 	if (left->get_min(left->addr) >= right->get_max(right->addr))
 		return 1;
+	if (left->get_max(left->addr) <= right->get_min(right->addr))
+		return -1;
 	return 0;
 }
 
@@ -105,6 +120,7 @@ ravl_interval_insert(struct ravl_interval *ri, void *addr)
 	rin.addr = addr;
 	rin.get_min = ri->get_min;
 	rin.get_max = ri->get_max;
+	rin.overlap = false;
 
 	int ret = ravl_emplace_copy(ri->tree, &rin);
 
@@ -131,29 +147,44 @@ ravl_interval_remove(struct ravl_interval *ri, struct ravl_interval_node *rin)
 }
 
 /*
- * ravl_interval_find_prior_or_eq -- find overlapping interval starting prior to
- *                                   the current one or at the same place
+ * ravl_interval_find_prior -- find overlapping interval starting prior to
+ *                             the current one
  */
 static struct ravl_interval_node *
-ravl_interval_find_prior_or_eq(struct ravl *tree,
-		struct ravl_interval_node *rin)
+ravl_interval_find_prior(struct ravl *tree, struct ravl_interval_node *rin)
 {
 	struct ravl_node *node;
 	struct ravl_interval_node *cur;
 
-	node = ravl_find(tree, rin, RAVL_PREDICATE_LESS_EQUAL);
+	node = ravl_find(tree, rin, RAVL_PREDICATE_LESS);
 	if (!node)
 		return NULL;
 
 	cur = ravl_data(node);
 	/*
 	 * If the end of the found interval is below the searched boundary, then
-	 * this is not our interval.
+	 * those intervals are not overlapping.
 	 */
 	if (cur->get_max(cur->addr) <= rin->get_min(rin->addr))
 		return NULL;
 
 	return cur;
+}
+
+/*
+ * ravl_interval_find_eq -- find overlapping interval starting neither prior or
+ *                          lather than the current one
+ */
+static struct ravl_interval_node *
+ravl_interval_find_eq(struct ravl *tree, struct ravl_interval_node *rin)
+{
+	struct ravl_node *node;
+
+	node = ravl_find(tree, rin, RAVL_PREDICATE_EQUAL);
+	if (!node)
+		return NULL;
+
+	return ravl_data(node);
 }
 
 /*
@@ -174,7 +205,7 @@ ravl_interval_find_later(struct ravl *tree, struct ravl_interval_node *rin)
 
 	/*
 	 * If the beginning of the found interval is above the end of
-	 * the searched range, then this is not our interval.
+	 * the searched range, then those interval are not overlapping
 	 */
 	if (cur->get_min(cur->addr) >= rin->get_max(rin->addr))
 		return NULL;
@@ -192,6 +223,7 @@ ravl_interval_find_equal(struct ravl_interval *ri, void *addr)
 	range.addr = addr;
 	range.get_min = ri->get_min;
 	range.get_max = ri->get_max;
+	range.overlap = true;
 
 	struct ravl_node *node;
 	node = ravl_find(ri->tree, &range, RAVL_PREDICATE_EQUAL);
@@ -211,9 +243,12 @@ ravl_interval_find(struct ravl_interval *ri, void *addr)
 	range.addr = addr;
 	range.get_min = ri->get_min;
 	range.get_max = ri->get_max;
+	range.overlap = true;
 
 	struct ravl_interval_node *cur;
-	cur = ravl_interval_find_prior_or_eq(ri->tree, &range);
+	cur = ravl_interval_find_prior(ri->tree, &range);
+	if (!cur)
+		cur = ravl_interval_find_eq(ri->tree, &range);
 	if (!cur)
 		cur = ravl_interval_find_later(ri->tree, &range);
 
@@ -231,6 +266,7 @@ ravl_interval_find_closest_prior(struct ravl_interval *ri, void *addr)
 	range.addr = addr;
 	range.get_min = ri->get_min;
 	range.get_max = ri->get_max;
+	range.overlap = true;
 
 	struct ravl_node *node;
 	node = ravl_find(ri->tree, &range, RAVL_PREDICATE_LESS);
@@ -251,6 +287,7 @@ ravl_interval_find_closest_later(struct ravl_interval *ri, void *addr)
 	range.addr = addr;
 	range.get_min = ri->get_min;
 	range.get_max = ri->get_max;
+	range.overlap = true;
 
 	struct ravl_node *node;
 	node = ravl_find(ri->tree, &range, RAVL_PREDICATE_GREATER);
@@ -293,6 +330,7 @@ ravl_interval_find_next(struct ravl_interval *ri, void *addr)
 	range.addr = addr;
 	range.get_min = ri->get_min;
 	range.get_max = ri->get_max;
+	range.overlap = true;
 
 	struct ravl_node *next = NULL;
 	next = ravl_find(ri->tree, &range, RAVL_PREDICATE_GREATER);


### PR DESCRIPTION
This function was supposed to return the earliest entry that overlaps
with the provided region (offset, offset + size).
It meets this criteria now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5146)
<!-- Reviewable:end -->
