### PR TITLE
drop RPMEM_DPKG + obsolete doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,18 +373,6 @@ If you want to build/install experimental packages run:
 	$ make EXPERIMENTAL=y [install,rpm,dpkg]
 ```
 
-### The librpmem and rpmemd packages
-
-**NOTE:**
-The **libfabric** package required to build the **librpmem** and **rpmemd** is
-not yet available on stable Debian-based distributions. This makes it
-impossible to create Debian packages.
-
-If you want to build Debian packages of **librpmem** and **rpmemd** run:
-```
-	$ make RPMEM_DPKG=y dpkg
-```
-
 ### Experimental Support for 64-bit ARM
 
 There is an initial support for 64-bit ARM processors provided,

--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2014-2020, Intel Corporation
+# Copyright 2014-2021, Intel Corporation
 
 #
 # build-dpkg.sh - Script for building deb packages
@@ -849,7 +849,7 @@ new-package-should-close-itp-bug
 EOF
 
 # librpmem & rpmemd
-if [ "${BUILD_RPMEM}" = "y" -a "${RPMEM_DPKG}" = "y" ]
+if [ "${BUILD_RPMEM}" = "y" ]
 then
 	append_rpmem_control;
 	rpmem_install_triggers_overrides;


### PR DESCRIPTION
We already have BUILD_RPMEM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5279)
<!-- Reviewable:end -->
