### PR TITLE
common: fix default cflags in makefiles

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2014-2021, Intel Corporation
+# Copyright 2014-2022, Intel Corporation
 #
 # src/Makefile.inc -- common Makefile rules for PMDK
 #
@@ -66,6 +66,11 @@ endif
 ifeq ($(WSTRINGOP_TRUNCATION_AVAILABLE), y)
 DEFAULT_CFLAGS += -DSTRINGOP_TRUNCATION_SUPPORTED
 endif
+
+# Librpmem is deprecated.
+# This flag allows to build tests, examples and benchmarks
+# using rpmem despite the deprecated state.
+DEFAULT_CFLAGS += -Wno-deprecated-declarations
 
 ifeq ($(DEBUG),1)
 # Undefine _FORTIFY_SOURCE in case it's set in system-default or

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -13,7 +13,3 @@ include ../Makefile.inc
 
 CFLAGS += $(LIBNDCTL_CFLAGS) $(MINIASYNC_CFLAGS) -DPMEM2_USE_MINIASYNC=1
 CFLAGS += -DUSE_LIBDL
-# Librpmem is deprecated.
-# This flag allows to build tests, examples and benchmarks
-# using rpmem despite the deprecated state.
-CFLAGS += -Wno-deprecated-declarations

--- a/src/common/pmemcommon.inc
+++ b/src/common/pmemcommon.inc
@@ -56,8 +56,3 @@ SOURCE +=\
 	$(PMEM2)/region_namespace_none.c\
 	$(PMEM2)/numa_none.c
 endif
-
-# Librpmem is deprecated.
-# This flag allows to build tests, examples and benchmarks
-# using rpmem despite the deprecated state.
-CFLAGS += -Wno-deprecated-declarations

--- a/src/core/Makefile
+++ b/src/core/Makefile
@@ -10,8 +10,3 @@ LIBRARY_NAME = pmemcore
 include pmemcore.inc
 
 include ../Makefile.inc
-
-# Librpmem is deprecated.
-# This flag allows to build tests, examples and benchmarks
-# using rpmem despite the deprecated state.
-CFLAGS += -Wno-deprecated-declarations


### PR DESCRIPTION
A recent change tried to globally add a new flag
in the makefiles, which inadvertently caused
the build system to stop adding important
compile flags like '-O2'...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5488)
<!-- Reviewable:end -->
