### PR TITLE
common: silently skip ppc64 tests

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -929,6 +929,7 @@ function require_x86_64() {
 # require_ppc64 -- Skip tests if the running platform is not ppc64 or ppc64le
 #
 function require_ppc64() {
+	exit 0
 	require_arch "ppc64" "ppc64le" "ppc64el"
 }
 


### PR DESCRIPTION
The ppc64 tests execution has been disabled by #5729.
All ppc64 tests are silently skipped as there is no easy way to disable them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5744)
<!-- Reviewable:end -->
