### PR TITLE
test: disable ex_libpmem2 TEST6 until #5638 and #5593 are fixed

### DIFF
--- a/src/test/ex_libpmem2/TESTS.py
+++ b/src/test/ex_libpmem2/TESTS.py
@@ -100,6 +100,12 @@ class TEST501(EX_LIBPMEM2_TEST5):  # to be removed when fixed
 
 
 @t.windows_exclude
+# XXX disable the test for `memcheck'
+# until https://github.com/pmem/pmdk/issues/5638 is fixed.
+@t.require_valgrind_disabled('memcheck')
+# XXX disable the test for `drd'
+# until https://github.com/pmem/pmdk/issues/5593 is fixed.
+@t.require_valgrind_disabled('drd')
 # This test case would require two VALGRIND_SET_CLEAN() calls
 # to be added to the "src/examples/libpmem2/ringbuf/ringbuf.c"
 # example (see https://github.com/pmem/pmdk/pull/5604)


### PR DESCRIPTION
Ref:
- #5638
- #5593 
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5664)
<!-- Reviewable:end -->
