### PR TITLE
common: bump compatibility level for debhelper

### DIFF
--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -281,7 +281,7 @@ mkdir debian
 
 # Generate compat file
 cat << EOF > debian/compat
-9
+10
 EOF
 
 # Generate control file


### PR DESCRIPTION
As of right now, compat level equal to 10 is adequate for:
- Debian 10 (Buster),
- Ubuntu 18.04 (bionic).

This change will eliminate warnings produced while preparing deb packages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5525)
<!-- Reviewable:end -->
