### PR TITLE
common: fix ndctl & jq detection for testconfig generation

### DIFF
--- a/utils/create-testconfig.sh
+++ b/utils/create-testconfig.sh
@@ -59,7 +59,7 @@ TM=1
 # lookup all Device DAX devices in the system
 DEVICE_DAX_PATH=
 device_dax_path=
-if [ `which ndctl` -a `which jq` ]; then
+if which ndctl > /dev/null 2>&1 && which jq > /dev/null 2>&1; then
     DEVICE_DAX_PATH="$(ndctl list -X | jq -r '.[].daxregion.devices[].chardev' | awk '$0="/dev/"$0' | paste -sd' ')"
     device_dax_path="$(ndctl list -X | jq -r '.[].daxregion.devices[].chardev' | awk '$0="'\''/dev/"$0"'\''"' | paste -sd',')"
 fi


### PR DESCRIPTION
Currently, it does not work as intended and looks really ugly in the output when fails.

https://github.com/pmem/pmdk/actions/runs/5599256917/jobs/10240056624?pr=5807#step:5:27

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5809)
<!-- Reviewable:end -->
