### PR TITLE
obj: handle ENOMEM during vector allocations

### DIFF
--- a/src/libpmemobj/memops.c
+++ b/src/libpmemobj/memops.c
@@ -20,59 +20,10 @@
 #include "ravl.h"
 #include "ulog.h"
 #include "valgrind_internal.h"
-#include "vecq.h"
 #include "sys_util.h"
 
 #define ULOG_BASE_SIZE 1024
 #define OP_MERGE_SEARCH 64
-
-enum operation_state {
-	OPERATION_IDLE,
-	OPERATION_IN_PROGRESS,
-	OPERATION_CLEANUP,
-};
-
-struct operation_log {
-	size_t capacity; /* capacity of the ulog log */
-	size_t offset; /* data offset inside of the log */
-	struct ulog *ulog; /* DRAM allocated log of modifications */
-};
-
-/*
- * operation_context -- context of an ongoing palloc operation
- */
-struct operation_context {
-	enum log_type type;
-
-	ulog_extend_fn extend; /* function to allocate next ulog */
-	ulog_free_fn ulog_free; /* function to free next ulogs */
-
-	const struct pmem_ops *p_ops;
-	struct pmem_ops t_ops; /* used for transient data processing */
-	struct pmem_ops s_ops; /* used for shadow copy data processing */
-
-	size_t ulog_curr_offset; /* offset in the log for buffer stores */
-	size_t ulog_curr_capacity; /* capacity of the current log */
-	size_t ulog_curr_gen_num; /* transaction counter in the current log */
-	struct ulog *ulog_curr; /* current persistent log */
-	size_t total_logged; /* total amount of buffer stores in the logs */
-
-	struct ulog *ulog; /* pointer to the persistent ulog log */
-	size_t ulog_base_nbytes; /* available bytes in initial ulog log */
-	size_t ulog_capacity; /* sum of capacity, incl all next ulog logs */
-	int ulog_auto_reserve; /* allow or do not to auto ulog reservation */
-	int ulog_any_user_buffer; /* set if any user buffer is added */
-
-	struct ulog_next next; /* vector of 'next' fields of persistent ulog */
-
-	enum operation_state state; /* operation sanity check */
-
-	struct operation_log pshadow_ops; /* shadow copy of persistent ulog */
-	struct operation_log transient_ops; /* log of transient changes */
-
-	/* collection used to look for potential merge candidates */
-	VECQ(, struct ulog_entry_val *) merge_entries;
-};
 
 /*
  * operation_log_transient_init -- (internal) initialize operation log
@@ -614,7 +565,6 @@ operation_add_user_buffer(struct operation_context *ctx,
 	last_log->next = buffer_offset;
 	pmemops_persist(ctx->p_ops, &last_log->next, next_size);
 
-	VEC_PUSH_BACK(&ctx->next, buffer_offset);
 	ctx->ulog_capacity += capacity;
 	operation_set_any_user_buffer(ctx, 1);
 }

--- a/src/libpmemobj/memops.h
+++ b/src/libpmemobj/memops.h
@@ -15,6 +15,7 @@
 #include "pmemops.h"
 #include "ulog.h"
 #include "lane.h"
+#include "vecq.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,7 +40,53 @@ struct user_buffer_def {
 	size_t size;
 };
 
-struct operation_context;
+enum operation_state {
+	OPERATION_IDLE,
+	OPERATION_IN_PROGRESS,
+	OPERATION_CLEANUP,
+};
+
+struct operation_log {
+	size_t capacity; /* capacity of the ulog log */
+	size_t offset; /* data offset inside of the log */
+	struct ulog *ulog; /* DRAM allocated log of modifications */
+};
+
+/*
+ * operation_context -- context of an ongoing palloc operation
+ */
+struct operation_context {
+	enum log_type type;
+
+	ulog_extend_fn extend; /* function to allocate next ulog */
+	ulog_free_fn ulog_free; /* function to free next ulogs */
+
+	const struct pmem_ops *p_ops;
+	struct pmem_ops t_ops; /* used for transient data processing */
+	struct pmem_ops s_ops; /* used for shadow copy data processing */
+
+	size_t ulog_curr_offset; /* offset in the log for buffer stores */
+	size_t ulog_curr_capacity; /* capacity of the current log */
+	size_t ulog_curr_gen_num; /* transaction counter in the current log */
+	struct ulog *ulog_curr; /* current persistent log */
+	size_t total_logged; /* total amount of buffer stores in the logs */
+
+	struct ulog *ulog; /* pointer to the persistent ulog log */
+	size_t ulog_base_nbytes; /* available bytes in initial ulog log */
+	size_t ulog_capacity; /* sum of capacity, incl all next ulog logs */
+	int ulog_auto_reserve; /* allow or do not to auto ulog reservation */
+	int ulog_any_user_buffer; /* set if any user buffer is added */
+
+	struct ulog_next next; /* vector of 'next' fields of persistent ulog */
+
+	enum operation_state state; /* operation sanity check */
+
+	struct operation_log pshadow_ops; /* shadow copy of persistent ulog */
+	struct operation_log transient_ops; /* log of transient changes */
+
+	/* collection used to look for potential merge candidates */
+	VECQ(, struct ulog_entry_val *) merge_entries;
+};
 
 struct operation_context *
 operation_new(struct ulog *redo, size_t ulog_base_nbytes,

--- a/src/libpmemobj/recycler.c
+++ b/src/libpmemobj/recycler.c
@@ -274,7 +274,8 @@ recycler_recalc(struct recycler *r, int force)
 			if (VEC_PUSH_BACK(&runs, nm) != 0)
 				ASSERT(0); /* XXX: fix after refactoring */
 		} else {
-			VEC_PUSH_BACK(&r->recalc, e);
+			if (VEC_PUSH_BACK(&r->recalc, e) != 0)
+				ASSERT(0); /* XXX: fix after refactoring */
 		}
 	} while (found_units < search_limit);
 

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -194,7 +194,8 @@ tx_action_add(struct tx *tx)
 	if (tx_action_reserve(tx, 1) != 0)
 		return NULL;
 
-	VEC_INC_BACK(&tx->actions);
+	if (VEC_INC_BACK(&tx->actions) == -1)
+		return NULL;
 
 	return &VEC_BACK(&tx->actions);
 }
@@ -710,6 +711,11 @@ tx_construct_user_buffer(struct tx *tx, void *addr, size_t size,
 		tx->redo_userbufs_capacity +=
 			userbuf.size - TX_INTENT_LOG_BUFFER_OVERHEAD;
 	} else {
+		uint64_t buffer_offset = OBJ_PTR_TO_OFF(ctx->p_ops->base,
+							userbuf.addr);
+
+		if (VEC_PUSH_BACK(&ctx->next, buffer_offset) != 0)
+			goto err;
 		operation_add_user_buffer(ctx, &userbuf);
 	}
 
@@ -1013,8 +1019,16 @@ pmemobj_tx_commit(void)
 		operation_start(tx->lane->external);
 
 		struct user_buffer_def *userbuf;
-		VEC_FOREACH_BY_PTR(userbuf, &tx->redo_userbufs)
-			operation_add_user_buffer(tx->lane->external, userbuf);
+		struct operation_context *ctx = tx->lane->external;
+		uint64_t buf_off;
+		VEC_FOREACH_BY_PTR(userbuf, &tx->redo_userbufs) {
+			buf_off = OBJ_PTR_TO_OFF(ctx->p_ops->base,
+						userbuf->addr);
+			if (VEC_PUSH_BACK(&ctx->next, buf_off) != 0)
+				FATAL("%s: failed to allocate the next vector",
+					__func__);
+			operation_add_user_buffer(ctx, userbuf);
+		}
 
 		palloc_publish(&pop->heap, VEC_ARR(&tx->actions),
 			VEC_SIZE(&tx->actions), tx->lane->external);
@@ -1921,7 +1935,11 @@ pmemobj_tx_xpublish(struct pobj_action *actv, size_t actvcnt, uint64_t flags)
 	}
 
 	for (size_t i = 0; i < actvcnt; ++i) {
-		VEC_PUSH_BACK(&tx->actions, actv[i]);
+		if (VEC_PUSH_BACK(&tx->actions, actv[i]) != 0) {
+			int ret = obj_tx_fail_err(ENOMEM, flags);
+			PMEMOBJ_API_END();
+			return ret;
+		}
 	}
 
 	PMEMOBJ_API_END();

--- a/src/libpmemobj/ulog.c
+++ b/src/libpmemobj/ulog.c
@@ -225,7 +225,7 @@ ulog_rebuild_next_vec(struct ulog *ulog, struct ulog_next *next,
 {
 	do {
 		if (ulog->next != 0)
-			VEC_PUSH_BACK(next, ulog->next);
+			ASSERT(VEC_PUSH_BACK(next, ulog->next) == 0);
 	} while ((ulog = ulog_next(ulog, p_ops)) != NULL);
 }
 
@@ -257,7 +257,7 @@ ulog_reserve(struct ulog *ulog,
 	while (capacity < *new_capacity) {
 		if (extend(p_ops->base, &ulog->next, gen_num) != 0)
 			return -1;
-		VEC_PUSH_BACK(next, ulog->next);
+		ASSERT(VEC_PUSH_BACK(next, ulog->next) == 0);
 		ulog = ulog_next(ulog, p_ops);
 		ASSERTne(ulog, NULL);
 


### PR DESCRIPTION
When missing, Handle ENOMEM during vector allocations to avoid later crashing.

Ref: pmem/issues#5515
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>