### PR TITLE
common: why Python-based tests are not used for package testing

### DIFF
--- a/utils/docker/run-build-package.sh
+++ b/utils/docker/run-build-package.sh
@@ -82,6 +82,8 @@ PMDK_LIB_PATH_DEBUG=$PMDK_LIB_PATH_NONDEBUG/$DEBUG_DIR
 EOF
 
 ./RUNTESTS.sh -t check
+# XXX The Python-based test framework is not able yet to run tests against
+# binaries installed in the system. https://github.com/pmem/pmdk/issues/5839
 popd
 
 popd


### PR DESCRIPTION
Ref: #5839

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5840)
<!-- Reviewable:end -->
