### PR TITLE
test: skip elapsed time calculation when start_time unavailable

### DIFF
--- a/src/test/RUNTESTS.py
+++ b/src/test/RUNTESTS.py
@@ -133,7 +133,7 @@ class TestRunner:
 
     def _test_failed(self, tc, ctx, fail):
         """Print message specific for failed test"""
-        if self.config.tm:
+        if self.config.tm and hasattr(tc, "elapsed"):
             tm = '\t[{:06.3F} s]'.format(tc.elapsed)
         else:
             tm = ''

--- a/src/test/unittest/basetest.py
+++ b/src/test/unittest/basetest.py
@@ -179,7 +179,8 @@ class BaseTest(metaclass=_TestCase):
             self.check(c)
 
         except futils.Fail:
-            self.elapsed = (datetime.now() - start_time).total_seconds()
+            if start_time is not None:
+                self.elapsed = (datetime.now() - start_time).total_seconds()
             self._on_fail()
             raise
 
@@ -192,7 +193,8 @@ class BaseTest(metaclass=_TestCase):
             msg = '{}: {}TIMEOUT{}\t({})'.format(self, futils.Color.RED,
                                                  futils.Color.END,
                                                  self.ctx)
-            self.elapsed = (datetime.now() - start_time).total_seconds()
+            if start_time is not None:
+                self.elapsed = (datetime.now() - start_time).total_seconds()
             raise futils.Fail(msg)
 
         else:


### PR DESCRIPTION
test: skip elapsed time calculation when start_time unavailable
Avoid elapsed time calculation in case the test setup fails and
start_time is not available.

https://github.com/pmem/pmdk/actions/runs/5150199008/jobs/9274067958#step:6:1942

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5712)
<!-- Reviewable:end -->
