### PR TITLE
Update configure runner and opensuse setup scripts

### DIFF
--- a/utils/ansible/configure-self-hosted-runner.yml
+++ b/utils/ansible/configure-self-hosted-runner.yml
@@ -37,7 +37,7 @@
 #  connection: local
   vars:
     testUser: pmdkuser
-    package_url: https://github.com/actions/runner/releases/download/v2.304.0/actions-runner-linux-x64-2.304.0.tar.gz
+    package_url: https://github.com/actions/runner/releases/download/v2.306.0/actions-runner-linux-x64-2.306.0.tar.gz
     runner_folder: /home/{{ testUser }}/actions-runner
     repo_url: https://github.com/pmem/pmdk
     vars_list: "{{ vars_gha.split(',') }}"
@@ -59,7 +59,15 @@
         remote_src: yes
 
     - name: "Change owner to {{ testUser }}"
-      shell: chown -R {{ testUser }} {{ runner_folder }}
+      shell: chown -R $(id -u {{ testUser }}).$(id -g {{ testUser }}) {{ runner_folder }}
+
+    # Make sure the following environment variables are present in the env
+    # to ensure propagation to the actions-runner environment.
+    - name: "Add env variables into env.sh checklist"
+      lineinfile:
+        path: "{{ runner_folder }}/env.sh"
+        line: "    'PKG_CONFIG_PATH'\n    'HOME'"
+        insertafter: "^varCheckList=\\("
 
     - name: "Add runner to GHA"
       shell: |

--- a/utils/ansible/opensuse-setup.yml
+++ b/utils/ansible/opensuse-setup.yml
@@ -145,9 +145,6 @@
     - name: "Install valgrind from source"
       script: ../docker/images/install-valgrind.sh
 
-    - name: "Run the install-libndctl script with arguments"
-      script: ../docker/images/install-libndctl.sh tags/v70.1
-
     # Disable AppArmor. 
     # AppArmor may block proper GHA runner installation and startup.
     # ==`Suse` condition is inherited from the original version of 


### PR DESCRIPTION
- Update actions-runner release version to v2.306.0,
- choch should also change the group for actions-runner folder,
- ensure HOME and PKG_CONFIG_PATH are propagated to actions-runner environment
- remove stale reference to install-libndctl.sh in opensuse-setup