### PR TITLE
pool: fix dependencies with pmempool

### DIFF
--- a/src/test/tools/ddmap/Makefile
+++ b/src/test/tools/ddmap/Makefile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2023, Intel Corporation
 #
 # Makefile -- Makefile for ddmap tool
 #
@@ -12,6 +12,7 @@ OBJS = ddmap.o
 
 LIBPMEM=y
 TOOLS_COMMON=y
+TOOLS_PMEMPOOL_COMMON=y
 LIBPMEMBLK_PRIV=btt_info_convert2h
 
 include $(TOP)/src/tools/Makefile.inc

--- a/src/test/tools/pmemobjcli/Makefile
+++ b/src/test/tools/pmemobjcli/Makefile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2014-2022, Intel Corporation
+# Copyright 2014-2023, Intel Corporation
 #
 # Makefile -- Makefile for pmemalloc tool
 #
@@ -13,6 +13,7 @@ OBJS = pmemobjcli.o
 LIBPMEM=y
 LIBPMEMOBJ=y
 TOOLS_COMMON=y
+TOOLS_PMEMPOOL_COMMON=y
 LIBPMEMBLK_PRIV=btt_info_convert2h
 
 include $(TOP)/src/tools/Makefile.inc

--- a/src/test/tools/pmemspoil/Makefile
+++ b/src/test/tools/pmemspoil/Makefile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2014-2022, Intel Corporation
+# Copyright 2014-2023, Intel Corporation
 #
 # Makefile -- Makefile for pmemspoil tool
 #
@@ -12,6 +12,7 @@ OBJS = spoil.o
 
 LIBPMEM=y
 TOOLS_COMMON=y
+TOOLS_PMEMPOOL_COMMON=y
 LIBPMEMBLK_PRIV=btt_info_convert2h
 
 include $(TOP)/src/tools/Makefile.inc

--- a/src/test/tools/pmemwrite/Makefile
+++ b/src/test/tools/pmemwrite/Makefile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2023, Intel Corporation
 #
 # Makefile -- Makefile for pmemwrite tool
 #
@@ -14,6 +14,7 @@ LIBPMEM=y
 LIBPMEMBLK=y
 LIBPMEMLOG=y
 TOOLS_COMMON=y
+TOOLS_PMEMPOOL_COMMON=y
 LIBPMEMBLK_PRIV=btt_info_convert2h
 
 include $(TOP)/src/tools/Makefile.inc

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2014-2022, Intel Corporation
+# Copyright 2014-2023, Intel Corporation
 #
 # src/tools/Makefile.inc -- Makefile include for all tools
 #
@@ -191,18 +191,18 @@ LIBS += $(LIBDL)
 endif
 
 ifeq ($(TOOLS_COMMON), y)
-vpath %.c $(TOP)/src/tools/pmempool
-
-OBJS += common.o output.o
-
 CFLAGS += -I$(TOP)/src/core
 CFLAGS += -I$(TOP)/src/common
 CFLAGS += -I$(TOP)/src/libpmemlog
 CFLAGS += -I$(TOP)/src/libpmemblk
 CFLAGS += -I$(TOP)/src/libpmemobj
-CFLAGS += -I$(TOP)/src/tools/pmempool
 CFLAGS += $(UNIX98_CFLAGS)
+endif
 
+ifeq ($(TOOLS_PMEMPOOL_COMMON), y)
+vpath %.c $(TOP)/src/tools/pmempool
+CFLAGS += -I$(TOP)/src/tools/pmempool
+OBJS += common.o output.o
 endif
 
 ifneq ($(LIBPMEMLOG_PRIV),)

--- a/src/tools/pmempool/Makefile
+++ b/src/tools/pmempool/Makefile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2014-2022, Intel Corporation
+# Copyright 2014-2023, Intel Corporation
 #
 # Makefile -- top Makefile for pmempool
 #
@@ -18,6 +18,7 @@ LIBPMEMOBJ=y
 LIBPMEMLOG=y
 LIBPMEMPOOL=y
 TOOLS_COMMON=y
+TOOLS_PMEMPOOL_COMMON=y
 
 LIBPMEMOBJ_PRIV=memblock_from_offset alloc_class_by_id\
 	memblock_rebuild_state alloc_class_by_run\


### PR DESCRIPTION
Fix dependencies with pmempool.
Not all tools that include 'src/tools/Makefile.inc' require linking with the common.o and output.o objects from pmempool. Only pmempool itself, ddmap, pmemobjcli, pmemspoil and pmemwrite tool require that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5521)
<!-- Reviewable:end -->
