### PR TITLE
pmempool: Match function prototypes of enum_to_str_fn function pointer

### DIFF
--- a/src/tools/pmempool/common.c
+++ b/src/tools/pmempool/common.c
@@ -41,7 +41,7 @@
 
 #define REQ_BUFF_SIZE	2048U
 #define Q_BUFF_SIZE	8192
-typedef const char *(*enum_to_str_fn)(int);
+typedef const char *(*enum_to_str_fn)(enum chunk_type);
 
 /*
  * pmem_pool_type -- return pool type based on first two pages.
@@ -790,7 +790,7 @@ util_parse_enum(const char *str, int first, int max, uint64_t *bitmap,
 		enum_to_str_fn enum_to_str)
 {
 	for (int i = first; i < max; i++) {
-		if (strcmp(str, enum_to_str(i)) == 0) {
+		if (strcmp(str, enum_to_str((enum chunk_type)i)) == 0) {
 			*bitmap |= (uint64_t)1<<i;
 			return 0;
 		}


### PR DESCRIPTION
This is flagged by clang 16+
common.c:844:4: error: cast from 'const char *(*)(enum chunk_type)' to 'enum_to_str_fn' (aka 'const char *(*)(int)') converts to incompatible function type [-Werror,-Wcast-function-type-strict]
                        (enum_to_str_fn)out_get_chunk_type_str);
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5543)
<!-- Reviewable:end -->
