### PR TITLE
common: generate public API list based on linker file

### DIFF
--- a/utils/call_stacks_analysis/api-from-link-file.sh
+++ b/utils/call_stacks_analysis/api-from-link-file.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2023, Intel Corporation
+#
+#
+# Generate a list of all libpmem and libpmemobj public API functions.
+# The script shall be run from the main PMDK folder.
+#
+
+grep ";" src/libpmem/libpmem.link.in src/libpmemobj/libpmemobj.link.in | \
+	grep -v -e'*' -e'}' -e'_pobj_cache' | \
+	gawk -F "[;\t]" '{ print $3 }' | sort |  uniq  > $(dirname "$0")/api.txt


### PR DESCRIPTION
Generate a list of libpmem and libpmemobj public API functions based on linker files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5899)
<!-- Reviewable:end -->
