### PR TITLE
common: force no LTO for rpm build

### DIFF
--- a/utils/pmdk.spec.in
+++ b/utils/pmdk.spec.in
@@ -703,6 +703,7 @@ a device.
 
 
 %build
+%define _lto_cflags %{nil}
 # For debug build default flags may be overridden to disable compiler
 # optimizations.
 CFLAGS="%{optflags}" \


### PR DESCRIPTION
This is only a workaround, we'd want to get rid of the objcopy weirdness, but there's quite a bit of stuff to untangle.

Fixes #4938

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5150)
<!-- Reviewable:end -->
