### PR TITLE
test: add real pmem requirement to test framework

### DIFF
--- a/src/test/pmem2_badblock/TESTS.py
+++ b/src/test/pmem2_badblock/TESTS.py
@@ -13,6 +13,7 @@ import re
 @t.require_admin
 @g.require_granularity(g.CACHELINE)
 @t.require_ndctl(require_namespace=True)
+@g.require_real_pmem()
 class PMEM2_BADBLOCK_COUNT(t.Test):
     test_type = t.Short
 
@@ -54,6 +55,7 @@ class PMEM2_BADBLOCK_COUNT(t.Test):
 @t.require_admin
 @g.require_granularity(g.CACHELINE)
 @t.require_ndctl(require_namespace=True)
+@g.require_real_pmem()
 class PMEM2_BADBLOCK(t.Test):
     test_type = t.Short
 

--- a/src/test/pmemset_badblock/TESTS.py
+++ b/src/test/pmemset_badblock/TESTS.py
@@ -11,6 +11,7 @@ from testframework import granularity as g
 @t.require_admin
 @g.require_granularity(g.CACHELINE)
 @t.require_ndctl(require_namespace=True)
+@g.require_real_pmem()
 class PMEMSET_BADBLOCK(t.Test):
     test_type = t.Short
 

--- a/src/test/unittest/badblock.py
+++ b/src/test/unittest/badblock.py
@@ -73,18 +73,8 @@ class NdctlBB(tools.Ndctl, BBTool):
         super().__init__()
         self.util_tools = util_tools
 
-    def _get_file_device(self, file):
-        blockdev = futils.run_command("df -P {} | tail -n 1 | cut -f 1 -d ' '"
-                                      .format(file)).strip().decode('UTF8')
-        if blockdev == "devtmpfs":
-            device = file  # devdax
-        else:
-            device = blockdev  # fsdax
-
-        return device
-
     def inject_bad_block(self, file, offset):
-        device = self._get_file_device(file)
+        device = self._get_path_device(file)
         namespace = self.get_dev_namespace(device)
 
         count = 1
@@ -106,11 +96,11 @@ class NdctlBB(tools.Ndctl, BBTool):
                            "injecting bad block failed")
 
     def get_bad_blocks_count(self, file):
-        device = self._get_file_device(file)
+        device = self._get_path_device(file)
         return self.get_dev_bb_count(device)
 
     def clear_all_bad_blocks(self, file):
-        device = self._get_file_device(file)
+        device = self._get_path_device(file)
         namespace = self.get_dev_namespace(device)
 
         if self.is_devdax(device):

--- a/src/test/unittest/devdax.py
+++ b/src/test/unittest/devdax.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2019-2020, Intel Corporation
+# Copyright 2019-2021, Intel Corporation
 #
 
 """Device dax context classes and utilities"""
@@ -126,8 +126,9 @@ class DevDaxes():
 
         """
         dax_devices, _ = ctx.get_requirement(tc, 'devdax', ())
-        cls.check_fs_exec, kwargs = ctx.get_requirement(tc, 'require_fs_exec',
-                                                        None)
+        cls.check_fs_exec, _ = ctx.get_requirement(tc, 'require_fs_exec',
+                                                   None)
+        req_real_pmem, _ = ctx.get_requirement(tc, 'require_real_pmem', False)
 
         if not dax_devices:
             return ctx.NO_CONTEXT
@@ -150,6 +151,17 @@ class DevDaxes():
 
         assigned = _try_assign_by_requirements(config.device_dax_path,
                                                dax_devices)
+
+        # filter out the emulated devdaxes from the assigned ones
+        if req_real_pmem:
+            assigned_filtered = []
+
+            for dd in assigned:
+                if not ndctl.is_emulated(dd.path):
+                    assigned_filtered.append(dd)
+
+            assigned = tuple(assigned_filtered)
+
         if not assigned:
             raise futils.Skip('Dax devices in test configuration do not '
                               'meet test requirements')

--- a/src/test/unittest/requirements.py
+++ b/src/test/unittest/requirements.py
@@ -137,6 +137,7 @@ def require_ndctl(**kwargs):
         if key not in valid_kwarg_keys:
             raise KeyError('provided key {} is invalid'.format(key))
 
+    # namespace requirement
     namespace_kw = 'require_namespace'
     namespace_val = kwargs.get(namespace_kw, False)
     if not isinstance(namespace_val, bool):


### PR DESCRIPTION
Added new require_real_pmem decorator.
When require_real_pmem parameter is set on the test case then every
pmem device that would be used in ths test case is checked to be
real, non-emulated pmem. Devdaxes and fsdaxes are both checked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5356)
<!-- Reviewable:end -->
