### PR TITLE
test: avoid unnecessary skip in case of different expected test type

### DIFF
--- a/src/test/libpmempool_backup/TEST6
+++ b/src/test/libpmempool_backup/TEST6
@@ -9,13 +9,12 @@
 
 . ../unittest/unittest.sh
 
-EXE=../libpmempool_api/libpmempool_test$EXESUFFIX
+require_test_type medium
 
 # This test memcpy + persist entire pool, and it runs
 # forever under pmemcheck.
+EXE=../libpmempool_api/libpmempool_test$EXESUFFIX
 configure_valgrind pmemcheck force-disable $EXE
-
-require_test_type medium
 
 require_fs_type pmem non-pmem
 

--- a/src/test/obj_many_size_allocs/TEST0
+++ b/src/test/obj_many_size_allocs/TEST0
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2015-2019, Intel Corporation
+# Copyright 2015-2023, Intel Corporation
 #
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
@@ -36,10 +36,10 @@
 
 . ../unittest/unittest.sh
 
+require_test_type long
+
 # covered by TEST3
 configure_valgrind memcheck force-disable
-
-require_test_type long
 
 setup
 

--- a/src/test/obj_pmalloc_mt/TEST0
+++ b/src/test/obj_pmalloc_mt/TEST0
@@ -9,9 +9,9 @@
 
 . ../unittest/unittest.sh
 
-require_valgrind 3.10
 require_fs_type pmem non-pmem
 require_test_type long
+require_valgrind 3.10
 configure_valgrind helgrind force-enable
 setup
 

--- a/src/test/obj_pmalloc_mt/TEST2
+++ b/src/test/obj_pmalloc_mt/TEST2
@@ -9,9 +9,9 @@
 
 . ../unittest/unittest.sh
 
-require_valgrind 3.10
 require_fs_type pmem non-pmem
 require_test_type medium
+require_valgrind 3.10
 configure_valgrind helgrind force-enable
 setup
 

--- a/src/test/obj_pmalloc_mt/TEST3
+++ b/src/test/obj_pmalloc_mt/TEST3
@@ -9,9 +9,9 @@
 
 . ../unittest/unittest.sh
 
-require_valgrind 3.10
 require_fs_type pmem non-pmem
 require_test_type long
+require_valgrind 3.10
 configure_valgrind drd force-enable
 setup
 

--- a/src/test/obj_pmalloc_rand_mt/TEST0
+++ b/src/test/obj_pmalloc_rand_mt/TEST0
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2017-2019, Intel Corporation
+# Copyright 2017-2023, Intel Corporation
 
 #
 # src/test/obj_pmalloc_rand_mt/TEST0 -- multithreaded allocator test
@@ -8,9 +8,9 @@
 
 . ../unittest/unittest.sh
 
-require_valgrind 3.10
 require_fs_type pmem
 require_test_type long
+require_valgrind 3.10
 configure_valgrind helgrind force-enable
 setup
 

--- a/src/test/obj_reserve_mt/TEST0
+++ b/src/test/obj_reserve_mt/TEST0
@@ -9,9 +9,9 @@
 
 . ../unittest/unittest.sh
 
-require_valgrind 3.10
 require_fs_type pmem non-pmem
 require_test_type long
+require_valgrind 3.10
 configure_valgrind helgrind force-enable
 setup
 

--- a/src/test/obj_reserve_mt/TEST2
+++ b/src/test/obj_reserve_mt/TEST2
@@ -9,9 +9,9 @@
 
 . ../unittest/unittest.sh
 
-require_valgrind 3.10
 require_fs_type pmem non-pmem
 require_test_type medium
+require_valgrind 3.10
 configure_valgrind helgrind force-enable
 setup
 

--- a/src/test/obj_reserve_mt/TEST3
+++ b/src/test/obj_reserve_mt/TEST3
@@ -9,9 +9,9 @@
 
 . ../unittest/unittest.sh
 
-require_valgrind 3.10
 require_fs_type pmem non-pmem
 require_test_type long
+require_valgrind 3.10
 configure_valgrind drd force-enable
 setup
 

--- a/src/test/obj_tx_alloc_mt/TEST0
+++ b/src/test/obj_tx_alloc_mt/TEST0
@@ -9,9 +9,9 @@
 
 . ../unittest/unittest.sh
 
-require_valgrind 3.10
 require_fs_type pmem non-pmem
 require_test_type long
+require_valgrind 3.10
 configure_valgrind helgrind force-enable
 setup
 

--- a/src/test/obj_tx_alloc_mt/TEST2
+++ b/src/test/obj_tx_alloc_mt/TEST2
@@ -9,9 +9,9 @@
 
 . ../unittest/unittest.sh
 
-require_valgrind 3.10
 require_fs_type pmem non-pmem
 require_test_type medium
+require_valgrind 3.10
 configure_valgrind helgrind force-enable
 setup
 

--- a/src/test/obj_tx_flow/TEST0
+++ b/src/test/obj_tx_flow/TEST0
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2015-2019, Intel Corporation
+# Copyright 2015-2023, Intel Corporation
 
 #
 # src/test/obj_tx_flow/TEST0 -- unit test for transaction flow
@@ -9,9 +9,9 @@
 . ../unittest/unittest.sh
 
 # this test verifies the correctness of the tx management functions only
-configure_valgrind pmemcheck force-disable
-
 require_test_type medium
+
+configure_valgrind pmemcheck force-disable
 
 setup
 

--- a/src/test/obj_tx_locks/TEST0
+++ b/src/test/obj_tx_locks/TEST0
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2015-2019, Intel Corporation
+# Copyright 2015-2023, Intel Corporation
 
 #
 # src/test/obj_tx_locks/TEST0 -- unit test for transaction locks
@@ -9,9 +9,9 @@
 . ../unittest/unittest.sh
 
 # this test verifies the correctness of the tx management functions only
-configure_valgrind pmemcheck force-disable
-
 require_test_type medium
+
+configure_valgrind pmemcheck force-disable
 
 setup
 

--- a/src/test/obj_zones/TEST0
+++ b/src/test/obj_zones/TEST0
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2017-2019, Intel Corporation
+# Copyright 2017-2023, Intel Corporation
 
 . ../unittest/unittest.sh
 
+require_test_type medium
+
 # too large
 configure_valgrind force-disable
-
-require_test_type medium
 
 setup
 

--- a/src/test/obj_zones/TEST1
+++ b/src/test/obj_zones/TEST1
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2019, Intel Corporation
+# Copyright 2023, Intel Corporation
 
 . ../unittest/unittest.sh
 
+require_test_type medium
+
 # too large
 configure_valgrind force-disable
-
-require_test_type medium
 
 # runs too long on debug builds
 require_build_type nondebug


### PR DESCRIPTION
configure_valgrind and require_valgrind shall be used after require_test_type and require_fs_type to avoid SKIPs with message due to unsupported/unselected Valgrind configuration.

In case of require_test_type and require_fs_type the SKIP is executed but without message added to a test log.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5799)
<!-- Reviewable:end -->
