### PR TITLE
obj: main memory consumption optimizations

### DIFF
--- a/doc/libpmemobj/pmemobj_ctl_get.3.md
+++ b/doc/libpmemobj/pmemobj_ctl_get.3.md
@@ -207,6 +207,14 @@ The argument for this CTL is an enum with the following types:
 Changing this value has no impact on already open pools. It should typically be
 set at the beginning of the application, before any pools are opened or created.
 
+heap.arenas_default_max | rw- | global | unsigned | unsigned | - | integer
+
+Reads or writes the number of arenas that are created by default on startup of
+the heap's runtime state.
+This value by default is equal to the number of online CPUs available on the
+platform, but can be decreased or increased depending on application's
+scalability requirements.
+
 heap.alloc_class.[class_id].desc | rw | - | `struct pobj_alloc_class_desc` |
 `struct pobj_alloc_class_desc` | - | integer, integer, integer, string
 

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -37,6 +37,8 @@
 enum pobj_arenas_assignment_type Default_arenas_assignment_type =
 	POBJ_ARENAS_ASSIGNMENT_THREAD_KEY;
 
+ssize_t Default_arenas_max = -1;
+
 struct arenas_thread_assignment {
 	enum pobj_arenas_assignment_type type;
 	union {
@@ -1437,9 +1439,9 @@ heap_set_arena_thread(struct palloc_heap *heap, unsigned arena_id)
 }
 
 /*
- * heap_get_procs -- (internal) returns the number of arenas to create
+ * heap_get_procs -- returns the number of arenas to create
  */
-static unsigned
+unsigned
 heap_get_procs(void)
 {
 	long cpus = sysconf(_SC_NPROCESSORS_ONLN);
@@ -1629,7 +1631,8 @@ heap_boot(struct palloc_heap *heap, void *heap_start, uint64_t heap_size,
 		goto error_alloc_classes_new;
 	}
 
-	unsigned narenas_default = heap_get_procs();
+	unsigned narenas_default = Default_arenas_max == -1 ?
+		heap_get_procs() : (unsigned)Default_arenas_max;
 
 	if (heap_arenas_init(&h->arenas) != 0) {
 		err = errno;

--- a/src/libpmemobj/heap.h
+++ b/src/libpmemobj/heap.h
@@ -22,6 +22,7 @@ extern "C" {
 #endif
 
 extern enum pobj_arenas_assignment_type Default_arenas_assignment_type;
+extern ssize_t Default_arenas_max;
 
 #define HEAP_OFF_TO_PTR(heap, off) ((void *)((char *)((heap)->base) + (off)))
 #define HEAP_PTR_TO_OFF(heap, ptr)\
@@ -105,6 +106,8 @@ int heap_set_arena_auto(struct palloc_heap *heap, unsigned arena_id,
 		int automatic);
 
 void heap_set_arena_thread(struct palloc_heap *heap, unsigned arena_id);
+
+unsigned heap_get_procs(void);
 
 void heap_vg_open(struct palloc_heap *heap, object_callback cb,
 		void *arg, int objects);

--- a/src/libpmemobj/pmalloc.c
+++ b/src/libpmemobj/pmalloc.c
@@ -860,8 +860,48 @@ static const struct ctl_argument CTL_ARG(arenas_assignment_type) = {
 	}
 };
 
+/*
+ * CTL_READ_HANDLER(arenas_default_max) -- reads a max number of arenas
+ *	created by default at startup
+ */
+static int
+CTL_READ_HANDLER(arenas_default_max)(void *ctx,
+	enum ctl_query_source source, void *arg, struct ctl_indexes *indexes)
+{
+	unsigned *max = arg;
+
+	*max = Default_arenas_max == -1 ?
+		heap_get_procs() : (unsigned)Default_arenas_max;
+
+	return 0;
+}
+
+/*
+ * CTL_WRITE_HANDLER(arenas_default_max) -- writes a max number of arenas
+ *	created by default at startup
+ */
+static int
+CTL_WRITE_HANDLER(arenas_default_max)(void *ctx,
+	enum ctl_query_source source, void *arg, struct ctl_indexes *indexes)
+{
+	unsigned size = *(unsigned *)arg;
+
+	if (size == 0) {
+		LOG(1, "number of default arenas can't be 0");
+		return -1;
+	}
+
+	Default_arenas_max = size;
+
+	return 0;
+}
+
+static const struct ctl_argument CTL_ARG(arenas_default_max) =
+	CTL_ARG_LONG_LONG;
+
 static const struct ctl_node CTL_NODE(heap_global)[] = {
 	CTL_LEAF_RW(arenas_assignment_type),
+	CTL_LEAF_RW(arenas_default_max),
 
 	CTL_NODE_END
 };

--- a/src/test/obj_ctl_arenas/TEST10
+++ b/src/test/obj_ctl_arenas/TEST10
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2021, Intel Corporation
+
+#
+# src/test/obj_ctl_arenas/TEST10 -- test for max default arenas
+#
+
+. ../unittest/unittest.sh
+
+require_test_type short
+require_fs_type any
+
+setup
+
+expect_normal_exit ./obj_ctl_arenas$EXESUFFIX $DIR/testset1 b
+
+pass

--- a/src/test/obj_ctl_arenas/TEST10.PS1
+++ b/src/test/obj_ctl_arenas/TEST10.PS1
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2021, Intel Corporation
+
+#
+# src/test/obj_ctl_arenas/TEST10 -- test for max default arenas
+#
+
+. ..\unittest\unittest.ps1
+
+require_test_type short
+require_fs_type any
+
+setup
+
+expect_normal_exit $Env:EXE_DIR\obj_ctl_arenas$Env:EXESUFFIX $DIR\testset1 b
+
+pass


### PR DESCRIPTION
This PR has two separate patches.
1. `obj: lazily initialize recycler` - moves the initialization of recyclers (which can be quite big) to first use.
2. `obj: add heap.arenas_default_max global ctl` - allows applications to reduce the number of arenas, which will reduce memory use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5280)
<!-- Reviewable:end -->
