### PR TITLE
don't vary cacheline size at runtime in rpmem_basic/TEST22

### DIFF
--- a/src/test/rpmem_basic/TEST22
+++ b/src/test/rpmem_basic/TEST22
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2019, Intel Corporation
+# Copyright 2019-2021, Intel Corporation
 
 #
 # src/test/rpmem_basic/TEST22 -- unit test for mixed workloads
@@ -14,6 +14,11 @@ require_test_type medium
 . setup.sh
 
 setup
+
+case `uname -m` in
+ppc64*)	CACHELINE_SIZE=128 ;;
+*)	CACHELINE_SIZE=64 ;;
+esac
 
 create_poolset $DIR/pool0.set 8M:$PART_DIR/pool0.part0 8M:$PART_DIR/pool0.part1
 # Pool set file with the SINGLEHDR option

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2014-2020, Intel Corporation
+# Copyright 2014-2021, Intel Corporation
 #
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
@@ -152,7 +152,6 @@ NODES_MAX=-1
 SIZE_4KB=4096
 SIZE_2MB=2097152
 readonly PAGE_SIZE=$(getconf PAGESIZE)
-readonly CACHELINE_SIZE=$(cat /sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size 2>/dev/null || echo 64)
 
 # PMEMOBJ limitations
 PMEMOBJ_MAX_ALLOC_SIZE=17177771968


### PR DESCRIPTION
The way we guess cacheline size is not only problematic, it will also cause a failure if participating machines differ.  Instead, let's use fixed cacheline sizes.  It's just a test anyway, let's not complicate things optimizing it.

Replaces #5271

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5290)
<!-- Reviewable:end -->
