### PR TITLE
common: supress false positve of '-Wunused-parameter'

### DIFF
--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -1132,6 +1132,8 @@ pmemobj_tx_process(void)
 static void
 vg_verify_initialized(PMEMobjpool *pop, const struct tx_range_def *def)
 {
+	/* suppress unused-parameter errors */
+	SUPPRESS_UNUSED(pop, def);
 #if VG_MEMCHECK_ENABLED
 	if (!On_memcheck)
 		return;


### PR DESCRIPTION
When valgrind is disabled there is error caused by
'-Wunused-parameter' flag in vg_verify_initialized.

Change-Id: I8c511974c2372baea64442c15a589b7a4684487f
Signed-off-by: Jun He <jun.he@arm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5321)
<!-- Reviewable:end -->
