### PR TITLE
test:  fail pmem tests if ndctl is not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,9 @@ This requires **devscripts** to be installed.
 
 ### Testing Libraries on Linux and FreeBSD
 
+You will need to install the following package to run unit tests:
+* **ndctl**
+
 Before running the tests, you may need to prepare a test configuration file (src/test/testconfig.sh). Please see the available configuration settings in the example file [src/test/testconfig.sh.example](src/test/testconfig.sh.example).
 
 To build and run the **unit tests**:

--- a/src/test/README
+++ b/src/test/README
@@ -13,6 +13,10 @@ testconfig.sh.example provides more detail.  The script RUNTESTS, when run with
 no arguments, will run all unit tests through all the combinations of fs-types
 and build-types, running the "check" level test.
 
+DEPENDENCIES
+You will need to install the following package to run unit tests:
+	ndctl
+
 DETAILS ON HOW TO RUN UNIT TESTS
 
 See the top-level README for instructions on building, installing, running

--- a/src/test/unittest/requirements.py
+++ b/src/test/unittest/requirements.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2021, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 #
 """Various requirements"""
 
@@ -66,8 +66,11 @@ class Requirements:
     def check_namespace(self):
         cmd = ['ndctl', 'list']
         cmd_as_str = ' '.join(cmd)
-        proc = sp.run(cmd, stdout=sp.PIPE, stderr=sp.STDOUT,
-                      universal_newlines=True)
+        try:
+            proc = sp.run(cmd, stdout=sp.PIPE, stderr=sp.STDOUT,
+                          universal_newlines=True)
+        except (OSError):
+            raise futils.Fail('ndctl is not installed')
         if proc.returncode != 0:
             raise futils.Fail('"{}" failed:{}{}'.format(cmd_as_str, os.linesep,
                                                         proc.stdout))


### PR DESCRIPTION
ndctl-related tests explicitly fail if ndctl is not installed instead of RUNTESTS.py script crash

Fixes: #5554

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5559)
<!-- Reviewable:end -->
