### PR TITLE
common: update rpm building script for new RHEL like OSes

### DIFF
--- a/utils/pkg-common.sh
+++ b/utils/pkg-common.sh
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2014-2019, Intel Corporation
+# Copyright 2014-2021, Intel Corporation
 
 #
 # pkg-common.sh - common functions and variables for building packages
@@ -45,7 +45,7 @@ function get_os() {
 	then
 		local OS=$(cat /etc/os-release | grep -m1 -o -P '(?<=NAME=).*($)')
 		[[ "$OS" =~ SLES|openSUSE ]] && echo -n "SLES_like" ||
-		([[ "$OS" =~ "Fedora"|"Red Hat"|"CentOS" ]] && echo -n "RHEL_like" || echo 1)
+		([[ "$OS" =~ "Fedora"|"Red Hat"|"CentOS"|"AlmaLinux"|"Rocky Linux" ]] && echo -n "RHEL_like" || echo 1)
 	else
 		echo 1
 	fi


### PR DESCRIPTION
AlmaLinux and Rocky Linux suppose to be a CentOS replacements,
since it is EOL-ing soon (at least in current form).

// tested it on my branch, on pmemkv using AlmaLinux and it worked just fine: https://github.com/lukaszstolarczuk/pmemkv/runs/3526201154?check_suite_focus=true#step:4:12939

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5304)
<!-- Reviewable:end -->
