### PR TITLE
riscv port

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,16 +374,15 @@ If you want to build/install experimental packages run:
 	$ make EXPERIMENTAL=y [install,rpm,dpkg]
 ```
 
-### Experimental Support for 64-bit ARM
+### Experimental Support for 64-bit ARM and RISC-V
 
-There is an initial support for 64-bit ARM processors provided,
-currently only for aarch64.  All the PMDK libraries except **librpmem**
-can be built for 64-bit ARM.  The examples, tools and benchmarks
-are not ported yet and may not get built on ARM cores.
+There is an initial support for 64-bit ARM and RISC-V processors provided.
+While PMDK's internal testsuite passes on DRAM-only systems, support for
+neither of these architectures has been validated on any persistent memory
+hardware, nor has the code received review from any person with professional
+knowledge of either of these platforms.
 
-**NOTE:**
-The support for ARM processors is highly experimental. The libraries
-are only validated to "early access" quality with Cortex-A53 processor.
+Thus, these architectures should not be used in a production environment.
 
 ### PowerPC support
 

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -150,7 +150,7 @@ ifneq ($(TESTBUILD), 1)
 $(error "$(TESTCMD)" failed)
 endif
 
-ifeq ($(filter $(ARCH), x86_64 aarch64 ppc64),)
+ifeq ($(filter $(ARCH), x86_64 aarch64 ppc64 riscv64),)
 $(error unsupported architecture: $(ARCH))
 endif
 

--- a/src/common/pool_hdr.c
+++ b/src/common/pool_hdr.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2014-2019, Intel Corporation */
+/* Copyright 2014-2021, Intel Corporation */
 
 /*
  * pool_hdr.c -- pool header utilities
@@ -26,6 +26,10 @@
 
 #elif defined(__PPC64__)
 #define PMDK_MACHINE PMDK_MACHINE_PPC64
+#define PMDK_MACHINE_CLASS PMDK_MACHINE_CLASS_64
+
+#elif defined(__riscv) && defined(_LP64)
+#define PMDK_MACHINE PMDK_MACHINE_RISCV64
 #define PMDK_MACHINE_CLASS PMDK_MACHINE_CLASS_64
 
 #else

--- a/src/common/pool_hdr.h
+++ b/src/common/pool_hdr.h
@@ -77,6 +77,7 @@ struct arch_flags {
 #define PMDK_MACHINE_X86_64 62
 #define PMDK_MACHINE_AARCH64 183
 #define PMDK_MACHINE_PPC64 21
+#define PMDK_MACHINE_RISCV64 243
 
 /* possible values of the data field in the above struct */
 #define PMDK_DATA_LE 1 /* 2's complement, little endian */

--- a/src/core/page_size.h
+++ b/src/core/page_size.h
@@ -1,11 +1,12 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2019-2020, Intel Corporation */
+/* Copyright 2019-2021, Intel Corporation */
 /* Copyright 2019, IBM Corporation */
 
 #ifndef PMDK_PAGE_SIZE_H
 #define PMDK_PAGE_SIZE_H
 
-#if defined(__x86_64) || defined(_M_X64) || defined(__aarch64__)
+#if defined(__x86_64) || defined(_M_X64) || defined(__aarch64__) || \
+	defined(__riscv)
 
 #define PMEM_PAGESIZE 4096
 

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -58,7 +58,8 @@ extern "C" {
 extern unsigned long long Pagesize;
 extern unsigned long long Mmap_align;
 
-#if defined(__x86_64) || defined(_M_X64) || defined(__aarch64__)
+#if defined(__x86_64) || defined(_M_X64) || defined(__aarch64__) || \
+	defined(__riscv)
 #define CACHELINE_SIZE 64ULL
 #elif defined(__PPC64__)
 #define CACHELINE_SIZE 128ULL

--- a/src/core/valgrind_internal.h
+++ b/src/core/valgrind_internal.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2015-2020, Intel Corporation */
+/* Copyright 2015-2021, Intel Corporation */
 
 /*
  * valgrind_internal.h -- internal definitions for valgrind macros
@@ -8,7 +8,7 @@
 #ifndef PMDK_VALGRIND_INTERNAL_H
 #define PMDK_VALGRIND_INTERNAL_H 1
 
-#if !defined(_WIN32) && !defined(__FreeBSD__)
+#if !defined(_WIN32) && !defined(__FreeBSD__) && !defined(__riscv)
 #ifndef VALGRIND_ENABLED
 #define VALGRIND_ENABLED 1
 #endif

--- a/src/examples/libpmem2/redo/redo.c
+++ b/src/examples/libpmem2/redo/redo.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * redo.c -- Implementation of simple persistent memory located redo log.
@@ -22,7 +22,8 @@
 #endif
 #include <libpmem2.h>
 
-#if defined(__x86_64) || defined(_M_X64) || defined(__aarch64__)
+#if defined(__x86_64) || defined(_M_X64) || defined(__aarch64__) || \
+	defined(__riscv)
 #define CACHELINE 64ULL
 #elif defined(__PPC64__)
 #define CACHELINE 128ULL

--- a/src/include/libpmemblk.h
+++ b/src/include/libpmemblk.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2014-2020, Intel Corporation */
+/* Copyright 2014-2021, Intel Corporation */
 
 /*
  * libpmemblk.h -- definitions of libpmemblk entry points
@@ -72,7 +72,8 @@ const wchar_t *pmemblk_check_versionW(unsigned major_required,
 /* XXX - unify minimum pool size for both OS-es */
 
 #ifndef _WIN32
-#if defined(__x86_64__) || defined(__M_X64__) || defined(__aarch64__)
+#if defined(__x86_64__) || defined(__M_X64__) || defined(__aarch64__) || \
+	defined(__riscv)
 /* minimum pool size: 16MiB + 4KiB (minimum BTT size + mmap alignment) */
 #define PMEMBLK_MIN_POOL ((size_t)((1u << 20) * 16 + (1u << 10) * 8))
 #elif defined(__PPC64__)

--- a/src/libpmem2/riscv64/flags.inc
+++ b/src/libpmem2/riscv64/flags.inc
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2021, Intel Corporation
+
+#
+# src/libpmem2/riscv64/flags.inc -- flags for libpmem2/riscv64
+#
+
+vpath %.c $(TOP)/src/libpmem2/riscv64
+vpath %.h $(TOP)/src/libpmem2/riscv64
+
+CFLAGS += -Iriscv64

--- a/src/libpmem2/riscv64/init.c
+++ b/src/libpmem2/riscv64/init.c
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2021, Intel Corporation */
+
+#include <string.h>
+
+#include "auto_flush.h"
+#include "out.h"
+#include "pmem2_arch.h"
+#include "rv_cacheops.h"
+
+/*
+ * memory_barrier -- (internal) issue the fence instruction
+ */
+static void
+memory_barrier(void)
+{
+	LOG(15, NULL);
+	riscv_store_memory_barrier();
+}
+
+static void
+noop(const void *addr, size_t len)
+{
+}
+
+/*
+ * pmem2_arch_init -- initialize architecture-specific list of pmem operations
+ */
+void
+pmem2_arch_init(struct pmem2_arch_info *info)
+{
+	LOG(3, NULL);
+
+	info->fence = memory_barrier;
+	info->flush = noop;
+}

--- a/src/libpmem2/riscv64/rv_cacheops.h
+++ b/src/libpmem2/riscv64/rv_cacheops.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright 2021, Intel Corporation */
+
+#ifndef RISCV64_CACHEOPS_H
+#define RISCV64_CACHEOPS_H
+
+#include <stdlib.h>
+
+static inline void
+riscv_store_memory_barrier(void)
+{
+	asm volatile("fence w,w" : : : "memory");
+}
+#endif

--- a/src/libpmem2/riscv64/sources.inc
+++ b/src/libpmem2/riscv64/sources.inc
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2021, Intel Corporation
+
+#
+# src/libpmem2/riscv64/sources.inc -- list of files for libpmem2/riscv64
+#
+
+LIBPMEM2_ARCH_SOURCE = init.c

--- a/src/test/pmem_deep_persist/Makefile
+++ b/src/test/pmem_deep_persist/Makefile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2017-2019, Intel Corporation
+# Copyright 2017-2021, Intel Corporation
 
 #
 # src/test/pmem_deep_persist/Makefile -- build pmem_deep_persist test
@@ -21,6 +21,9 @@ OBJS = pmem_deep_persist.o\
 	mocks_posix.o
 
 ifeq ($(ARCH), aarch64)
+OBJS += init.o
+endif
+ifeq ($(ARCH), riscv64)
 OBJS += init.o
 endif
 ifeq ($(ARCH), x86_64)

--- a/src/test/pmem_is_pmem_posix/Makefile
+++ b/src/test/pmem_is_pmem_posix/Makefile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2019, Intel Corporation
+# Copyright 2016-2021, Intel Corporation
 
 #
 # src/test/pmem_is_pmem_posix/Makefile -- build pmem_is_pmem_posix unit test
@@ -18,6 +18,9 @@ OBJS = pmem_is_pmem_posix.o\
 	memops_generic.o
 
 ifeq ($(ARCH), aarch64)
+OBJS += init.o
+endif
+ifeq ($(ARCH), riscv64)
 OBJS += init.o
 endif
 ifeq ($(ARCH), x86_64)


### PR DESCRIPTION
Thanks to cacheline/page sizes matching those of x86 and usual arm64 (pages are 4K/2M/1G/512G), all structs work unmodified, and the port Just Works, after adding an implementation of barriers, filing in magic numbers, and updating Makefiles.

The only oddity comes from the ISA designers being strongly opposed to any cache control from user code — their design for persistent memory is to require CPU caches being power fail protected.  This is the new mode supported by PMDK; cacheline granularity is impossible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5265)
<!-- Reviewable:end -->
