### PR TITLE
common: fix missing sfence in non-temporal memcpy

### DIFF
--- a/src/common/uuid.c
+++ b/src/common/uuid.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2014-2018, Intel Corporation */
+/* Copyright 2014-2021, Intel Corporation */
 
 /*
  * uuid.c -- uuid utilities
@@ -53,7 +53,7 @@ util_uuid_to_string(const uuid_t u, char *buf)
  * f81d4fae-7dec-11d0-a765-00a0c91e6bf6
  */
 int
-util_uuid_from_string(const char *uuid, struct uuid *ud)
+util_uuid_from_string(const char uuid[POOL_HDR_UUID_STR_LEN], struct uuid *ud)
 {
 	if (strlen(uuid) != 36) {
 		LOG(2, "invalid uuid string");

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2014-2020, Intel Corporation */
+/* Copyright 2014-2021, Intel Corporation */
 /*
  * Copyright (c) 2016-2020, Microsoft Corporation. All rights reserved.
  *
@@ -133,12 +133,23 @@ void util_set_alloc_funcs(
 #ifdef _MSC_VER
 #define force_inline inline __forceinline
 #define NORETURN __declspec(noreturn)
-#define barrier() _ReadWriteBarrier()
 #else
 #define force_inline __attribute__((always_inline)) inline
 #define NORETURN __attribute__((noreturn))
-#define barrier() asm volatile("" ::: "memory")
 #endif
+
+/*
+ * compiler_barrier -- issues a compiler barrier
+ */
+static force_inline void
+compiler_barrier(void)
+{
+#ifdef _MSC_VER
+	_ReadWriteBarrier();
+#else
+	asm volatile("" ::: "memory");
+#endif
+}
 
 #ifdef _MSC_VER
 typedef UNALIGNED uint64_t ua_uint64_t;

--- a/src/libpmem2/x86_64/memcpy/memcpy_nt_avx.c
+++ b/src/libpmem2/x86_64/memcpy/memcpy_nt_avx.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2017-2020, Intel Corporation */
+/* Copyright 2017-2021, Intel Corporation */
 
 #include <immintrin.h>
 #include <stddef.h>
@@ -22,7 +22,7 @@ static force_inline void
 mm256_stream_si256(char *dest, unsigned idx, __m256i src)
 {
 	_mm256_stream_si256((__m256i *)dest + idx, src);
-	barrier();
+	compiler_barrier();
 }
 
 static force_inline void

--- a/src/libpmem2/x86_64/memcpy/memcpy_nt_avx512f.c
+++ b/src/libpmem2/x86_64/memcpy/memcpy_nt_avx512f.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2017-2020, Intel Corporation */
+/* Copyright 2017-2021, Intel Corporation */
 
 #include <immintrin.h>
 #include <stddef.h>
@@ -22,7 +22,7 @@ static force_inline void
 mm512_stream_si512(char *dest, unsigned idx, __m512i src)
 {
 	_mm512_stream_si512((__m512i *)dest + idx, src);
-	barrier();
+	compiler_barrier();
 }
 
 static force_inline void

--- a/src/libpmem2/x86_64/memcpy/memcpy_nt_sse2.c
+++ b/src/libpmem2/x86_64/memcpy/memcpy_nt_sse2.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2017-2020, Intel Corporation */
+/* Copyright 2017-2021, Intel Corporation */
 
 #include <immintrin.h>
 #include <stddef.h>
@@ -21,7 +21,7 @@ static force_inline void
 mm_stream_si128(char *dest, unsigned idx, __m128i src)
 {
 	_mm_stream_si128((__m128i *)dest + idx, src);
-	barrier();
+	compiler_barrier();
 }
 
 static force_inline void

--- a/src/libpmem2/x86_64/memset/memset_nt_avx.c
+++ b/src/libpmem2/x86_64/memset/memset_nt_avx.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2017-2020, Intel Corporation */
+/* Copyright 2017-2021, Intel Corporation */
 
 #include <immintrin.h>
 #include <stddef.h>
@@ -17,7 +17,7 @@ static force_inline void
 mm256_stream_si256(char *dest, unsigned idx, __m256i src)
 {
 	_mm256_stream_si256((__m256i *)dest + idx, src);
-	barrier();
+	compiler_barrier();
 }
 
 static force_inline void

--- a/src/libpmem2/x86_64/memset/memset_nt_avx512f.c
+++ b/src/libpmem2/x86_64/memset/memset_nt_avx512f.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2017-2020, Intel Corporation */
+/* Copyright 2017-2021, Intel Corporation */
 
 #include <immintrin.h>
 #include <stddef.h>
@@ -18,7 +18,7 @@ static force_inline void
 mm512_stream_si512(char *dest, unsigned idx, __m512i src)
 {
 	_mm512_stream_si512((__m512i *)dest + idx, src);
-	barrier();
+	compiler_barrier();
 }
 
 static force_inline void

--- a/src/libpmem2/x86_64/memset/memset_nt_sse2.c
+++ b/src/libpmem2/x86_64/memset/memset_nt_sse2.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2017-2020, Intel Corporation */
+/* Copyright 2017-2021, Intel Corporation */
 
 #include <immintrin.h>
 #include <stddef.h>
@@ -16,7 +16,7 @@ static force_inline void
 mm_stream_si128(char *dest, unsigned idx, __m128i src)
 {
 	_mm_stream_si128((__m128i *)dest + idx, src);
-	barrier();
+	compiler_barrier();
 }
 
 static force_inline void


### PR DESCRIPTION
The implementation of hardware fencing for non-temporal
memcpy variants is done using a function pointer. Some
of those pointers were called "barrier" which unfortunately
overlaps with a function-like macro that's used for compiler
barriers. This meant that a compiler barrier was being used
instead of a hardware store barrier.

This patch changes the compiler barrier to a static inline
function called "compiler_barrier" to avoid name conflicts.

Fixes #5292
Reported-by: @Transpeptidase

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5293)
<!-- Reviewable:end -->
