### PR TITLE
Fix pmempool_sync/transform test failures on PowerPC

### DIFF
--- a/src/test/pmempool_sync/out6.log.match
+++ b/src/test/pmempool_sync/out6.log.match
@@ -25,7 +25,7 @@ Pool set UUID            : $(nW)
 
 PMEM OBJ Header:
 Layout                   : OBJ_LAYOUT$(nW)
-Lanes offset             : 0x2000
+Lanes offset             : 0x$(nW)
 Number of lanes          : 1024
 Heap offset              : $(nW)
 Heap size                : $(nW)

--- a/src/test/pmempool_sync/out7.log.match
+++ b/src/test/pmempool_sync/out7.log.match
@@ -31,7 +31,7 @@ Pool set UUID            : $(nW)
 
 PMEM OBJ Header:
 Layout                   : OBJ_LAYOUT$(nW)
-Lanes offset             : 0x2000
+Lanes offset             : 0x$(nW)
 Number of lanes          : 1024
 Heap offset              : $(nW)
 Heap size                : $(nW)

--- a/src/test/pmempool_transform/out7.log.match
+++ b/src/test/pmempool_transform/out7.log.match
@@ -35,7 +35,7 @@ Pool set UUID            : $(nW)
 
 PMEM OBJ Header:
 Layout                   : OBJ_LAYOUT$(nW)
-Lanes offset             : 0x2000
+Lanes offset             : 0x$(nW)
 Number of lanes          : 1024
 Heap offset              : $(nW)
 Heap size                : $(nW)

--- a/src/test/pmempool_transform/out8.log.match
+++ b/src/test/pmempool_transform/out8.log.match
@@ -29,7 +29,7 @@ Pool set UUID            : $(nW)
 
 PMEM OBJ Header:
 Layout                   : OBJ_LAYOUT$(nW)
-Lanes offset             : 0x2000
+Lanes offset             : 0x$(nW)
 Number of lanes          : 1024
 Heap offset              : $(nW)
 Heap size                : $(nW)
@@ -50,7 +50,7 @@ Pool set UUID            : $(nW)
 
 PMEM OBJ Header:
 Layout                   : OBJ_LAYOUT$(nW)
-Lanes offset             : 0x2000
+Lanes offset             : 0x$(nW)
 Number of lanes          : 1024
 Heap offset              : $(nW)
 Heap size                : $(nW)

--- a/src/test/pmempool_transform/out9.log.match
+++ b/src/test/pmempool_transform/out9.log.match
@@ -30,7 +30,7 @@ Pool set UUID            : $(nW)
 
 PMEM OBJ Header:
 Layout                   : OBJ_LAYOUT$(nW)
-Lanes offset             : 0x2000
+Lanes offset             : 0x$(nW)
 Number of lanes          : 1024
 Heap offset              : $(nW)
 Heap size                : $(nW)
@@ -52,7 +52,7 @@ Pool set UUID            : $(nW)
 
 PMEM OBJ Header:
 Layout                   : OBJ_LAYOUT$(nW)
-Lanes offset             : 0x2000
+Lanes offset             : 0x$(nW)
 Number of lanes          : 1024
 Heap offset              : $(nW)
 Heap size                : $(nW)


### PR DESCRIPTION
For pmempool_sync and pmempool_transform tests, the lane offset is 0x2000 (8196) on
x86, while on PowerPC (64k page size), the lane offset will be 0x20000 (131072).

      out7.log.match:34  Lanes offset             : 0x2000
      out7.log:34        Lanes offset             : 0x20000

So replace 0x2000 with a $(nW).

Signed-off-by: Santosh Sivaraj <santosh@fossix.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5232)
<!-- Reviewable:end -->
