### PR TITLE
pmreorder: add more debug/info logs

### DIFF
--- a/src/test/pmreorder_simple/pmreorder0.log.match
+++ b/src/test/pmreorder_simple/pmreorder0.log.match
@@ -1,4 +1,4 @@
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -7,7 +7,7 @@ Store [1]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -16,7 +16,7 @@ Store [1]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -25,7 +25,7 @@ Store [1]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -34,7 +34,7 @@ Store [1]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -43,7 +43,7 @@ Store [1]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -52,19 +52,7 @@ Store [1]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
-WARNING:pmreorder:Call trace:
-Store [0]:
-    by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
-    by	0x$(nW): main (pmreorder_simple.c:$(N))
-Store [1]:
-    by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
-    by	0x$(nW): main (pmreorder_simple.c:$(N))
-Store [2]:
-    by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
-    by	0x$(nW): main (pmreorder_simple.c:$(N))
-
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -76,7 +64,7 @@ Store [2]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -88,7 +76,7 @@ Store [2]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -100,7 +88,7 @@ Store [2]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -112,7 +100,7 @@ Store [2]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -124,7 +112,7 @@ Store [2]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -136,7 +124,7 @@ Store [2]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -148,7 +136,7 @@ Store [2]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -160,7 +148,7 @@ Store [2]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -172,7 +160,7 @@ Store [2]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -184,7 +172,7 @@ Store [2]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -196,7 +184,7 @@ Store [2]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -208,7 +196,7 @@ Store [2]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -220,7 +208,7 @@ Store [2]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -232,7 +220,7 @@ Store [2]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -244,7 +232,7 @@ Store [2]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -256,7 +244,19 @@ Store [2]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
+WARNING:pmreorder:Call trace:
+Store [0]:
+    by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
+    by	0x$(nW): main (pmreorder_simple.c:$(N))
+Store [1]:
+    by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
+    by	0x$(nW): main (pmreorder_simple.c:$(N))
+Store [2]:
+    by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
+    by	0x$(nW): main (pmreorder_simple.c:$(N))
+
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))

--- a/src/test/pmreorder_simple/pmreorder3.log.match
+++ b/src/test/pmreorder_simple/pmreorder3.log.match
@@ -1,4 +1,4 @@
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
@@ -7,7 +7,7 @@ Store [1]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))
     by	0x$(nW): main (pmreorder_simple.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	0x$(nW): write_inconsistent (pmreorder_simple.c:$(N))

--- a/src/test/pmreorder_stack/pmreorder0.log.match
+++ b/src/test/pmreorder_stack/pmreorder0.log.match
@@ -1,13 +1,13 @@
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	$(nW): write_fields (pmreorder_stack.c:$(N))
     by	$(nW): main (pmreorder_stack.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	$(nW): write_fields (pmreorder_stack.c:$(N))
@@ -16,7 +16,7 @@ Store [1]:
     by	$(nW): write_fields (pmreorder_stack.c:$(N))
     by	$(nW): main (pmreorder_stack.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	$(nW): write_fields (pmreorder_stack.c:$(N))
@@ -28,7 +28,7 @@ Store [2]:
     by	$(nW): write_fields (pmreorder_stack.c:$(N))
     by	$(nW): main (pmreorder_stack.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	$(nW): write_fields (pmreorder_stack.c:$(N))
@@ -43,10 +43,10 @@ Store [3]:
     by	$(nW): write_fields (pmreorder_stack.c:$(N))
     by	$(nW): main (pmreorder_stack.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	$(nW): write_fields (pmreorder_stack.c:$(N))
@@ -55,7 +55,7 @@ Store [1]:
     by	$(nW): write_fields (pmreorder_stack.c:$(N))
     by	$(nW): main (pmreorder_stack.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	$(nW): write_fields (pmreorder_stack.c:$(N))
@@ -67,7 +67,7 @@ Store [2]:
     by	$(nW): write_fields (pmreorder_stack.c:$(N))
     by	$(nW): main (pmreorder_stack.c:$(N))
 
-WARNING:pmreorder:File $(nW)/testfile inconsistent
+WARNING:pmreorder:File $(nW)/testfile (base: 0x$(N), size: 0x$(N)) inconsistent
 WARNING:pmreorder:Call trace:
 Store [0]:
     by	$(nW): write_fields (pmreorder_stack.c:$(N))

--- a/src/tools/pmreorder/operationfactory.py
+++ b/src/tools/pmreorder/operationfactory.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2019, Intel Corporation
+# Copyright 2018-2021, Intel Corporation
 
 import memoryoperations
 from reorderexceptions import NotSupportedOperationException
@@ -24,6 +24,7 @@ class OperationFactory:
     :cvar __factories: The registered object factories.
     :type __factories: dict
     """
+
     __factories = {}
     __suffix = ['.BEGIN', '.END']
     memoryoperations.BaseOperation()
@@ -46,7 +47,6 @@ class OperationFactory:
 
     @staticmethod
     def create_operation(string_operation, markers, stack):
-
         def check_marker_format(marker):
             """
             Checks if marker has proper suffix.
@@ -56,8 +56,8 @@ class OperationFactory:
                     return
 
             raise NotSupportedOperationException(
-                        "Incorrect marker format {}, suffix is missing."
-                        .format(marker))
+                "Incorrect marker format {}, suffix is missing.".format(marker)
+            )
 
         def check_pair_consistency(stack, marker):
             """
@@ -85,8 +85,8 @@ class OperationFactory:
 
             if top != marker:
                 raise NotSupportedOperationException(
-                        "Cannot cross markers: {0}, {1}"
-                        .format(top, marker))
+                    "Cannot cross markers: {0}, {1}".format(top, marker)
+                )
 
         """
         Creates the object based on the pre-formatted string.
@@ -114,15 +114,15 @@ class OperationFactory:
             # if id_ is section BEGIN
             if id_.endswith(OperationFactory.__suffix[0]):
                 # BEGIN defined by user
-                marker_name = id_.partition('.')[0]
+                marker_name = id_.partition(".")[0]
                 if markers is not None and marker_name in markers:
                     engine = markers[marker_name]
                     try:
                         mem_ops = getattr(memoryoperations, engine)
                     except AttributeError:
                         raise NotSupportedOperationException(
-                                "Not supported reorder engine: {}"
-                                .format(engine))
+                            "Not supported reorder engine: {}".format(engine)
+                        )
                 # BEGIN but not defined by user
                 else:
                     mem_ops = stack[-1][1]

--- a/src/tools/pmreorder/opscontext.py
+++ b/src/tools/pmreorder/opscontext.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2021, Intel Corporation
 
 from operationfactory import OperationFactory
 from binaryoutputhandler import BinaryOutputHandler
@@ -24,6 +24,7 @@ class OpsContext:
     :type default_barrier: bool
     :ivar file_handler: The file handler used.
     """
+
     def __init__(self, log_file, checker, logger, arg_engine, markers):
         """
         Splits the operations in the log file and sets the instance variables
@@ -41,11 +42,11 @@ class OpsContext:
         self.test_on_barrier = engine.test_on_barrier
         self.default_engine = self.reorder_engine
         self.default_barrier = self.default_engine.test_on_barrier
-        self.file_handler = BinaryOutputHandler(checker)
+        self.file_handler = BinaryOutputHandler(checker, logger)
         self.checker = checker
         self.logger = logger
         self.markers = markers
-        self.stack_engines = [('START', getattr(memoryoperations, arg_engine))]
+        self.stack_engines = [("START", getattr(memoryoperations, arg_engine))]
 
     # TODO this should probably be made a generator
     def extract_operations(self):
@@ -63,6 +64,11 @@ class OpsContext:
             elif "STOP" in elem:
                 stop_index = i
 
-        return list(map(OperationFactory.create_operation,
-                        self._operations[start_index + 1:stop_index],
-                        repeat(self.markers), repeat(self.stack_engines)))
+        return list(
+            map(
+                OperationFactory.create_operation,
+                self._operations[start_index + 1:stop_index],
+                repeat(self.markers),
+                repeat(self.stack_engines),
+            )
+        )

--- a/src/tools/pmreorder/pmreorder.py
+++ b/src/tools/pmreorder/pmreorder.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2019, Intel Corporation
+# Copyright 2018-2021, Intel Corporation
 
 import argparse
 import statemachine
@@ -66,7 +66,8 @@ def main():
     checker = consistencycheckwrap.get_checker(
                                                args.checker,
                                                ' '.join(args.path),
-                                               args.name)
+                                               args.name,
+                                               logger)
 
     markers = markerparser.MarkerParser().get_markers(args.extended_macros)
 
@@ -77,6 +78,7 @@ def main():
                                     logger,
                                     args.default_engine,
                                     markers)
+    logger.debug("Input parameters: {}".format(context.__dict__))
 
     # init and run the state machine
     a = statemachine.StateMachine(statemachine.InitState(context))


### PR DESCRIPTION
Debug logs in pmreorder are rather empty right now. This PR extends and adds lots of new logs.

// example log output for failing test: [example.pmreorder.txt](https://github.com/pmem/pmdk/files/7363606/example.pmreorder.txt)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5348)
<!-- Reviewable:end -->
