### PR TITLE
obj: fix invalid type when setting cache size ctl

### DIFF
--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -2195,7 +2195,7 @@ CTL_WRITE_HANDLER(size)(void *ctx,
 
 	PMEMobjpool *pop = ctx;
 
-	ssize_t arg_in = *(int *)arg;
+	ssize_t arg_in = *(long long *)arg;
 
 	if (arg_in < 0 || arg_in > (ssize_t)PMEMOBJ_MAX_ALLOC_SIZE) {
 		errno = EINVAL;

--- a/src/test/obj_ulog_size/out0.log.match
+++ b/src/test/obj_ulog_size/out0.log.match
@@ -39,4 +39,5 @@ Estimated intent log buffer size is sufficient
 do_log_snapshot_max_size_limits
 do_log_snapshot_max_size
 Estimated snapshot log buffer size is sufficient
+do_ctl_snapshots_cache_size
 obj_ulog_size$(nW)TEST0: DONE

--- a/src/test/obj_ulog_size/out1.log.match
+++ b/src/test/obj_ulog_size/out1.log.match
@@ -39,4 +39,5 @@ Estimated intent log buffer size is sufficient
 do_log_snapshot_max_size_limits
 do_log_snapshot_max_size
 Estimated snapshot log buffer size is sufficient
+do_ctl_snapshots_cache_size
 obj_ulog_size$(nW)TEST1: DONE

--- a/src/test/obj_ulog_size/out2.log.match
+++ b/src/test/obj_ulog_size/out2.log.match
@@ -39,4 +39,5 @@ Estimated intent log buffer size is sufficient
 do_log_snapshot_max_size_limits
 do_log_snapshot_max_size
 Estimated snapshot log buffer size is sufficient
+do_ctl_snapshots_cache_size
 obj_ulog_size$(nW)TEST2: DONE


### PR DESCRIPTION

Ref: pmem/issues#5291

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5326)
<!-- Reviewable:end -->
