### PR TITLE
common: remove unneeded '*' at start of expressions

### DIFF
--- a/utils/check_license/check-headers.sh
+++ b/utils/check_license/check-headers.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2020, Intel Corporation
+# Copyright 2016-2023, Intel Corporation
 
 # check-headers.sh - check copyright and license in source files
 
@@ -87,10 +87,10 @@ else
 fi
 
 FILES=$($GIT $GIT_COMMAND | ${SOURCE_ROOT}/utils/check_license/file-exceptions.sh | \
-	grep    -E -e '*\.[chs]$' -e '*\.[ch]pp$' -e '*\.sh$' \
-		   -e '*\.py$' -e '*\.link$' -e 'Makefile*' -e 'TEST*' \
+	grep    -E -e '\.[chs]$' -e '\.[ch]pp$' -e '\.sh$' \
+		   -e '\.py$' -e '\.link$' -e 'Makefile*' -e 'TEST*' \
 		   -e '/common.inc$' -e '/match$' -e '/check_whitespace$' \
-		   -e 'LICENSE$' -e 'CMakeLists.txt$' -e '*\.cmake$' | \
+		   -e 'LICENSE$' -e 'CMakeLists.txt$' -e '\.cmake$' | \
 	xargs)
 
 RV=0


### PR DESCRIPTION
It silents the following warnings:

grep: warning: * at start of expression

See: pmem/rpma@8dd612d

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5533)
<!-- Reviewable:end -->
