### PR TITLE
pmem2: removed file's size alignment during map fit check

### DIFF
--- a/src/libpmem2/config.c
+++ b/src/libpmem2/config.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2019-2020, Intel Corporation */
+/* Copyright 2019-2021, Intel Corporation */
 
 /*
  * config.c -- pmem2_config implementation
@@ -145,13 +145,10 @@ pmem2_config_validate_length(const struct pmem2_config *cfg,
 		return PMEM2_E_MAP_RANGE;
 	}
 
-	/* let's align the file size */
-	size_t aligned_file_len = file_len;
-	if (file_len % alignment)
-		aligned_file_len = ALIGN_UP(file_len, alignment);
-
-	/* validate mapping fit into the file */
-	if (end > aligned_file_len) {
+	/*
+	 * Validate the file size to be sure the mapping will fit in the file.
+	 */
+	if (end > file_len) {
 		ERR("mapping larger than file size");
 		return PMEM2_E_MAP_RANGE;
 	}

--- a/src/test/pmem2_map/pmem2_map.c
+++ b/src/test/pmem2_map/pmem2_map.c
@@ -582,10 +582,8 @@ test_map_larger_than_unaligned_file_size(const struct test_case *tc, int argc,
 	cfg.length = ALIGN_UP(length, alignment);
 
 	int ret = pmem2_map_new(&map, &cfg, src);
-	UT_PMEM2_EXPECT_RETURN(ret, 0);
+	UT_PMEM2_EXPECT_RETURN(ret, PMEM2_E_MAP_RANGE);
 
-	unmap_map(map);
-	FREE(map);
 	PMEM2_SOURCE_DELETE(&src);
 	UT_FH_CLOSE(fh);
 


### PR DESCRIPTION
I removed file's size alignment when validating mapping fit into the file's size. After the change real size of the file is verified, instead of aligning-up this size (to the system's allocation granularity) before check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5194)
<!-- Reviewable:end -->
