### PR TITLE
test:@t.req...val..._disable() used only once in ex_libpmem2/TEST6

### DIFF
--- a/src/test/ex_libpmem2/TESTS.py
+++ b/src/test/ex_libpmem2/TESTS.py
@@ -102,17 +102,19 @@ class TEST501(EX_LIBPMEM2_TEST5):  # to be removed when fixed
 @t.windows_exclude
 # XXX disable the test for `memcheck'
 # until https://github.com/pmem/pmdk/issues/5638 is fixed.
-@t.require_valgrind_disabled('memcheck')
+# @t.require_valgrind_disabled('memcheck')
 # XXX disable the test for `drd'
 # until https://github.com/pmem/pmdk/issues/5593 is fixed.
-@t.require_valgrind_disabled('drd')
+# @t.require_valgrind_disabled('drd')
 # This test case would require two VALGRIND_SET_CLEAN() calls
 # to be added to the "src/examples/libpmem2/ringbuf/ringbuf.c"
 # example (see https://github.com/pmem/pmdk/pull/5604)
 # in order to pass under pmemcheck, but examples
 # do not use valgrind macros on purpose (to avoid unnecessary
 # complication), so this test case just should not be run under pmemcheck.
-@t.require_valgrind_disabled('pmemcheck')
+# @t.require_valgrind_disabled('pmemcheck')
+# XXX _disabled() can be used only once.
+@t.require_valgrind_disabled('memcheck', 'drd', 'pmemcheck')
 class TEST6(EX_LIBPMEM2):
 
     def run(self, ctx):


### PR DESCRIPTION
@t.require_valgrind_disabled() can only be used one time as a class decorator.
This fix improves the fix #5664

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5668)
<!-- Reviewable:end -->
