### PR TITLE
doc: rename 1.14.0 to 2.0.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -85,7 +85,7 @@ Wed Apr 26 2023 Łukasz Stolarczuk <lukasz.stolarczuk@intel.com>
 	Known issues:
 	- The latest validation cycle exposed previously unknown persistency issues
 	related to pmem2 async functions (DEPRECATED) and miniasync (EXPERIMENTAL):
-	#5596 and #5597. Both will be removed in the PMDK 1.14 release. These issues
+	#5596 and #5597. Both will be removed in the PMDK 2.0 release. These issues
 	do NOT affect any other PMDK library.
 
 Tue Aug 25 2022 Łukasz Plewa <lukasz.plewa@intel.com>

--- a/RELEASE_STEPS.md
+++ b/RELEASE_STEPS.md
@@ -9,8 +9,8 @@ of the PMDK repository. The second commit is required to restore a "default" sta
 As a helper you can export these 2 variables in your bash - with proper version set:
 
 ```bash
-export VERSION=1.14.0-rc1   # the full version of the new release; -rc1 included just as an example
-export VER=1.14             # the major+minor only version
+export VERSION=2.0.1-rc1   # the full version of the new release; -rc1 included just as an example
+export VER=2.0             # the major+minor only version
 ```
 
 ## 1. Make a release locally


### PR DESCRIPTION
The next major version after 1.13 is 2.0 instead of 1.14.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5876)
<!-- Reviewable:end -->
