### PR TITLE
obj: make sure nothing is accessed TX_STAGE_NONE cb

### DIFF
--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -1062,6 +1062,7 @@ pmemobj_tx_end(void)
 	Free(txd);
 
 	VALGRIND_END_TX;
+	int ret = tx->last_errnum;
 
 	if (PMDK_SLIST_EMPTY(&tx->tx_entries)) {
 		ASSERTeq(tx->lane, NULL);
@@ -1080,6 +1081,7 @@ pmemobj_tx_end(void)
 			tx->stage_callback_arg = NULL;
 
 			cb(tx->pop, TX_STAGE_NONE, arg);
+			/* tx should not be accessed after this callback */
 		}
 	} else {
 		/* resume the next transaction */
@@ -1090,7 +1092,7 @@ pmemobj_tx_end(void)
 			obj_tx_abort(tx->last_errnum, 0);
 	}
 
-	return tx->last_errnum;
+	return ret;
 }
 
 /*


### PR DESCRIPTION
The transactional TX_STAGE_NONE callback is executed after
the end of the transaction indicating that transaction
can now execute on the same thread. However, currently
the pmemobj_tx_end() function will actually read from
the per-thread transaction state after this callback.

This patch addresses the problem by reading all the necessary
state prior to the callback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5345)
<!-- Reviewable:end -->
