### PR TITLE
riscv fixes

### DIFF
--- a/src/libpmem2/riscv64/init.c
+++ b/src/libpmem2/riscv64/init.c
@@ -21,6 +21,7 @@ memory_barrier(void)
 static void
 noop(const void *addr, size_t len)
 {
+	SUPPRESS_UNUSED(addr, len);
 }
 
 /*

--- a/src/test/libpmempool_bttdev/TEST11
+++ b/src/test/libpmempool_bttdev/TEST11
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2021, Intel Corporation
 #
 #
 # libpmempool_bttdev/TEST11 -- test for checking btt
@@ -9,8 +9,8 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-
 require_fs_type any
+require_unlimited_vm
 
 # Valgrind cannot trace more than 32G which is required for this test
 configure_valgrind memcheck force-disable

--- a/src/test/libpmempool_bttdev/TEST3
+++ b/src/test/libpmempool_bttdev/TEST3
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2021, Intel Corporation
 #
 #
 # libpmempool_bttdev/TEST3 -- test for checking btt
@@ -9,8 +9,8 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-
 require_fs_type any
+require_unlimited_vm
 
 # Valgrind cannot trace more than 32G which is required for this test
 configure_valgrind memcheck force-disable

--- a/src/test/libpmempool_bttdev/TEST4
+++ b/src/test/libpmempool_bttdev/TEST4
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2021, Intel Corporation
 #
 #
 # libpmempool_bttdev/TEST4 -- test for checking btt
@@ -9,8 +9,8 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-
 require_fs_type any
+require_unlimited_vm
 
 # Valgrind cannot trace more than 32G which is required for this test
 configure_valgrind memcheck force-disable

--- a/src/test/libpmempool_bttdev/TEST5
+++ b/src/test/libpmempool_bttdev/TEST5
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2021, Intel Corporation
 #
 #
 # libpmempool_bttdev/TEST5 -- test for checking btt
@@ -9,8 +9,8 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-
 require_fs_type any
+require_unlimited_vm
 
 # Valgrind cannot trace more than 32G which is required for this test
 configure_valgrind memcheck force-disable

--- a/src/test/libpmempool_bttdev/TEST6
+++ b/src/test/libpmempool_bttdev/TEST6
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2018, Intel Corporation
+# Copyright 2016-2021, Intel Corporation
 #
 #
 # libpmempool_bttdev/TEST6 -- test for checking btt
@@ -9,8 +9,8 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-
 require_fs_type any
+require_unlimited_vm
 
 # Valgrind cannot trace more than 32G which is required for this test
 configure_valgrind memcheck force-disable

--- a/src/test/pmempool_check/TEST5
+++ b/src/test/pmempool_check/TEST5
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2014-2018, Intel Corporation
+# Copyright 2014-2021, Intel Corporation
 #
 #
 # pmempool_check/TEST5 -- test for checking pools
@@ -9,8 +9,8 @@
 . ../unittest/unittest.sh
 
 require_test_type medium
-
 require_fs_type pmem non-pmem
+require_unlimited_vm
 
 # Valgrind cannot trace more than 32G which is required for this test
 configure_valgrind force-disable

--- a/src/test/pmempool_info/out27.log.match
+++ b/src/test/pmempool_info/out27.log.match
@@ -21,6 +21,7 @@ Class                    : $(*)
 Data                     : $(*)
 $(OPT)Machine                  : AMD X86-64
 $(OPT)Machine                  : Aarch64
+$(OPT)Machine                  : RISCV
 $(OPX)Machine                  : PPC64
 Last shutdown            : clean
 Checksum                 : $(*) [OK]

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1004,8 +1004,13 @@ function check_pools() {
 # This implies requirements for:
 # - overcommit_memory enabled (/proc/sys/vm/overcommit_memory is 0 or 1)
 # - unlimited virtual memory (ulimit -v is unlimited)
+# - big enough virtual memory (sv39 is too small)
 #
 function require_unlimited_vm() {
+	if grep -q "^mmu[[:blank:]]*: sv39" /proc/cpuinfo; then
+		msg "$UNITTEST_NAME: SKIP required: 4+ level virtual memory"
+		exit 0
+	fi
 	$VM_OVERCOMMIT && [ $(ulimit -v) = "unlimited" ] && return
 	msg "$UNITTEST_NAME: SKIP required: overcommit_memory enabled and unlimited virtual memory"
 	exit 0

--- a/src/tools/pmempool/output.c
+++ b/src/tools/pmempool/output.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2014-2020, Intel Corporation */
+/* Copyright 2014-2021, Intel Corporation */
 
 /*
  * output.c -- definitions of output printing related functions
@@ -726,6 +726,8 @@ out_get_arch_machine_str(uint16_t machine)
 		return "Aarch64";
 	case PMDK_MACHINE_PPC64:
 		return "PPC64";
+	case PMDK_MACHINE_RISCV64:
+		return "RISCV";
 	default:
 		break;
 	}


### PR DESCRIPTION
Three more issues popped up:
* `-Wunused-parameter` broke the build
* a pmempool test revealed that its info lacked the arch name
* tests with large sparse allocations won't fit within a sv39 (ie, 3-level page) model

The latter two tests were apparently skipped before, and got unblocked once I improved either the running kernel or disk space (I've replaced a shiny 16GB Optane NVMe with a boring legacy 250GB piece...).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5322)
<!-- Reviewable:end -->