### PR TITLE
test: fix CHECK_TYPE behaviour

### DIFF
--- a/src/test/RUNTESTS.sh
+++ b/src/test/RUNTESTS.sh
@@ -315,10 +315,8 @@ runtest() {
 			do
 				export RUNTEST_DIR=$1
 				export RUNTEST_PARAMS="TEST=$ttype FS=$fs BUILD=$build"
-				# FORCE_CHECK_TYPE is required for easy force-enable condition failure detection.
-				# Please see require_valgrind() for details.
 				export RUNTEST_EXTRA="CHECK_TYPE=$checktype \
-					FORCE_CHECK_TYPE=$checktype \
+					DISABLE_VALGRIND_TESTS=$disable_valgrind_tests \
 					CHECK_POOL=$check_pool \
 					$special_params"
 				export RUNTEST_SCRIPT="$runscript"
@@ -369,6 +367,7 @@ testfile=all
 testseq=all
 check_pool=0
 checktype="none"
+disable_valgrind_tests=0
 skip_dir=""
 keep_going=n
 keep_going_skip=n
@@ -456,15 +455,15 @@ do
 		case "$receivetype"
 		in
 		none)
-			forcechecktype=$receivetype
+			disable_valgrind_tests=1
 			;;
 		memcheck|pmemcheck|helgrind|drd)
+			checktype=$receivetype
 			;;
 		*)
 			usage "bad force-enable: $receivetype"
 			;;
 		esac
-		checktype=$receivetype
 		;;
 	-k)
 		skip_dir="$skip_dir $2"

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -46,6 +46,10 @@ fi
 . ../testconfig.sh
 . ../envconfig.sh
 
+# Required for easy force-enable condition failure detection.
+# Please see require_valgrind() for details.
+FORCED_CHECK_TYPE=$CHECK_TYPE
+
 if [ -t 1 ]; then
 	IS_TERMINAL_STDOUT=YES
 fi
@@ -1441,8 +1445,9 @@ function valgrind_version_no_check() {
 #	valgrind package is installed
 #
 function require_valgrind() {
-	if [ "$FORCE_CHECK_TYPE" == "none" ]; then
-		msg "$UNITTEST_NAME: SKIP valgrind test"
+	if [ "$DISABLE_VALGRIND_TESTS" == "1" ]; then
+		msg=$(interactive_yellow STDOUT "SKIP:")
+		echo -e "$UNITTEST_NAME: $msg all Valgrind tests are disabled"
 		exit 0
 	fi
 	# bc is used inside valgrind_version_no_check
@@ -1453,17 +1458,18 @@ function require_valgrind() {
 	local ret=$?
 	restore_exit_on_error
 	if [ $ret -ne 0 ]; then
-		# FORCE_CHECK_TYPE is basically a copy of CHECK_TYPE as it is provided by force-enable.
+		# FORCED_CHECK_TYPE is a copy of CHECK_TYPE as it is provided by force-enable.
 		# This copy allowed us to workaround the overcomplicated legacy Valgrind processing logic
 		# and here just check whether any Valgrind tool has been force-enabled or not.
 		# Lack of Valgrind when it is force-enabled causes test failure.
 		# Lack of Valgrind, when it was just required by the given test, causes a skip.
-		if [ "$FORCE_CHECK_TYPE" != "none" ]; then
+		if [ "$FORCED_CHECK_TYPE" != "none" ]; then
 			msg=$(interactive_red STDOUT "FAIL:")
-			echo -e "$UNITTEST_NAME: $msg valgrind not installed"
+			echo -e "$UNITTEST_NAME: $msg Valgrind not installed"
 			exit 1
 		else
-			msg "$UNITTEST_NAME: SKIP valgrind required"
+			msg=$(interactive_yellow STDOUT "SKIP:")
+			echo -e "$UNITTEST_NAME: $msg Valgrind required"
 			exit 0
 		fi
 	fi


### PR DESCRIPTION
- By default, no Valgrind tool has been forced, and a Valgrind tool or lack of it will be picked depending on the particular test's requirements.
- Providing 'force-enable [memcheck|pmemcheck|helgrind|drd]' will force all tests to be run under the forced Valgrind tool unless a test forced a different Valgrind tool in which case the given will test will be skipped.
- Providing 'force-enable none' will run all tests that do not require explicitly any Valgrind tool and skip all other tests.

Ref: #5811
Ref: #5791

# No `force-enable` provided - regression and fix

PMem Long (no force-enable provided)

Before regression: https://github.com/pmem/pmdk/actions/runs/5838427329/job/15835451743
After regression: https://github.com/pmem/pmdk/actions/runs/5908491536/job/16027995086
After fix: https://github.com/pmem/pmdk/actions/runs/5927643088/job/16071573582

# Explicit `force-enable` is provided - no change

PMem Valgrind (force-enable: none)

Before fix: https://github.com/pmem/pmdk/actions/runs/5925859348/job/16066125162#step:6:125
After fix: https://github.com/pmem/pmdk/actions/runs/5927719561/job/16071794659#step:6:125

PMem Valgrind (force-enable: pmemcheck)

Before fix: https://github.com/pmem/pmdk/actions/runs/5914014610/job/16038896782
After fix: https://github.com/pmem/pmdk/actions/runs/5927719561/job/16071794960

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5868)
<!-- Reviewable:end -->
