### PR TITLE
test: enable Python tests (short+medium) to be run on PMem

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Create testconfig files
         run: ./$WORKDIR/create-testconfig.sh
 
-      - name: Run tests
+      - name: Run tests (Bash)
         run: make check
+
+      - name: Run tests (Python)
+        run: cd src/test/ && ./RUNTESTS.py -t check


### PR DESCRIPTION
Enable Python tests (short+medium) to be run on PMem

Requires:
- [x] #5650

Fixes: #5649
Signed-off-by: Tomasz Gromadzki <tomasz.gromadzki@intel.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5648)
<!-- Reviewable:end -->
