### PR TITLE
test: disable pmempool_sync/TEST18 until #5708 is fixed

### DIFF
--- a/src/test/pmempool_sync/TEST18
+++ b/src/test/pmempool_sync/TEST18
@@ -11,6 +11,9 @@
 
 . ../unittest/unittest.sh
 
+# XXX Disable tests for all configurations until the issue #5708 is fixed.
+DISABLED
+
 require_test_type medium
 require_fs_type any
 


### PR DESCRIPTION
Disable tests for all configurations until issue #5708 is fixed.

Requires:
- [x] #5789

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5796)
<!-- Reviewable:end -->
