### PR TITLE
doc: fix 'pmem2_source_from_fd.3' manpage a little

### DIFF
--- a/doc/libpmem2/pmem2_badblock_clear.3.md
+++ b/doc/libpmem2/pmem2_badblock_clear.3.md
@@ -75,4 +75,4 @@ all bad blocks
 # SEE ALSO #
 
 **pmem2_badblock_context_new**(3), **pmem2_badblock_next**(3),
-**libpmem2**(7) and **<http://pmem.io>**
+**libpmem2**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_badblock_context_new.3.md
+++ b/doc/libpmem2/pmem2_badblock_context_new.3.md
@@ -114,4 +114,4 @@ of the given *src*.
 # SEE ALSO #
 
 **pmem2_badblock_next**(3), **pmem2_badblock_clear**(3),
-**libpmem2**(7) and **<http://pmem.io>**
+**libpmem2**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_badblock_next.3.md
+++ b/doc/libpmem2/pmem2_badblock_next.3.md
@@ -61,4 +61,4 @@ bad block context *\*bbctx*, *\*bb* is undefined in this case.
 # SEE ALSO #
 
 **pmem2_badblock_context_new**(3), **pmem2_badblock_clear**(3),
-**libpmem2**(7) and **<http://pmem.io>**
+**libpmem2**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_config_new.3.md
+++ b/doc/libpmem2/pmem2_config_new.3.md
@@ -60,4 +60,4 @@ The **pmem2_config_delete**() function always returns 0.
 
 **errno**(3), **pmem2_map_new**(3), **pmem2_config_set_handle**(3),
 **pmem2_config_set_fd**(3), **pmem2_config_get_file_size**(3),
-**libpmem2**(7) and **<http://pmem.io>**
+**libpmem2**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_config_set_length.3.md
+++ b/doc/libpmem2/pmem2_config_set_length.3.md
@@ -48,4 +48,4 @@ The **pmem2_config_set_length**() function always returns 0.
 # SEE ALSO #
 
 **libpmem2**(7), **pmem2_map_new**(3), **pmem2_source_alignment**(3),
-**pmem2_config_new**(3), **sysconf**(3) and **<http://pmem.io>**
+**pmem2_config_new**(3), **sysconf**(3) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_config_set_offset.3.md
+++ b/doc/libpmem2/pmem2_config_set_offset.3.md
@@ -57,4 +57,4 @@ The **pmem2_config_set_offset**() can fail with the following errors:
 # SEE ALSO #
 
 **libpmem2**(7), **pmem2_source_alignment**(3), **pmem2_config_new**(3),
-**pmem2_map_new**(3), **sysconf**(3) and **<http://pmem.io>**
+**pmem2_map_new**(3), **sysconf**(3) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_config_set_protection.3.md
+++ b/doc/libpmem2/pmem2_config_set_protection.3.md
@@ -73,4 +73,4 @@ The **pmem2_config_set_protection**() can fail with the following errors:
 # SEE ALSO #
 
 **libpmem2**(7), **pmem2_config_new**(3), **pmem2_map_new**(3)
-and **<http://pmem.io>**
+and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_config_set_required_store_granularity.3.md
+++ b/doc/libpmem2/pmem2_config_set_required_store_granularity.3.md
@@ -67,4 +67,4 @@ with the following errors:
 
 # SEE ALSO #
 **pmem2_config_new**(3), **libpmem2**(7)
-and **<http://pmem.io>**
+and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_config_set_sharing.3.md
+++ b/doc/libpmem2/pmem2_config_set_sharing.3.md
@@ -61,4 +61,4 @@ The **pmem2_config_set_sharing**() can fail with the following errors:
 # SEE ALSO #
 
 **libpmem2**(7), **pmem2_config_new**(3), **pmem2_map_new**(3), **sysconf**(3)
-and **<http://pmem.io>**
+and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_config_set_vm_reservation.3.md
+++ b/doc/libpmem2/pmem2_config_set_vm_reservation.3.md
@@ -47,4 +47,4 @@ reservation for the mapping.
 
 # SEE ALSO #
 
-**pmem2_vm_reservation_new**(3), **libpmem2**(7) and **<http://pmem.io>**
+**pmem2_vm_reservation_new**(3), **libpmem2**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_deep_flush.3.md
+++ b/doc/libpmem2/pmem2_deep_flush.3.md
@@ -70,4 +70,4 @@ a deep flush on a regular DAX volume.
 # SEE ALSO #
 
 **msync**(2), **open**(2), **pmem2_get_drain_fn**(3), **pmem2_get_persist_fn**(3)
-**pmem2_map_new**(3), **write**(2), **libpmem2**(7) and **<http://pmem.io>**
+**pmem2_map_new**(3), **write**(2), **libpmem2**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_get_drain_fn.3.md
+++ b/doc/libpmem2/pmem2_get_drain_fn.3.md
@@ -58,4 +58,4 @@ be necessary.
 # SEE ALSO #
 
 **pmem2_get_flush_fn**(3), **pmem2_get_persist_fn**(3), **pmem2_map_new**(3),
-**libpmem2**(7) and **<http://pmem.io>**
+**libpmem2**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_get_flush_fn.3.md
+++ b/doc/libpmem2/pmem2_get_flush_fn.3.md
@@ -71,4 +71,4 @@ be necessary.
 # SEE ALSO #
 
 **pmem2_get_drain_fn**(3), **pmem2_get_persist_fn**(3), **pmem2_map_new**(3),
-**libpmem2**(7) and **<http://pmem.io>**
+**libpmem2**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_get_memmove_fn.3.md
+++ b/doc/libpmem2/pmem2_get_memmove_fn.3.md
@@ -143,4 +143,4 @@ functions for a range spanning those mappings.
 
 **memcpy**(3), **memmove**(3), **memset**(3), **pmem2_get_drain_fn**(3),
 **pmem2_get_memcpy_fn**(3), **pmem2_get_memset_fn**(3), **pmem2_map_new**(3),
-**pmem2_get_persist_fn**(3), **libpmem2**(7) and **<http://pmem.io>**
+**pmem2_get_persist_fn**(3), **libpmem2**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_get_persist_fn.3.md
+++ b/doc/libpmem2/pmem2_get_persist_fn.3.md
@@ -96,4 +96,4 @@ necessary.
 # SEE ALSO #
 
 **pmem2_get_drain_fn**(3), **pmem2_get_flush_fn**(3), **pmem2_map_new**(3),
-**libpmem2**(7) and **<http://pmem.io>**
+**libpmem2**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_map_delete.3.md
+++ b/doc/libpmem2/pmem2_map_delete.3.md
@@ -63,4 +63,4 @@ On systems other than Windows it can also return **-EINVAL** from the underlying
 
 # SEE ALSO #
 
-**pmem2_map_new(3)**, **libpmem2**(7) and **<http://pmem.io>**
+**pmem2_map_new(3)**, **libpmem2**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_map_from_existing.3.md
+++ b/doc/libpmem2/pmem2_map_from_existing.3.md
@@ -60,4 +60,4 @@ It can also return **-ENOMEM**  from the underlying **malloc**(2) function.
 # SEE ALSO #
 
 **malloc(2)**, **pmem2_map_delete**(3), **pmem2_map_new**(3),
-**pmem2_source_from_fd**(3), **libpmem2**(7) and **<http://pmem.io>**
+**pmem2_source_from_fd**(3), **libpmem2**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_map_get_store_granularity.3.md
+++ b/doc/libpmem2/pmem2_map_get_store_granularity.3.md
@@ -50,4 +50,4 @@ a granularity of the mapped area.
 
 # SEE ALSO #
 
-**pmem2_map_new**(3), **libpmem2**(7) and **<http://pmem.io>**
+**pmem2_map_new**(3), **libpmem2**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_map_new.3.md
+++ b/doc/libpmem2/pmem2_map_new.3.md
@@ -122,4 +122,4 @@ It can also return all errors from the underlying
 **pmem2_source_alignment**(3), **pmem2_source_from_fd**(3),
 **pmem2_source_size**(3), **pmem2_map_delete**(3),
 **pmem2_config_set_vm_reservation**(3),
-**libpmem2**(7) and **<http://pmem.io>**
+**libpmem2**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_perror.3.md
+++ b/doc/libpmem2/pmem2_perror.3.md
@@ -43,4 +43,4 @@ how the error message is generated, please see **pmem2_errormsg**(3).
 
 # SEE ALSO #
 
-**libpmem2**(7), **perror**(3), **pmem2_errormsg**(3), **printf**(3) and **<http://pmem.io>**
+**libpmem2**(7), **perror**(3), **pmem2_errormsg**(3), **printf**(3) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_source_alignment.3.md
+++ b/doc/libpmem2/pmem2_source_alignment.3.md
@@ -84,4 +84,4 @@ descriptor.
 
 **errno**(3),  **fstat**(2), **realpath**(3), **read**(2), **strtoull**(3),
 **pmem2_config_new**(3), **pmem2_source_from_handle**(3),
-**pmem2_source_from_fd**(3), **libpmem2**(7) and **<http://pmem.io>**
+**pmem2_source_from_fd**(3), **libpmem2**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_source_device_id.3.md
+++ b/doc/libpmem2/pmem2_source_device_id.3.md
@@ -92,4 +92,4 @@ NDCTL library context.
 # SEE ALSO #
 
 **fstat**(2), **errno**(3), **malloc**(3), **libpmem2_unsafe_shutdown**(7),
- and **<http://pmem.io>**
+ and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_source_device_usc.3.md
+++ b/doc/libpmem2/pmem2_source_device_usc.3.md
@@ -86,4 +86,4 @@ while trying to obtain DIMM **USC** value.
 # SEE ALSO #
 
 **fstat**(2), **errno**(3), **malloc**(3), **libpmem2_unsafe_shutdown**(7),
- and **<http://pmem.io>**
+ and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_source_from_anon.3.md
+++ b/doc/libpmem2/pmem2_source_from_anon.3.md
@@ -60,4 +60,4 @@ memory to allocate an instance of *struct pmem2_source*.
 # SEE ALSO #
 **errno**(3), **pmem2_config_set_length**(3), **pmem2_map_new**(3),
 **pmem2_source_size**(3), **pmem2_config_set_length**(3), **libpmem2**(7)
-and **<http://pmem.io>**
+and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_source_from_fd.3.md
+++ b/doc/libpmem2/pmem2_source_from_fd.3.md
@@ -8,7 +8,7 @@ date: pmem2 API version 1.0
 ...
 
 [comment]: <> (SPDX-License-Identifier: BSD-3-Clause)
-[comment]: <> (Copyright 2019-2020, Intel Corporation)
+[comment]: <> (Copyright 2019-2021, Intel Corporation)
 
 [comment]: <> (pmem2_source_from_fd.3 -- man page for pmem2_source_from_fd
 
@@ -41,8 +41,8 @@ int pmem2_source_delete(struct pmem2_source **src);
 On Linux the **pmem2_source_from_fd**() function validates the file descriptor
 and instantiates a new *struct pmem2_source** object describing the data source.
 
-On Windows the **pmem2_source_from_fd**() function converts a file descriptor to a file handle (using **_get_osfhandle**()), and passes
-it to **pmem2_source_from_handle**().
+On Windows the **pmem2_source_from_fd**() function converts a file descriptor to a file handle
+(using **_get_osfhandle**()), and passes it to **pmem2_source_from_handle**().
 By default **_get_osfhandle**() calls abort() in case of invalid file descriptor,
 but this behavior can be suppressed by **_set_abort_behavior**() and **SetErrorMode**()
 functions.
@@ -60,7 +60,8 @@ The handle has to be created with an access mode of *GENERIC_READ* or
 *(GENERIC_READ | GENERIC_WRITE)*. For details please see the **CreateFile**()
 documentation.
 
-The **pmem2_source_delete**() function frees *\*src* returned by **pmem2_source_from_fd**() or **pmem2_source_from_handle**() and sets *\*src* to NULL. If *\*src* is NULL, no operation is performed.
+The **pmem2_source_delete**() function frees *\*src* returned by **pmem2_source_from_fd**()
+or **pmem2_source_from_handle**() and sets *\*src* to NULL. If *\*src* is NULL, no operation is performed.
 
 # RETURN VALUE #
 
@@ -71,7 +72,7 @@ The **pmem2_source_delete**() function always returns 0.
 
 # ERRORS #
 
-The **pmem2_source_from_[fd|handle]**() function can fail with the following errors:
+The **pmem2_source_from_fd**()/**pmem2_source_from_handle**() functions can fail with the following errors:
 
  * **PMEM2_E_INVALID_FILE_HANDLE** - *fd* is not an open and valid file descriptor. On Windows the function can **abort**() on this failure based on CRT's abort() behavior.
 
@@ -105,5 +106,6 @@ On non-DAX Windows volumes, *fd*/*handle* must remain open while the mapping
 is in use.
 
 # SEE ALSO #
+
 **errno**(3), **pmem2_map_new**(3), **libpmem2**(7)
-and **<http://pmem.io>**
+and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_source_get_fd.3.md
+++ b/doc/libpmem2/pmem2_source_get_fd.3.md
@@ -54,4 +54,4 @@ support file descriptors, eg. anonymous data source.
 
 # SEE ALSO #
 
-**pmem2_source_get_handle**(3), **libpmem2**(7) and **<http://pmem.io>**
+**pmem2_source_get_handle**(3), **libpmem2**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_source_get_handle.3.md
+++ b/doc/libpmem2/pmem2_source_get_handle.3.md
@@ -59,4 +59,4 @@ The **pmem2_source_get_handle**() returns a file handle of data source.
 
 # SEE ALSO #
 
-**pmem2_source_from_fd**(3), **pmem2_source_get_fd**(3), **libpmem2**(7) and **<http://pmem.io>**
+**pmem2_source_from_fd**(3), **pmem2_source_get_fd**(3), **libpmem2**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_source_numa_node.3.md
+++ b/doc/libpmem2/pmem2_source_numa_node.3.md
@@ -70,4 +70,4 @@ It also does not work under Windows or systems without **libndctl**.
 # SEE ALSO #
 
 **errno**(3), **ndctl_new**(3), **pmem2_source_from_handle**(3),
-**pmem2_source_from_fd**(3), **libpmem2**(7), **libndctl**(7) and **<http://pmem.io>**
+**pmem2_source_from_fd**(3), **libpmem2**(7), **libndctl**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_source_size.3.md
+++ b/doc/libpmem2/pmem2_source_size.3.md
@@ -98,4 +98,4 @@ descriptor.
 
 **errno**(3),  **fstat**(2), **realpath**(3), **open**(2), **read**(2),
 **strtoull**(3), **pmem2_config_new**(3), **libpmem2**(7)
-and **<http://pmem.io>**
+and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_vm_reservation_extend.3.md
+++ b/doc/libpmem2/pmem2_vm_reservation_extend.3.md
@@ -94,4 +94,4 @@ It can also return **-EAGAIN** and **-ENOMEM** from the underlying **munmap**(2)
 # SEE ALSO #
 
 **pmem2_vm_reservation_new**(3), **pmem2_config_set_vm_reservation**(3),
-**libpmem2**(7) and **<http://pmem.io>**
+**libpmem2**(7) and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_vm_reservation_map_find.3.md
+++ b/doc/libpmem2/pmem2_vm_reservation_map_find.3.md
@@ -56,4 +56,4 @@ specified by *reserv_offset* and *len* variables.
 
 # SEE ALSO #
 
-**libpmem2**(7), and **<http://pmem.io>**
+**libpmem2**(7), and **<https://pmem.io>**

--- a/doc/libpmem2/pmem2_vm_reservation_new.3.md
+++ b/doc/libpmem2/pmem2_vm_reservation_new.3.md
@@ -87,4 +87,4 @@ It can also return errors from the underlying **munmap**(2) function.
 
 # SEE ALSO #
 
-**pmem2_config_set_vm_reservation**(3), **libpmem2**(7) and **<http://pmem.io>**
+**pmem2_config_set_vm_reservation**(3), **libpmem2**(7) and **<https://pmem.io>**


### PR DESCRIPTION
and update http->https URLs in libpmem2 docs' directory.

//
Main issue is some random table appearing in here: https://pmem.io/pmdk/manpages/linux/master/libpmem2/pmem2_source_from_fd.3#errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5180)
<!-- Reviewable:end -->
