### PR TITLE
common: allow failure of arm64 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ env:
 jobs:
   allow_failures:
     - arch: ppc64le
+    - arch: arm64-graviton2
 
 before_install:
   - echo $TRAVIS_COMMIT_RANGE


### PR DESCRIPTION
Instead of completely disabling the builds on Travis we can set them as allow failure.
I do not know if this will allow our workflow to go green. We will find out in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5439)
<!-- Reviewable:end -->
