### PR TITLE
common: list nd resources in get-system-info.sh

### DIFF
--- a/utils/gha-runners/get-system-info.sh
+++ b/utils/gha-runners/get-system-info.sh
@@ -45,6 +45,12 @@ function system_info {
 	echo "**********list-avaialble-pmem-devices**********"
 	ls -la /dev/dax*
 	ls -la /dev/pmem*
+	echo "**********list-nd-resources**********"
+	ls -la /sys/bus/nd/devices/ndbus*/region*/resource
+	ls -la /sys/bus/nd/devices/ndbus*/region*/dax*/resource
+	ls -la /sys/bus/nd/devices/ndbus*/region*/pfn*/resource
+	ls -la /sys/bus/nd/devices/ndbus*/region*/namespace*/resource
+	ls -la /sys/bus/nd/devices/region*/deep_flush
 }
 
 # Call the function above to print system info.


### PR DESCRIPTION
testconfig.sh.example says:
```
It is required to have [...] at least RO access to all of the following resource files (containing physical addresses) of NVDIMM devices (only root can read them by default):

/sys/bus/nd/devices/ndbus*/region*/resource
/sys/bus/nd/devices/ndbus*/region*/dax*/resource
/sys/bus/nd/devices/ndbus*/region*/pfn*/resource
/sys/bus/nd/devices/ndbus*/region*/namespace*/resource

Note: some tests require write access to:
/sys/bus/nd/devices/region*/deep_flush
```
(https://github.com/pmem/pmdk/blob/acd71e818af4afc2eb917e9d3b2e11a39f0381f3/src/test/testconfig.sh.example#L58-L67)

Let's print all those files to be able to check if they have required accesses.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5591)
<!-- Reviewable:end -->
