### PR TITLE
use daxctl/libdaxctl.h instead of ndctl/libdaxctl.h

### DIFF
--- a/src/libpmem2/badblocks_ndctl.c
+++ b/src/libpmem2/badblocks_ndctl.c
@@ -16,7 +16,7 @@
 #include <sys/sysmacros.h>
 #include <fcntl.h>
 #include <ndctl/libndctl.h>
-#include <ndctl/libdaxctl.h>
+#include <daxctl/libdaxctl.h>
 
 #include "libpmem2.h"
 #include "pmem2_utils.h"

--- a/src/libpmem2/region_namespace_ndctl.c
+++ b/src/libpmem2/region_namespace_ndctl.c
@@ -6,7 +6,7 @@
  */
 
 #include <ndctl/libndctl.h>
-#include <ndctl/libdaxctl.h>
+#include <daxctl/libdaxctl.h>
 #include <sys/sysmacros.h>
 #include <fcntl.h>
 

--- a/src/libpmem2/usc_ndctl.c
+++ b/src/libpmem2/usc_ndctl.c
@@ -5,7 +5,7 @@
  * usc_ndctl.c -- pmem2 usc function for platforms using ndctl
  */
 #include <ndctl/libndctl.h>
-#include <ndctl/libdaxctl.h>
+#include <daxctl/libdaxctl.h>
 #include <sys/types.h>
 #include <sys/sysmacros.h>
 #include <fcntl.h>

--- a/src/tools/daxio/daxio.c
+++ b/src/tools/daxio/daxio.c
@@ -21,7 +21,7 @@
 #include <string.h>
 
 #include <ndctl/libndctl.h>
-#include <ndctl/libdaxctl.h>
+#include <daxctl/libdaxctl.h>
 #include <libpmem.h>
 
 #include "util.h"


### PR DESCRIPTION
Signed-off-by: Khem Raj <raj.khem@gmail.com>