### PR TITLE
common: Specify ansible_user var for local playbook run

### DIFF
--- a/utils/ansible/README.md
+++ b/utils/ansible/README.md
@@ -111,6 +111,11 @@ ansible-playbook -i $TARGET_IP, configure-self-hosted-runner.yml --extra-vars
 
 # Provisioning from the target platform itself
 It is possible to run playbooks directly on the target platform.
+In this case, you have to always pass `ansible_user=pmdkuser` as an additional
+variable since the playbooks are fine-tuned for remote execution and assume
+the `ansible_user` variable is defined. When running on a remote target the
+connection plugin does it for you.
+
 To run playbooks inside the platform please comment out the line:
 ```
 - hosts: "{{ host }}"
@@ -123,18 +128,18 @@ uncomment the following two:
 and run commands as follows e.g.
 ```sh
 export SETUP_SCRIPT= # opensuse-setup.yml or rockylinux-setup.yml
-sudo ansible-playbook $SETUP_SCRIPT --extra-vars "testUser=pmdkuser"
+sudo ansible-playbook $SETUP_SCRIPT --extra-vars "ansible_user=pmdkuser"
 ```
 **Note**: If a reboot is necessary, as described above, perform it manually and
 rerun the playbook without in question.
 
 And next log in as `pmdkuser`:
 ```sh
-ansible-playbook configure-pmem.yml --extra-vars "newRegions=true"
+ansible-playbook configure-pmem.yml --extra-vars "ansible_user=pmdkuser newRegions=true"
 # you will have to perform a reboot manually
 sudo reboot
 # and re-run the playbook without newRegions=true to finalize the setup
-ansible-playbook configure-pmem.yml
+ansible-playbook configure-pmem.yml --extra-vars "ansible_user=pmdkuser"
 ```
 
 # Example - GitHub self-hosted runner setup
@@ -167,19 +172,19 @@ Log in as `pmdkuser` and execute:
 ```sh
 # as pmdkuser
 cd pmdk/utils/ansible
-ansible-playbook configure-pmem.yml --extra-vars "newRegions=true"
+ansible-playbook configure-pmem.yml --extra-vars "ansible_user=pmdkuser newRegions=true"
 sudo reboot
 # ...
 cd pmdk/utils/ansible
 # note - no newRegions=true when running the playbook after the reboot
-ansible-playbook configure-pmem.yml
+ansible-playbook configure-pmem.yml --extra-vars "ansible_user=pmdkuser"
 
 export GHA_TOKEN= # GitHub token generated for a new self-hosted runner
 export HOST_NAME=`hostname`
 export LABELS=rhel
 export VARS_GHA=http_proxy=http://proxy-dmz.{XXX}.com:911,https_proxy=http://proxy-dmz.{XXX}.com:912
 ansible-playbook configure-self-hosted-runner.yml -extra-vars \
-"runner_name=$HOST_NAME labels=$LABELS token=$GHA_TOKEN vars_gha=$VARS_GHA"
+"ansible_user=pmdkuser runner_name=$HOST_NAME labels=$LABELS token=$GHA_TOKEN vars_gha=$VARS_GHA"
 cd
 rm -rf pmdk
 ```
@@ -207,19 +212,19 @@ Log in as `pmdkuser` and execute:
 ```sh
 # as pmdkuser:
 cd pmdk/utils/ansible
-ansible-playbook configure-pmem.yml --extra-vars "newRegions=true"
+ansible-playbook configure-pmem.yml --extra-vars "ansible_user=pmdkuser newRegions=true"
 sudo reboot
 # ...
 cd pmdk/utils/ansible
 # note - no newRegions=true when running the playbook after the reboot
-ansible-playbook configure-pmem.yml
+ansible-playbook configure-pmem.yml --extra-vars "ansible_user=pmdkuser"
 
 export GHA_TOKEN= # GitHub token generated for a new self-hosted runner
 export HOST_NAME=`hostname`
 export LABELS=opensuse
 export VARS_GHA=http_proxy=http://proxy-dmz.{XXX}.com:911,https_proxy=http://proxy-dmz.{XXX}.com:912
 ansible-playbook configure-self-hosted-runner.yml -extra-vars \
-"runner_name=$HOST_NAME labels=$LABELS token=$GHA_TOKEN vars_gha=$VARS_GHA"
+"ansible_user=pmdkuser runner_name=$HOST_NAME labels=$LABELS token=$GHA_TOKEN vars_gha=$VARS_GHA"
 cd
 rm -rf pmdk
 ```

--- a/utils/ansible/configure-pmem.yml
+++ b/utils/ansible/configure-pmem.yml
@@ -33,9 +33,9 @@
 # - hosts: localhost
 #   connection: local
 # c) setup PMem for the first time (establish regions):
-# ansible-playbook configure-pmem.yml --extra-vars "newRegions=true"
+# ansible-playbook configure-pmem.yml --extra-vars "ansible_user=pmdkuser newRegions=true"
 # d) setup PMem if it already has been initialized before:
-# ansible-playbook configure-pmem.yml
+# ansible-playbook configure-pmem.yml --extra-vars "ansible_user=pmdkuser"
 #
 
 - hosts: "{{ host }}"

--- a/utils/ansible/configure-self-hosted-runner.yml
+++ b/utils/ansible/configure-self-hosted-runner.yml
@@ -26,7 +26,7 @@
 # export LABELS= # rhel or opensuse
 # export VARS_GHA=http_proxy=http://proxy-dmz.{XXX}.com:911,https_proxy=http://proxy-dmz.{XXX}.com:912
 # ansible-playbook configure-self-hosted-runner.yml --extra-vars \
-#   "runner_name=$HOST_NAME labels=$LABELS vars_gha=$VARS_GHA token=$GHA_TOKEN"
+#   "ansible_user=pmdkuser runner_name=$HOST_NAME labels=$LABELS vars_gha=$VARS_GHA token=$GHA_TOKEN"
 #
 
 #


### PR DESCRIPTION
Ansible_user is undefined on Localhost with local connection and needs to be always passed with --extra-vars
https://radeksprta.eu/posts/ansible_user-is-undefined-on-localhost/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5955)
<!-- Reviewable:end -->
