### PR TITLE
test: disable avx512f tests (pmem2_mem_ext) under Valgrind

### DIFF
--- a/src/test/pmem2_mem_ext/TESTS.py
+++ b/src/test/pmem2_mem_ext/TESTS.py
@@ -115,13 +115,13 @@ class Pmem2MemExt(t.Test):
         ret = tools.Tools(ctx.env, ctx.build).cpufd()
         self.check_arch(ctx.variant(), ret.returncode)
 
-# All tests with variant VARIANT_AVX512F are disabled under Valgrind
-# until the issue https://github.com/pmem/pmdk/issues/5640 is fixed.
-        if not sys.platform.startswith('win32'):
-            if ctx.valgrind is not None:
-                if ctx.valgrind.tool.name != "NONE":
-                    if ctx.variant() == VARIANT_AVX512F:
-                        raise futils.Skip("AVX512F unavailable under Valigrind")
+        # XXX all tests with VARIANT_AVX512F are disabled under Valgrind
+        # until the issue https://github.com/pmem/pmdk/issues/5640 is fixed.
+        # "win32" `if`` is related to unknown `is not None` by Windows Python
+        if not sys.platform.startswith('win32') and ctx.valgrind is not None:
+            if ctx.valgrind.tool.name != "NONE":
+                if ctx.variant() == VARIANT_AVX512F:
+                    raise futils.Skip("AVX512F unavailable under Valigrind")
 
     def check_arch(self, variant, available_arch):
         if variant == VARIANT_MOVDIR64B:

--- a/src/test/pmem2_mem_ext/TESTS.py
+++ b/src/test/pmem2_mem_ext/TESTS.py
@@ -1,6 +1,6 @@
 #!../env.py
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2022, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 #
 
 import testframework as t
@@ -114,6 +114,13 @@ class Pmem2MemExt(t.Test):
         super().setup(ctx)
         ret = tools.Tools(ctx.env, ctx.build).cpufd()
         self.check_arch(ctx.variant(), ret.returncode)
+
+# All tests with variant VARIANT_AVX512F are disabled under Valgrind
+# until the issue https://github.com/pmem/pmdk/issues/5640 is fixed.
+        if ctx.valgrind is not None:
+            if ctx.valgrind.tool.name != "NONE":
+                if ctx.variant() == VARIANT_AVX512F:
+                    raise futils.Skip("AVX512F unavailable under Valigrind")
 
     def check_arch(self, variant, available_arch):
         if variant == VARIANT_MOVDIR64B:

--- a/src/test/pmem2_mem_ext/TESTS.py
+++ b/src/test/pmem2_mem_ext/TESTS.py
@@ -117,10 +117,11 @@ class Pmem2MemExt(t.Test):
 
 # All tests with variant VARIANT_AVX512F are disabled under Valgrind
 # until the issue https://github.com/pmem/pmdk/issues/5640 is fixed.
-        if ctx.valgrind is not None:
-            if ctx.valgrind.tool.name != "NONE":
-                if ctx.variant() == VARIANT_AVX512F:
-                    raise futils.Skip("AVX512F unavailable under Valigrind")
+        if not sys.platform.startswith('win32'):
+            if ctx.valgrind is not None:
+                if ctx.valgrind.tool.name != "NONE":
+                    if ctx.variant() == VARIANT_AVX512F:
+                        raise futils.Skip("AVX512F unavailable under Valigrind")
 
     def check_arch(self, variant, available_arch):
         if variant == VARIANT_MOVDIR64B:


### PR DESCRIPTION
Disable avx512f tests (pmem2_mem_ext) until Valigrind will provide support for avx512f instruction.

See: #5640

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5658)
<!-- Reviewable:end -->
