### PR TITLE
test: replace a confusing message with a comment

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1398,7 +1398,9 @@ function configure_valgrind() {
 
 	if [ "$CHECK_TYPE" == "none" ]; then
 		if [ "$1" == "force-disable" ]; then
-			msg "$UNITTEST_NAME: all valgrind tests disabled"
+			# The test requires Valgrind to be disabled and no Valgrind tool
+			# is forced by the user. The requirement is met.
+			:
 		elif [ "$2" = "force-enable" ]; then
 			CHECK_TYPE="$1"
 			require_valgrind_tool $1 $3


### PR DESCRIPTION
There is no practice of verbosely stating that the given requirement was met. What is more, this message was particularly confusing since no user-forced Valgrind tool does not mean no Valgrind test will be run. If a given test requires a Valgrind tool it still will be used.

Hence, the decision to replace it with a comment hopefully more precisely describing the situation and definitely less polluting the console.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5844)
<!-- Reviewable:end -->
