### PR TITLE
common: call abort() after reporting a fatal issue

### DIFF
--- a/src/core/log_internal.h
+++ b/src/core/log_internal.h
@@ -218,7 +218,11 @@ void core_log_to_last(const char *file_name, int line_no,
 	_CORE_LOG_W_ERRNO(CORE_LOG_LEVEL_ERROR, format, ##__VA_ARGS__)
 
 #define CORE_LOG_FATAL_W_ERRNO(format, ...) \
-	_CORE_LOG_W_ERRNO(CORE_LOG_LEVEL_FATAL, format, ##__VA_ARGS__)
+	do { \
+		_CORE_LOG_W_ERRNO(CORE_LOG_LEVEL_FATAL, \
+			format, ##__VA_ARGS__); \
+		abort(); \
+	} while (0)
 
 /*
  * 'Last' macros' flavours. Additionally writes the produced error message


### PR DESCRIPTION
`CORE_LOG_FATAL_W_ERRNO()` calls `abort()` in the same way as `CORE_LOG_FATAL()`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/6003)
<!-- Reviewable:end -->
