### PR TITLE
common: remove remaining references to librpmem library

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2014-2022, Intel Corporation
+# Copyright 2014-2023, Intel Corporation
 #
 # src/Makefile.inc -- common Makefile rules for PMDK
 #
@@ -63,11 +63,6 @@ endif
 ifeq ($(WSTRINGOP_TRUNCATION_AVAILABLE), y)
 DEFAULT_CFLAGS += -DSTRINGOP_TRUNCATION_SUPPORTED
 endif
-
-# Librpmem is deprecated.
-# This flag allows to build tests, examples and benchmarks
-# using rpmem despite the deprecated state.
-DEFAULT_CFLAGS += -Wno-deprecated-declarations
 
 ifeq ($(DEBUG),1)
 # Undefine _FORTIFY_SOURCE in case it's set in system-default or

--- a/utils/check-manpages
+++ b/utils/check-manpages
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2019-2020, Intel Corporation
+# Copyright 2019-2023, Intel Corporation
 
 # check-manpages -- a tool to test against some manpage errors
 
@@ -9,8 +9,5 @@ MANS="$*"
 [ -n "$MANS" ] || { echo >&2 "No man pages given, and none found in doc/"; exit 1;}
 
 for page in $MANS;do
-	if [ "${page/rpmem/}" != "$page" ] && [ "$BUILD_RPMEM" != "y" ]; then
-		continue
-	fi
 	echo $page
 done | xargs -P `nproc` -n1 -- utils/check-manpage


### PR DESCRIPTION
Few references to librpmem/rpmemd have been detected and removed.

Signed-off-by: Tomasz Gromadzki <tomasz.gromadzki@intel.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5519)
<!-- Reviewable:end -->
