### PR TITLE
Call stack analysis w/ core_log_default_function()

### DIFF
--- a/src/core/out.c
+++ b/src/core/out.c
@@ -327,23 +327,6 @@ out(const char *fmt, ...)
 }
 
 /*
- * out_nonl -- output a line, no newline added automatically
- */
-void
-out_nonl(int level, const char *fmt, ...)
-{
-	va_list ap;
-
-	if (Log_level < level)
-			return;
-
-	va_start(ap, fmt);
-	out_common(NULL, 0, NULL, level, "", fmt, ap);
-
-	va_end(ap);
-}
-
-/*
  * out_log_va/out_log -- output a log line if Log_level >= level
  */
 void

--- a/src/core/out.c
+++ b/src/core/out.c
@@ -313,20 +313,6 @@ end:
 }
 
 /*
- * out -- output a line, newline added automatically
- */
-void
-out(const char *fmt, ...)
-{
-	va_list ap;
-	va_start(ap, fmt);
-
-	out_common(NULL, 0, NULL, 0, "\n", fmt, ap);
-
-	va_end(ap);
-}
-
-/*
  * out_log_va/out_log -- output a log line if Log_level >= level
  */
 void

--- a/src/core/out.h
+++ b/src/core/out.h
@@ -73,7 +73,6 @@ void out_init(const char *log_prefix, const char *log_level_var,
 		const char *log_file_var, int major_version,
 		int minor_version);
 void out_fini(void);
-void out(const char *fmt, ...) FORMAT_PRINTF(1, 2);
 void out_log_va(const char *file, int line, const char *func, int level,
 		const char *fmt, va_list ap);
 void out_log(const char *file, int line, const char *func, int level,

--- a/src/core/out.h
+++ b/src/core/out.h
@@ -53,17 +53,30 @@ out_nonl_discard(int level, const char *fmt, ...)
 
 #endif
 
+#if defined(DEBUG) || defined(__KLOCWORK__)
+
 /* produce debug/trace output */
 #define LOG(level, ...) do { \
 	if (!EVALUATE_DBG_EXPRESSIONS) break;\
 	OUT_LOG(__FILE__, __LINE__, __func__, level, __VA_ARGS__);\
 } while (0)
 
-/* produce debug/trace output without prefix and new line */
-#define LOG_NONL(level, ...) do { \
-	if (!EVALUATE_DBG_EXPRESSIONS) break; \
-	OUT_NONL(level, __VA_ARGS__); \
-} while (0)
+#else
+/* macro for suppresing errors from unused variables (up to 9) */
+#define LOG_SUPPRESS_UNUSED(...)\
+	GLUE(LOG_SUPPRESS_ARG_, COUNT(__VA_ARGS__))(__VA_ARGS__)
+#define LOG_SUPPRESS_ARG_1(X)
+#define LOG_SUPPRESS_ARG_2(X, ...) SUPPRESS_ARG_1(__VA_ARGS__)
+#define LOG_SUPPRESS_ARG_3(X, ...) SUPPRESS_ARG_2(__VA_ARGS__)
+#define LOG_SUPPRESS_ARG_4(X, ...) SUPPRESS_ARG_3(__VA_ARGS__)
+#define LOG_SUPPRESS_ARG_5(X, ...) SUPPRESS_ARG_4(__VA_ARGS__)
+#define LOG_SUPPRESS_ARG_6(X, ...) SUPPRESS_ARG_5(__VA_ARGS__)
+#define LOG_SUPPRESS_ARG_7(X, ...) SUPPRESS_ARG_6(__VA_ARGS__)
+#define LOG_SUPPRESS_ARG_8(X, ...) SUPPRESS_ARG_7(__VA_ARGS__)
+#define LOG_SUPPRESS_ARG_9(X, ...) SUPPRESS_ARG_8(__VA_ARGS__)
+
+#define LOG(level, ...) LOG_SUPPRESS_UNUSED(__VA_ARGS__)
+#endif
 
 void out_init(const char *log_prefix, const char *log_level_var,
 		const char *log_file_var, int major_version,

--- a/src/core/out.h
+++ b/src/core/out.h
@@ -53,20 +53,7 @@ out_log_discard(const char *file, int line, const char *func, int level,
 } while (0)
 
 #else
-/* macro for suppresing errors from unused variables (up to 9) */
-#define LOG_SUPPRESS_UNUSED(...)\
-	GLUE(LOG_SUPPRESS_ARG_, COUNT(__VA_ARGS__))(__VA_ARGS__)
-#define LOG_SUPPRESS_ARG_1(X)
-#define LOG_SUPPRESS_ARG_2(X, ...) SUPPRESS_ARG_1(__VA_ARGS__)
-#define LOG_SUPPRESS_ARG_3(X, ...) SUPPRESS_ARG_2(__VA_ARGS__)
-#define LOG_SUPPRESS_ARG_4(X, ...) SUPPRESS_ARG_3(__VA_ARGS__)
-#define LOG_SUPPRESS_ARG_5(X, ...) SUPPRESS_ARG_4(__VA_ARGS__)
-#define LOG_SUPPRESS_ARG_6(X, ...) SUPPRESS_ARG_5(__VA_ARGS__)
-#define LOG_SUPPRESS_ARG_7(X, ...) SUPPRESS_ARG_6(__VA_ARGS__)
-#define LOG_SUPPRESS_ARG_8(X, ...) SUPPRESS_ARG_7(__VA_ARGS__)
-#define LOG_SUPPRESS_ARG_9(X, ...) SUPPRESS_ARG_8(__VA_ARGS__)
-
-#define LOG(level, ...) LOG_SUPPRESS_UNUSED(__VA_ARGS__)
+#define LOG(level, ...) SUPPRESS_UNUSED(__VA_ARGS__)
 #endif
 
 void out_init(const char *log_prefix, const char *log_level_var,

--- a/src/core/out.h
+++ b/src/core/out.h
@@ -30,7 +30,6 @@ extern "C" {
 /* klocwork does not seem to respect __attribute__((noreturn)) */
 #if defined(DEBUG) || defined(__KLOCWORK__)
 #define OUT_LOG out_log
-#define OUT_NONL out_nonl
 #else
 
 static __attribute__((always_inline)) inline void
@@ -41,15 +40,7 @@ out_log_discard(const char *file, int line, const char *func, int level,
 	SUPPRESS_UNUSED(file, line, func, level, fmt);
 }
 
-static __attribute__((always_inline)) inline void
-out_nonl_discard(int level, const char *fmt, ...)
-{
-	/* suppress unused-parameter errors */
-	SUPPRESS_UNUSED(level, fmt);
-}
-
 #define OUT_LOG out_log_discard
-#define OUT_NONL out_nonl_discard
 
 #endif
 
@@ -83,7 +74,6 @@ void out_init(const char *log_prefix, const char *log_level_var,
 		int minor_version);
 void out_fini(void);
 void out(const char *fmt, ...) FORMAT_PRINTF(1, 2);
-void out_nonl(int level, const char *fmt, ...) FORMAT_PRINTF(2, 3);
 void out_log_va(const char *file, int line, const char *func, int level,
 		const char *fmt, va_list ap);
 void out_log(const char *file, int line, const char *func, int level,

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -321,7 +321,7 @@ char *util_concat_str(const char *s1, const char *s2);
 /* macro for suppresing errors from unused variables (up to 9) */
 #define SUPPRESS_UNUSED(...)\
 	GLUE(SUPPRESS_ARG_, COUNT(__VA_ARGS__))(__VA_ARGS__)
-#define SUPPRESS_ARG_1(X) (void) X
+#define SUPPRESS_ARG_1(X) (void) (X)
 #define SUPPRESS_ARG_2(X, ...) SUPPRESS_ARG_1(X); SUPPRESS_ARG_1(__VA_ARGS__)
 #define SUPPRESS_ARG_3(X, ...) SUPPRESS_ARG_1(X); SUPPRESS_ARG_2(__VA_ARGS__)
 #define SUPPRESS_ARG_4(X, ...) SUPPRESS_ARG_1(X); SUPPRESS_ARG_3(__VA_ARGS__)

--- a/src/libpmempool/feature.c
+++ b/src/libpmempool/feature.c
@@ -261,8 +261,10 @@ typedef enum {
 	ENABLED
 } fstate_t;
 
+#ifdef DEBUG
 #define FEATURE_IS_ENABLED_STR	"feature already enabled: %s"
 #define FEATURE_IS_DISABLED_STR	"feature already disabled: %s"
+#endif
 
 /*
  * require_feature_is -- (internal) check if required feature is enabled
@@ -277,9 +279,11 @@ require_feature_is(struct pool_set *set, features_t feature, fstate_t req_state)
 	if (state == req_state)
 		return 1;
 
+#ifdef DEBUG
 	const char *msg = (state == ENABLED)
 			? FEATURE_IS_ENABLED_STR : FEATURE_IS_DISABLED_STR;
 	LOG(3, msg, util_feature2str(feature, NULL));
+#endif
 	return 0;
 }
 

--- a/src/test/helgrind-log.supp
+++ b/src/test/helgrind-log.supp
@@ -21,17 +21,6 @@
     fun:out_log_va
     fun:out_log
 }
-{
-    <debug_err_suppress>
-    Helgrind:Race
-    fun:*mem*cpy
-    ...
-    fun:_IO_file_xsputn@@GLIBC*
-    ...
-    fun:out_print_func
-    fun:out_error
-    fun:out_err
-}
 
 {
     <ut_log_suppress>

--- a/src/test/tools/anonymous_mmap/anonymous_mmap.c
+++ b/src/test/tools/anonymous_mmap/anonymous_mmap.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2018, Intel Corporation */
+/* Copyright 2018-2024, Intel Corporation */
 
 /*
  * anonymous_mmap.c -- tool for verifying if given memory length can be
@@ -18,7 +18,7 @@ main(int argc, char *argv[])
 	out_init("ANONYMOUS_MMAP", "ANONYMOUS_MMAP", "", 1, 0);
 
 	if (argc != 2) {
-		out("Usage: %s <length>", argv[0]);
+		printf("Usage: %s <length>\n", argv[0]);
 		return -1;
 	}
 
@@ -26,8 +26,9 @@ main(int argc, char *argv[])
 	char *addr = mmap(NULL, length, PROT_READ,
 				MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
 	if (addr == MAP_FAILED) {
-		out("anonymous_mmap.c: Failed to mmap length=%lu of memory, "
-			"errno=%d", length, errno);
+		printf(
+			"anonymous_mmap.c: Failed to mmap length=%lu of memory, errno=%d\n",
+			length, errno);
 		return errno;
 	}
 

--- a/src/test/tools/obj_verify/obj_verify.c
+++ b/src/test/tools/obj_verify/obj_verify.c
@@ -94,13 +94,13 @@ do_create(const char *path, const char *layout)
 	if ((pop = pmemobj_create(path, layout, 0,
 						S_IWUSR | S_IRUSR)) == NULL) {
 		if (errno != EEXIST) {
-			out("!%s: pmemobj_create: %s",
+			printf("!%s: pmemobj_create: %s\n",
 				path, pmemobj_errormsg());
 			exit(-1);
 		}
 
 		if ((pop = pmemobj_open(path, layout)) == NULL) {
-			out("!%s: pmemobj_open: %s",
+			printf("!%s: pmemobj_open: %s\n",
 				path, pmemobj_errormsg());
 			exit(-1);
 		}
@@ -115,11 +115,11 @@ do_create(const char *path, const char *layout)
 
 	if (pmemobj_ctl_set(pop, "heap.alloc_class.new.desc", &class) != 0) {
 		pmemobj_close(pop);
-		out("!pmemobj_ctl_set: %s", path);
+		printf("!pmemobj_ctl_set: %s\n", path);
 		exit(-1);
 	}
 
-	out("create(%s): allocating records in the pool ...", path);
+	printf("create(%s): allocating records in the pool ...\n", path);
 
 	count = D_RO(root)->count;
 
@@ -129,10 +129,10 @@ do_create(const char *path, const char *layout)
 
 	count = D_RO(root)->count - count;
 	if (count) {
-		out("create(%s): allocated %lu records (of size %zu)",
+		printf("create(%s): allocated %lu records (of size %zu)\n",
 			path, count, sizeof(struct data_s));
 	} else {
-		out("create(%s): pool is full", path);
+		printf("create(%s): pool is full\n", path);
 	}
 
 	pmemobj_close(pop);
@@ -148,10 +148,12 @@ do_verify(const char *path, const char *layout)
 	PMEMoid oid;
 	uint64_t count = 0;
 	int error = 0;
+	char buff[128];
 
 	if ((pop = pmemobj_open(path, layout)) == NULL) {
-		out("!%s: pmemobj_open: %s",
-			path, pmemobj_errormsg());
+		strerror_r(errno, buff, 128);
+		printf("%s: pmemobj_open: %s: %s\n",
+			path, pmemobj_errormsg(), buff);
 		exit(-1);
 	}
 
@@ -163,7 +165,7 @@ do_verify(const char *path, const char *layout)
 		if (!util_checksum(D_RW(rec), sizeof(*D_RW(rec)),
 					&D_RW(rec)->checksum,
 					0 /* verify */, SKIP_OFFSET)) {
-			out("verify(%s): incorrect record: %s (#%lu)",
+			printf("verify(%s): incorrect record: %s (#%lu)\n",
 				path, D_RW(rec)->signature, count);
 			error = 1;
 			break;
@@ -173,8 +175,8 @@ do_verify(const char *path, const char *layout)
 	}
 
 	if (D_RO(root)->count != count) {
-		out(
-			"verify(%s): incorrect number of records (is: %lu, should be: %lu)",
+		printf(
+			"verify(%s): incorrect number of records (is: %lu, should be: %lu)\n",
 			path, count, D_RO(root)->count);
 		error = 1;
 	}
@@ -182,12 +184,12 @@ do_verify(const char *path, const char *layout)
 	pmemobj_close(pop);
 
 	if (error) {
-		out("verify(%s): pool file contains error", path);
+		printf("verify(%s): pool file contains error\n", path);
 		exit(-1);
 	}
 
-	out(
-		"verify(%s): pool file successfully verified (%lu records of size %zu)",
+	printf(
+		"verify(%s): pool file successfully verified (%lu records of size %zu)\n",
 		path, count, sizeof(struct data_s));
 }
 
@@ -198,7 +200,7 @@ main(int argc, char *argv[])
 	out_init("OBJ_VERIFY", "OBJ_VERIFY", "", 1, 0);
 
 	if (argc < 4) {
-		out("Usage: %s <obj_pool> <layout> <op:c|v>\n"
+		printf("Usage: %s <obj_pool> <layout> <op:c|v>\n"
 		    "Options:\n"
 		    "   c - create\n"
 		    "   v - verify\n",
@@ -222,7 +224,7 @@ main(int argc, char *argv[])
 		op = argv[arg];
 
 		if (op[1] != '\0') {
-			out("op must be c or v (c=create, v=verify)");
+			printf("op must be c or v (c=create, v=verify)\n");
 			exit(-1);
 		}
 
@@ -236,7 +238,7 @@ main(int argc, char *argv[])
 			break;
 
 		default:
-			out("op must be c or v (c=create, v=verify)");
+			printf("op must be c or v (c=create, v=verify)\n");
 			exit(-1);
 			break;
 		}

--- a/src/tools/pmempool/output.h
+++ b/src/tools/pmempool/output.h
@@ -14,8 +14,6 @@ void out_set_stream(FILE *stream);
 void out_set_prefix(const char *prefix);
 void out_set_col_width(unsigned col_width);
 void outv_err(const char *fmt, ...) FORMAT_PRINTF(1, 2);
-void out_err(int use_errno, const char *file, int line, const char *func,
-		const char *fmt, ...) FORMAT_PRINTF(5, 6);
 void outv_err_vargs(const char *fmt, va_list ap);
 void outv_indent(int vlevel, int i);
 void outv(int vlevel, const char *fmt, ...) FORMAT_PRINTF(2, 3);

--- a/utils/call_stacks_analysis/make_extra.py
+++ b/utils/call_stacks_analysis/make_extra.py
@@ -21,7 +21,7 @@ def dict_extend(dict_, key, values):
 
 def inlines(calls: Calls) -> Calls:
         # common
-        calls['core_init'] = ['util_init', 'out_init']
+        calls['core_init'] = ['util_init', 'core_log_init', 'out_init']
         calls['core_fini'] = ['out_fini']
         calls['common_init'] = ['core_init', 'util_mmap_init']
         calls['common_fini'] = ['util_mmap_fini', 'core_fini']

--- a/utils/call_stacks_analysis/make_extra.py
+++ b/utils/call_stacks_analysis/make_extra.py
@@ -27,7 +27,6 @@ def inlines(calls: Calls) -> Calls:
         calls['common_fini'] = ['util_mmap_fini', 'core_fini']
         calls['Last_errormsg_key_alloc'] = ['_Last_errormsg_key_alloc']
         calls['_Last_errormsg_key_alloc'] = ['os_once', 'os_tls_key_create']
-        calls['out_common'] = ['out_snprintf']
         calls['core_log_va'] = ['core_log_default_function']
 
         # libpmem

--- a/utils/call_stacks_analysis/make_extra.py
+++ b/utils/call_stacks_analysis/make_extra.py
@@ -28,6 +28,7 @@ def inlines(calls: Calls) -> Calls:
         calls['Last_errormsg_key_alloc'] = ['_Last_errormsg_key_alloc']
         calls['_Last_errormsg_key_alloc'] = ['os_once', 'os_tls_key_create']
         calls['out_common'] = ['out_snprintf']
+        calls['core_log_va'] = ['core_log_default_function']
 
         # libpmem
         calls['flush_empty'] = ['flush_empty_nolog']

--- a/utils/call_stacks_analysis/white_list.json
+++ b/utils/call_stacks_analysis/white_list.json
@@ -127,6 +127,8 @@
         "os_writev",
         "out_log",
         "out_log_va",
+        "out_common",
+        "out_snprintf",
         "pmalloc_operation_hold_no_start",
         "pmalloc",
         "pmem2_badblock_clear",
@@ -177,6 +179,7 @@
         "util_safe_strcpy",
         "util_str2feature",
         "util_str2pmempool_feature",
+        "util_strerror",
         "util_unlink_flock",
         "util_uuid_to_string",
         "util_write_all"

--- a/utils/call_stacks_analysis/white_list.json
+++ b/utils/call_stacks_analysis/white_list.json
@@ -127,7 +127,6 @@
         "os_writev",
         "out_log",
         "out_log_va",
-        "out_nonl",
         "pmalloc_operation_hold_no_start",
         "pmalloc",
         "pmem2_badblock_clear",


### PR DESCRIPTION
Include `core_log_default_function()` in call stack analysis 
and remove obsolete implementation of `LOG()` macro in release version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/6007)
<!-- Reviewable:end -->
