### PR TITLE
add a yet another helgrind suppression

### DIFF
--- a/src/test/helgrind-log.supp
+++ b/src/test/helgrind-log.supp
@@ -4,7 +4,7 @@
     fun:*mem*cpy
     ...
     fun:_IO_file_xsputn@@GLIBC*
-    fun:fputs
+    ...
     fun:out_print_func
     fun:out_common
     fun:out_log
@@ -25,7 +25,7 @@
     fun:*mem*cpy
     ...
     fun:_IO_file_xsputn@@GLIBC*
-    fun:fputs
+    ...
     fun:out_print_func
     fun:out_error
     fun:out_err


### PR DESCRIPTION
In this episode of helgrind failures, 2021 season, our star is ppc64el on Debian unstable, which has just got its glibc bumped to 2.32 (and aurel is going to upload 2.33 then 2.34 soonish...).  Here, fun:fputs is somehow missing from the backtrace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5328)
<!-- Reviewable:end -->
