### PR TITLE
common: pmempool documentation w/o btt/log/blk

### DIFF
--- a/doc/pmempool/pmempool-check.1.md
+++ b/doc/pmempool/pmempool-check.1.md
@@ -5,7 +5,7 @@ description: ""
 disclaimer: "The contents of this web site and the associated <a href=\"https://github.com/pmem\">GitHub repositories</a> are BSD-licensed open source."
 aliases: ["pmempool-check.1.html"]
 title: "pmempool | PMDK"
-header: "pmem Tools version 1.4"
+header: "pmem Tools version 1.5"
 ---
 
 [comment]: <> (SPDX-License-Identifier: BSD-3-Clause)
@@ -29,11 +29,6 @@ header: "pmem Tools version 1.4"
 $ pmempool check [<options>] <file>
 ```
 
-# NOTE #
-
-> NOTICE:
-The **libpmemblk** and **libpmemlog** libraries are deprecated since PMDK 1.13.0 release.
-
 # DESCRIPTION #
 
 The **pmempool** invoked with *check* command checks consistency of a given pool file.
@@ -50,7 +45,8 @@ pool file using **-b** option or just print what would be fixed
 without modifying original pool using **-N** option.
 
 > NOTE:
-Currently, checking the consistency of a *pmemobj* pool is **not** supported.
+Currently, checking the *pmemobj* pool is limited to pool header consistency
+only and neither *repair* nor *advanced* options are supported.
 
 ##### Available options: #####
 
@@ -95,26 +91,11 @@ Display help message and exit.
 # EXAMPLE #
 
 ```
-$ pmempool check pool.bin
+$ pmempool check pool.obj
 ```
 
-Check consistency of "pool.bin" pool file
-
-```
-$ pmempool check --repair --backup pool.bin.backup pool.bin
-```
-
-Check consistency of "pool.bin" pool file, create backup and repair
-if necessary.
-
-```
-$ pmempool check -rvN pool.bin
-```
-
-Check consistency of "pool.bin" pool file, print what would be repaired with
-increased verbosity level.
+Check consistency of "pool.obj" pool file
 
 # SEE ALSO #
 
-**pmempool**(1), **libpmemblk**(7), **libpmemlog**(7),
-**libpmemobj**(7), **libpmempool**(7) and **<https://pmem.io>**
+**pmempool**(1), **libpmemobj**(7), **libpmempool**(7) and **<https://pmem.io>**

--- a/doc/pmempool/pmempool-convert.1.md
+++ b/doc/pmempool/pmempool-convert.1.md
@@ -5,7 +5,7 @@ description: ""
 disclaimer: "The contents of this web site and the associated <a href=\"https://github.com/pmem\">GitHub repositories</a> are BSD-licensed open source."
 aliases: ["pmempool-convert.1.html"]
 title: "pmempool | PMDK"
-header: "pmem Tools version 1.4"
+header: "pmem Tools version 1.5"
 ---
 
 [comment]: <> (SPDX-License-Identifier: BSD-3-Clause)
@@ -14,9 +14,6 @@ header: "pmem Tools version 1.4"
 [comment]: <> (pmempool-convert.1 -- man page for pmempool-convert)
 
 [NAME](#name)<br />
-[SYNOPSIS](#synopsis)<br />
-[DESCRIPTION](#description)<br />
-[EXAMPLE](#example)<br />
 [SEE ALSO](#see-also)<br />
 
 # NAME #
@@ -24,12 +21,7 @@ header: "pmem Tools version 1.4"
 **pmempool-convert** - this is a wrapper around pmdk-convert tool. More information
 can be found in **pmdk-convert**(1) man page.
 
-# NOTE #
-
-> NOTICE:
-The **libpmemblk** and **libpmemlog** libraries are deprecated since PMDK 1.13.0 release.
-
 # SEE ALSO #
 
-**pmdk-convert**(1), **pmempool**(1), **libpmemblk**(7), **libpmemlog**(7),
-**libpmemobj**(7), **libpmempool**(7) and **<https://pmem.io>**
+**pmdk-convert**(1), **pmempool**(1), **libpmemobj**(7), **libpmempool**(7)
+and **<https://pmem.io>**

--- a/doc/pmempool/pmempool-create.1.md
+++ b/doc/pmempool/pmempool-create.1.md
@@ -5,7 +5,7 @@ description: ""
 disclaimer: "The contents of this web site and the associated <a href=\"https://github.com/pmem\">GitHub repositories</a> are BSD-licensed open source."
 aliases: ["pmempool-create.1.html"]
 title: "pmempool | PMDK"
-header: "pmem Tools version 1.4"
+header: "pmem Tools version 1.5"
 ---
 
 [comment]: <> (SPDX-License-Identifier: BSD-3-Clause)
@@ -26,28 +26,18 @@ header: "pmem Tools version 1.4"
 # SYNOPSIS #
 
 ```
-$ pmempool create [<options>] [<type>] [<bsize>] <file>
+$ pmempool create [<options>] [<type>] <file>
 ```
-
-# NOTE #
-
-> NOTICE:
-The **libpmemblk** and **libpmemlog** libraries are deprecated since PMDK 1.13.0 release.
 
 # DESCRIPTION #
 
 The **pmempool** invoked with *create* command creates a pool file
-of specified type. Depending on a pool type it is possible to provide more properties of pool.
+of specified type.
 
-Valid pool types are: **blk**, **log** and **obj** which stands for
-*pmemblk*, *pmemlog* and *pmemobj* pools respectively. By default
-the pool file is created with *minimum* allowed size for specified
-pool type. The minimum sizes for **blk**, **log** and **obj** pool
-types are **PMEMBLK_MIN_POOL**, **PMEMLOG_MIN_POOL** and **PMEMOBJ_MIN_POOL**
-respectively. See **libpmemblk**(7), **libpmemlog**(7)
-and **libpmemobj**(7) for details.
-
-For *pmemblk* pool type block size *\<bsize\>* is a required argument.
+The only valid pool types is: **obj** which stands for *pmemobj* pool.
+By default the pool file is created with *minimum* allowed size for specified
+pool type. The minimum sizes for **obj** pool type is **PMEMOBJ_MIN_POOL**.
+See **libpmemobj**(7) for details.
 
 In order to set custom size of pool use **-s** option, or use **-M** option
 to create a pool of maximum available size on underlying file system.
@@ -93,47 +83,24 @@ Increase verbosity level.
 
 Display help message and exit.
 
-##### Options for PMEMBLK: #####
-
-By default when creating a pmem **blk** pool, the **BTT** layout is *not*
-written until the first *write operation* of block entry is performed.
-Using **-w** option you can force writing the **BTT** layout by writing
-zero data to specified block number. By default the *write operation*
-is performed to block number 0. Please refer to **libpmemblk**(7) for details.
-
-`-w, --write-layout`
-
-Force writing the **BTT** layout by performing *write operation* to block number zero.
-
-##### Options for PMEMOBJ: #####
-
-By default when creating a pmem **obj** pool, the layout name provided to
-the **libpmemobj** library is an empty string. Please refer to
-**libpmemobj**(7) for details.
-
 `-l, --layout <layout>`
 
-Layout name of the **pmemobj** pool.
+Layout name of the **pmemobj** pool. By default when creating a pmem **obj**
+pool, the layout name provided to the **libpmemobj** library is an empty string.
+Please refer to **libpmemobj**(7) for details.
 
 # EXAMPLE #
 
 ```
-$ pmempool create blk 512 pool.blk
+$ pmempool create obj pool.obj
 ```
-
-Create a blk pool file of minimum allowed size and block size 512 bytes
-
-```
-$ pmempool create log -M pool.log
-```
-
-Create a log pool file of maximum allowed size
+Create a obj pool file of minimum allowed size
 
 ```
-$ pmempool create blk --size=4G --write-layout 1K pool.blk
+$ pmempool create obj -M pool.obj
 ```
 
-Create a blk pool file of size 4G, block size 1K and write the BTT layout
+Create a obj pool file of maximum allowed size
 
 ```
 $ pmempool create --layout my_layout obj pool.obj
@@ -142,12 +109,11 @@ $ pmempool create --layout my_layout obj pool.obj
 Create an obj pool file of minimum allowed size and layout "my_layout"
 
 ```
-$ pmempool create --inherit=pool.log new_pool.log
+$ pmempool create --inherit=pool.obj new_pool.obj
 ```
 
-Create a pool file based on pool.log file
+Create a pool file based on pool.obj file
 
 # SEE ALSO #
 
-**pmempool**(1), **libpmemblk**(7), **libpmemlog**(7),
-**libpmemobj**(7) and **<https://pmem.io>**
+**pmempool**(1), **libpmemobj**(7) and **<https://pmem.io>**

--- a/doc/pmempool/pmempool-dump.1.md
+++ b/doc/pmempool/pmempool-dump.1.md
@@ -5,7 +5,7 @@ description: ""
 disclaimer: "The contents of this web site and the associated <a href=\"https://github.com/pmem\">GitHub repositories</a> are BSD-licensed open source."
 aliases: ["pmempool-dump.1.html"]
 title: "pmempool | PMDK"
-header: "pmem Tools version 1.4"
+header: "pmem Tools version 1.5"
 ---
 
 [comment]: <> (SPDX-License-Identifier: BSD-3-Clause)
@@ -16,8 +16,6 @@ header: "pmem Tools version 1.4"
 [NAME](#name)<br />
 [SYNOPSIS](#synopsis)<br />
 [DESCRIPTION](#description)<br />
-[RANGE](#range)<br />
-[EXAMPLE](#example)<br />
 [SEE ALSO](#see-also)<br />
 
 # NAME #
@@ -33,7 +31,12 @@ $ pmempool dump [<options>] <file>
 # NOTE #
 
 > NOTICE:
-The **libpmemblk** and **libpmemlog** libraries are deprecated since PMDK 1.13.0 release.
+
+The **obj** pool type is not supported by the dump command.
+
+> NOTICE:
+
+The dump command is left only for backward compatibility.
 
 # DESCRIPTION #
 
@@ -45,7 +48,7 @@ By default the output format is hexadecimal.
 By default data is dumped to standard output. It is possible to dump data to other
 file by specifying **-o** option. In this case data will be appended to this file.
 
-Using **-r** option you can specify number of blocks/bytes/data chunks using
+Using **-r** option you can specify number of data chunks using
 special text format. See **RANGE** section for details.
 
 ##### Available options: #####
@@ -53,15 +56,6 @@ special text format. See **RANGE** section for details.
 `-b, --binary`
 
 Dump data in binary format.
-
-`-r, --range <range>`
-
-Range of pool file to dump. This may be number of blocks for **blk** pool
-type or either number of bytes or number of data chunks for **log** pool type.
-
-`-c, --chunk <size>`
-
-Size of chunk for **log** pool type. See **pmemlog_walk**(3) in **libpmemlog**(7) for details.
 
 `-o, --output <file>`
 
@@ -94,28 +88,6 @@ All blocks/bytes/data chunks starting from *\<first\>* will be dumped.
 
 Only *\<number\>* block/byte/data chunk will be dumped.
 
-# EXAMPLE #
-
-```
-$ pmempool dump pool.bin
-```
-
-Dump user data from pool.bin file to standard output
-
-```
-$ pmempool dump -o output.bin -r1,10-100 pool_blk.bin
-```
-
-Dump block number 1 and blocks from 10 to 100 from pool_blk.bin
-containing pmem blk pool to output.bin file
-
-```
-$ pmempool dump -r 1K-2K pool.bin
-```
-
-Dump data form 1K to 2K from pool.bin file.
-
 # SEE ALSO #
 
-**pmempool**(1), **libpmemblk**(7), **libpmemlog**(7),
-**libpmemobj**(7) and **<https://pmem.io>**
+**pmempool**(1), **libpmemobj**(7) and **<https://pmem.io>**

--- a/doc/pmempool/pmempool-feature.1.md
+++ b/doc/pmempool/pmempool-feature.1.md
@@ -5,7 +5,7 @@ description: ""
 disclaimer: "The contents of this web site and the associated <a href=\"https://github.com/pmem\">GitHub repositories</a> are BSD-licensed open source."
 aliases: ["pmempool-feature.1.html"]
 title: "pmempool | PMDK"
-header: "pmem Tools version 1.4"
+header: "pmem Tools version 1.5"
 ---
 
 [comment]: <> (SPDX-License-Identifier: BSD-3-Clause)

--- a/doc/pmempool/pmempool-info.1.md
+++ b/doc/pmempool/pmempool-info.1.md
@@ -5,7 +5,7 @@ description: ""
 disclaimer: "The contents of this web site and the associated <a href=\"https://github.com/pmem\">GitHub repositories</a> are BSD-licensed open source."
 aliases: ["pmempool-info.1.html"]
 title: "pmempool | PMDK"
-header: "pmem Tools version 1.4"
+header: "pmem Tools version 1.5"
 ---
 
 [comment]: <> (SPDX-License-Identifier: BSD-3-Clause)
@@ -30,13 +30,6 @@ header: "pmem Tools version 1.4"
 ```
 $ pmempool info [<options>] <file>
 ```
-
-# NOTE #
-
-> NOTICE:
-
-The **libpmemblk** and **libpmemlog** libraries are deprecated (this affects pool types
-**blk**, **btt** and **log**) since PMDK 1.13.0 release.
 
 # DESCRIPTION #
 
@@ -69,42 +62,37 @@ The statistics are specific to the type of pool. See **STATISTICS** section for 
 Although the pool consistency is *not* checked by the *info* command,
 it prints information about checksum errors and/or offsets errors.
 
-##### Common options: #####
+##### Available options: #####
 
 By default the *info* command of **pmempool** prints information about the most important
 internal data structures from pool. The particular set of headers and meta-data depend on
 pool type. The pool type is recognized automatically and appropriate information is displayed
 in human-readable format.
 
-To force processing specified file(s) as desired pool type use **-f** option with appropriate
-name of pool type. The valid names off pool types are **blk**, **log**, **obj** or **btt**.
-This option may be useful when the pool header is corrupted and automatic recognition of
-pool type fails.
+To force processing specified file(s) as desired pool type use **-f** option
+with appropriate name of pool type. The valid name of the pool type is **obj**.
+This option may be useful when the pool header is corrupted and automatic
+recognition of pool type fails.
 
-`-f, --force blk|log|obj|btt`
+`-f, --force obj`
 
 Force parsing pool as specified pool type.
 
 >NOTE:
 By default only pool headers and internal meta-data are displayed.
 To display user data use **-d** option. Using **-r** option you can
-specify number of blocks/bytes/data chunks or objects using special
-text format. See **RANGE** section for details. The range refers to
-*block numbers* in case of pmem blk pool type, to *chunk numbers*
-in case of pmem log pool type and to *object numbers* in case of
-pmem obj pool type.
-See **EXAMPLES** section for an example of usage of these options.
+specify number of objects using special text format.
+See **RANGE** section for details. The range refers to
+*object numbers* in case of pmem obj pool type.
+See the **EXAMPLE** section for an example of usage of these options.
 
 `-d, --data`
 
 Dump user data in hexadecimal format.
-In case of pmem *blk* pool type data is dumped in *blocks*.
-In case of pmem *log* pool type data is dumped as a wholeor in *chunks* if **-w**
-option is used (See **Options for PMEMLOG** section for details).
 
 `-r, --range <range>`
 
-Range of blocks/data chunks/objects/zone headers/chunk headers/lanes.
+Range of objects/zone headers/chunk headers/lanes.
 See **RANGE** section for details about range format.
 
 `-n, --human`
@@ -129,35 +117,6 @@ Print bad blocks found in the pool.
 
 Display help message and exit.
 
-##### Options for PMEMLOG: #####
-
-`-w, --walk <size>`
-
-Use this option to walk through used data with fixed data chunk size.
-See **pmemlog_walk**(3) in **libpmemlog**(7) for details.
-
-##### Options for PMEMBLK: #####
-
-By default the *info* command displays the **pmemblk** header and
-BTT (Block Translation Table) Info header in case of **pmemblk** pool type.
-
-To display BTT Map and/or BTT FLOG (Free List and Log) use **-m**
-and **-g** options respectively or increase verbosity level.
-
-In order to display BTT Info header backup use **-B** option.
-
-`-m, --map`
-
-Print BTT Map entries.
-
-`-g, --flog`
-
-Print BTT FLOG entries.
-
-`-B, --backup`
-
-Print BTT Info header backup.
-
 >NOTE:
 By default the *info* command displays all data blocks when **-d** options is used.
 However it is possible to skip blocks marked with *zero* and/or *error* flags.
@@ -176,8 +135,6 @@ Skip blocks marked with *error* flag.
 `-u, --skip-no-flag`
 
 Skip blocks *not* marked with any flag.
-
-##### Options for PMEMOBJ: #####
 
 By default the *info* command displays pool header and **pmemobj** pool descriptor.
 In order to print information about other data structures one of the
@@ -270,43 +227,23 @@ You can specify multiple ranges separated by commas.
 
 `<first>-<last>`
 
-All blocks/bytes/data chunks from *\<first\>* to *\<last\>* will be dumped.
+All data chunks from *\<first\>* to *\<last\>* will be dumped.
 
 `-<last>`
 
-All blocks/bytes/data chunks up to *\<last\>* will be dumped.
+All data chunks up to *\<last\>* will be dumped.
 
 `<first>-`
 
-All blocks/bytes/data chunks starting from *\<first\>* will be dumped.
+All data chunks starting from *\<first\>* will be dumped.
 
 `<number>`
 
-Only *\<number\>* block/byte/data chunk will be dumped.
+Only *\<number\>* data chunk will be dumped.
 
 # STATISTICS #
 
-Below is the description of statistical measures for specific pool types.
-
-##### PMEMLOG #####
-
-+ **Total** - Total space in pool.
-+ **Available** - Size and percentage of available space.
-+ **Used** - Size and percentage of used space.
-
-##### PMEMBLK #####
-
-+ **Total blocks** - Total number of blocks in pool.
-+ **Zeroed blocks** - Number and percentage of blocks marked with *zero* flag.
-+ **Error blocks** - Number and percentage of blocks marked with *error* flag.
-+ **Blocks without any flag** - Number and percentage of blocks *not* marked with any flag.
-
->NOTE:
-In case of pmemblk, statistics are evaluated for blocks which meet requirements regarding:
-*range* of blocks (**-r** option),
-*skipped* types of blocks (**-z**, **-e**, **-u** options).
-
-##### PMEMOBJ #####
+Below is the description of statistical measures for the *obj* pool type.
 
 + **Object store**
 
@@ -335,31 +272,24 @@ In case of pmemblk, statistics are evaluated for blocks which meet requirements 
 # EXAMPLE #
 
 ```
-$ pmempool info ./pmemblk
+$ pmempool info pool.obj
 ```
 
-Parse and print information about "pmemblk" pool file.
+Parse and print information about pool.obj pool file.
 
 ```
-$ pmempool info -f blk ./pmempool
+$ pmempool info -d pool.obj
 ```
 
-Force parsing "pmempool" file as **pmemblk** pool type.
+Print information and data in hexadecimal dump format for the pool.obj file.
 
 ```
-$ pmempool info -d ./pmemlog
+$ pmempool info -d -r10-100 -eu pool.obj
 ```
 
-Print information and data in hexadecimal dump format for file "pmemlog".
-
-```
-$ pmempool info -d -r10-100 -eu ./pmemblk
-```
-
-Print information from "pmemblk" file. Dump data blocks from 10 to 100,
+Print information from the pool.obj file. Dump data chunks from 10 to 100,
 skip blocks marked with error flag and not marked with any flag.
 
 # SEE ALSO #
 
-**pmempool**(1), **libpmemblk**(7), **libpmemlog**(7),
-**libpmemobj**(7) and **<https://pmem.io>**
+**pmempool**(1), **libpmemobj**(7) and **<https://pmem.io>**

--- a/doc/pmempool/pmempool-rm.1.md
+++ b/doc/pmempool/pmempool-rm.1.md
@@ -5,7 +5,7 @@ description: ""
 disclaimer: "The contents of this web site and the associated <a href=\"https://github.com/pmem\">GitHub repositories</a> are BSD-licensed open source."
 aliases: ["pmempool-rm.1.html"]
 title: "pmempool | PMDK"
-header: "pmem Tools version 1.4"
+header: "pmem Tools version 1.5"
 ---
 
 [comment]: <> (SPDX-License-Identifier: BSD-3-Clause)
@@ -29,11 +29,6 @@ header: "pmem Tools version 1.4"
 $ pmempool rm [<options>] <file>..
 ```
 
-# NOTE #
-
-> NOTICE:
-The **libpmemblk** and **libpmemlog** libraries are deprecated since PMDK 1.13.0 release.
-
 # DESCRIPTION #
 
 The **pmempool rm** command removes each specified file. If the specified file
@@ -43,7 +38,7 @@ files. All pool files are removed using **unlink**(3) call,
 except the pools created on **device dax** which are zeroed instead.
 If specified file does not exist the **pmempool rm** command terminates with an error code.
 By default it prompts before removing *write-protected* files.
-See **EXAMPLES** section for example usage of the *rm* command.
+See the **EXAMPLE** section for an example usage of the *rm* command.
 
 ##### Available options: #####
 
@@ -78,7 +73,7 @@ Prompt before removing every single file.
 # EXAMPLE #
 
 ```
-$ pmempool rm pool.obj pool.blk
+$ pmempool rm pool1.obj pool2.obj
 ```
 
 Remove specified pool files.
@@ -87,15 +82,15 @@ Remove specified pool files.
 $ pmempool rm pool.set
 ```
 
-Remove all pool files from the "pool.set", do not remove *pool.set* itself.
+Remove all pool files defined in the *pool.set* file.
+Do not remove *pool.set* itself.
 
 ```
 $ pmempool rm -a pool.set
 ```
 
-Remove all pool files from the "pool.set".
+Remove all pool files defined in the *pool.set* file and remove the *pool.set* itself.
 
 # SEE ALSO #
 
-**pmempool**(1), **libpmemblk**(7), **libpmemlog**(7),
-**libpmemobj**(7) and **<https://pmem.io>**
+**pmempool**(1), **libpmemobj**(7) and **<https://pmem.io>**

--- a/doc/pmempool/pmempool-sync.1.md
+++ b/doc/pmempool/pmempool-sync.1.md
@@ -5,7 +5,7 @@ description: ""
 disclaimer: "The contents of this web site and the associated <a href=\"https://github.com/pmem\">GitHub repositories</a> are BSD-licensed open source."
 aliases: ["pmempool-sync.1.html"]
 title: "pmempool | PMDK"
-header: "pmem Tools version 1.4"
+header: "pmem Tools version 1.5"
 ---
 
 [comment]: <> (SPDX-License-Identifier: BSD-3-Clause)
@@ -16,7 +16,6 @@ header: "pmem Tools version 1.4"
 [NAME](#name)<br />
 [SYNOPSIS](#synopsis)<br />
 [DESCRIPTION](#description)<br />
-[EXAMPLES](#examples)<br />
 [SEE ALSO](#see-also)<br />
 
 # NAME #
@@ -31,11 +30,6 @@ pmempool sync [options] <poolset_file>
 
 NOTE: Only the pool set file used to create the pool should be used
 for syncing the pool.
-
-# NOTE #
-
-> NOTICE:
-The **libpmemblk** and **libpmemlog** libraries are deprecated since PMDK 1.13.0 release.
 
 # DESCRIPTION #
 
@@ -58,7 +52,7 @@ be opened are recreated.=e=)
 
 `-b, --bad-blocks`
 
-: Fix bad blocks - it causes creating or reading special recovery files.
+Fix bad blocks - it causes creating or reading special recovery files.
 When bad blocks are detected, special recovery files have to be created
 in order to fix them safely. A separate recovery file is created for each part
 of the pool. The recovery files are created in the same directory
@@ -67,8 +61,8 @@ where the poolset file is located using the following name pattern:
 These recovery files are automatically removed if the sync operation finishes
 successfully.
 
-	If the last sync operation was interrupted and not finished correctly
-(eg. the application crashed) and the bad blocks fixing procedure was
+If the last sync operation was interrupted and not finished correctly
+(e.g. the application crashed) and the bad blocks fixing procedure was
 in progress, the bad block recovery files may be left over. In such case
 bad blocks might have been cleared and zeroed, but the correct data from these
 blocks was not recovered (not copied from a healthy replica), so the recovery
@@ -79,24 +73,23 @@ bad blocks using the left-over bad block recovery files (the bad blocks
 will be read from the saved recovery files). Pmempool will delete the recovery
 files automatically at the end of the sync operation.
 
-	Using this option may have limitations depending on the operating system.
+Using this option may have limitations depending on the operating system.
 For details see description of the CHECK_BAD_BLOCKS feature
 in **pmempool-feature**(1).
 
 `-d, --dry-run`
 
-: Enable dry run mode. In this mode no changes are applied, only check for
+Enable dry run mode. In this mode no changes are applied, only check for
 viability of synchronization.
 
 `-v, --verbose`
 
-: Increase verbosity level.
+Increase verbosity level.
 
 `-h, --help`
 
-: Display help message and exit.
+Display help message and exit.
 
 # SEE ALSO #
 
-**pmempool(1)**, **libpmemblk(7)**, **libpmemlog(7)**,
-**libpmempool(7)** and **<https://pmem.io>**
+**pmempool(1)**, **libpmempool(7)** and **<https://pmem.io>**

--- a/doc/pmempool/pmempool-transform.1.md
+++ b/doc/pmempool/pmempool-transform.1.md
@@ -5,7 +5,7 @@ description: ""
 disclaimer: "The contents of this web site and the associated <a href=\"https://github.com/pmem\">GitHub repositories</a> are BSD-licensed open source."
 aliases: ["pmempool-transform.1.html"]
 title: "pmempool | PMDK"
-header: "pmem Tools version 1.4"
+header: "pmem Tools version 1.5"
 ---
 
 [comment]: <> (SPDX-License-Identifier: BSD-3-Clause)
@@ -28,11 +28,6 @@ header: "pmem Tools version 1.4"
 ```
 pmempool transform [options] <poolset_file_src> <poolset_file_dst>
 ```
-
-# NOTE #
-
-> NOTICE:
-The **libpmemblk** and **libpmemlog** libraries are deprecated since PMDK 1.13.0 release.
 
 # DESCRIPTION #
 
@@ -73,16 +68,16 @@ utilized for storing internal metadata of the pool part files.=e=)
 
 `-d, --dry-run`
 
-: Enable dry run mode. In this mode no changes are applied, only check for
+Enable dry run mode. In this mode no changes are applied, only check for
 viability of the operation is performed.
 
 `-v, --verbose`
 
-: Increase verbosity level.
+Increase verbosity level.
 
 `-h, --help`
 
-: Display help message and exit.
+Display help message and exit.
 
 # EXAMPLES #
 
@@ -151,5 +146,4 @@ unchanged and the size of the pool is still 60M.
 
 # SEE ALSO #
 
-**pmempool(1)**, **libpmemblk(7)**, **libpmemlog(7)**,
-**libpmempool(7)** and **<https://pmem.io>**
+**pmempool(1)**, **libpmemobj(7)**, **libpmempool(7)** and **<https://pmem.io>**

--- a/doc/pmempool/pmempool.1.md
+++ b/doc/pmempool/pmempool.1.md
@@ -5,7 +5,7 @@ description: ""
 disclaimer: "The contents of this web site and the associated <a href=\"https://github.com/pmem\">GitHub repositories</a> are BSD-licensed open source."
 aliases: ["pmempool.1.html"]
 title: "pmempool | PMDK"
-header: "pmem Tools version 1.4"
+header: "pmem Tools version 1.5"
 ---
 
 [comment]: <> (SPDX-License-Identifier: BSD-3-Clause)
@@ -30,11 +30,6 @@ header: "pmem Tools version 1.4"
 ```
 $ pmempool [--help] [--version] <command> [<args>]
 ```
-
-# NOTE #
-
-> NOTICE:
-The **libpmemblk** and **libpmemlog** libraries are deprecated since PMDK 1.13.0 release.
 
 # DESCRIPTION #
 
@@ -98,8 +93,8 @@ In order to get more information about specific *command* you can use **pmempool
 
 The debug logs are available only in the debug version of the tool,
 which is not provided by binary packages, but can be built from sources.
-The **pmempool.static_debug** binary blob can be found
-in the 'src/tools/pmempool/' subdirectory.
+The **pmempool.static-debug** binary can be found in the 'src/tools/pmempool/'
+subdirectory.
 
 + **PMEMPOOL_TOOL_LOG_LEVEL**
 
@@ -130,5 +125,4 @@ If **PMEMPOOL_TOOL_LOG_FILE** is not set, output is written to *stderr*.
 
 # SEE ALSO #
 
-**libpmemblk**(7), **libpmemlog**(7), **libpmemobj**(7)
-and **<https://pmem.io>**
+**libpmempool**(7) and **<https://pmem.io>**

--- a/src/tools/pmempool/README
+++ b/src/tools/pmempool/README
@@ -102,11 +102,7 @@ pmempool with *info* command should be invoked off-line. Using pmempool on
 pool file which may be modified by another process may lead to stopping
 processing the file.
 
-There is a set of common features for all pool types and a set of features
-specific for particular pool type.
-All features are described below.
-
-** Common features
+Below is the description of available features:
 
  * The basic function of *info* command is to print information about the
    most important internal data structures from specific pool. By default this
@@ -136,34 +132,6 @@ All features are described below.
    them in more human-readable formats with appropriate units
    (e.g. 4k, 8M, 16G).
 
-** Features for *log* pool type (DEPRECATED)
-
- * By default pmempool with *info* command displays the pool header, log pool
-   type specific header and statistics. It is possible to print data in
-   hexadecimal format by passing appropriate command line option.
-
- * It is possible to walk through the usable data using fixed data chunk size.
-   This feature uses similar approach as pmemlog_walk() function. For details
-   please refer to libpmemlog(7).
-
-** Features for *blk* pool type (DEPRECATED)
-
- * By default pmempool with *info* command displays the pool header, blk pool
-   type specific header, BTT Info header and statistics.
-
- * It is possible to print more headers and internal data by passing specific
-   command line options. It is possible to print the following sections:
-   BTT Map entries, BTT FLOG, BTT Info backup and data blocks.
-
- * It is possible to print specific range of blocks in both absolute or relative
-   manner (e.g. display blocks from 10 to 1000, display 10 blocks starting from
-   block number 1000)
-
- * By default when displaying data blocks all blocks are displayed. However it
-   is possible to skip blocks marked with zero or error flags, or to skip blocks
-   which are not marked by any flag. Skipping blocks has impact on blocks ranges
-   (e.g. display 10 blocks marked with error flag in the range from 0 to 10000)
-
 2.2. check
 ----------
 
@@ -171,33 +139,17 @@ The pmempool invoked with *check* command checks existing pool's consistency.
 If the pool is consistent pmempool exits with exit code 0. Otherwise nonzero
 error code is returned and appropriate message is displayed.
 
-In addition it may also try to fix some common known errors upon explicit demand
-of user. In this case a pool file will be opened in read-write mode so the user
-should be aware of modifications made by pmempool application.
-
 Below is the description of available features:
 
- * By default pmempool with *check* command prints brief description about
+ * Pmempool with *check* command prints brief description about
    encountered error(s) and proper error value is returned. If there is no error
    nothing is printed and exit code is 0.
-
- * If an error is encountered while checking a consistency of a pool it is
-   possible to try to fix all errors. In this case the pool file will be opened
-   in read-write mode.
-
- * User may request to _not_ modify pool's file when trying to repair it but
-   just to report what would be done if the repair was performed.
-
- * When repairing a pool user may request to create backup before any
-   modification is made. If it is not possible to create full backup of existing
-   pool, the process will terminate.
 
 2.3. create
 -----------
 
-The pmempool invoked with *create* command creates a pool file of specific
-type and size. Depending on pool's type it is possible to provide more desired
-properties of a pool.
+The pmempool invoked with the *create* command creates a pool file of a specific
+type and size.
 
 Below is the description of available features:
 
@@ -227,12 +179,6 @@ Below is the description of available features:
 
  * By default data is dumped to standard output. However it is possible to
    specify a file name to dump data into.
-
- * In case of pmem blk pool type it is possible to set range of blocks in either
-   absolute or relative manner. (DEPRECATED)
-
- * In case of pmem log pool type it is possible to set size of chunk and range
-   of chunks to dump in either absolute or relative manner. (DEPRECATED)
 
 2.5. rm
 -------


### PR DESCRIPTION
Adjust the pmempool documentation to follow the removal of blk/log/btt support from pmempool.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5759)
<!-- Reviewable:end -->
