### PR TITLE
test: explicit failure if Valgrind is explicitly required but not installed

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@
 	- removes libpmemblk/libpmemlog source code and documentation
 	- removes support for Travis bulids
 	- removes libvmem and libvmmalloc folders
+	- adds explicit test failure when Valgrind is not installed but required
 	- ...
 
 Wed May 31 2023 Oksana Sałyk <oksana.salyk@intel.com>

--- a/src/test/RUNTESTS.sh
+++ b/src/test/RUNTESTS.sh
@@ -315,7 +315,9 @@ runtest() {
 			do
 				export RUNTEST_DIR=$1
 				export RUNTEST_PARAMS="TEST=$ttype FS=$fs BUILD=$build"
-				export RUNTEST_EXTRA="CHECK_TYPE=$checktype CHECK_POOL=$check_pool \
+				export RUNTEST_EXTRA="CHECK_TYPE=$checktype \
+					FORCE_CHECK_TYPE=$checktype \
+					CHECK_POOL=$check_pool \
 					$special_params"
 				export RUNTEST_SCRIPT="$runscript"
 				export RUNTEST_TIMEOUT="$req_timeout"

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1442,8 +1442,14 @@ function require_valgrind() {
 	local ret=$?
 	restore_exit_on_error
 	if [ $ret -ne 0 ]; then
-		msg "$UNITTEST_NAME: SKIP valgrind required"
-		exit 0
+		if [ "$FORCE_CHECK_TYPE" != "none" ]; then
+			msg=$(interactive_red STDOUT "FAIL:")
+			echo -e "$UNITTEST_NAME: $msg valgrind not installed"
+			exit 1
+		else
+			msg "$UNITTEST_NAME: SKIP valgrind required"
+			exit 0
+		fi
 	fi
 }
 

--- a/src/test/unittest/valgrind.py
+++ b/src/test/unittest/valgrind.py
@@ -76,7 +76,7 @@ class Valgrind:
 
     """
 
-    def __init__(self, tool, cwd, testnum):
+    def __init__(self, tool, cwd, testnum, valgrind_required):
         self.tool = NONE if tool is None else tool
         self.tool_name = self.tool.name.lower()
         self.cwd = cwd
@@ -87,7 +87,7 @@ class Valgrind:
         if self.tool == NONE:
             self.valgrind_exe = None
         else:
-            self.valgrind_exe = self._get_valgrind_exe()
+            self.valgrind_exe = self._get_valgrind_exe(valgrind_required)
 
         if self.valgrind_exe is None:
             return
@@ -161,8 +161,8 @@ class Valgrind:
 
             else:
                 vg_tool = config.force_enable
-
-        return [cls(vg_tool, tc.cwd, tc.testnum, **kwargs), ]
+        return [cls(vg_tool, tc.cwd, tc.testnum,
+                    config.force_enable is not None, **kwargs), ]
 
     @property
     def cmd(self):
@@ -184,7 +184,7 @@ class Valgrind:
     def check(self, **kwargs):
         self.validate_log()
 
-    def _get_valgrind_exe(self):
+    def _get_valgrind_exe(self, valgrind_required):
         """
         On some systems "valgrind" is a shell script that calls the actual
         executable "valgrind.bin".
@@ -193,9 +193,12 @@ class Valgrind:
         """
         try:
             out = sp.check_output('which valgrind', shell=True,
-                                  universal_newlines=True)
+                                  universal_newlines=True, stderr=sp.STDOUT)
         except sp.CalledProcessError:
-            raise futils.Skip('Valgrind not found')
+            if valgrind_required:
+                raise futils.Fail('Valgrind not found')
+            else:
+                raise futils.Skip('Valgrind not found')
 
         valgrind_bin = path.join(path.dirname(out), 'valgrind.bin')
         if path.isfile(valgrind_bin):


### PR DESCRIPTION
Fail all Valgrind tests when --force-enable option is used for RUNTESTS.[sh|py] and Valgrind is not installed.