### PR TITLE
Revisit the tests with pmemcheck support on ppc64le

### DIFF
--- a/src/test/log_basic/out4.log.match
+++ b/src/test/log_basic/out4.log.match
@@ -12,7 +12,8 @@ append   str[4] 5th test string
 
 append   str[5] 6th test string
 
-usable size: 2088960
+$(OPT)usable size: 2088960
+$(OPX)usable size: 1966080
 tell 96
 1st test string
 2nd test string
@@ -41,7 +42,8 @@ tell 0
 walk all at once
 walk by 16
 appendv
-usable size: 2088960
+$(OPT)usable size: 2088960
+$(OPX)usable size: 1966080
 tell 144
 1st test string
 2nd test string

--- a/src/test/obj_list/obj_list.h
+++ b/src/test/obj_list/obj_list.h
@@ -17,7 +17,7 @@
 /* offset to "in band" item */
 #define OOB_OFF	 (sizeof(struct oob_header))
 /* pmemobj initial heap offset */
-#define HEAP_OFFSET	8192
+#define HEAP_OFFSET	OBJ_LANES_OFFSET
 
 TOID_DECLARE(struct item, 0);
 TOID_DECLARE(struct list, 1);

--- a/src/test/pmem_valgr_simple/pmem_valgr_simple.c
+++ b/src/test/pmem_valgr_simple/pmem_valgr_simple.c
@@ -8,6 +8,7 @@
  */
 
 #include "unittest.h"
+#include "util.h"
 
 int
 main(int argc, char *argv[])
@@ -17,6 +18,7 @@ main(int argc, char *argv[])
 	int is_pmem;
 
 	START(argc, argv, "pmem_valgr_simple");
+	util_init();
 
 	if (argc != 4)
 		UT_FATAL("usage: %s file offset length", argv[0]);
@@ -32,7 +34,7 @@ main(int argc, char *argv[])
 	*(int *)dest = 4;
 
 	/* this will be made persistent */
-	uint64_t *tmp64dst = (void *)((uintptr_t)dest + 4096);
+	uint64_t *tmp64dst = (void *)((uintptr_t)dest + Pagesize);
 	*tmp64dst = 50;
 
 	if (is_pmem) {

--- a/src/test/pmem_valgr_simple/pmemcheck0.log.match
+++ b/src/test/pmem_valgr_simple/pmemcheck0.log.match
@@ -6,6 +6,7 @@
 ==$(N)== 
 ==$(N)== 
 $(OPT)==$(N)== Number of stores not made persistent: 3
+$(OPT)==$(N)== Number of stores not made persistent: 4
 $(OPX)==$(N)== Number of stores not made persistent: 10
 ==$(N)== Stores not made persistent properly:
 ==$(N)== [0]    at 0x$(X): main (pmem_valgr_simple.c:$(N))
@@ -13,6 +14,7 @@ $(OPX)==$(N)== Number of stores not made persistent: 10
 ==$(N)== [1]    at 0x$(X): $(nW)memset$(nW) ($(*))
 ==$(N)==    by 0x$(X): main (pmem_valgr_simple.c:$(N))
 $(OPT)==$(N)== 	Address: 0x$(X)	size: 8	state: DIRTY
+$(OPT)==$(N)== 	Address: 0x$(X)	size: 4	state: DIRTY
 $(OPX)==$(N)== 	Address: 0x$(X)	size: 1	state: DIRTY
 $(OPT)==$(N)== [$(N)]    at 0x$(X): $(nW)memset$(nW) ($(*))
 $(OPT)==$(N)==    by 0x$(X): main (pmem_valgr_simple.c:$(N))
@@ -35,6 +37,12 @@ $(OPT)==$(N)== 	Address: 0x$(X)	size: 1	state: DIRTY
 $(OPT)==$(N)== [$(N)]    at 0x$(X): $(nW)memset$(nW) ($(*))
 $(OPT)==$(N)==    by 0x$(X): main (pmem_valgr_simple.c:$(N))
 $(OPT)==$(N)== 	Address: 0x$(X)	size: 1	state: DIRTY
+$(OPT)==$(N)== [$(N)]    at 0x$(X): $(nW)memset$(nW) ($(*))
+$(OPT)==$(N)==    by 0x$(X): main (pmem_valgr_simple.c:$(N))
+$(OPT)==$(N)== 	Address: 0x$(X)	size: 4	state: DIRTY
+$(OPT)==$(N)== [$(N)]    at 0x$(X): $(nW)memset$(nW) ($(*))
+$(OPT)==$(N)==    by 0x$(X): main (pmem_valgr_simple.c:$(N))
+$(OPT)==$(N)== 	Address: 0x$(X)	size: 4	state: DIRTY
 ==$(N)== [$(N)]    at 0x$(X): main (pmem_valgr_simple.c:$(N))
 $(OPT)==$(N)== 	Address: 0x$(X)	size: 2	state: FLUSHED
 $(OPT)==$(N)== 	Address: 0x$(X)	size: 2	state: FENCED
@@ -46,4 +54,5 @@ $(OPT)==$(N)== [0]    at 0x$(X): $(nW)memset ($(*))
 $(OPT)==$(N)==    by 0x$(X): main (pmem_valgr_simple.c:$(N))
 $(OPT)==$(N)== 	Address: 0x$(X)	size: 8	state: DIRTY
 $(OPT)==$(N)== ERROR SUMMARY: 3 errors
+$(OPT)==$(N)== ERROR SUMMARY: 4 errors
 $(OPX)==$(N)== ERROR SUMMARY: 10 errors

--- a/src/test/pmempool_transform/out12.log.match
+++ b/src/test/pmempool_transform/out12.log.match
@@ -30,7 +30,8 @@ Pool set UUID            : $(nW)
 
 PMEM OBJ Header:
 Layout                   : OBJ_LAYOUT$(nW)
-Lanes offset             : 0x2000
+$(OPT)Lanes offset             : 0x2000
+$(OPX)Lanes offset             : 0x20000
 Number of lanes          : 1024
 Heap offset              : $(nW)
 Heap size                : $(nW)
@@ -52,7 +53,8 @@ Pool set UUID            : $(nW)
 
 PMEM OBJ Header:
 Layout                   : OBJ_LAYOUT$(nW)
-Lanes offset             : 0x2000
+$(OPT)Lanes offset             : 0x2000
+$(OPX)Lanes offset             : 0x20000
 Number of lanes          : 1024
 Heap offset              : $(nW)
 Heap size                : $(nW)

--- a/src/test/pmreorder_flushes/Makefile
+++ b/src/test/pmreorder_flushes/Makefile
@@ -14,3 +14,6 @@ LIBPMEM=y
 LIBPMEMCOMMON=y
 
 include ../Makefile.inc
+ifeq ($(ARCH), ppc64)
+CFLAGS += -fsigned-char
+endif

--- a/src/test/pmreorder_flushes/pmreorder_flushes.c
+++ b/src/test/pmreorder_flushes/pmreorder_flushes.c
@@ -18,7 +18,12 @@
 #include "util.h"
 #include "valgrind_internal.h"
 
+#if defined(__PPC64__)
+#define STORE_SIZE 128
+#else
 #define STORE_SIZE 64
+#endif
+
 static FILE *fp;
 
 struct stores_fields {

--- a/src/tools/pmreorder/binaryoutputhandler.py
+++ b/src/tools/pmreorder/binaryoutputhandler.py
@@ -5,6 +5,7 @@ from loggingfacility import LoggingBase
 from reorderexceptions import InconsistentFileException
 from sys import byteorder
 import utils
+import os
 
 
 class BinaryOutputHandler:
@@ -190,8 +191,9 @@ class BinaryFile(utils.Rangeable):
         )
 
         # write out the new value
+        pagesize = os.sysconf("SC_PAGE_SIZE")
         self._file_map[base_off:max_off] = store_op.new_value
-        self._file_map.flush(base_off & ~4095, 4096)
+        self._file_map.flush(base_off & ~(pagesize - 1), pagesize)
 
     def do_revert(self, store_op):
         """
@@ -214,8 +216,9 @@ class BinaryFile(utils.Rangeable):
             )
         )
         # write out the old value
+        pagesize = os.sysconf("SC_PAGE_SIZE")
         self._file_map[base_off:max_off] = store_op.old_value
-        self._file_map.flush(base_off & ~4095, 4096)
+        self._file_map.flush(base_off & ~(pagesize - 1), pagesize)
 
     def check_consistency(self):
         """


### PR DESCRIPTION
The pmemcheck works on ppc64le with https://github.com/pmem/valgrind/pull/90

Having that support, several tests on PMDK which were before failing need few tweaks in output, or ppc64le specific changes like pagesize(64k), cacheline size(128) or object lane offset(0x20000).

The pull request addresses these differences to get those tests working.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5518)
<!-- Reviewable:end -->
