### PR TITLE
test: verify prealloc result to avoid skipping wrong function execution

### DIFF
--- a/src/test/obj_pmalloc_mt/TEST0
+++ b/src/test/obj_pmalloc_mt/TEST0
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2015-2019, Intel Corporation
+# Copyright 2015-2023, Intel Corporation
 
 #
 # src/test/obj_pmalloc_mt/TEST0 -- multithreaded allocator test
@@ -16,6 +16,6 @@ configure_valgrind helgrind force-enable
 setup
 
 PMEM_IS_PMEM_FORCE=1 expect_normal_exit\
-	./obj_pmalloc_mt$EXESUFFIX 32 1000 100 $DIR/testfile
+	./obj_pmalloc_mt$EXESUFFIX 32 1000 100 $DIR/testfile0
 
 pass

--- a/src/test/obj_pmalloc_mt/TEST1
+++ b/src/test/obj_pmalloc_mt/TEST1
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2019, Intel Corporation
+# Copyright 2016-2023, Intel Corporation
 
 #
 # src/test/obj_pmalloc_mt/TEST1 -- multithreaded allocator test
@@ -16,6 +16,6 @@ configure_valgrind helgrind force-disable
 setup
 
 PMEM_IS_PMEM_FORCE=1 expect_normal_exit\
-	./obj_pmalloc_mt$EXESUFFIX 32 1000 100 $DIR/testfile
+	./obj_pmalloc_mt$EXESUFFIX 32 1000 100 $DIR/testfile1
 
 pass

--- a/src/test/obj_pmalloc_mt/TEST2
+++ b/src/test/obj_pmalloc_mt/TEST2
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2015-2019, Intel Corporation
+# Copyright 2015-2023, Intel Corporation
 
 #
 # src/test/obj_pmalloc_mt/TEST2 -- multithreaded allocator test
@@ -16,6 +16,6 @@ configure_valgrind helgrind force-enable
 setup
 
 PMEM_IS_PMEM_FORCE=1 expect_normal_exit\
-	./obj_pmalloc_mt$EXESUFFIX 4 64 4 $DIR/testfile
+	./obj_pmalloc_mt$EXESUFFIX 4 64 4 $DIR/testfile2
 
 pass

--- a/src/test/obj_pmalloc_mt/TEST3
+++ b/src/test/obj_pmalloc_mt/TEST3
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2015-2019, Intel Corporation
+# Copyright 2015-2023, Intel Corporation
 
 #
 # src/test/obj_pmalloc_mt/TEST3 -- multithreaded allocator test
@@ -16,6 +16,6 @@ configure_valgrind drd force-enable
 setup
 
 PMEM_IS_PMEM_FORCE=1 expect_normal_exit\
-	./obj_pmalloc_mt$EXESUFFIX 4 64 4 $DIR/testfile
+	./obj_pmalloc_mt$EXESUFFIX 4 64 4 $DIR/testfile3
 
 pass

--- a/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
+++ b/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
@@ -59,9 +59,12 @@ static void *
 realloc_worker(void *arg)
 {
 	struct worker_args *a = arg;
+	int ret;
 
 	for (unsigned i = 0; i < Ops_per_thread; ++i) {
-		prealloc(a->pop, &a->r->offs[a->idx][i], REALLOC_SIZE, 0, 0);
+		ret = prealloc(a->pop, &a->r->offs[a->idx][i],
+							REALLOC_SIZE, 0, 0);
+		UT_ASSERTeq(ret, 0);
 		UT_ASSERTne(a->r->offs[a->idx][i], 0);
 	}
 
@@ -85,6 +88,7 @@ static void *
 mix_worker(void *arg)
 {
 	struct worker_args *a = arg;
+	int ret;
 
 	/*
 	 * The mix scenario is ran twice to increase the chances of run
@@ -92,8 +96,9 @@ mix_worker(void *arg)
 	 */
 	for (unsigned j = 0; j < MIX_RERUNS; ++j) {
 		for (unsigned i = 0; i < Ops_per_thread; ++i) {
-			pmalloc(a->pop, &a->r->offs[a->idx][i],
+			ret = pmalloc(a->pop, &a->r->offs[a->idx][i],
 				ALLOC_SIZE, 0, 0);
+			UT_ASSERTeq(ret, 0);
 			UT_ASSERTne(a->r->offs[a->idx][i], 0);
 		}
 


### PR DESCRIPTION
prealloc might fail in case of pool reopen after transaction abort

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5568)
<!-- Reviewable:end -->
