### PR TITLE
don't access the address of a FILE after fclose

### DIFF
--- a/src/test/unittest/ut_file.c
+++ b/src/test/unittest/ut_file.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2014-2018, Intel Corporation */
+/* Copyright 2014-2021, Intel Corporation */
 
 /*
  * ut_file.c -- unit test file operations
@@ -88,10 +88,8 @@ ut_fclose(const char *file, int line, const char *func, FILE *stream)
 {
 	int retval = os_fclose(stream);
 
-	if (retval != 0) {
-		ut_fatal(file, line, func, "!fclose: 0x%llx",
-			(unsigned long long)stream);
-	}
+	if (retval != 0)
+		ut_fatal(file, line, func, "!fclose");
 
 	return retval;
 }


### PR DESCRIPTION
```
ut_file.c: In function ‘ut_fclose’:
ut_file.c:92:17: error: pointer ‘stream’ may be used after ‘fclose’ [-Werror=use-after-free]
   92 |                 ut_fatal(file, line, func, "!fclose: 0x%llx",
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   93 |                         (unsigned long long)stream);
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5400)
<!-- Reviewable:end -->
