### PR TITLE
common: import python scripts for PKG tests

### DIFF
--- a/utils/gha-runners/scripts/cleanup-packages.py
+++ b/utils/gha-runners/scripts/cleanup-packages.py
@@ -1,0 +1,112 @@
+#!usr/bin/env python3
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2020-2023, Intel Corporation
+
+"""
+This module includes functions which clean up environment system after
+installation of rpm packages from PMDK library.
+"""
+
+from os import listdir, path, linesep
+import distro
+from subprocess import check_output
+from argparse import ArgumentParser
+import re
+import json
+from pathlib import Path
+
+PMDK_VERSION = ''
+SYSTEM_ARCHITECTURE = ''
+
+
+def get_package_version_and_system_architecture(pmdk_path):
+    """
+    Returns packages version and system architecture from names of directories
+    from rpm directory.
+    """
+    version = ''
+    architecture = ''
+    os_distro=distro.id()
+
+    # first check if there is a json file with version and architecture
+    pkg_version_file_path = Path(pmdk_path).joinpath("pkgVersion.json")
+    if pkg_version_file_path.exists() and pkg_version_file_path.is_file():
+        with open(pkg_version_file_path) as pkg_version_file:
+            version_from_file = {}
+            try:
+                version_from_file = json.load(pkg_version_file)
+                version = version_from_file.get('PMDK_VERSION', '')
+                architecture = version_from_file.get('SYSTEM_ARCHITECTURE', '')
+            except:
+                pass
+
+    # if cannot read values from json file, read them from rpms:
+    if version == '' or architecture == '':
+        if os_distro == 'fedora' or os_distro == "rhel":
+            pkg_directory = path.join(pmdk_path, 'rpm')
+            for elem in listdir(pkg_directory):
+                if '.src.rpm' in elem:
+                    version = re.search(r'[\s]*pmdk-([\S]+).src.rpm', elem).group(1)
+                else:
+                    architecture = elem
+
+        elif os_distro == 'ubuntu':
+            pkg_directory = path.join(pmdk_path, 'dpkg')
+            for elem in listdir(pkg_directory):
+                if '.changes' in elem:
+                    # looks for the version number of dpkg package in dpkg package name
+                    version = re.search(r'pmdk_*(.+)_(.+).changes', elem).group(1)
+                    architecture = re.search(r'pmdk_*(.+)_(.+).changes', elem).group(2)
+
+    return version, architecture
+
+
+def remove_install_rpm_packages(pmdk_path):
+    """
+    Removes binaries installed from packages from PMDK library.
+    """
+    try:
+        rpm_to_uninstall = check_output(
+            'rpm -qa | grep ' + PMDK_VERSION, cwd=pmdk_path, shell=True)
+        pkg_to_uninstall = rpm_to_uninstall.decode(
+            'UTF-8').replace(linesep, ' ')
+    except:
+        pkg_to_uninstall = ''
+
+    if pkg_to_uninstall:
+        check_output('rpm -e ' + pkg_to_uninstall, cwd=pmdk_path, shell=True)
+
+
+def remove_install_dpkg_packages(pmdk_path):
+    """
+    Removes binaries installed from packages from PMDK library.
+    """
+    try:
+        dpkg_to_uninstall = check_output(
+            'dpkg-query --show | grep ' + PMDK_VERSION + ''' | awk '{print $1}' ''', cwd=pmdk_path, shell=True)
+        pkg_to_uninstall = dpkg_to_uninstall.decode(
+            'UTF-8').replace(linesep, ' ')
+    except:
+        pkg_to_uninstall = ''
+
+    if pkg_to_uninstall:
+        check_output('dpkg -r ' + pkg_to_uninstall, cwd=pmdk_path, shell=True)
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser(
+        description='''Clean up system environment after installation rpm
+        packages from PMDK library''')
+    parser.add_argument("-r", "--pmdk-path", required=True,
+                        help="the PMDK library root path.")
+
+    args = parser.parse_args()
+    PMDK_VERSION, SYSTEM_ARCHITECTURE =\
+        get_package_version_and_system_architecture(args.pmdk_path)
+
+    os_distro=distro.id()
+    if os_distro == 'fedora' or os_distro == "rhel":
+        remove_install_rpm_packages(args.pmdk_path)
+    elif os_distro == 'ubuntu':
+        remove_install_dpkg_packages(args.pmdk_path)

--- a/utils/gha-runners/scripts/install-packages.py
+++ b/utils/gha-runners/scripts/install-packages.py
@@ -1,0 +1,189 @@
+#!usr/bin/env python3
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2020-2023, Intel Corporation
+
+
+"""
+This module includes functions which install packages from PMDK library.
+"""
+
+from os import listdir, path, linesep
+from subprocess import check_output
+from argparse import ArgumentParser
+import distro
+import re
+import json
+
+PMDK_VERSION = ''
+SYSTEM_ARCHITECTURE = ''
+
+def get_package_version_and_system_architecture(pmdk_path):
+    """
+    Returns packages version and system architecture from names of directories
+    from packages directory.
+    """
+    os_distro=distro.id()
+    if os_distro == 'fedora' or os_distro == "rhel":
+        pkg_directory = path.join(pmdk_path, 'rpm')
+    elif os_distro == 'ubuntu':
+        pkg_directory = path.join(pmdk_path, 'dpkg')
+
+    version = ''
+    architecture = ''
+    for elem in listdir(pkg_directory):
+        if os_distro == 'fedora' or os_distro == "rhel":
+            if '.src.rpm' in elem:
+                # looks for the version number of package in package name
+                version = re.search(r'[\s]*pmdk-([\S]+).src.rpm', elem).group(1)
+            else:
+                architecture = elem
+
+        elif os_distro == 'ubuntu':
+            if '.changes' in elem:
+                # looks for the version number of packages in package name
+                version = re.search(r'pmdk_*(.+)_(.+).changes', elem).group(1)
+                architecture = re.search(r'pmdk_*(.+)_(.+).changes', elem).group(2)
+    return version, architecture
+
+
+def save_pkg_version(pkg_version_file_path):
+    values_to_save = {
+        'PMDK_VERSION': PMDK_VERSION,
+        'SYSTEM_ARCHITECTURE': SYSTEM_ARCHITECTURE
+        }
+    with open(pkg_version_file_path, 'w') as file:
+        json.dump(values_to_save, file, indent=2)
+
+
+def get_built_rpm_packages(pmdk_path):
+    """
+    Returns built pkg packages from pkg directory.
+    """
+    path_to_rpm_files = path.join(pmdk_path, 'rpm', SYSTEM_ARCHITECTURE)
+    packages = listdir(path_to_rpm_files)
+    return packages
+
+
+def get_built_dpkg_packages(pmdk_path):
+    """
+    Returns built pkg packages from pkg directory.
+    """
+    path_to_dpkg_files = path.join(pmdk_path, 'dpkg')
+    packages =''
+    for elem in listdir(path_to_dpkg_files):
+        if '.deb' in elem:
+            packages += elem + ' '
+
+    return packages
+
+
+def install_rpm_packages(pmdk_path):
+    """
+    Install packages from PMDK library.
+    """
+    packages = ' '.join(get_built_rpm_packages(pmdk_path))
+    path_to_rpm_files = path.join(pmdk_path, 'rpm', SYSTEM_ARCHITECTURE)
+    check_output('rpm -i --nodeps ' + packages,
+                 cwd=path_to_rpm_files, shell=True)
+
+
+def install_dpkg_packages(pmdk_path):
+    """
+    Install packages from PMDK library.
+    """
+    packages = get_built_dpkg_packages(pmdk_path)
+    path_to_dpkg_files = path.join(pmdk_path, 'dpkg')
+    check_output('dpkg -i ' + packages,
+                 cwd=path_to_dpkg_files, shell=True)
+
+
+def get_names_of_rpm_content():
+    """
+    Returns names of elements, for which are installed from packages from PMDK
+    library.
+    """
+    packages_path = path.join(args.pmdk_path, 'rpm', SYSTEM_ARCHITECTURE)
+    installed_packages = check_output(
+        'ls | grep ' + PMDK_VERSION, cwd=packages_path, shell=True)
+    delimiter  = '-'
+
+    installed_packages = installed_packages.decode(
+        'UTF-8').split(linesep)
+
+    libraries_names = [item.split(
+        '-')[0] for item in installed_packages if item.split('-')[0]]
+    return set(libraries_names)
+
+
+def get_names_of_dpkg_content():
+    """
+    Returns names of elements, for which are installed from packages from PMDK
+    library.
+    """
+    packages_path = path.join(args.pmdk_path, 'dpkg')
+    installed_packages = check_output(
+        'ls | grep ' + PMDK_VERSION + ' | grep .deb', cwd=packages_path, shell=True)
+
+    installed_packages = installed_packages.decode(
+        'UTF-8').split(linesep)
+
+    libraries_names = [item.split(
+        '_')[0] for item in installed_packages if item.split('-')[0]]
+    return set(libraries_names)
+
+
+def get_installed_packages(so_path, split_param, packages_path):
+    """
+    Returns names of packages from PMDK library, which are installed.
+    """
+    libraries = get_names_of_pkg_content_func()
+    installed_packages = []
+
+    for library in libraries:
+        if library == "pmempool" and check_output(
+                'find /usr/bin/ -name ' + library, cwd=args.pmdk_path,
+                shell=True):
+            installed_packages.append(library)
+        elif library == "libpmemobj++" and check_output(
+                'find /usr/include/' + library + ' -name *.hpp',
+                cwd=args.pmdk_path, shell=True):
+            installed_packages.append(library)
+        elif library == "pmdk":
+            pass
+        elif check_output('find ' + so_path + ' -name ' + library + '.so',
+                          cwd=args.pmdk_path, shell=True):
+            installed_packages.append(library)
+    return installed_packages
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser(
+        description='Install packages from PMDK library')
+    parser.add_argument("-r", "--pmdk-path", required=True,
+                        help="the PMDK library root path.")
+
+    args = parser.parse_args()
+    os_distro=distro.id()
+    PMDK_VERSION, SYSTEM_ARCHITECTURE =\
+        get_package_version_and_system_architecture(args.pmdk_path)
+    save_pkg_version(args.pmdk_path + "/pkgVersion.json")
+    if os_distro == 'fedora' or os_distro == "rhel":
+        so_path = '/usr/lib64/'
+        split_param = '-'
+        packages_path = path.join(args.pmdk_path, 'rpm', SYSTEM_ARCHITECTURE)
+        install_cmd = 'rpm -i --nodeps '
+        install_func = install_rpm_packages
+        get_names_of_pkg_content_func = get_names_of_rpm_content
+    elif os_distro == 'ubuntu':
+        so_path = '/lib/x86_64-linux-gnu/'
+        split_param = '_'
+        packages_path = path.join(args.pmdk_path, 'dpkg')
+        install_cmd = 'dpkg -i '
+        install_func = install_dpkg_packages
+        get_names_of_pkg_content_func = get_names_of_dpkg_content
+
+    if not get_installed_packages(so_path, packages_path, get_names_of_pkg_content_func):
+        install_func(args.pmdk_path)
+    else:
+        print("PMDK library is still installed")

--- a/utils/gha-runners/scripts/test-build-packages.py
+++ b/utils/gha-runners/scripts/test-build-packages.py
@@ -1,0 +1,292 @@
+#!usr/bin/env python3
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2018-2023, Intel Corporation
+
+
+"""
+This module includes tests that check if all packages in PMDK library are
+built correctly.
+Tests check:
+-if all required packages are built,
+-if built packages are consistent with names of libraries read from
+ .so files and other elements (tools and "PMDK").
+Required arguments:
+-r <PMDK_path>    the PMDK library root path.
+Optional arguments:
+--without-rpmem    the flag if rpmem and rpmemd packages should not be built.
+--without-pmem2    the flag if pmem2 package should not be built.
+--without-pmemset    the flag if pmemset package should not be built.
+"""
+
+from os import listdir, path, linesep
+from collections import namedtuple
+import distro
+import unittest
+import xmlrunner
+import sys
+import re
+
+PACKAGES_INFO = namedtuple('packages_info',
+                           'basic devel debug debuginfo debug_debuginfo')
+PMDK_VERSION = ''
+SYSTEM_ARCHITECTURE = ''
+
+
+def get_package_version_and_system_architecture(pmdk_path):
+    """
+    Returns packages version and system architecture from names of directories
+    from packages directory.
+    """
+    os_distro=distro.id()
+    if os_distro == 'fedora' or os_distro == "rhel":
+        pkg_directory = path.join(pmdk_path, 'rpm')
+    elif os_distro == 'ubuntu':
+        pkg_directory = path.join(pmdk_path, 'dpkg')
+
+    version = ''
+    architecture = ''
+    for elem in listdir(pkg_directory):
+        if os_distro == 'fedora' or os_distro == "rhel":
+            if '.src.rpm' in elem:
+                # looks for the version number of rpm package in rpm package name
+                version = re.search(r'[\s]*pmdk-([\S]+).src.rpm', elem).group(1)
+            else:
+                architecture = elem
+
+        elif os_distro == 'ubuntu':
+            if '.changes' in elem:
+                # looks for the version number of packages in package name
+                version = re.search(r'pmdk_*(.+)_(.+).changes', elem).group(1)
+                architecture = re.search(r'pmdk_*(.+)_(.+).changes', elem).group(2)
+    return version, architecture
+
+
+def get_built_packages(pmdk_pkg_path):
+    """
+    Returns built packages.
+    """
+    packages = listdir(pmdk_pkg_path)
+    return packages
+
+
+def get_libraries_names_from_so_files(pmdk_path, is_pmdk_debuginfo, without_pmem2, without_pmemset):
+    """
+    Returns names of libraries from .so files, and information which packages
+    should be built for individual libraries.
+    """
+    libraries_from_so_files = dict()
+    path_to_so_files = path.join(pmdk_path, 'src', 'nondebug')
+
+    for elem in listdir(path_to_so_files):
+        if without_pmem2 and elem.startswith('libpmem2'):
+            continue
+        if without_pmemset and elem.startswith('libpmemset'):
+            continue
+        if elem.endswith('.so') and elem.startswith('lib'):
+            library_name = elem.split('.')[0]
+            if is_pmdk_debuginfo:
+                libraries_from_so_files[library_name] =\
+                    PACKAGES_INFO(basic=True, devel=True, debug=True,
+                                  debuginfo=False, debug_debuginfo=False)
+            else:
+                libraries_from_so_files[library_name] =\
+                    PACKAGES_INFO(basic=True, devel=True, debug=True,
+                                  debuginfo=True, debug_debuginfo=True)
+    return libraries_from_so_files
+
+
+def get_names_of_packages(packages_info, without_rpmem):
+    """
+    Returns names of packages, that should be built.
+    """
+    packages = []
+    pkg_ext = ''
+    separator = ''
+    os_distro=distro.id()
+    if os_distro == 'fedora' or os_distro == "rhel":
+        types = ['-', '-debug-', '-devel-', '-debuginfo-', '-debug-debuginfo-']
+        pkg_ext = '.rpm'
+        separator ='.'
+
+    elif os_distro == 'ubuntu':
+        types = ['_', '-dev_']
+        pkg_ext = '.deb'
+        separator = '_'
+
+    for elem in packages_info:
+        # checks if rpmem and rpmemd packages should be built
+        # skips creating names of packages for rpmemd and librpmem
+        if without_rpmem:
+            if elem in ['rpmemd', 'librpmem']:
+                continue
+        sets_of_information = zip(packages_info[elem], types)
+        for kit in sets_of_information:
+            if kit[0]:
+                package_name = elem + kit[1] + PMDK_VERSION + separator +\
+                    SYSTEM_ARCHITECTURE + pkg_ext
+                packages.append(package_name)
+    return packages
+
+
+def check_existence_of_pmdk_debuginfo_package(pmdk_debuginfo_package_name, built_packages):
+    """
+    Checks if 'pmdk-debuginfo' package is built
+    """
+    is_pmdk_debuginfo_package = False
+    if pmdk_debuginfo_package_name in built_packages:
+        is_pmdk_debuginfo_package = True
+    return is_pmdk_debuginfo_package
+
+
+def find_missing_packages(packages_path, pmdk_path, pmdk_debuginfo_package_name, without_rpmem, without_pmem2, without_pmemset):
+    """
+    Checks if names of built packages are the same as names of packages,
+    which should be built and returns missing packages. Tools are taken
+    into account.
+    """
+    built_packages = get_built_packages(packages_path)
+    is_pmdk_debuginfo =\
+        check_existence_of_pmdk_debuginfo_package(pmdk_debuginfo_package_name, built_packages)
+    tools = {
+        'rpmemd': PACKAGES_INFO(basic=True, devel=False, debug=False,
+                                debuginfo=True, debug_debuginfo=False),
+        'pmempool': PACKAGES_INFO(basic=True, devel=False, debug=False,
+                                  debuginfo=True, debug_debuginfo=False),
+        'pmreorder': PACKAGES_INFO(basic=True, devel=False, debug=False,
+                                   debuginfo=False, debug_debuginfo=False),
+        'daxio': PACKAGES_INFO(basic=True, devel=False, debug=False,
+                               debuginfo=True, debug_debuginfo=False)
+    }
+    tools_packages = get_names_of_packages(tools, without_rpmem)
+    missing_tools_packages = [
+        elem for elem in tools_packages if elem not in built_packages]
+    libraries = get_libraries_names_from_so_files(pmdk_path, is_pmdk_debuginfo, without_pmem2, without_pmemset)
+    library_packages = get_names_of_packages(libraries, without_rpmem)
+    missing_library_packages = [
+        elem for elem in library_packages if elem not in built_packages]
+    missing_packages = missing_library_packages + missing_tools_packages
+    return missing_packages
+
+
+def find_missing_libraries_and_other_elements(packages_path, pmdk_path, pmdk_debuginfo_package_name, library_name_pattern, without_rpmem, without_pmem2, without_pmemset):
+    """
+    Checks if names of functions from .so files are the same as names of
+    functions extracted from built packages and returns missing functions.
+    Others pkg (tools and "PMDK") are taken into account.
+    """
+    others_pkg = ['pmempool', 'daxio', 'rpmemd', 'pmdk', 'pmreorder']
+    built_packages = get_built_packages(packages_path)
+    is_pmdk_debuginfo =\
+        check_existence_of_pmdk_debuginfo_package(pmdk_debuginfo_package_name, built_packages)
+    libraries = get_libraries_names_from_so_files(pmdk_path, is_pmdk_debuginfo, without_pmem2, without_pmemset)
+
+    missing_elements = []
+    # looks for the name of library/others in package name
+    for elem in listdir(packages_path):
+        library_name = re.search(library_name_pattern, elem).group(1)
+        if library_name not in libraries.keys() and library_name not in\
+                others_pkg and library_name not in missing_elements:
+            missing_elements.append(library_name)
+    return missing_elements
+
+
+def parse_argument(argument_option):
+    """
+    Parses an option from the command line.
+    """
+    index = sys.argv.index(argument_option)
+    try:
+        argument = sys.argv[index+1]
+    except IndexError:
+        print('ERROR: Invalid argument!')
+        print(__doc__)
+        print(unittest.main.__doc__)
+    else:
+        sys.argv.pop(index)
+        sys.argv.pop(index)
+        return argument
+
+
+class TestBuildPackages(unittest.TestCase):
+
+    def test_completeness_of_built_packages(self):
+        """
+        Checks if all packages are built.
+        """
+        missing_packages =\
+            find_missing_packages(packages_path, pmdk_path, pmdk_debuginfo_package_name, without_rpmem, without_pmem2, without_pmemset)
+        error_msg = linesep + 'List of missing packages:'
+
+        for package in missing_packages:
+            error_msg += linesep + package
+        self.assertFalse(missing_packages, error_msg)
+
+    def test_completeness_of_name_of_libraries_and_others(self):
+        """
+        Checks if names of functions from .so files and other elements (tools
+        and "PMDK") are the same as functions/other elements extracted from
+        the name of built packages.
+        """
+        os_distro=distro.id()
+        missing_elements =\
+        find_missing_libraries_and_other_elements(packages_path, pmdk_path, pmdk_debuginfo_package_name,library_name_pattern, without_rpmem, without_pmem2, without_pmemset)
+        error_msg = linesep +\
+            'List of missing libraries and other elements (tools and "PMDK"):'
+        for elem in missing_elements:
+            error_msg += linesep + elem
+
+        self.assertFalse(missing_elements, error_msg)
+
+
+if __name__ == '__main__':
+    path_argument = '-r'
+    rpmem_build_argument = '--without-rpmem'
+    without_rpmem = False
+    pmem2_build_argument = '--without-pmem2'
+    without_pmem2 = False
+    pmemset_build_argument = '--without-pmemset'
+    without_pmemset = False
+    if '-h' in sys.argv or '--help' in sys.argv:
+        print(__doc__)
+        unittest.main()
+    elif path_argument in sys.argv:
+        pmdk_path = parse_argument(path_argument)
+        if rpmem_build_argument in sys.argv:
+            without_rpmem = True
+            index = sys.argv.index(rpmem_build_argument)
+            sys.argv.pop(index)
+        if pmem2_build_argument in sys.argv:
+            without_pmem2 = True
+            index = sys.argv.index(pmem2_build_argument)
+            sys.argv.pop(index)
+        if pmemset_build_argument in sys.argv:
+            without_pmemset = True
+            index = sys.argv.index(pmemset_build_argument)
+            sys.argv.pop(index)
+        if pmdk_path:
+            PMDK_VERSION, SYSTEM_ARCHITECTURE =\
+                get_package_version_and_system_architecture(pmdk_path)
+            os_distro=distro.id()
+            if os_distro == 'fedora' or os_distro == "rhel":
+                packages_path = path.join(pmdk_path, 'rpm', SYSTEM_ARCHITECTURE)
+                pmdk_debuginfo_package_name = 'pmdk-debuginfo-' + PMDK_VERSION + '.' + SYSTEM_ARCHITECTURE + '.rpm'
+                if without_pmem2:
+                    library_name_pattern = r'[\s]*([a-zA-Z+]+)-'
+                else:
+                    library_name_pattern = r'[\s]*([2a-zA-Z+]+)-'
+            elif os_distro == 'ubuntu':
+                packages_path = path.join(pmdk_path, 'dpkg')
+                pmdk_debuginfo_package_name = 'pmdk-debuginfo-' + PMDK_VERSION + '.' + '.deb'
+                if without_pmem2:
+                    library_name_pattern = r'^([a-zA-Z]+)[-_].*$'
+                else:
+                    library_name_pattern = r'^([2a-zA-Z]+)[-_].*$'
+            unittest.main(
+                testRunner=xmlrunner.XMLTestRunner(output='test-reports'),
+                # these make sure that some options that are not applicable
+                # remain hidden from the help menu.
+                failfast=False, buffer=False, catchbreak=False)
+    else:
+        print(__doc__)
+        print(unittest.main.__doc__)

--- a/utils/gha-runners/scripts/test-packages-installation.py
+++ b/utils/gha-runners/scripts/test-packages-installation.py
@@ -1,0 +1,173 @@
+#!usr/bin/env python3
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2018-2023, Intel Corporation
+
+
+"""
+This module includes tests for PMDK packages installation.
+Tests check:
+-compatibility of the version of installed  packages from PMDK library with
+ the current version of PMDK library,
+-if all packages from PMDK library are installed.
+Required arguments:
+-r <PMDK_path>    the PMDK library root path.
+"""
+
+from os import listdir, path, linesep, walk
+from subprocess import check_output
+import distro
+import unittest
+import xmlrunner
+import sys
+import re
+
+NO_PKG_CONFIGS = ('pmdk', 'pmempool', 'daxio', 'pmreorder', 'rpmemd')
+PMDK_TOOLS = ('pmempool', 'daxio', 'pmreorder', 'rpmemd')
+PMDK_VERSION = ''
+SYSTEM_ARCHITECTURE = ''
+PMDK_PATH = ''
+
+
+def get_package_version_and_system_architecture():
+    """
+    Returns packages version and system architecture from names of directories
+    from pkg directory.
+    """
+    global PMDK_VERSION
+    global SYSTEM_ARCHITECTURE
+    os_distro = distro.id()
+    if os_distro == 'fedora' or os_distro == "rhel":
+        pkg_directory = path.join(PMDK_PATH, 'rpm')
+        for elem in listdir(pkg_directory):
+            if '.src.rpm' in elem:
+                # looks for the version number of package in package name
+                PMDK_VERSION = re.search(
+                    r'[\s]*pmdk-([\S]+).src.rpm', elem).group(1)
+            else:
+                    SYSTEM_ARCHITECTURE = elem
+
+    elif os_distro == 'ubuntu':
+        pkg_directory = path.join(PMDK_PATH, 'dpkg')
+        for elem in listdir(pkg_directory):
+            if '.changes' in elem:
+                # looks for the version number of package in package name
+                PMDK_VERSION = re.search(r'pmdk_*(.+)_(.+).changes', elem).group(1)
+                SYSTEM_ARCHITECTURE = re.search(r'pmdk_*(.+)_(.+).changes', elem).group(2)
+
+
+def get_libraries_names(packages_path, split_param):
+    """
+    Returns names of elements, for which are installed packages from PMDK
+    library.
+    """
+    libraries_names = [re.split(split_param, elem)[0] for elem in listdir(packages_path)
+                           if PMDK_VERSION in elem]
+
+    return set(libraries_names)
+
+
+def get_not_installed_packages(packages_path, so_path, split_param):
+    """
+    Returns names of packages from PMDK library, which are not installed.
+    """
+    def is_installed(elem):
+        return elem in PMDK_TOOLS and elem in listdir('/usr/bin/') or\
+            elem == "pmdk" or elem + '.so' in listdir(so_path)
+
+    elements = get_libraries_names(packages_path, split_param)
+    not_installed_packages = []
+    for elem in elements:
+        if not is_installed(elem):
+            not_installed_packages.append(elem)
+    return not_installed_packages
+
+
+def get_incompatible_packages(packages_path, pkgconfig_directory, split_param):
+    """
+    Returns names of packages from PMDK library, which are not compatible
+    with the current version of PMDK library.
+    """
+    incompatibe_packages = []
+    libraries = get_libraries_names(packages_path, split_param) - set(NO_PKG_CONFIGS)
+    for library in libraries:
+        with open(pkgconfig_directory + library + '.pc') as f:
+            out = f.readlines()
+        for line in out:
+            if 'version=' in line:
+                version = line.split('=')[1].strip(linesep)
+        if not version in PMDK_VERSION.replace('~', '-'):
+            incompatibe_packages.append(library)
+    return incompatibe_packages
+
+
+class TestBuildPackages(unittest.TestCase):
+
+    def test_compatibility_of_version_of_installed_packages(self):
+        """
+        Checks if the version of installed packages is correct.
+        """
+        incompatible_packages = get_incompatible_packages(packages_path, pkgconfig_directory, split_param)
+        error_msg = linesep + 'List of incompatible packages: '
+        for package in incompatible_packages:
+            error_msg += linesep + package
+        self.assertFalse(incompatible_packages, error_msg)
+
+    def test_correctness_of_installed_packages(self):
+        """
+        Checks if all packages from PMDK library are installed.
+        """
+        not_installed_packages = get_not_installed_packages(packages_path, so_path, split_param)
+        error_msg = linesep + 'List of not installed packages: '
+        for package in not_installed_packages:
+            error_msg += linesep + package
+        self.assertFalse(not_installed_packages, error_msg)
+
+
+def parse_argument(argument_option):
+    """
+    Parses an option from the command line.
+    """
+    index = sys.argv.index(argument_option)
+    try:
+        argument = sys.argv[index+1]
+    except IndexError:
+        print('ERROR: Invalid argument!')
+        print(__doc__)
+        print(unittest.main.__doc__)
+    else:
+        sys.argv.pop(index)
+        sys.argv.pop(index)
+        return argument
+
+
+if __name__ == '__main__':
+
+    if '-h' in sys.argv or '--help' in sys.argv:
+        print(__doc__)
+        unittest.main()
+    elif '-r' in sys.argv:
+        PMDK_PATH = parse_argument('-r')
+        get_package_version_and_system_architecture()
+        os_distro = distro.id()
+        if os_distro == 'fedora' or os_distro == "rhel":
+            packages_path = path.join(PMDK_PATH, 'rpm', SYSTEM_ARCHITECTURE)
+            pkgconfig_directory = '/usr/lib64/pkgconfig/'
+            so_path = '/usr/lib64/'
+            split_param = '-'
+        elif os_distro == 'ubuntu':
+            packages_path = path.join(PMDK_PATH, 'dpkg')
+            pkgconfig_directory = '/lib/x86_64-linux-gnu/pkgconfig/'
+            so_path = '/lib/x86_64-linux-gnu/'
+            split_param = '[-_]'
+
+        if PMDK_VERSION == '' or SYSTEM_ARCHITECTURE == '':
+            sys.exit("FATAL ERROR: command 'make rpm/dpkg' was not done correctly")
+        unittest.main(
+                testRunner=xmlrunner.XMLTestRunner(output='test-reports'),
+                # these make sure that some options that are not applicable
+                # remain hidden from the help menu.
+                failfast=False, buffer=False, catchbreak=False)
+    else:
+        print(__doc__)
+        print(unittest.main.__doc__)


### PR DESCRIPTION
Added python scripts used by PKG tests

Files were moved from frameworks.devops.pmdk.files repo

// This PR contains "clean" scripts (with no changes) required for https://github.com/pmem/pmdk/pull/5555

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5558)
<!-- Reviewable:end -->
