### PR TITLE
common: fix libpmem CFLAGS

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 	* Unreleased *
 
 	This release:
-	- ...
+	- Significantly reduces the libpmem's stack usage.
 
 Tue Aug 8 2023 Oksana Sałyk <oksana.salyk@intel.com>
 

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -4,6 +4,9 @@
 # src/Makefile.inc -- common Makefile rules for PMDK
 #
 
+# Note: Please do not set CFLAGS before this file is included unless you do not
+# want to use default CFLAGS.
+
 TOP := $(dir $(lastword $(MAKEFILE_LIST)))..
 
 include $(TOP)/src/common.inc

--- a/src/libpmem/Makefile
+++ b/src/libpmem/Makefile
@@ -50,8 +50,6 @@ ifeq ($(OS_DIMM),ndctl)
 SOURCE +=\
 	region_namespace_ndctl.c\
 	numa_ndctl.c
-CFLAGS += $(LIBNDCTL_CFLAGS)
-LIBS += $(LIBNDCTL_LIBS)
 else
 SOURCE +=\
 	region_namespace_none.c\
@@ -68,5 +66,5 @@ include ../Makefile.inc
 
 include $(PMEM2)/$(ARCH)/flags.inc
 
-CFLAGS += -I.
-LIBS += -pthread
+CFLAGS += -I. $(LIBNDCTL_CFLAGS)
+LIBS += -pthread $(LIBNDCTL_LIBS)


### PR DESCRIPTION
For libpmem `CFLAGS` are set before the `src/Makefile.inc` is included. As far as I can tell it was unintentionally introduced by #4797. This oversight excluded libpmem from using `DEFAULT_CFLAGS`. Which has significant consequences on the outcome e.g. restoring the use of `DEFAULT_CFLAGS` reduces the maximum stack usage from 50kB to 8kB.

The issue is present in releases >= 1.9. Note that non-NDCTL builds were not affected.

This regression although unintentional might had a not yet known influence on the performance.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5890)
<!-- Reviewable:end -->
