### PR TITLE
test: 'none' value of force-enable to optimize PMem workflow

### DIFF
--- a/.github/workflows/pmem_valgrind.yml
+++ b/.github/workflows/pmem_valgrind.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         script: ['sh', 'py']
-        config: ['drd', 'pmemcheck', 'memcheck', 'helgrind']
+        config: ['none', 'drd', 'pmemcheck', 'memcheck', 'helgrind']
         build: ['debug', 'nondebug']
         os: [[self-hosted, rhel],[self-hosted, opensuse]]
 

--- a/src/test/README
+++ b/src/test/README
@@ -65,7 +65,7 @@ RUNTESTS.sh takes options to limit what it runs.  The usage is:
  RUNTESTS.sh [ -hnv ] [ -b build-type ] [ -t test-type ] [ -f fs-type ]
 	    [ -o timeout ] [ -s test-file ] [ -k skip-dir ]
 	    [[ -m memcheck ] [-p pmemcheck ] [ -e helgrind ] [ -d drd ] ||
-	      [ --force-enable memcheck|pmemcheck|helgrind|drd ]] [ -c ]
+	      [ --force-enable memcheck|pmemcheck|helgrind|drd|none ]] [ -c ]
 	    [tests...]
 
  Build types are: debug, nondebug, static_debug, static_nondebug, all (default)
@@ -77,7 +77,7 @@ RUNTESTS.sh takes options to limit what it runs.  The usage is:
 		 Default value is 3 minutes.
  Test file is: a name of the particular test script (test case).
 		 all (default), TEST0, TEST1, ...
- Memcheck, helgrind, drd and pmemcheck modes are:
+ memcheck, helgrind, drd and pmemcheck modes are:
 		 auto (default, enable/disable based on test requirements),
 		 force-enable (enable when test does not require given valgrind tool,
 		 but obey test's explicit tool disable)

--- a/src/test/RUNTESTS.sh
+++ b/src/test/RUNTESTS.sh
@@ -16,7 +16,7 @@ usage()
 Usage: $0 [ -hnv ] [ -b build-type ] [ -t test-type ] [ -f fs-type ]
 		[ -o timeout ] [ -s test-file | -u test-sequence ] [-k skip-dir ]
 		[[ -m memcheck ] [-p pmemcheck ] [ -e helgrind ] [ -d drd ] ||
-		[ --force-enable memcheck|pmemcheck|helgrind|drd ]]
+		[ --force-enable memcheck|pmemcheck|helgrind|drd|none ]]
 		[ -c ] [tests...]
 -h			print this help message
 -n			dry run
@@ -53,7 +53,7 @@ Usage: $0 [ -hnv ] [ -b build-type ] [ -t test-type ] [ -f fs-type ]
 			drd: auto (default, enable/disable based on test requirements),
 			force-enable (enable when test does not require drd, but
 			obey test's explicit drd disable)
---force-enable memcheck|pmemcheck|helgrind|drd
+--force-enable memcheck|pmemcheck|helgrind|drd|none
 			allows to force the use of a specific valgrind tool,
 			but skips tests where the tool is explicitly disabled
 			Can not be use with -m, -p, -e, -d.
@@ -455,6 +455,9 @@ do
 
 		case "$receivetype"
 		in
+		none)
+			forcechecktype=$receivetype
+			;;
 		memcheck|pmemcheck|helgrind|drd)
 			;;
 		*)

--- a/src/test/unittest/configurator.py
+++ b/src/test/unittest/configurator.py
@@ -136,7 +136,7 @@ def _str2ctx(config):
     convert_internal('test_type', test_types._TestType)
     convert_internal('granularity', granularity.Granularity)
 
-    if config['force_enable'] is not None:
+    if config['force_enable'] is not None and config['force_enable'] != 'none':
         config['force_enable'] = next(
             t for t in vg.TOOLS
             if t.name.lower() == config['force_enable'])
@@ -288,7 +288,10 @@ class Configurator():
         tracers.add_argument('--cgdb', dest='tracer', action='store_const',
                              const='cgdb --args', help='run cgdb as a tracer')
 
-        fe_choices = [str(t) for t in vg.TOOLS]
-        parser.add_argument('--force-enable', choices=fe_choices, default=None)
+        fe_choices = [str(t) for t in vg.TOOLS] + ['none']
+        parser.add_argument('--force-enable', choices=fe_choices, default=None,
+                            help='allows to force the use of a specific '
+                            'valgrind tool, but skips tests where the tool is '
+                            'explicitly disabled')
 
         return parser

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1441,6 +1441,10 @@ function valgrind_version_no_check() {
 #	valgrind package is installed
 #
 function require_valgrind() {
+	if [ "$FORCE_CHECK_TYPE" == "none" ]; then
+		msg "$UNITTEST_NAME: SKIP valgrind test"
+		exit 0
+	fi
 	# bc is used inside valgrind_version_no_check
 	require_command bc
 	require_no_asan


### PR DESCRIPTION
With the `none` parameter added to the matrix, only one workflow
is needed to run all tests (with and without Valgrind)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5811)
<!-- Reviewable:end -->
