### PR TITLE
test: fix types in rpmemd_db_test

### DIFF
--- a/src/test/rpmemd_db/rpmemd_db_test.c
+++ b/src/test/rpmemd_db/rpmemd_db_test.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2016-2020, Intel Corporation */
+/* Copyright 2016-2021, Intel Corporation */
 
 /*
  * rpmemd_db_test.c -- unit test for pool set database
@@ -50,7 +50,7 @@ fill_rand(void *addr, size_t len)
 
 	srand(time(NULL));
 	for (unsigned i = 0; i < len; i++)
-		buff[i] = (rand() % ('z' - 'a')) + 'a';
+		buff[i] = ((unsigned char)rand() % ('z' - 'a')) + 'a';
 
 }
 


### PR DESCRIPTION
It fixes conversion issue on Ubuntu 21.04 under clang.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5221)
<!-- Reviewable:end -->
