### PR TITLE
test: don't spam warnings if cacheline size can't be determined

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -152,7 +152,7 @@ NODES_MAX=-1
 SIZE_4KB=4096
 SIZE_2MB=2097152
 readonly PAGE_SIZE=$(getconf PAGESIZE)
-readonly CACHELINE_SIZE=$(cat /sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size)
+readonly CACHELINE_SIZE=$(cat /sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size 2>/dev/null || echo 64)
 
 # PMEMOBJ limitations
 PMEMOBJ_MAX_ALLOC_SIZE=17177771968


### PR DESCRIPTION
On arm64, cores in the same system can have different caches (typically in
big.LITTLE).  Assuming the worse-case (ie, 64 bytes) ensures correctness
at the cost of some performance -- this is what our actual code does.  On
the other hand, tests insist on reading this data from hard-coded path of
CPU0's coherency_line_size; this file is not present on ARM, causing the
test framework to spew a massive number of warnings.

https://www.mono-project.com/news/2016/09/12/arm64-icache/ tells a tale
that gives interesting caveats, like eg. reading the value at runtime
being a Wrong Thing unless you pin your thread to identical cores only.

If someone wants to optimize this, patches welcome!  For now, I'm only
making the tests correct and non-spammy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5256)
<!-- Reviewable:end -->
