### PR TITLE
test: shortening the overall execution of valgrind tests

### DIFF
--- a/.github/workflows/unittest_valgrind_py.yml
+++ b/.github/workflows/unittest_valgrind_py.yml
@@ -17,9 +17,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [[self-hosted, rhel],[self-hosted, opensuse]]
+        config: ['drd', 'pmemcheck', 'memcheck', 'helgrind']
         build: ['debug', 'release', 'static_debug', 'static_release']
-        config: ['memcheck', 'pmemcheck', 'drd', 'helgrind']
+        os: [[self-hosted, rhel],[self-hosted, opensuse]]
+
     env:
       WORKDIR: utils/gha-runners
 

--- a/.github/workflows/unittest_valgrind_sh.yml
+++ b/.github/workflows/unittest_valgrind_sh.yml
@@ -17,9 +17,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [[self-hosted, rhel],[self-hosted, opensuse]]
+        config: ['-d', '-p', '-m', '-e']
         build: ['debug', 'nondebug', 'static-debug', 'static-nondebug']
-        config: ['-m', '-p', '-d', '-e']
+        os: [[self-hosted, rhel],[self-hosted, opensuse]]
+
     env:
       WORKDIR: utils/gha-runners
 


### PR DESCRIPTION
Reorder test execution to place long tests sequence (drd/pmemcheck)
 at the beginning to complete all tests execution in a shorter time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5693)
<!-- Reviewable:end -->
