### PR TITLE
obj: reduce stack usage of obj_vg_check_no_undef

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 
 	This release:
 	- Significantly reduces the libpmem's stack usage.
+	- pmemobj_open() stack usage reduction below 12kB threshold.
 
 Tue Aug 8 2023 Oksana Sałyk <oksana.salyk@intel.com>
 

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -550,7 +550,7 @@ obj_vg_check_no_undef(struct pmemobjpool *pop)
 {
 	LOG(4, "pop %p", pop);
 
-	struct {
+	static struct {
 		void *start, *end;
 	} undefs[MAX_UNDEFS];
 	int num_undefs = 0;
@@ -647,7 +647,7 @@ obj_vg_boot(struct pmemobjpool *pop)
 		obj_vg_check_no_undef(pop);
 }
 
-#endif
+#endif /* VG_MEMCHECK_ENABLED */
 
 /*
  * obj_runtime_init_common -- (internal) runtime initialization

--- a/utils/call_stacks_analysis/stack_usage.txt
+++ b/utils/call_stacks_analysis/stack_usage.txt
@@ -1,4 +1,3 @@
-16448 obj_vg_check_no_undef : src/nondebug/libpmemobj/obj.su:obj.c static
 8432 out_common : src/nondebug/libpmem/out.su:out.c dynamic,bounded
 8432 out_common : src/nondebug/libpmemobj/out.su:out.c dynamic,bounded
 8432 out_common : src/nondebug/core/out.su:out.c dynamic,bounded
@@ -36,6 +35,7 @@
 464 util_emit_log : src/nondebug/libpmem/util.su:util.c static
 464 util_emit_log : src/nondebug/libpmemobj/util.su:util.c static
 464 util_emit_log : src/nondebug/core/util.su:util.c static
+464 obj_vg_check_no_undef : src/nondebug/libpmemobj/obj.su:obj.c static
 464 heap_vg_open : src/nondebug/libpmemobj/heap.su:heap.c static
 432 util_init : src/nondebug/libpmem/util.su:util.c static
 432 util_init : src/nondebug/libpmemobj/util.su:util.c static


### PR DESCRIPTION
obj_vg_check_no_undef is called from one thread at a time, as it is called in between
os_mutex_lock(&pools_mutex);
...
os_mutex_unlock(&pools_mutex);
We can use one instance of the function's data and limit stack usage to ~480 bytes (instead of ~16k). 
This is critical when libpmeobj is used in solutions with restricted stack size.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5893)
<!-- Reviewable:end -->
