### PR TITLE
Common: Add package name of RHEL for ndctl and daxctl library on build error

### DIFF
--- a/src/common.inc
+++ b/src/common.inc
@@ -373,11 +373,11 @@ ifeq ($(NDCTL_ENABLE),y)
         ifeq ($(HAS_NDCTL),y)
             OS_DIMM_CFLAG=-DNDCTL_ENABLED=1
         else
-            $(error Please install libndctl-dev/libndctl-devel >= $(NDCTL_MIN_VERSION))
+            $(error Please install libndctl-dev/libndctl-devel/ndctl-devel >= $(NDCTL_MIN_VERSION))
         endif
         HAS_DAXCTL := $(call check_package, libdaxctl --atleast-version $(NDCTL_MIN_VERSION))
         ifeq ($(HAS_DAXCTL),n)
-            $(error Please install libdaxctl-dev/libdaxctl-devel >= $(NDCTL_MIN_VERSION))
+            $(error Please install libdaxctl-dev/libdaxctl-devel/daxctl-devel >= $(NDCTL_MIN_VERSION))
         endif
         LIBNDCTL_PKG_CONFIG_DEPS := libndctl libdaxctl
         LIBNDCTL_PKG_CONFIG_DEPS_VAR := ,libndctl,libdaxctl


### PR DESCRIPTION
This may be a bit trivial, but when there are missing packages in build, I'm always a bit annoying to find the right package due to the difference package names among each distributions. I suppose that error message need to display the package names of RHEL which are ndctl-devel and daxctl-devel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5305)
<!-- Reviewable:end -->
