### PR TITLE
common: use Fedora 37 version of docker images

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -28,9 +28,9 @@ jobs:
                  "N=2 OS=ubuntu OS_VER=22.04 FAULT_INJECTION=1 TEST_BUILD=nondebug UBSAN=1",
                  "N=3 OS=ubuntu OS_VER=22.04 PMDK_CC=clang PMDK_CXX=clang++ TEST_BUILD=debug SRC_CHECKERS=1",
                  "N=4 OS=ubuntu OS_VER=22.04 PMDK_CC=clang PMDK_CXX=clang++ TEST_BUILD=nondebug",
-                 "N=5 OS=fedora OS_VER=35    PMDK_CC=clang PMDK_CXX=clang++ TEST_BUILD=debug",
-                 "N=6 OS=fedora OS_VER=35    PMDK_CC=clang PMDK_CXX=clang++ TEST_BUILD=nondebug AUTO_DOC_UPDATE=1",
-                 "N=7 OS=fedora OS_VER=35    MAKE_PKG=1 EXPERIMENTAL=y VALGRIND=0 PUSH_IMAGE=1",
+                 "N=5 OS=fedora OS_VER=37    PMDK_CC=clang PMDK_CXX=clang++ TEST_BUILD=debug",
+                 "N=6 OS=fedora OS_VER=37    PMDK_CC=clang PMDK_CXX=clang++ TEST_BUILD=nondebug AUTO_DOC_UPDATE=1",
+                 "N=7 OS=fedora OS_VER=37    MAKE_PKG=1 EXPERIMENTAL=y VALGRIND=0 PUSH_IMAGE=1",
                  "N=8 OS=ubuntu OS_VER=22.04 MAKE_PKG=1 EXPERIMENTAL=y VALGRIND=0 NDCTL_ENABLE=n PUSH_IMAGE=1",
                  "N=9 OS=ubuntu OS_VER=22.04 MAKE_PKG=1 EXPERIMENTAL=y VALGRIND=0 NDCTL_ENABLE=n PMDK_CC=clang PMDK_CXX=clang++",
                 "N=10 OS=ubuntu OS_VER=22.04 COVERAGE=1 FAULT_INJECTION=1 TEST_BUILD=debug"]

--- a/utils/docker/images/Dockerfile.fedora-37
+++ b/utils/docker/images/Dockerfile.fedora-37
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2022, Intel Corporation
+# Copyright 2016-2023, Intel Corporation
 
 #
 # Dockerfile - a 'recipe' for Docker to build an image of fedora-based
@@ -7,7 +7,7 @@
 #
 
 # Pull base image
-FROM fedora:35
+FROM fedora:37
 MAINTAINER piotr.balcer@intel.com
 
 ENV VALGRIND_DEPS "\
@@ -103,6 +103,6 @@ USER $USER
 
 # Set required environment variables
 ENV OS fedora
-ENV OS_VER 35
+ENV OS_VER 37
 ENV PACKAGE_MANAGER rpm
 ENV NOTTY 1


### PR DESCRIPTION
Update docker images to use Fedora 37.

Signed-off-by: Tomasz Gromadzki <tomasz.gromadzki@intel.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5520)
<!-- Reviewable:end -->
