### PR TITLE
test: disable ex_libpmem2/TEST5 with memcheck

### DIFF
--- a/src/test/ex_libpmem2/TESTS.py
+++ b/src/test/ex_libpmem2/TESTS.py
@@ -74,8 +74,8 @@ class TEST4(EX_LIBPMEM2):
         ctx.exec(example_path, *args, stdout_file='out4.log')
 
 
-# XXX Disable the test execution under pmemcheck with g.PAGE until fixed.
-# https://github.com/pmem/pmdk/issues/5641
+# XXX Disable the test execution under pmemcheck with g.PAGE until the issue
+# https://github.com/pmem/pmdk/issues/5641 is fixed.
 # additionall test TEST501 has been added to cover non-pmemcheck configs.
 class EX_LIBPMEM2_TEST5(EX_LIBPMEM2):
 
@@ -93,7 +93,12 @@ class TEST5(EX_LIBPMEM2_TEST5):
     pass
 
 
-@t.require_valgrind_disabled('pmemcheck')
+# XXX Disable the test execution with 'memcheck' until the issue:
+# https://github.com/pmem/pmdk/issues/5635 is fixed.
+# additionall test TEST501 has been added to cover non-pmemcheck configs.
+# @t.require_valgrind_disabled('memcheck')  # to be removed when fixed
+# @t.require_valgrind_disabled('pmemcheck')
+@t.require_valgrind_disabled('pmemcheck', 'memcheck')
 class TEST501(EX_LIBPMEM2_TEST5):  # to be removed when fixed
 
     pass


### PR DESCRIPTION
Disable ex_libpmem2/TEST5 with memcheck until issue #5635 is fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5667)
<!-- Reviewable:end -->
