### PR TITLE
obj: ensure zones are reclaimed prior to free (1.11)

### DIFF
--- a/src/PMDK.sln
+++ b/src/PMDK.sln
@@ -905,6 +905,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_list_remove", "test\obj
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_defrag", "test\obj_defrag\obj_defrag.vcxproj", "{FF6E5B0C-DC00-4C93-B9C2-63D1E858BA80}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_heap_reopen", "test\obj_heap_reopen\obj_heap_reopen.vcxproj", "{FF6E5B0C-DC00-4C93-B9C2-63D1E858BA81}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -2040,6 +2042,10 @@ Global
 		{FF6E5B0C-DC00-4C93-B9C2-63D1E858BA80}.Debug|x64.Build.0 = Debug|x64
 		{FF6E5B0C-DC00-4C93-B9C2-63D1E858BA80}.Release|x64.ActiveCfg = Release|x64
 		{FF6E5B0C-DC00-4C93-B9C2-63D1E858BA80}.Release|x64.Build.0 = Release|x64
+		{FF6E5B0C-DC00-4C93-B9C2-63D1E858BA81}.Debug|x64.ActiveCfg = Debug|x64
+		{FF6E5B0C-DC00-4C93-B9C2-63D1E858BA81}.Debug|x64.Build.0 = Debug|x64
+		{FF6E5B0C-DC00-4C93-B9C2-63D1E858BA81}.Release|x64.ActiveCfg = Release|x64
+		{FF6E5B0C-DC00-4C93-B9C2-63D1E858BA81}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2364,6 +2370,7 @@ Global
 		{FEA09B48-34C2-4963-8A5A-F97BDA136D72} = {B870D8A6-12CD-4DD0-B843-833695C2310A}
 		{FF6E5B0C-DC00-4C93-B9C2-63D1E858BA79} = {63C9B3F8-437D-4AD9-B32D-D04AE38C35B6}
 		{FF6E5B0C-DC00-4C93-B9C2-63D1E858BA80} = {63C9B3F8-437D-4AD9-B32D-D04AE38C35B6}
+		{FF6E5B0C-DC00-4C93-B9C2-63D1E858BA81} = {63C9B3F8-437D-4AD9-B32D-D04AE38C35B6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5E690324-2D48-486A-8D3C-DCB520D3F693}

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2015-2021, Intel Corporation */
+/* Copyright 2015-2022, Intel Corporation */
 
 /*
  * heap.c -- heap implementation
@@ -10,6 +10,8 @@
 #include <string.h>
 #include <float.h>
 
+#include "bucket.h"
+#include "heap_layout.h"
 #include "libpmemobj/ctl.h"
 #include "queue.h"
 #include "heap.h"
@@ -90,7 +92,7 @@ struct heap_rt {
 	unsigned nlocks;
 
 	unsigned nzones;
-	unsigned zones_exhausted;
+	int *zone_reclaimed_map;
 };
 
 /*
@@ -740,6 +742,41 @@ heap_reclaim_zone_garbage(struct palloc_heap *heap, struct bucket *bucket,
 }
 
 /*
+ * heap_ensure_zone_reclaimed -- make sure that the specified zone has been
+ * already reclaimed.
+ */
+void
+heap_ensure_zone_reclaimed(struct palloc_heap *heap, uint32_t zone_id)
+{
+	int zone_reclaimed;
+	util_atomic_load_explicit32(&heap->rt->zone_reclaimed_map[zone_id],
+		&zone_reclaimed, memory_order_acquire);
+	if (zone_reclaimed)
+		return;
+
+	struct bucket *defb = heap_bucket_acquire(heap,
+		DEFAULT_ALLOC_CLASS_ID,
+		HEAP_ARENA_PER_THREAD);
+
+	struct zone *z = ZID_TO_ZONE(heap->layout, zone_id);
+	ASSERTeq(z->header.magic, ZONE_HEADER_MAGIC);
+
+	/* check a second time just to make sure no other thread was first */
+	util_atomic_load_explicit32(&heap->rt->zone_reclaimed_map[zone_id],
+		&zone_reclaimed, memory_order_acquire);
+	if (zone_reclaimed)
+		goto out;
+
+	util_atomic_store_explicit32(&heap->rt->zone_reclaimed_map[zone_id], 1,
+		memory_order_release);
+
+	heap_reclaim_zone_garbage(heap, defb, zone_id);
+
+out:
+	heap_bucket_release(heap, defb);
+}
+
+/*
  * heap_populate_bucket -- (internal) creates volatile state of memory blocks
  */
 static int
@@ -747,11 +784,19 @@ heap_populate_bucket(struct palloc_heap *heap, struct bucket *bucket)
 {
 	struct heap_rt *h = heap->rt;
 
+	unsigned zone_id; /* first not reclaimed zone */
+	for (zone_id = 0; zone_id < h->nzones; ++zone_id) {
+		if (h->zone_reclaimed_map[zone_id] == 0)
+			break;
+	}
+
 	/* at this point we are sure that there's no more memory in the heap */
-	if (h->zones_exhausted == h->nzones)
+	if (zone_id == h->nzones)
 		return ENOMEM;
 
-	uint32_t zone_id = h->zones_exhausted++;
+	util_atomic_store_explicit32(&heap->rt->zone_reclaimed_map[zone_id], 1,
+		memory_order_release);
+
 	struct zone *z = ZID_TO_ZONE(heap->layout, zone_id);
 
 	/* ignore zone and chunk headers */
@@ -1576,6 +1621,13 @@ heap_boot(struct palloc_heap *heap, void *heap_start, uint64_t heap_size,
 		goto error_heap_malloc;
 	}
 
+	h->nzones = heap_max_zone(heap_size);
+	h->zone_reclaimed_map = Zalloc(sizeof(int) * h->nzones);
+	if (h->zone_reclaimed_map == NULL) {
+		err = ENOMEM;
+		goto err_reclaimed_map_malloc;
+	}
+
 	if ((err = arena_thread_assignment_init(&h->arenas.assignment,
 		Default_arenas_assignment_type)) != 0) {
 		goto error_assignment_init;
@@ -1593,10 +1645,6 @@ heap_boot(struct palloc_heap *heap, void *heap_start, uint64_t heap_size,
 		err = errno;
 		goto error_arenas_malloc;
 	}
-
-	h->nzones = heap_max_zone(heap_size);
-
-	h->zones_exhausted = 0;
 
 	h->nlocks = On_valgrind ? MAX_RUN_LOCKS_VG : MAX_RUN_LOCKS;
 	for (unsigned i = 0; i < h->nlocks; ++i)
@@ -1634,6 +1682,8 @@ error_arenas_malloc:
 error_alloc_classes_new:
 	arena_thread_assignment_fini(&h->arenas.assignment);
 error_assignment_init:
+	Free(h->zone_reclaimed_map);
+err_reclaimed_map_malloc:
 	Free(h);
 	heap->rt = NULL;
 error_heap_malloc:
@@ -1729,6 +1779,7 @@ heap_cleanup(struct palloc_heap *heap)
 
 	VALGRIND_DO_DESTROY_MEMPOOL(heap->layout);
 
+	Free(rt->zone_reclaimed_map);
 	Free(rt);
 	heap->rt = NULL;
 }

--- a/src/libpmemobj/heap.h
+++ b/src/libpmemobj/heap.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2015-2021, Intel Corporation */
+/* Copyright 2015-2022, Intel Corporation */
 
 /*
  * heap.h -- internal definitions for heap
@@ -72,6 +72,9 @@ heap_discard_run(struct palloc_heap *heap, struct memory_block *m);
 
 void
 heap_memblock_on_free(struct palloc_heap *heap, const struct memory_block *m);
+
+void
+heap_ensure_zone_reclaimed(struct palloc_heap *heap, uint32_t zone_id);
 
 int
 heap_free_chunk_reuse(struct palloc_heap *heap,

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2014-2021, Intel Corporation
+# Copyright 2014-2022, Intel Corporation
 #
 
 #
@@ -69,6 +69,7 @@ OBJ_TESTS = \
 	obj_fragmentation2\
 	obj_heap\
 	obj_heap_interrupt\
+	obj_heap_reopen\
 	obj_heap_state\
 	obj_include\
 	obj_lane\

--- a/src/test/obj_heap_reopen/.gitignore
+++ b/src/test/obj_heap_reopen/.gitignore
@@ -1,0 +1,1 @@
+obj_heap_reopen

--- a/src/test/obj_heap_reopen/Makefile
+++ b/src/test/obj_heap_reopen/Makefile
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
+#
+# src/test/obj_heap_reopen/Makefile -- build obj_heap_reopen test
+#
+TARGET = obj_heap_reopen
+OBJS = obj_heap_reopen.o
+
+LIBPMEMOBJ=y
+
+include ../Makefile.inc
+INCS += -I../../libpmemobj

--- a/src/test/obj_heap_reopen/TESTS.py
+++ b/src/test/obj_heap_reopen/TESTS.py
@@ -1,0 +1,20 @@
+#!../env.py
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
+
+import testframework as t
+from testframework import granularity as g
+
+
+class BASIC(t.Test):
+    test_type = t.Medium
+
+    def run(self, ctx):
+        filepath = ctx.create_holey_file(16 * t.MiB, 'testfile1')
+        ctx.exec('obj_heap_reopen', filepath)
+
+
+@g.require_granularity(g.BYTE, g.CACHELINE)
+class TEST0(BASIC):
+    pass

--- a/src/test/obj_heap_reopen/obj_heap_reopen.c
+++ b/src/test/obj_heap_reopen/obj_heap_reopen.c
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
+
+/*
+ * obj_heap_reopen.c -- test for reopening an existing heap and deallocating
+ * objects prior to any allocations to validate the memory reclamation process.
+ */
+
+#include <stddef.h>
+
+#include "libpmemobj/action_base.h"
+#include "libpmemobj/atomic_base.h"
+#include "out.h"
+#include "unittest.h"
+#include "obj.h"
+
+#define TEST_OBJECT_SIZE (4 << 20)
+
+int
+main(int argc, char *argv[])
+{
+	START(argc, argv, "obj_heap_reopen");
+
+	if (argc < 2)
+		UT_FATAL("usage: %s file-name", argv[0]);
+
+	const char *path = argv[1];
+	PMEMobjpool *pop = NULL;
+
+	if ((pop = pmemobj_create(path, POBJ_LAYOUT_NAME(basic),
+			0, S_IWUSR | S_IRUSR)) == NULL)
+		UT_FATAL("!pmemobj_create: %s", path);
+
+	PMEMoid oid;
+	pmemobj_alloc(pop, &oid, 4 << 20, 0, NULL, NULL);
+
+	pmemobj_close(pop);
+
+	if ((pop = pmemobj_open(path, POBJ_LAYOUT_NAME(basic))) == NULL)
+		UT_FATAL("!pmemobj_open: %s", path);
+
+	uint64_t freed_oid_off = oid.off;
+	pmemobj_free(&oid);
+
+	struct pobj_action act;
+	oid = pmemobj_reserve(pop, &act, TEST_OBJECT_SIZE, 0);
+	UT_ASSERTeq(oid.off, freed_oid_off);
+
+	for (;;) {
+		PMEMoid oid2;
+		if (pmemobj_alloc(pop, &oid2, 1, 0, NULL, NULL) != 0)
+			break;
+		UT_ASSERT(!(oid2.off >= oid.off &&
+			oid2.off <= oid.off + TEST_OBJECT_SIZE));
+	}
+
+	pmemobj_publish(pop, &act, 1);
+
+	pmemobj_close(pop);
+
+	DONE(NULL);
+}

--- a/src/test/obj_heap_reopen/obj_heap_reopen.vcxproj
+++ b/src/test/obj_heap_reopen/obj_heap_reopen.vcxproj
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{58386481-30B7-40FC-96AF-0723A4A7B228}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>obj_heap_reopen</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\test_debug.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\test_release.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(SolutionDir)libpmemobj;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>$(SolutionDir)libpmemobj;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>Disabled</Optimization>
+      <DisableSpecificWarnings>
+      </DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <DisableSpecificWarnings>
+      </DisableSpecificWarnings>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="obj_heap_reopen.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TESTS.py" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\libpmemobj\libpmemobj.vcxproj">
+      <Project>{1baa1617-93ae-4196-8a1a-bd492fb18aef}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\libpmem\libpmem.vcxproj">
+      <Project>{9e9e3d25-2139-4a5d-9200-18148ddead45}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\unittest\libut.vcxproj">
+      <Project>{ce3f2dfb-8470-4802-ad37-21caf6cb2681}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/obj_heap_reopen/obj_heap_reopen.vcxproj.filters
+++ b/src/test/obj_heap_reopen/obj_heap_reopen.vcxproj.filters
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Test Scripts">
+      <UniqueIdentifier>{c0f52631-8f99-42f0-8d94-07ddeba87436}</UniqueIdentifier>
+      <Extensions>py</Extensions>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{fdf90df9-299e-4772-9987-80b460bd2573}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Match Files">
+      <UniqueIdentifier>{7782ecac-f1e4-49cb-b06c-0fc343dd3a97}</UniqueIdentifier>
+      <Extensions>match</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="obj_heap_reopen.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TESTS.py">
+      <Filter>Test Scripts</Filter>
+    </None>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This patch fixes a bug where free prior to any allocs,
combined with reservations, could have led to overlapping
allocations - which ultimately was causing corrupted heap
and incorrect statistics.

This problem is caused by lazy heap runtime state reclamation.
Heap runtime state is rebuilt lazily whenever required
to serve allocation requests. Deallocations (free) simply update
persistent metadata and, in case of huge allocations, inserts
the freed chunk into a container of free chunks. On reclaim,
all free chunks not already deallocated are inserted into a freelist.

This would have been fine, but libpmemobj's allocator enables
software to reserve a chunk, removing it from the heap runtime state
without updating the persistent on-media layout.
This means that software can deallocate a chunk, reserve
that same chunk, allocate something normally - triggering
heap zone reclamation, and then it can finally
publish (actually persistently allocate) that reserved chunk.
This can lead to the same chunk being potentially allocated twice...

This patch fixes this problem by ensuring that object's
zone is fully processed and reclaimed prior to deallocation.

Reported-by: @jolivier23

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5489)
<!-- Reviewable:end -->
