### PR TITLE
common: omit checks for 'cron' jobs in build-CI.sh

### DIFF
--- a/utils/docker/build-CI.sh
+++ b/utils/docker/build-CI.sh
@@ -14,20 +14,6 @@ set -e
 source $(dirname $0)/set-ci-vars.sh
 source $(dirname $0)/set-vars.sh
 
-if [[ "$CI_EVENT_TYPE" != "cron" && "$CI_BRANCH" != "coverity_scan" \
-	&& "$COVERITY" -eq 1 ]]; then
-	echo "INFO: Skip Coverity scan job if build is triggered neither by " \
-		"'cron' nor by a push to 'coverity_scan' branch"
-	exit 0
-fi
-
-if [[ ( "$CI_EVENT_TYPE" == "cron" || "$CI_BRANCH" == "coverity_scan" )\
-	&& "$COVERITY" -ne 1 ]]; then
-	echo "INFO: Skip regular jobs if build is triggered either by 'cron'" \
-		" or by a push to 'coverity_scan' branch"
-	exit 0
-fi
-
 if [[ -z "$OS" || -z "$OS_VER" || -z "$IMG_VER" ]]; then
 	echo "ERROR: The variables OS, OS_VER and IMG_VER have to be set properly " \
 		"(eg. OS=ubuntu, OS_VER=16.04, IMG_VER=1.10)."
@@ -51,11 +37,7 @@ if [[ $MAKE_PKG -eq 0 ]] ; then command="./run-build.sh"; fi
 if [[ $MAKE_PKG -eq 1 ]] ; then command="./run-build-package.sh"; fi
 if [[ $COVERAGE -eq 1 ]] ; then command="./run-coverage.sh"; fi
 if [[ $BANDIT -eq 1 ]] ; then command="./run-bandit.sh"; fi
-
-if [[ ( "$CI_EVENT_TYPE" == "cron" || "$CI_BRANCH" == "coverity_scan" )\
-	&& "$COVERITY" -eq 1 ]]; then
-	command="./run-coverity.sh"
-fi
+if [[ "$COVERITY" -eq 1 ]]; then command="./run-coverity.sh"; fi
 
 if [ -n "$DNS_SERVER" ]; then DNS_SETTING=" --dns=$DNS_SERVER "; fi
 if [[ -f $CI_FILE_SKIP_BUILD_PKG_CHECK ]]; then BUILD_PACKAGE_CHECK=n; else BUILD_PACKAGE_CHECK=y; fi


### PR DESCRIPTION
The approach, when we run Coverity along other tests is long gone. Now various build can be run on cron jobs, and run-coverity.sh is now only executed in a separate workflow.

This cleanup enables Nightly jobs to run properly (now they are skipped).
// example skip in Nightly: https://github.com/pmem/pmdk/actions/runs/4549226087/jobs/8021078686#step:4:24

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5563)
<!-- Reviewable:end -->
