### PR TITLE
obj: always perform cleanup of logs with leftover state

### DIFF
--- a/src/libpmemobj/memops.c
+++ b/src/libpmemobj/memops.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2016-2021, Intel Corporation */
+/* Copyright 2016-2022, Intel Corporation */
 
 /*
  * memops.c -- aggregated memory operations helper implementation
@@ -18,6 +18,7 @@
 #include "obj.h"
 #include "out.h"
 #include "ravl.h"
+#include "ulog.h"
 #include "valgrind_internal.h"
 #include "vecq.h"
 #include "sys_util.h"
@@ -744,6 +745,13 @@ operation_resume(struct operation_context *ctx)
 {
 	operation_start(ctx);
 	ctx->total_logged = ulog_base_nbytes(ctx->ulog);
+	/*
+	 * Even if the log appears empty, it needs to be cleaned up
+	 * if it contains any leftover state (links to connected ulogs).
+	 */
+	if (ulog_next(ctx->ulog, ctx->p_ops) != NULL) {
+		ctx->state = OPERATION_CLEANUP;
+	}
 }
 
 /*


### PR DESCRIPTION
This patch fixes a bug where an invalidated undo log might have not been
properly cleaned up after a crash. Such a log would show that it has
no entries, so seemingly nothing to cleanup. However, a single log
can be composed of multiple allocations in a singly-linked list.
Typically all allocations but the first one are deallocated as part
of the cleanup process on recovery. And the log creation logic
makes decisions based on that assumption. And that assumption
was being violated in certain circumstanes where applications
crashed in large transactions, after a commit but before the undo log
was fully invalidated.

Reported-by: @task3r (email?)

Fixes #5461

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5465)
<!-- Reviewable:end -->
