### PR TITLE
common: use real asserts under klocwork

### DIFF
--- a/src/core/out.h
+++ b/src/core/out.h
@@ -22,8 +22,7 @@ extern "C" {
  * Suppress errors which are after appropriate ASSERT* macro for nondebug
  * builds.
  */
-#if !defined(DEBUG) && (defined(__clang_analyzer__) || defined(__COVERITY__) ||\
-		defined(__KLOCWORK__))
+#if !defined(DEBUG) && (defined(__clang_analyzer__) || defined(__COVERITY__))
 #define OUT_FATAL_DISCARD_NORETURN __attribute__((noreturn))
 #else
 #define OUT_FATAL_DISCARD_NORETURN
@@ -38,7 +37,8 @@ extern "C" {
 #endif
 #endif
 
-#ifdef DEBUG
+/* klocwork does not seem to respect __attribute__((noreturn)) */
+#if defined(DEBUG) || defined(__KLOCWORK__)
 
 #define OUT_LOG out_log
 #define OUT_NONL out_nonl


### PR DESCRIPTION
We currently use attribute((noreturn)) for empty asserts
in release builds, primarly to placate static analysis tools.
Until recently, this worked just fine. Lately klocwork started
reporting false-positives, seemingly ignoring any asserts in
the code.

This patch uses real asserts for release build that are used
for evaluation under klocwork.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5388)
<!-- Reviewable:end -->
