### PR TITLE
common: disable pmem check tests for every pull request

### DIFF
--- a/.github/workflows/pmem_check.yml
+++ b/.github/workflows/pmem_check.yml
@@ -3,7 +3,11 @@
 # This workflow is run on 'self-hosted' runners.
 name: PMEM check
 
-on: [push, pull_request, workflow_dispatch]
+on: 
+  workflow_dispatch:
+  schedule:
+    # run this job every 8 hours
+    - cron:  '0 */8 * * *'
 
 jobs:
   linux:


### PR DESCRIPTION
pmem check test will be executed every 8 hours on the stable master branch instead of dealing with trivial issues like license errors, cstyle errors, etc.

https://crontab.guru/#0_*/8_*_*_*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5758)
<!-- Reviewable:end -->
