### PR TITLE
Fix FreeBSD compilation when doing gmake

### DIFF
--- a/src/common/file_posix.c
+++ b/src/common/file_posix.c
@@ -5,8 +5,10 @@
  * file_posix.c -- Posix versions of file APIs
  */
 
+#ifndef __FreeBSD__
 /* for O_TMPFILE */
 #define _GNU_SOURCE
+#endif
 
 #include <errno.h>
 #include <signal.h>

--- a/src/common/os_deep_linux.c
+++ b/src/common/os_deep_linux.c
@@ -5,7 +5,9 @@
  * os_deep_linux.c -- Linux abstraction layer
  */
 
+#ifndef __FreeBSD__
 #define _GNU_SOURCE
+#endif
 
 #include <inttypes.h>
 #include <fcntl.h>

--- a/src/common/set.c
+++ b/src/common/set.c
@@ -36,7 +36,7 @@
  * set.c -- pool set utilities
  */
 
-#ifndef _GNU_SOURCE
+#if !defined(_GNU_SOURCE) && !defined(__FreeBSD__)
 #define _GNU_SOURCE
 #endif
 

--- a/src/common/set_badblocks.c
+++ b/src/common/set_badblocks.c
@@ -4,7 +4,9 @@
 /*
  * set_badblocks.c - common part of implementation of bad blocks API
  */
+#ifndef __FreeBSD__
 #define _GNU_SOURCE
+#endif
 
 #include <fcntl.h>
 #include <inttypes.h>

--- a/src/core/os_posix.c
+++ b/src/core/os_posix.c
@@ -5,7 +5,9 @@
  * os_posix.c -- abstraction layer for basic Posix functions
  */
 
+#ifndef __FreeBSD__
 #define _GNU_SOURCE
+#endif
 
 #include <fcntl.h>
 #include <stdarg.h>

--- a/src/core/os_thread_posix.c
+++ b/src/core/os_thread_posix.c
@@ -5,7 +5,9 @@
  * os_thread_posix.c -- Posix thread abstraction layer
  */
 
+#ifndef __FreeBSD__
 #define _GNU_SOURCE
+#endif
 #include <pthread.h>
 #ifdef __FreeBSD__
 #include <pthread_np.h>

--- a/src/core/util_posix.c
+++ b/src/core/util_posix.c
@@ -6,6 +6,7 @@
  */
 
 #include <fcntl.h>
+#include <signal.h>
 #include <string.h>
 #include <limits.h>
 #include <stdlib.h>

--- a/src/libpmemobj/lane.c
+++ b/src/libpmemobj/lane.c
@@ -5,7 +5,7 @@
  * lane.c -- lane implementation
  */
 
-#ifndef _GNU_SOURCE
+#if !defined(_GNU_SOURCE) && !defined(__FreeBSD__)
 #define _GNU_SOURCE
 #endif
 


### PR DESCRIPTION
_GNU_SOURCE is not for FreeBSD and defining it unconditionally lead
to conflicts with -Wunused-macros.

Wrap _GNU_SOURCE with !defined(__FreeBSD__) for now.
For src/core/util_posix.c, includes signal.h also.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5216)
<!-- Reviewable:end -->
