### PR TITLE
doc: rename 1.14.0 to 2.0.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -60,7 +60,7 @@ Wed Apr 26 2023 Łukasz Stolarczuk <lukasz.stolarczuk@intel.com>
 	Known issues:
 	- The latest validation cycle exposed previously unknown persistency issues
 	related to pmem2 async functions (DEPRECATED) and miniasync (EXPERIMENTAL):
-	#5596 and #5597. Both will be removed in the PMDK 1.14 release. These issues
+	#5596 and #5597. Both will be removed in the PMDK 2.0 release. These issues
 	do NOT affect any other PMDK library.
 
 Tue Aug 25 2022 Łukasz Plewa <lukasz.plewa@intel.com>

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Libraries available in this repository:
 
 > NOTICE:
 Support for async functions is deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release along with the miniasync dependency.
+and will be removed in the PMDK 2.0.0 release along with the miniasync dependency.
 
 - [libpmemobj](https://pmem.io/pmdk/libpmemobj/):  provides a transactional object store, providing memory allocation, transactions, and general facilities for persistent memory programming.
 
@@ -55,13 +55,13 @@ and will be removed in the PMDK 1.14.0 release along with the miniasync dependen
 
 > NOTICE:
 The **libpmemblk** library is deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 - [libpmemlog](https://pmem.io/pmdk/libpmemlog/):  provides a pmem-resident log file. (DEPRECATED)
 
 > NOTICE:
 The **libpmemlog** library is deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 - [libpmempool](https://pmem.io/pmdk/libpmempool/):  provides support for off-line pool management and diagnostics.
 
@@ -84,7 +84,7 @@ For information on how these libraries are licensed, see our [LICENSE](LICENSE) 
 
 > NOTICE:
 Support for Windows and FreeBSD are deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 ><sup>1</sup> Not supported on Windows.
 >
@@ -113,7 +113,7 @@ Additionally, we recommend reading [Introduction to Programming with Persistent 
 
 > NOTICE:
 Support for Windows is deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 The recommended and easiest way to install PMDK on Windows is to use Microsoft vcpkg. Vcpkg is an open source tool and ecosystem created for library management.
 
@@ -169,7 +169,7 @@ see https://github.com/pmem/pmdk/issues/4207.
 
 > NOTICE:
 Support for Windows is deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 * **MS Visual Studio 2022**
 * [Windows SDK 10.0.22000.0](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/)
@@ -181,7 +181,7 @@ and will be removed in the PMDK 1.14.0 release.
 
 > NOTICE:
 Support for FreeBSD is deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 * **autoconf**
 * **bash**
@@ -199,7 +199,7 @@ and will be removed in the PMDK 1.14.0 release.
 
 > NOTICE:
 Support for FreeBSD is deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 To build from source, clone this tree:
 ```
@@ -304,7 +304,7 @@ This requires **devscripts** to be installed.
 
 > NOTICE:
 Support for FreeBSD is deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 You will need to install the following package to run unit tests:
 * **ndctl**
@@ -351,7 +351,7 @@ and UndefinedBehaviorSanitizer, run:
 
 > NOTICE:
 Support for Windows is deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 Clone the PMDK tree and open the solution:
 ```
@@ -367,7 +367,7 @@ Select the desired configuration (Debug or Release) and build the solution
 
 > NOTICE:
 Support for Windows is deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 Before running the tests, you may need to prepare a test configuration file (src/test/testconfig.ps1). Please see the available configuration settings in the example file [src/test/testconfig.ps1.example](src/test/testconfig.ps1.example).
 

--- a/doc/README
+++ b/doc/README
@@ -30,7 +30,7 @@ pmempool -- persistent memory pool management tool
 daxio -- perform I/O on Device DAX device
 
 NOTE: Support for Windows and FreeBSD are deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 These man pages provide the API specification for the corresponding libraries
 and commands in this source tree, so any updates to one should be tested,

--- a/doc/RELEASE_STEPS.md
+++ b/doc/RELEASE_STEPS.md
@@ -9,8 +9,8 @@ of the PMDK repository. The second commit is required to restore a "default" sta
 As a helper you can export these 2 variables in your bash - with proper version set:
 
 ```bash
-export VERSION=1.14.0-rc1   # the full version of the new release; -rc1 included just as an example
-export VER=1.14             # the major+minor only version
+export VERSION=2.0.0-rc1   # the full version of the new release; -rc1 included just as an example
+export VER=2.0             # the major+minor only version
 ```
 
 ## 1. Make a release locally

--- a/doc/libpmem/libpmem.7.md
+++ b/doc/libpmem/libpmem.7.md
@@ -30,7 +30,7 @@ header: "pmem API version 1.1"
 
 >NOTE:
 Support for Windows and FreeBSD are deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 # SYNOPSIS #
 

--- a/doc/libpmem2/libpmem2.7.md
+++ b/doc/libpmem2/libpmem2.7.md
@@ -30,7 +30,7 @@ header: "pmem2 API version 1.0"
 
 >NOTE:
 Support for Windows and FreeBSD deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 # SYNOPSIS #
 

--- a/doc/libpmem2/pmem2_async.3.md
+++ b/doc/libpmem2/pmem2_async.3.md
@@ -25,7 +25,7 @@ header: "pmem2 API version 1.0"
 
 > NOTICE:
 Support for async functions is deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release along with the miniasync dependency.
+and will be removed in the PMDK 2.0.0 release along with the miniasync dependency.
 
 # SYNOPSIS #
 
@@ -85,4 +85,3 @@ The **pmem2_memset_async** returns a new instance of **pmem2_future** performing
 **pmem2_get_memcpy_fn**(3), **pmem2_get_memset_fn**(3), **pmem2_map_new**(3),
 **pmem2_get_persist_fn**(3), **vdm_memcpy**(3), **miniasync**(7), **miniasync_future**(7),
 **libpmem2**(7) and **<https://pmem.io>**
-

--- a/doc/libpmemblk/libpmemblk.7.md
+++ b/doc/libpmemblk/libpmemblk.7.md
@@ -30,7 +30,7 @@ header: "pmemblk API version 1.1"
 
 >NOTE:
 Support for Windows and FreeBSD deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 # SYNOPSIS #
 
@@ -308,7 +308,7 @@ Thus, specifying replica sections in pool set files is not allowed.
 
 > NOTICE:
 The **libpmemblk** library is deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 # ACKNOWLEDGEMENTS #
 

--- a/doc/libpmemlog/libpmemlog.7.md
+++ b/doc/libpmemlog/libpmemlog.7.md
@@ -31,7 +31,7 @@ header: "pmemlog API version 1.1"
 
 >NOTE:
 Support for Windows and FreeBSD deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 # SYNOPSIS #
 
@@ -311,7 +311,7 @@ Thus, specifying replica sections in pool set files is not allowed.
 
 > NOTICE:
 The **libpmemlog** library is deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 # ACKNOWLEDGEMENTS #
 

--- a/doc/libpmemobj/libpmemobj.7.md
+++ b/doc/libpmemobj/libpmemobj.7.md
@@ -29,7 +29,7 @@ header: "pmemobj API version 2.3"
 
 >NOTE:
 Support for Windows and FreeBSD deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 # SYNOPSIS #
 

--- a/doc/libpmempool/libpmempool.7.md
+++ b/doc/libpmempool/libpmempool.7.md
@@ -28,7 +28,7 @@ header: "pmempool API version 1.3"
 
 >NOTE:
 Support for Windows and FreeBSD deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 # SYNOPSIS #
 

--- a/doc/pmempool/pmempool.1.md
+++ b/doc/pmempool/pmempool.1.md
@@ -27,7 +27,7 @@ header: "pmem Tools version 1.4"
 
 >NOTE:
 Support for Windows and FreeBSD deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release.
+and will be removed in the PMDK 2.0.0 release.
 
 # SYNOPSIS #
 

--- a/src/deps/README.md
+++ b/src/deps/README.md
@@ -12,4 +12,4 @@ and uploaded to the vcpkg repository.
 
 > NOTICE:
 Support for async functions is deprecated since PMDK 1.13.0 release
-and will be removed in the PMDK 1.14.0 release along with the miniasync dependency.
+and will be removed in the PMDK 2.0.0 release along with the miniasync dependency.


### PR DESCRIPTION
The next major version after 1.13 will be 2.0 instead of 1.14.