### PR TITLE
test: disable obj_defrag_advanced/TEST5 until #5690 is fixed

### DIFF
--- a/src/test/obj_defrag_advanced/TESTS.py
+++ b/src/test/obj_defrag_advanced/TESTS.py
@@ -1,6 +1,6 @@
 #!../env.py
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 #
 
 import testframework as t
@@ -103,8 +103,12 @@ class TEST4(ObjDefragAdvancedMt):
     ncycles = 25
 
 
+# XXX disable the test for 'drd'
+# until https://github.com/pmem/pmdk/issues/5690 is fixed.
+# previousely the test has been disabled for other Valgrind options
 # This test last too long under helgrind/memcheck/pmemcheck
-@t.require_valgrind_disabled('helgrind', 'memcheck', 'pmemcheck')
+# @t.require_valgrind_disabled('helgrind', 'memcheck', 'pmemcheck')
+@t.require_valgrind_disabled('helgrind', 'memcheck', 'pmemcheck', 'drd')
 class TEST5(ObjDefragAdvancedMt):
 
     max_nodes = 256


### PR DESCRIPTION
Disable the test for 'drd' until https://github.com/pmem/pmdk/issues/5690 is fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5691)
<!-- Reviewable:end -->
