### PR TITLE
common: add win_depr_* defines to split_manpage_test's exceptions

### DIFF
--- a/utils/check_docs/exceptions.txt
+++ b/utils/check_docs/exceptions.txt
@@ -77,3 +77,5 @@ pobj_xpublish_no_abort
 pobj_xpublish_valid_flags
 pobj_xlog_append_buffer_no_abort
 pobj_xlog_append_buffer_valid_flags
+win_depr_str
+win_depr_attr


### PR DESCRIPTION
// without this fix - the CI is failing: https://github.com/pmem/pmdk/actions/runs/4580274940/jobs/8088859857#step:5:26

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5569)
<!-- Reviewable:end -->
