### PR TITLE
common: add out_log_va to white list

### DIFF
--- a/utils/call_stacks_analysis/white_list.json
+++ b/utils/call_stacks_analysis/white_list.json
@@ -127,6 +127,7 @@
         "os_writev",
         "out_fatal",
         "out_log",
+        "out_log_va",
         "out_nonl",
         "pmalloc_operation_hold_no_start",
         "pmalloc",


### PR DESCRIPTION
Add out_log_va to the white list as it is no longer used in the release version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/5986)
<!-- Reviewable:end -->
