### PR TITLE
pmemobj: introduce fuses against ill-considered use of NDCTL_ENABLE=n

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,12 +39,16 @@ jobs:
       - name: Check licenses
         env:
           NDCTL_ENABLE: n # just to speed up the job
+          PMEMOBJ_IGNORE_DIRTY_SHUTDOWN: y # not recommended for production
+          PMEMOBJ_IGNORE_BAD_BLOCKS: y # not recommended for production
         run: make -j$(nproc) check-license
 
       - name: Check style
         env:
           CSTYLE_FAIL_IF_CLANG_FORMAT_MISSING: 1
           NDCTL_ENABLE: n # just to speed up the job
+          PMEMOBJ_IGNORE_DIRTY_SHUTDOWN: y # not recommended for production
+          PMEMOBJ_IGNORE_BAD_BLOCKS: y # not recommended for production
         run: make -j$(nproc) cstyle
 
 
@@ -69,6 +73,8 @@ jobs:
       - name: Build sources
         env:
           NDCTL_ENABLE: n # just to speed up the job
+          PMEMOBJ_IGNORE_DIRTY_SHUTDOWN: y # not recommended for production
+          PMEMOBJ_IGNORE_BAD_BLOCKS: y # not recommended for production
           CC: ${{ matrix.CC }}
           CXX: ${{ matrix.CXX }}
         run: make -j$(nproc) test

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@ XXX
 	* Version 2.1.0
 
 	This release
+	- introduces fuses against ill-considered use of NDCTL_ENABLE=n
+	  - PMEMOBJ_IGNORE_DIRTY_SHUTDOWN and PMEMOBJ_IGNORE_BAD_BLOCKS are required to acknowledge the understanding of what production-critical functions are missing for the build without NDCTL
 	- does not allow opening pmem pool without unsafe shoutdown counter if not explicitly disabled
 	- remove support for build time define NO_LIBPTHREAD
 

--- a/src/libpmemobj/Makefile
+++ b/src/libpmemobj/Makefile
@@ -37,6 +37,28 @@ SOURCE +=\
 
 include ../Makefile.inc
 
+ifeq ($(OS_DIMM),none)
+	NOT_RECOMMENDED = Continuing the build without NDCTL is highly NOT recommended for production quality systems.
+	RAS_SUFFIX = Please see https://www.intel.com/content/www/us/en/developer/articles/technical/build-pmem-apps-with-ras.html for more info on RAS features.
+        PMEMOBJ_IGNORE_DIRTY_SHUTDOWN ?= n
+        ifneq ($(PMEMOBJ_IGNORE_DIRTY_SHUTDOWN),y)
+                $(info Libpmemobj without NDCTL cannot detect dirty shutdowns. This may result in silent data corruption.)
+                $(info $(NOT_RECOMMENDED))
+                $(info If you understand the consequences for consistency of your data please set PMEMOBJ_IGNORE_DIRTY_SHUTDOWN=y to silence this error.)
+                $(info $(RAS_SUFFIX))
+                $(error )
+        endif
+
+        PMEMOBJ_IGNORE_BAD_BLOCKS ?= n
+        ifneq ($(PMEMOBJ_IGNORE_BAD_BLOCKS),y)
+                $(info Libpmemobj without NDCTL cannot detect bad blocks up front. This may result in SIGBUS at runtime.)
+                $(info $(NOT_RECOMMENDED))
+                $(info If you understand the consequences for the behaviour of your application at runtime please set PMEMOBJ_IGNORE_BAD_BLOCKS=y to silence this error.)
+                $(info $(RAS_SUFFIX))
+                $(error )
+        endif
+endif
+
 CFLAGS += -DUSE_LIBDL -D_PMEMOBJ_INTRNL $(LIBNDCTL_CFLAGS)
 
 LIBS += -pthread -lpmem $(LIBDL) $(LIBNDCTL_LIBS)


### PR DESCRIPTION
Requires:

- [x] release 2.0.1
- [x] changelog entry

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5946)
<!-- Reviewable:end -->
