### PR TITLE
Fix compilation error on LoongArch.

### DIFF
--- a/src/libpmem2/loongarch64/init.c
+++ b/src/libpmem2/loongarch64/init.c
@@ -36,6 +36,6 @@ pmem2_arch_init(struct pmem2_arch_info *info)
 {
 	LOG(3, NULL);
 
-	info->fence = loongarch_fence;
+	info->fence = loongarch_memory_fence;
 	info->flush = loongarch_flush;
 }


### PR DESCRIPTION
The compiler error on LoongArch machine is as follows：

`../../src/../src/libpmem2/loongarch64/init.c: In function ‘pmem2_arch_init’:
../../src/../src/libpmem2/loongarch64/init.c:39:23: error: ‘loongarch_fence’ undeclared (first use in this function); did you mean ‘loongarch_flush’?
   39 |         info->fence = loongarch_fence;
      |                       ^~~~~~~~~~~~~~~
      |                       loongarch_flush
../../src/../src/libpmem2/loongarch64/init.c:39:23: note: each undeclared identifier is reported only once for each function it appears in`

This commit fixes the problem.