### PR TITLE
test: don't fail if valgrind can't resolve source lines

### DIFF
--- a/src/test/obj_action/memcheck1.log.match
+++ b/src/test/obj_action/memcheck1.log.match
@@ -5,35 +5,44 @@
 ==$(N)== Parent PID: $(N)
 ==$(N)== 
 ==$(N)== Invalid write of size 4
-==$(N)==    at 0x$(X): main (obj_action.c:$(N))
+==$(N)==    at 0x$(X): main ($(*)obj_action$(*))
 ==$(N)==  Address 0x$(X) is $(*)
 ==$(N)== 
 ==$(N)== Invalid write of size 4
-==$(N)==    at 0x$(X): main (obj_action.c:$(N))
+==$(N)==    at 0x$(X): main ($(*)obj_action$(*))
 ==$(N)==  Address 0x$(X) is $(*)
 ==$(N)== 
 ==$(N)== Invalid write of size 4
-==$(N)==    at 0x$(X): main (obj_action.c:$(N))
+==$(N)==    at 0x$(X): main ($(*)obj_action$(*))
 ==$(N)==  Address 0x$(X) is $(*)
 ==$(N)== 
 ==$(N)== Invalid write of size 4
-==$(N)==    at 0x$(X): test_defer_free (obj_action.c:$(N))
-==$(N)==    by 0x$(X): main (obj_action.c:$(N))
+==$(N)==    at 0x$(X): test_defer_free ($(*)obj_action$(*))
+==$(N)==    by 0x$(X): main ($(*)obj_action$(*))
 ==$(N)==  Address 0x$(X) is 0 bytes inside a block of size 112 free'd
-==$(N)==    at 0x$(X): palloc_heap_action_on_process (palloc.c:$(N))
-==$(N)==    by 0x$(X): palloc_exec_actions (palloc.c:$(N))
-==$(N)==    by 0x$(X): palloc_publish (palloc.c:$(N))
-==$(N)==    by 0x$(X): pmemobj_publish (obj.c:$(N))
-==$(N)==    by 0x$(X): test_defer_free (obj_action.c:$(N))
-==$(N)==    by 0x$(X): main (obj_action.c:$(N))
+$(OPT)==$(N)==    at 0x$(X): palloc_heap_action_on_process (palloc.c:$(N))
+$(OPX)==$(N)==    at 0x$(X): palloc_heap_action_on_process ($(*)src/debug/libpmemobj.so.1.0.0)
+$(OPT)==$(N)==    by 0x$(X): palloc_exec_actions (palloc.c:$(N))
+$(OPX)==$(N)==    by 0x$(X): palloc_exec_actions ($(*)src/debug/libpmemobj.so.1.0.0)
+$(OPT)==$(N)==    by 0x$(X): palloc_publish (palloc.c:$(N))
+$(OPX)==$(N)==    by 0x$(X): palloc_publish ($(*)src/debug/libpmemobj.so.1.0.0)
+$(OPT)==$(N)==    by 0x$(X): pmemobj_publish (obj.c:$(N))
+$(OPX)==$(N)==    by 0x$(X): pmemobj_publish ($(*)src/debug/libpmemobj.so.1.0.0)
+==$(N)==    by 0x$(X): test_defer_free ($(*)obj_action$(*))
+==$(N)==    by 0x$(X): main ($(*)obj_action$(*))
 ==$(N)==  Block was alloc'd at
-==$(N)==    at 0x$(X): alloc_prep_block (palloc.c:$(N))
-==$(N)==    by 0x$(X): palloc_reservation_create (palloc.c:$(N))
-==$(N)==    by 0x$(X): palloc_operation (palloc.c:$(N))
-==$(N)==    by 0x$(X): obj_alloc_construct (obj.c:$(N))
-==$(N)==    by 0x$(X): pmemobj_alloc (obj.c:$(N))
-==$(N)==    by 0x$(X): test_defer_free (obj_action.c:$(N))
-==$(N)==    by 0x$(X): main (obj_action.c:$(N))
+$(OPT)==$(N)==    at 0x$(X): alloc_prep_block (palloc.c:$(N))
+$(OPX)==$(N)==    at 0x$(X): alloc_prep_block ($(*)src/debug/libpmemobj.so.1.0.0)
+$(OPT)==$(N)==    by 0x$(X): palloc_reservation_create (palloc.c:$(N))
+$(OPX)==$(N)==    by 0x$(X): palloc_reservation_create ($(*)src/debug/libpmemobj.so.1.0.0)
+$(OPT)==$(N)==    by 0x$(X): palloc_operation (palloc.c:$(N))
+$(OPX)==$(N)==    by 0x$(X): palloc_operation ($(*)src/debug/libpmemobj.so.1.0.0)
+$(OPT)==$(N)==    by 0x$(X): obj_alloc_construct (obj.c:$(N))
+$(OPX)==$(N)==    by 0x$(X): obj_alloc_construct ($(*)src/debug/libpmemobj.so.1.0.0)
+$(OPT)==$(N)==    by 0x$(X): pmemobj_alloc (obj.c:$(N))
+$(OPX)==$(N)==    by 0x$(X): pmemobj_alloc ($(*)src/debug/libpmemobj.so.1.0.0)
+==$(N)==    by 0x$(X): test_defer_free ($(*)obj_action$(*))
+==$(N)==    by 0x$(X): main ($(*)obj_action$(*))
 ==$(N)== 
 ==$(N)== 
 ==$(N)== HEAP SUMMARY:

--- a/src/test/obj_memcheck/memcheck0.log.match
+++ b/src/test/obj_memcheck/memcheck0.log.match
@@ -5,20 +5,20 @@
 ==$(N)== Parent PID: $(N)
 ==$(N)== 
 ==$(N)== Conditional jump or move depends on uninitialised value(s)
-==$(N)==    at 0x$(X): test_everything (obj_memcheck.c:$(N))
-==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
+==$(N)==    at 0x$(X): test_everything ($(*)obj_memcheck$(*))
+==$(N)==    by 0x$(X): main ($(*)obj_memcheck$(*))
 ==$(N)== 
 ==$(N)== Invalid write of size 4
-==$(N)==    at 0x$(X): test_everything (obj_memcheck.c:$(N))
-==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
+==$(N)==    at 0x$(X): test_everything ($(*)obj_memcheck$(*))
+==$(N)==    by 0x$(X): main ($(*)obj_memcheck$(*))
 ==$(N)==  Address 0x$(X) is $(N) bytes inside a block of size $(N) free'd
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_heap_action_on_process|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_exec_actions|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_operation|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): ${obj_free|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): pmemobj_free $(*)
-==$(N)==    by 0x$(X): test_everything (obj_memcheck.c:$(N))
-==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
+==$(N)==    by 0x$(X): test_everything ($(*)obj_memcheck$(*))
+==$(N)==    by 0x$(X): main ($(*)obj_memcheck$(*))
 $(OPT)==$(N)==  Block was alloc'd at
 $(OPT)==$(N)==    $(S) 0x$(X): ${alloc_prep_block|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_reservation_create|???} $(*)
@@ -37,16 +37,16 @@ $(OPT)==$(N)==    by 0x$(X): ${pmemops_xpersist|???} $(*)
 $(OPT)==$(N)==    by 0x$(X): UnknownInlinedFun $(*)
 $(OPT)==$(N)==    by 0x$(X): ${pmemops_persist|???} $(*)
 $(OPT)==$(N)==    by 0x$(X): pmemobj_persist $(*)
-==$(N)==    by 0x$(X): test_everything (obj_memcheck.c:$(N))
-==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
+==$(N)==    by 0x$(X): test_everything ($(*)obj_memcheck$(*))
+==$(N)==    by 0x$(X): main ($(*)obj_memcheck$(*))
 ==$(N)==  Address 0x$(X) is 0 bytes inside a block of size $(N) free'd
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_heap_action_on_process|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_exec_actions|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_operation|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): ${obj_free|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): pmemobj_free $(*)
-==$(N)==    by 0x$(X): test_everything (obj_memcheck.c:$(N))
-==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
+==$(N)==    by 0x$(X): test_everything ($(*)obj_memcheck$(*))
+==$(N)==    by 0x$(X): main ($(*)obj_memcheck$(*))
 $(OPT)==$(N)==  Block was alloc'd at
 $(OPT)==$(N)==    $(S) 0x$(X): ${alloc_prep_block|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_reservation_create|???} $(*)
@@ -57,28 +57,28 @@ $(OPT)==$(N)==    $(S) 0x$(X): test_everything $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): main $(*)
 ==$(N)== 
 ==$(N)== Invalid write of size 4
-==$(N)==    at 0x$(X): test_everything (obj_memcheck.c:$(N))
-==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
+==$(N)==    at 0x$(X): test_everything ($(*)obj_memcheck$(*))
+==$(N)==    by 0x$(X): main ($(*)obj_memcheck$(*))
 $(OPT)==$(N)==  Address 0x$(X) is not stack'd, malloc'd or (recently) free'd
 $(OPT)==$(N)==  Address 0x$(X) is in a rw- mapped file $(nW) segment
 ==$(N)== 
 ==$(N)== Invalid write of size 4
-==$(N)==    at 0x$(X): test_everything (obj_memcheck.c:$(N))
-==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
+==$(N)==    at 0x$(X): test_everything ($(*)obj_memcheck$(*))
+==$(N)==    by 0x$(X): main ($(*)obj_memcheck$(*))
 $(OPT)==$(N)==  Address 0x$(X) is not stack'd, malloc'd or (recently) free'd
 $(OPT)==$(N)==  Address 0x$(X) is in a rw- mapped file $(nW) segment
 ==$(N)== 
 ==$(N)== Invalid write of size 4
-==$(N)==    at 0x$(X): test_everything (obj_memcheck.c:$(N))
-==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
+==$(N)==    at 0x$(X): test_everything ($(*)obj_memcheck$(*))
+==$(N)==    by 0x$(X): main ($(*)obj_memcheck$(*))
 ==$(N)==  Address 0x$(X) is $(N) bytes inside a block of size $(N) free'd
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_heap_action_on_process|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_exec_actions|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_operation|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): ${obj_free|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): pmemobj_free $(*)
-==$(N)==    by 0x$(X): test_everything (obj_memcheck.c:$(N))
-==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
+==$(N)==    by 0x$(X): test_everything ($(*)obj_memcheck$(*))
+==$(N)==    by 0x$(X): main ($(*)obj_memcheck$(*))
 $(OPT)==$(N)==  Block was alloc'd at
 $(OPT)==$(N)==    $(S) 0x$(X): ${alloc_prep_block|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_reservation_create|???} $(*)
@@ -89,16 +89,16 @@ $(OPT)==$(N)==    $(S) 0x$(X): test_everything $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): main $(*)
 ==$(N)== 
 ==$(N)== Invalid write of size 4
-==$(N)==    at 0x$(X): test_everything (obj_memcheck.c:$(N))
-==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
+==$(N)==    at 0x$(X): test_everything ($(*)obj_memcheck$(*))
+==$(N)==    by 0x$(X): main ($(*)obj_memcheck$(*))
 ==$(N)==  Address 0x$(X) is $(N) bytes inside a block of size $(N) free'd
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_heap_action_on_process|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_exec_actions|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_operation|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): ${obj_free|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): pmemobj_free $(*)
-==$(N)==    by 0x$(X): test_everything (obj_memcheck.c:$(N))
-==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
+==$(N)==    by 0x$(X): test_everything ($(*)obj_memcheck$(*))
+==$(N)==    by 0x$(X): main ($(*)obj_memcheck$(*))
 $(OPT)==$(N)==  Block was alloc'd at
 $(OPT)==$(N)==    $(S) 0x$(X): ${alloc_prep_block|???} $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): ${palloc_reservation_create|???} $(*)

--- a/src/test/obj_tx_add_range/memcheck3.log.match
+++ b/src/test/obj_tx_add_range/memcheck3.log.match
@@ -10,8 +10,8 @@
 ==$(*)==    by $(*): pmemobj_tx_add_snapshot ($(*))
 ==$(*)==    by $(*): pmemobj_tx_add_common ($(*))
 ==$(*)==    by $(*): pmemobj_tx_add_range ($(*))
-==$(*)==    by $(*): do_tx_add_range_no_uninit_check_commit_no_flag (obj_tx_add_range.c:$(*))
-==$(*)==    by $(*): main (obj_tx_add_range.c:$(*))
+==$(*)==    by $(*): do_tx_add_range_no_uninit_check_commit_no_flag ($(*)obj_tx_add_range$(*))
+==$(*)==    by $(*): main ($(*)obj_tx_add_range$(*))
 ==$(*)==  Address $(*) is 8 bytes inside a block of size $(*) client-defined
 ==$(*)==    at $(*): alloc_prep_block ($(*))
 ==$(*)==    by $(*): palloc_reservation_create ($(*))
@@ -19,8 +19,8 @@
 ==$(*)==    by $(*): tx_alloc_common ($(*))
 ==$(*)==    by $(*): pmemobj_tx_alloc ($(*))
 ==$(*)==    by $(*): do_tx_alloc ($(*))
-==$(*)==    by $(*): do_tx_add_range_no_uninit_check_commit_no_flag (obj_tx_add_range.c:$(*))
-==$(*)==    by $(*): main (obj_tx_add_range.c:$(*))
+==$(*)==    by $(*): do_tx_add_range_no_uninit_check_commit_no_flag ($(*)obj_tx_add_range$(*))
+==$(*)==    by $(*): main ($(*)obj_tx_add_range$(*))
 ==$(*)== 
 ==$(*)== 
 ==$(*)== HEAP SUMMARY:

--- a/src/test/obj_tx_add_range_direct/memcheck2.log.match
+++ b/src/test/obj_tx_add_range_direct/memcheck2.log.match
@@ -10,8 +10,8 @@
 ==$(*)==    by $(*): pmemobj_tx_add_snapshot ($(*))
 ==$(*)==    by $(*): pmemobj_tx_add_common ($(*))
 ==$(*)==    by $(*): pmemobj_tx_add_range_direct ($(*))
-==$(*)==    by $(*): do_tx_add_range_no_uninit_check_commit_no_flag (obj_tx_add_range_direct.c:$(*))
-==$(*)==    by $(*): main (obj_tx_add_range_direct.c:$(*))
+==$(*)==    by $(*): do_tx_add_range_no_uninit_check_commit_no_flag ($(*)obj_tx_add_range_direct$(*))
+==$(*)==    by $(*): main ($(*)obj_tx_add_range_direct$(*))
 ==$(*)==  Address $(*) is 8 bytes inside a block of size $(*) client-defined
 ==$(*)==    at $(*): alloc_prep_block ($(*))
 ==$(*)==    by $(*): palloc_reservation_create ($(*))
@@ -19,8 +19,8 @@
 ==$(*)==    by $(*): tx_alloc_common ($(*))
 ==$(*)==    by $(*): pmemobj_tx_alloc ($(*))
 ==$(*)==    by $(*): do_tx_alloc ($(*))
-==$(*)==    by $(*): do_tx_add_range_no_uninit_check_commit_no_flag (obj_tx_add_range_direct.c:$(*))
-==$(*)==    by $(*): main (obj_tx_add_range_direct.c:$(*))
+==$(*)==    by $(*): do_tx_add_range_no_uninit_check_commit_no_flag ($(*)obj_tx_add_range_direct$(*))
+==$(*)==    by $(*): main ($(*)obj_tx_add_range_direct$(*))
 ==$(*)== 
 ==$(*)== 
 ==$(*)== HEAP SUMMARY:


### PR DESCRIPTION
There are released distributions with gcc 11 but valgrind <3.17; as gcc11
defaults to DWARF5 but valgrind can't read it yet, this results in valgrind
reporting function names but not source lines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5248)
<!-- Reviewable:end -->
