### PR TITLE
common: Removing the annoying test directory suffix

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -126,7 +126,7 @@ fi
 [ "$CHECK_POOL" ] || CHECK_POOL=0
 [ "$VERBOSE" ] || VERBOSE=0
 [ "$TEST_LABEL" ] || TEST_LABEL=
-[ -n "${SUFFIX+x}" ] || SUFFIX="😘⠏⠍⠙⠅ɗPMDKӜ⥺🙋"
+[ -n "${SUFFIX+x}" ] || SUFFIX=""
 
 export UNITTEST_LOG_LEVEL GREP TEST FS BUILD CHECK_TYPE CHECK_POOL VERBOSE SUFFIX
 


### PR DESCRIPTION
Removing the Braille test directory suffix to simplify manual test reproduction.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5977)
<!-- Reviewable:end -->
