### PR TITLE
common: Unify PMEM setup scripts

### DIFF
--- a/utils/ansible/README.md
+++ b/utils/ansible/README.md
@@ -56,10 +56,10 @@ Use the below command to configure persistent memory on Intel servers to be
 used for PMDK libraries tests execution.
 ```sh
 export TARGET_IP= # ip of the target
-export ROOT_PASSWORD= # a password of root on the target
+export USER_PASSWORD= # a password on the target
 ansible-playbook -i $TARGET_IP, configure-pmem.yml \
-  --extra-vars "host=all ansible_user=root ansible_password=$ROOT_PASSWORD \
-  newRegions=true testUser=pmdkuser"
+  --extra-vars "host=all ansible_user=pmdkuser ansible_password=$USER_PASSWORD \
+  newRegions=true"
 ```
 The script creates a new region and set of namespaces regardless of the
 configuration already available on the target platform.
@@ -81,10 +81,9 @@ the test environment.
 parameter in this case.
 ```sh
 export TARGET_IP= # ip of the target
-export ROOT_PASSWORD= # a password of root on the target
+export USER_PASSWORD= # a password on the target
 ansible-playbook -i $TARGET_IP, configure-pmem.yml \
-  --extra-vars "host=all ansible_user=root ansible_password=$ROOT_PASSWORD \
-  testUser=pmdkuser"
+  --extra-vars "host=all ansible_user=pmdkuser ansible_password=$USER_PASSWORD"
 ```
 
 # Installing a GitHub Action self-hosted runner using Ansible palybook
@@ -94,16 +93,16 @@ the pmem/pmdk repository.
 
 ```sh
 export TARGET_IP= # ip of the target
-export ROOT_PASSWORD= # a password of root on the target
+export USER_PASSWORD= # a password on the target
 export GHA_TOKEN= # GitHub token generated for a new self-hosted runner
 export HOST_NAME= # host's name that will be visible on GitHub
 export LABELS= # rhel or opensuse
 export VARS_GHA= # e.g. proxy settings: http_proxy=http://proxy-dmz.{XXX}.com:911,https_proxy=http://proxy-dmz.{XXX}.com:912
 ansible-playbook -i $TARGET_IP, configure-self-hosted-runner.yml --extra-vars
-  "host=all ansible_user=root ansible_password=$ROOT_PASSWORD testUser=pmdkuser \
+  "host=all ansible_user=pmdkuser ansible_password=$USER_PASSWORD \
   runner_name=$HOST_NAME labels=$LABELS token=$GHA_TOKEN vars_gha=$VARS_GHA"
 ```
-**Note**: To obtain a token for a new self hosted runer visit
+**Note**: To obtain a token for a new self-hosted runer visit
 [Create self-hosted runner](https://gib.com/pmem/pmdk/settings/actions/runners/new)
 .
 
@@ -127,15 +126,15 @@ export SETUP_SCRIPT= # opensuse-setup.yml or rockylinux-setup.yml
 sudo ansible-playbook $SETUP_SCRIPT --extra-vars "testUser=pmdkuser"
 ```
 **Note**: If a reboot is necessary, as described above, perform it manually and
-rerun the playbook withot  in question.
+rerun the playbook without in question.
 
-And next:
+And next log in as `pmdkuser`:
 ```sh
-sudo ansible-playbook ./configure-pmem.yml --extra-vars "testUser=pmdkuser newRegions=true"
+ansible-playbook configure-pmem.yml --extra-vars "newRegions=true"
 # you will have to perform a reboot manually
-reboot
+sudo reboot
 # and re-run the playbook without newRegions=true to finalize the setup
-sudo ansible-playbook ./configure-pmem.yml --extra-vars "testUser=pmdkuser"
+ansible-playbook configure-pmem.yml
 ```
 
 # Example - GitHub self-hosted runner setup
@@ -163,19 +162,24 @@ reboot
 # ...
 cd pmdk/utils/ansible
 ansible-playbook rockylinux-setup.yml --extra-vars "testUser=pmdkuser testUserPass=pmdkpass"
+```
+Log in as `pmdkuser` and execute:
+```sh
+# as pmdkuser
+cd pmdk/utils/ansible
 ansible-playbook configure-pmem.yml --extra-vars "newRegions=true"
-reboot
+sudo reboot
 # ...
 cd pmdk/utils/ansible
 # note - no newRegions=true when running the playbook after the reboot
-ansible-playbook configure-pmem.yml --extra-vars "testUser=pmdkuser"
+ansible-playbook configure-pmem.yml
 
 export GHA_TOKEN= # GitHub token generated for a new self-hosted runner
 export HOST_NAME=`hostname`
-export LABELS= rhel
+export LABELS=rhel
 export VARS_GHA=http_proxy=http://proxy-dmz.{XXX}.com:911,https_proxy=http://proxy-dmz.{XXX}.com:912
 ansible-playbook configure-self-hosted-runner.yml -extra-vars \
-"testUser=pmdkuser runner_name=$HOST_NAME labels=$LABELS token=$GHA_TOKEN vars_gha=$VARS_GHA"
+"runner_name=$HOST_NAME labels=$LABELS token=$GHA_TOKEN vars_gha=$VARS_GHA"
 cd
 rm -rf pmdk
 ```
@@ -192,25 +196,30 @@ Update playbooks to be used directly on the target as described [above](#provisi
 and execute:
 ```sh
 # as root:
-ansible-playbook ./opensuse-setup.yml --extra-vars "testUser=pmdkuser testUserPass=pmdkpass"
+ansible-playbook opensuse-setup.yml --extra-vars "testUser=pmdkuser testUserPass=pmdkpass"
 # reboot shall be performed only if the playbook requests to do it.
 reboot
 # ...
 cd pmdk/utils/ansible
-ansible-playbook ./opensuse-setup.yml --extra-vars "testUser=pmdkuser testUserPass=pmdkpass"
-ansible-playbook ./configure-pmem.yml --extra-vars "newRegions=true"
-reboot
+ansible-playbook opensuse-setup.yml --extra-vars "testUser=pmdkuser testUserPass=pmdkpass"
+```
+Log in as `pmdkuser` and execute:
+```sh
+# as pmdkuser:
+cd pmdk/utils/ansible
+ansible-playbook configure-pmem.yml --extra-vars "newRegions=true"
+sudo reboot
 # ...
 cd pmdk/utils/ansible
 # note - no newRegions=true when running the playbook after the reboot
-ansible-playbook ./configure-pmem.yml --extra-vars "testUser=pmdkuser"
+ansible-playbook configure-pmem.yml
 
 export GHA_TOKEN= # GitHub token generated for a new self-hosted runner
 export HOST_NAME=`hostname`
-export LABELS= opensuse
+export LABELS=opensuse
 export VARS_GHA=http_proxy=http://proxy-dmz.{XXX}.com:911,https_proxy=http://proxy-dmz.{XXX}.com:912
 ansible-playbook configure-self-hosted-runner.yml -extra-vars \
-"testUser=pmdkuser runner_name=$HOST_NAME labels=$LABELS token=$GHA_TOKEN vars_gha=$VARS_GHA"
+"runner_name=$HOST_NAME labels=$LABELS token=$GHA_TOKEN vars_gha=$VARS_GHA"
 cd
 rm -rf pmdk
 ```

--- a/utils/ansible/configure-pmem.yml
+++ b/utils/ansible/configure-pmem.yml
@@ -16,11 +16,26 @@
 #
 # Below are examples of how to use this file:
 #
-# 1) setup PMem for the first time (establish regions):
-# sudo ansible-playbook ./configure-pmem.yml --extra-vars "testUser=pmdkuser newRegions='true'"
+# 1) remotely
+# export TARGET_IP= # ip of the target
+# export USER_PASSWORD= # a password on the target
+# a) setup PMem for the first time (establish regions):
+# ansible-playbook -i $TARGET_IP, configure-pmem.yml --extra-vars \
+#   "host=all ansible_user=pmdkuser ansible_password=$USER_PASSWORD newRegions=true"
+# b) setup PMem if it already has been initialized before:
+# ansible-playbook -i $TARGET_IP, configure-pmem.yml --extra-vars \
+#   "host=all ansible_user=pmdkuser ansible_password=$USER_PASSWORD"
 #
-# 2) setup PMem if it already has been initialized before:
-# sudo ansible-playbook ./configure-pmem.yml --extra-vars "testUser=pmdkuser"
+# 2) locally
+# For a playbook to be used on a local server please log in as pmdkuser:
+# a) comment out the first command: # -hosts: "{{ host }}"
+# b) uncomment the next two lines:
+# - hosts: localhost
+#   connection: local
+# c) setup PMem for the first time (establish regions):
+# ansible-playbook configure-pmem.yml --extra-vars "newRegions=true"
+# d) setup PMem if it already has been initialized before:
+# ansible-playbook configure-pmem.yml
 #
 
 - hosts: "{{ host }}"
@@ -28,45 +43,50 @@
 #   connection: local
   vars:
     newRegions: false
-    testUser: pmdkuser
     mountPoint: /mnt/pmem0
 
   tasks:
-    - name: "Test if ndctl is installed"
+    - name: Test if ndctl is installed
       shell: which ndctl
 
-    - name: "Remove fstab entry if it exist"
+    - name: Remove fstab entry if it exist
       ansible.posix.mount:
         path: "{{ mountPoint }}"
         state: absent_from_fstab
         backup: true
+      become: true
 
-    - name: "Unmount namespaces if they exist"
-      shell: sudo umount /dev/pmem* || true
+    - name: Unmount namespaces if they exist
+      shell: umount /dev/pmem* || true
+      become: true
 
-    - name: "Disable current namespaces"
-      shell: sudo ndctl disable-namespace all || true
+    - name: Disable current namespaces
+      shell: ndctl disable-namespace all || true
       register: namespaces
+      become: true
 
-    - name: "Destroy current namespaces"
-      shell: sudo ndctl destroy-namespace all || true
+    - name: Destroy current namespaces
+      shell: ndctl destroy-namespace all || true
       register: namespaces
+      become: true
 
     - debug: var=namespaces
 
-    - name: "Create new regions"
+    - name: Create new regions
       block:
-      - name: "Test if ipmctl is installed"
+      - name: Test if ipmctl is installed
         shell: which ipmctl
 
-      - name: "Create goal in AppDirectInterleaved mode"
+      - name: Create goal in AppDirectInterleaved mode
         shell: ipmctl create -f -goal
+        become: true
 
-      - name: "Reboot machine in order to apply new AppDirectInterleaved goal"
+      - name: Reboot machine in order to apply new AppDirectInterleaved goal
         reboot:
       when: newRegions == 'true'
+      become: true
 
-    - name: "Create new namespace configuration"
+    - name: Create new namespace configuration
       shell: |
         #!/usr/bin/env bash
         DEV_DAX_R=0x0000
@@ -74,7 +94,7 @@
 
         function check_alignment() {
           local size=$1
-          local interleave_width=$(sudo ipmctl show -dimm -socket 1 | grep "0x1" | wc -l)
+          local interleave_width=$(ipmctl show -dimm -socket 1 | grep "0x1" | wc -l)
           local size_alignment=$(expr $size % $interleave_width)
 
           if [ "$size_alignment" -gt "0" ]; then
@@ -93,7 +113,7 @@
             size_option=""
           fi
 
-          local cmd="sudo ndctl create-namespace --mode devdax -a ${align} ${size_option} -r ${DEV_DAX_R} -f"
+          local cmd="ndctl create-namespace --mode devdax -a ${align} ${size_option} -r ${DEV_DAX_R} -f"
           result=$(${cmd})
           if [ $? -ne 0 ]; then
             exit 1;
@@ -101,7 +121,7 @@
         }
 
         function create_fsdax() {
-          local cmd="sudo ndctl create-namespace --mode fsdax -r ${FS_DAX_R} -f"
+          local cmd="ndctl create-namespace --mode fsdax -r ${FS_DAX_R} -f"
           result=$(${cmd})
           if [ $? -ne 0 ]; then
             exit 1;
@@ -125,27 +145,28 @@
         pmem_name=$(create_fsdax)
 
         if [ ! -d "{{ mountPoint }}" ]; then
-          sudo mkdir {{ mountPoint }}
+          mkdir {{ mountPoint }}
         fi
 
-        sudo mkfs.ext4 -F /dev/${pmem_name}
-        sudo mount -o dax=always /dev/${pmem_name} {{ mountPoint }}
-        sudo chown -R {{ testUser }} {{ mountPoint }}
+        mkfs.ext4 -F /dev/${pmem_name}
+        mount -o dax=always /dev/${pmem_name} {{ mountPoint }}
+        chown -R $(id -u {{ ansible_user }}):$(id -g {{ ansible_user }}) {{ mountPoint }}
 
-        sudo chmod 777 /dev/dax* || true
-        sudo chmod a+rw /sys/bus/nd/devices/region*/deep_flush
-        sudo chmod +r /sys/bus/nd/devices/ndbus*/region*/resource
-        sudo chmod +r  /sys/bus/nd/devices/ndbus*/region*/dax*/resource
+        chmod 777 /dev/dax*
+        chmod +rw /sys/bus/nd/devices/region*/deep_flush
+        chmod +r /sys/bus/nd/devices/ndbus*/region*/resource
+        chmod +r /sys/bus/nd/devices/ndbus*/region*/dax*/resource
       register: script
+      become: true
 
     - debug: var=script
 
-    - name: "Get PMEM device name for {{ mountPoint }} mount point"
+    - name: Get PMEM device name for {{ mountPoint }} mount point
       shell: |
-        mount | sed -nr "s/^.*(\/dev\/\S+) on \/mnt\/pmem0.*$/\1/p"
+        mount | sed -nr 's/^.*(\/dev\/\S+) on \/mnt\/pmem0.*$/\1/p'
       register: pmem_name
 
-    - name: "Add /etc/fstab entry for PMEM"
+    - name: Add /etc/fstab entry for PMEM
       ansible.posix.mount:
         path: "{{ mountPoint }}"
         src: "{{ pmem_name.stdout }}"
@@ -153,3 +174,4 @@
         opts: rw,relatime,dax=always
         state: present
         backup: true
+      become: true

--- a/utils/ansible/configure-self-hosted-runner.yml
+++ b/utils/ansible/configure-self-hosted-runner.yml
@@ -5,17 +5,17 @@
 # Examples below show how to use this file:
 # 1) remotely
 # export TARGET_IP= # ip of the target
-# export ROOT_PASSWORD= # a password of root on the target
+# export USER_PASSWORD= # a password on the target
 # export GHA_TOKEN= # a GitHub token generated for a new self-hosted runner
 # export HOST_NAME= # host's name that will be visible on GitHub
 # export LABELS= # rhel or opensuse
 # export VARS_GHA=http_proxy=http://proxy-dmz.{XXX}.com:911,https_proxy=http://proxy-dmz.{XXX}.com:912
 # ansible-playbook -i $TARGET_IP, configure-self-hosted-runner.yml --extra-vars \
-#   "host=all ansible_user=root ansible_password=$ROOT_PASSWORD testUser=pmdkuser \
+#   "host=all ansible_user=pmdkuser ansible_password=$USER_PASSWORD \
 #   runner_name=$HOST_NAME labels=$LABELS token=$GHA_TOKEN vars_gha=$VARS_GHA"
 #
 # 2) locally
-# For a playbook to be used on a local server please:
+# For a playbook to be used on a local server please log in as pmdkuser:
 # a) comment out the first command: # -hosts: "{{ host }}"
 # b) uncomment the next two lines:
 # - hosts: localhost
@@ -36,9 +36,8 @@
 #- hosts: localhost
 #  connection: local
   vars:
-    testUser: pmdkuser
-    package_url: https://github.com/actions/runner/releases/download/v2.306.0/actions-runner-linux-x64-2.306.0.tar.gz
-    runner_folder: /home/{{ testUser }}/actions-runner
+    package_url: https://github.com/actions/runner/releases/download/v2.311.0/actions-runner-linux-x64-2.311.0.tar.gz
+    runner_folder: /home/{{ ansible_user }}/actions-runner
     repo_url: https://github.com/pmem/pmdk
     vars_list: "{{ vars_gha.split(',') }}"
 #    token: # a GitHub token generated for a new self-hosted runner
@@ -46,24 +45,21 @@
 #    runner_name: # Host name that will be visible on GitHub
 
   tasks:
-    - name: "Create a runner folder"
+    - name: Create a runner folder
       file:
-        path: '{{ runner_folder }}'
+        path: "{{ runner_folder }}"
         state: directory
         force: yes
 
-    - name: "Download and extract the installer"
+    - name: Download and extract the installer
       unarchive:
-        src: '{{ package_url }}'
-        dest: '{{ runner_folder }}'
+        src: "{{ package_url }}"
+        dest: "{{ runner_folder }}"
         remote_src: yes
-
-    - name: "Change owner to {{ testUser }}"
-      shell: chown -R $(id -u {{ testUser }}):$(id -g {{ testUser }}) {{ runner_folder }}
 
     # Make sure the following environment variables are present in the env
     # to ensure propagation to the actions-runner's environment.
-    - name: "Add env variables into env.sh checklist"
+    - name: Add env variables into env.sh checklist
       lineinfile:
         path: "{{ runner_folder }}/env.sh"
         line: "    '{{ item.line }}'"
@@ -72,30 +68,29 @@
         - line: PKG_CONFIG_PATH
         - line: HOME
 
-    - name: "Add runner to GHA"
+    - name: Add runner to GHA
       shell: |
         cd {{ runner_folder }}
         ./config.sh --url {{ repo_url }} --token {{ token }} --name {{ runner_name }} --labels {{ labels }} --runnergroup Default --work _work
-      become: yes
-      become_user: '{{ testUser }}'
 
-    - name: "Install runner service"
-      shell: |
-        cd {{ runner_folder }}
-        ./svc.sh install {{ testUser }}
+    - name: Install runner service
+      shell: ./svc.sh install {{ ansible_user }}
+      args:
+        chdir: "{{ runner_folder }}"
       become: true
-      become_user: root
 
-    - name: "Insert variables into runsvc.sh file"
+    - name: Insert variables into runsvc.sh file
       lineinfile:
         path: "{{ runner_folder }}/runsvc.sh"
         line: "export {{ item }}"
         insertbefore: "insert anything to setup env when running as a service"
       loop: "{{ vars_list }}"
 
-    - name: "Enable and restart runner service"
+    - name: Enable and restart runner service
+      # Note: The service name must match the repo_url.
+      # repo_url: https://github.com/{OWNER}/{REPO}
+      # service: actions.runner.{OWNER}-{REPO}.{{ runner_name }}.service
       shell: |
         systemctl enable actions.runner.pmem-pmdk.{{ runner_name }}.service
         systemctl restart actions.runner.pmem-pmdk.{{ runner_name }}.service
       become: true
-      become_user: root

--- a/utils/ansible/opensuse-setup.yml
+++ b/utils/ansible/opensuse-setup.yml
@@ -14,41 +14,40 @@
     testUserPass: pmdkpass
 
   tasks:
-
-    - name: "Update kernel packages"
+    - name: Update kernel packages
       package:
         name: "kernel-default"
         state: latest
       register: isUpdated
 
-    - name: "Update OS packages"
+    - name: Update OS packages
       package:
         name: "*"
         state: latest
 
-    - name: "Reboot platform to apply updates"
+    - name: Reboot platform to apply updates
       reboot:
       when: isUpdated.changed
 
-    - name: "Add permanent pkg config variable to the system"
+    - name: Add permanent pkg config variable to the system
       env:
         state: present
         name: PKG_CONFIG_PATH
         value: /usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig
 
-    - name: "Add permanent ld library path to the system"
+    - name: Add permanent ld library path to the system
       env:
         state: present
         name: LD_LIBRARY_PATH
         value: /usr/lib64:/usr/lib
 
-    - name: "Add openSUSE Leap 15.4 Oss repo"
+    - name: Add openSUSE Leap 15.4 Oss repo
       zypper_repository:
         name: oss
-        repo: 'http://download.opensuse.org/distribution/leap/15.4/repo/oss'
+        repo: "http://download.opensuse.org/distribution/leap/15.4/repo/oss"
         state: present
 
-    - name: "Install Valgrind dependencies"
+    - name: Install Valgrind dependencies
       package:
         state: present
         name:
@@ -58,7 +57,7 @@
           - findutils
           - git
 
-    - name: "Install PMDK base dependencies"
+    - name: Install PMDK base dependencies
       package:
         state: present
         name:
@@ -70,13 +69,13 @@
           - systemd
           - libndctl-devel
 
-    - name: "Install benchmarks dependencies (optional)"
+    - name: Install benchmarks dependencies (optional)
       package:
         state: present
         name:
           - glib2-devel
 
-    - name: "Install examples dependencies (optional)"
+    - name: Install examples dependencies (optional)
       package:
         state: present
         name:
@@ -85,13 +84,13 @@
           - ncurses-devel
           - libuv-devel
 
-    - name: "Install documentation dependencies (optional)"
+    - name: Install documentation dependencies (optional)
       package:
         state: present
         name:
           - pandoc
 
-    - name: "Install tests dependencies"
+    - name: Install tests dependencies
       package:
         state: present
         name:
@@ -100,14 +99,14 @@
           - libunwind-devel
           - strace
 
-    - name: "Install packaging dependencies"
+    - name: Install packaging dependencies
       package:
         state: present
         name:
           - rpm-build
           - rpmdevtools
 
-    - name: "Install miscellaneous dependencies"
+    - name: Install miscellaneous dependencies
       package:
         state: present
         name:
@@ -123,7 +122,7 @@
           - xmlto
           - jq
 
-    - name: "Install ndctl dependencies"
+    - name: Install ndctl dependencies
       package:
         state: present
         name:
@@ -136,13 +135,13 @@
           - libuuid-devel
           - systemd-devel
 
-    - name: "Install ipmctl"
+    - name: Install ipmctl
       package:
         state: present
         name:
           - ipmctl
 
-    - name: "Install valgrind from source"
+    - name: Install valgrind from source
       script: ../docker/images/install-valgrind.sh
 
     # Disable AppArmor. 
@@ -157,7 +156,7 @@
       ignore_errors: yes
       when: ansible_facts['os_family'] == 'Suse'
 
-    - name: "Add new user"
+    - name: Add new user
       shell: |
         #!/usr/bin/env bash
         export USER={{ testUser }}
@@ -173,26 +172,26 @@
         gpasswd wheel -a $USER
       when: testUser != None
 
-    - name: "Set variable OS"
+    - name: Set variable OS
       env:
         state: present
-        name: 'OS'
-        value: 'opensuse/leap'
+        name: "OS"
+        value: "opensuse/leap"
 
-    - name: "Set variable OS_VER"
+    - name: Set variable OS_VER
       env:
         state: present
-        name: 'OS_VER'
-        value: '15'
+        name: "OS_VER"
+        value: "15"
 
-    - name: "Set variable PACKAGE_MANAGER"
+    - name: Set variable PACKAGE_MANAGER
       env:
         state: present
-        name: 'PACKAGE_MANAGER'
-        value: 'rpm'
+        name: "PACKAGE_MANAGER"
+        value: "rpm"
 
-    - name: "Set variable NOTTY"
+    - name: Set variable NOTTY
       env:
         state: present
-        name: 'NOTTY'
-        value: '1'
+        name: "NOTTY"
+        value: "1"

--- a/utils/ansible/rockylinux-setup.yml
+++ b/utils/ansible/rockylinux-setup.yml
@@ -14,22 +14,22 @@
     testUserPass: pmdkpass
 
   tasks:
-    - name: "Update kernel packages"
+    - name: Update kernel packages
       package:
         name: "kernel.x86_64"
         state: latest
       register: isUpdated
 
-    - name: "Update OS packages"
+    - name: Update OS packages
       package:
         name: "*"
         state: latest
 
-    - name: "Reboot platform to apply updates"
+    - name: Reboot platform to apply updates
       reboot:
       when: isUpdated.changed
 
-    - name: "Add permanent pkg config variable to the system"
+    - name: Add permanent pkg config variable to the system
       env:
         state: present
         name: PKG_CONFIG_PATH
@@ -37,20 +37,20 @@
 
 # For `ansible_distribution_*` variables see:
 # https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_conditionals.html#commonly-used-facts
-    - name: "Rocky - adding additional repositories"
+    - name: Rocky - adding additional repositories
       block:
-        - name: "Rocky - adding epel repository"
+        - name: Rocky - adding epel repository
           shell: yum install epel-release -y
 
-        - name: "Rocky 9 - enabling Power Tools"
+        - name: Rocky 9 - enabling Power Tools
           shell: dnf config-manager --enable crb
           when: ansible_distribution_major_version == "9"
 
-        - name: "Rocky 8 - enabling Power Tools"
+        - name: Rocky 8 - enabling Power Tools
           shell: dnf config-manager --enable powertools
           when: ansible_distribution_major_version == "8"
 
-    - name: "Install Valgrind dependencies"
+    - name: Install Valgrind dependencies
       package:
         state: present
         name:
@@ -60,7 +60,7 @@
           - findutils
           - git
 
-    - name: "Install PMDK base dependencies"
+    - name: Install PMDK base dependencies
       package:
         state: present
         name:
@@ -71,13 +71,13 @@
           - passwd
           - pkgconfig
 
-    - name: "Install benchmarks dependencies (optional)"
+    - name: Install benchmarks dependencies (optional)
       package:
         state: present
         name:
           - glib2-devel
 
-    - name: "Install examples dependencies (optional)"
+    - name: Install examples dependencies (optional)
       package:
         state: present
         name:
@@ -86,13 +86,13 @@
           - ncurses-devel
           - libuv-devel
 
-    - name: "Install documentation dependencies (optional)"
+    - name: Install documentation dependencies (optional)
       package:
         state: present
         name:
           - pandoc
 
-    - name: "Install tests dependencies"
+    - name: Install tests dependencies
       package:
         state: present
         name:
@@ -103,7 +103,7 @@
           - openssh-server
           - strace
 
-    - name: "Install packaging dependencies"
+    - name: Install packaging dependencies
       package:
         state: present
         name:
@@ -111,7 +111,7 @@
           - rpm-build-libs
           - rpmdevtools
 
-    - name: "Install miscellaneous dependencies"
+    - name: Install miscellaneous dependencies
       package:
         state: present
         name:
@@ -128,13 +128,13 @@
           - xmlto
           - jq
 
-    - name: "Install ipmctl"
+    - name: Install ipmctl
       package:
         state: present
         name:
           - ipmctl
 
-    - name: "Install valgrind from source"
+    - name: Install valgrind from source
       script: ../docker/images/install-valgrind.sh
 
     # Disable SELinux. 
@@ -145,9 +145,9 @@
       selinux:
         state: disabled
       ignore_errors: yes
-      when: ansible_facts['os_family'] != 'Debian'
+      when: ansible_facts["os_family"] != "Debian"
 
-    - name: "Add new user"
+    - name: Add new user
       shell: |
         #!/usr/bin/env bash
         export USER={{ testUser }}
@@ -158,34 +158,34 @@
         echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
       when: testUser != none
 
-    - name: "Set variable OS"
+    - name: Set variable OS
       env:
         state: present
-        name: 'OS'
-        value: 'rockylinux/rockylinux'
+        name: "OS"
+        value: "rockylinux/rockylinux"
 
-    - name: "Set variable OS_VER (9)"
+    - name: Set variable OS_VER (9)
       env:
         state: present
-        name: 'OS_VER'
-        value: '9'
+        name: "OS_VER"
+        value: "9"
       when: ansible_distribution_major_version == "9"
 
-    - name: "Set variable OS_VER (8)"
+    - name: Set variable OS_VER (8)
       env:
         state: present
-        name: 'OS_VER'
-        value: '8'
+        name: "OS_VER"
+        value: "8"
       when: ansible_distribution_major_version == "8"
 
-    - name: "Set variable PACKAGE_MANAGER"
+    - name: Set variable PACKAGE_MANAGER
       env:
         state: present
-        name: 'PACKAGE_MANAGER'
-        value: 'rpm'
+        name: "PACKAGE_MANAGER"
+        value: "rpm"
 
-    - name: "Set variable NOTTY"
+    - name: Set variable NOTTY
       env:
         state: present
-        name: 'NOTTY'
-        value: '1'
+        name: "NOTTY"
+        value: "1"


### PR DESCRIPTION
- opensuse/rhel-setup.yml playbooks should be run as root (remotely with ansible_user=root)
- other playbooks (configure-pmem, update-os, configure-self-hosted-runner) should be run as `pmdkuser` (remotely with ansible_user=pmdkuser)
- remove testUser variable from user-executed playbooks
- unify quotation usage across ansible playbooks and GitHub workflows

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5954)
<!-- Reviewable:end -->
