### PR TITLE
Add HWCAP_DCPOP if not defined to avoid build failure

### DIFF
--- a/src/libpmem2/aarch64/init.c
+++ b/src/libpmem2/aarch64/init.c
@@ -10,6 +10,10 @@
 #include "out.h"
 #include "pmem2_arch.h"
 
+#ifndef HWCAP_DCPOP
+#define HWCAP_DCPOP (1 << 16)
+#endif
+
 /*
  * memory_barrier -- (internal) issue the fence instruction
  */


### PR DESCRIPTION
On Aarch64 platform, if the building is running on the Linux kernel which is previous than 4.14, it can not recognize the HWCAP_DCPOP feature.
So it's better to define it first to avoid the build failure.

Signed-off-by: Kevin Zhao <kevin.zhao@linaro.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5270)
<!-- Reviewable:end -->
