### PR TITLE
[TEST ONLY] common: change the url for pmdk-tests in ras tests

### DIFF
--- a/utils/gha-runners/run-ras-linux.yml
+++ b/utils/gha-runners/run-ras-linux.yml
@@ -90,8 +90,8 @@
         branch: master
         target_dir: "{{ working_dir_path }}/pmdk"
       pmdk_tests:
-        url: https://github.com/pmem/pmdk-tests
-        branch: master
+        url: https://github.com/tszczyp/pmdk-tests
+        branch: repo_cleanup
         target_dir: "{{ working_dir_path }}/pmdk-tests"
 
   tasks:


### PR DESCRIPTION
Changed the pmdk-tests url to test repo cleanup correctness

This PR should be deleted once the tests are over