### PR TITLE
common: log w/ errno handled internally

### DIFF
--- a/src/core/log.c
+++ b/src/core/log.c
@@ -6,6 +6,14 @@
  * via user defined function
  */
 
+/*
+ * Note: The undef below is critical to use the XSI-compliant version of
+ * the strerror_r(3) instead of the GNU-specific. Otherwise, the produced
+ * error string may not end up in the log buffer.
+ */
+#undef _GNU_SOURCE
+#include <string.h>
+
 #include <stdarg.h>
 #include <syslog.h>
 #include <time.h>
@@ -13,12 +21,12 @@
 #ifdef ATOMIC_OPERATIONS_SUPPORTED
 #include <stdatomic.h>
 #endif /* ATOMIC_OPERATIONS_SUPPORTED */
-#include <string.h>
 #include <stdio.h>
 
 #include "log_internal.h"
 #include "log_default.h"
 #include "last_error_msg.h"
+#include "core_assert.h"
 
 /*
  * Default levels of the logging thresholds
@@ -186,11 +194,28 @@ core_log_get_threshold(enum core_log_threshold threshold,
 
 static void inline
 core_log_va(char *buf, size_t buf_len, enum core_log_level level,
-	const char *file_name, int line_no, const char *function_name,
-	const char *message_format, va_list arg)
+	int errnum, const char *file_name, int line_no,
+	const char *function_name, const char *message_format, va_list arg)
 {
-	if (vsnprintf(buf, buf_len, message_format, arg) < 0) {
-		return;
+	int msg_len = vsnprintf(buf, buf_len, message_format, arg);
+	if (msg_len < 0)
+		goto end;
+
+	if (errnum != NO_ERRNO) {
+		char *msg_ptr = buf + msg_len;
+		size_t buf_len_left = buf_len - (size_t)msg_len;
+
+		/* Check if the longest possible error string can fit */
+		if (buf_len_left < _CORE_LOG_MAX_ERRNO_MSG) {
+			goto end;
+		}
+
+		/* Ask for the error string */
+		/*
+		 * If it fails, the best thing to do is to at least pass
+		 * the log message as is.
+		 */
+		(void) strerror_r(errnum, msg_ptr, buf_len_left);
 	}
 
 	/*
@@ -199,40 +224,44 @@ core_log_va(char *buf, size_t buf_len, enum core_log_level level,
 	 * performed in the case of the CORE_LOG_TO_LAST macro. Sorry.
 	 */
 	if (level > Core_log_threshold[CORE_LOG_THRESHOLD]) {
-		return;
+		goto end;
 	}
 
 	if (0 == Core_log_function) {
-		return;
+		goto end;
 	}
 
 	((core_log_function *)Core_log_function)(Core_log_function_context,
 		level, file_name, line_no, function_name, buf);
+
+end:
+	if (errnum != NO_ERRNO)
+		errno = errnum;
 }
 
 void
-core_log(enum core_log_level level, const char *file_name, int line_no,
-	const char *function_name, const char *message_format, ...)
+core_log(enum core_log_level level, int errnum, const char *file_name,
+	int line_no, const char *function_name, const char *message_format, ...)
 {
 	char message[1024] = "";
 	va_list arg;
 
 	va_start(arg, message_format);
-	core_log_va(message, sizeof(message), level, file_name, line_no,
-		function_name, message_format, arg);
+	core_log_va(message, sizeof(message), level, errnum, file_name,
+		line_no, function_name, message_format, arg);
 	va_end(arg);
 }
 
 void
-core_log_to_last(const char *file_name, int line_no, const char *function_name,
-	const char *message_format, ...)
+core_log_to_last(int errnum, const char *file_name, int line_no,
+	const char *function_name, const char *message_format, ...)
 {
 	char *last_error = (char *)last_error_msg_get();
 	va_list arg;
 
 	va_start(arg, message_format);
 	core_log_va(last_error, CORE_LAST_ERROR_MSG_MAXPRINT,
-		CORE_LOG_LEVEL_ERROR, file_name, line_no, function_name,
-		message_format, arg);
+		CORE_LOG_LEVEL_ERROR, errnum, file_name, line_no,
+		function_name, message_format, arg);
 	va_end(arg);
 }

--- a/src/core/log_internal.h
+++ b/src/core/log_internal.h
@@ -9,7 +9,6 @@
 #define CORE_LOG_INTERNAL_H
 
 #include <stdlib.h>
-#include <string.h>
 #include <stdint.h>
 #include <errno.h>
 
@@ -119,18 +118,21 @@ core_log_error_translate(int ret)
 	return 0;
 }
 
-void core_log(enum core_log_level level, const char *file_name, int line_no,
-	const char *function_name, const char *message_format, ...);
+#define NO_ERRNO (-1)
+
+void core_log(enum core_log_level level, int errnum, const char *file_name,
+	int line_no, const char *function_name,
+	const char *message_format, ...);
 
 /* Only error messages can last. So, no level has to be specified. */
-void core_log_to_last(const char *file_name, int line_no,
+void core_log_to_last(int errnum, const char *file_name, int line_no,
 	const char *function_name, const char *message_format, ...);
 
-#define _CORE_LOG(level, format, ...) \
+#define _CORE_LOG(level, errnum, format, ...) \
 	do { \
 		if (level <= Core_log_threshold[CORE_LOG_THRESHOLD]) { \
-			core_log(level, __FILE__, __LINE__, __func__, \
-				format, ##__VA_ARGS__); \
+			core_log(level, errnum, __FILE__, __LINE__, \
+			__func__, format, ##__VA_ARGS__); \
 		} \
 	} while (0)
 
@@ -138,73 +140,44 @@ void core_log_to_last(const char *file_name, int line_no,
  * Can't check the logging level here when logging to the last error message.
  * Since the log message has to be generated anyway.
  */
-#define CORE_LOG_TO_LAST(format, ...) \
-	core_log_to_last(__FILE__, __LINE__, __func__, format, ##__VA_ARGS__)
-
-/*
- * Required to handle both variants' return types.
- * The ideal solution would be to force using one variant or another.
- */
-#ifdef _GNU_SOURCE
-#define _CORE_LOG_STRERROR_R(buf, buf_len, out) \
-	do { \
-		char *ret = strerror_r(errno, (buf), (buf_len)); \
-		*(out) = ret; \
-	} while (0)
-#else
-#define _CORE_LOG_STRERROR_R(buf, buf_len, out) \
-	do { \
-		int ret = strerror_r(errno, (buf), (buf_len)); \
-		(void) ret; \
-		*(out) = buf; \
-	} while (0)
-#endif
-
-#define _CORE_LOG_STRERROR(buf, buf_len, out) \
-	do { \
-		int oerrno = errno; \
-		_CORE_LOG_STRERROR_R((buf), (buf_len), (out)); \
-		errno = oerrno; \
-	} while (0)
+#define CORE_LOG_TO_LAST(errnum, format, ...) \
+	core_log_to_last(errnum, __FILE__, __LINE__, __func__, \
+		format, ##__VA_ARGS__)
 
 /* The value fine-tuned to accommodate all possible errno message strings. */
 #define _CORE_LOG_MAX_ERRNO_MSG 50
 
 #define _CORE_LOG_W_ERRNO(level, format, ...) \
-	do { \
-		char buf[_CORE_LOG_MAX_ERRNO_MSG]; \
-		char *error_str; \
-		_CORE_LOG_STRERROR(buf, _CORE_LOG_MAX_ERRNO_MSG, &error_str); \
-		_CORE_LOG(level, format ": %s", ##__VA_ARGS__, error_str); \
-	} while (0)
+		_CORE_LOG(level, errno, format ": ", ##__VA_ARGS__)
 
 /*
  * Set of macros that should be used as the primary API for logging.
  * Direct call to log shall be used only in exceptional, corner cases.
  */
 #define CORE_LOG_DEBUG(format, ...) \
-	_CORE_LOG(CORE_LOG_LEVEL_DEBUG, format, ##__VA_ARGS__)
+	_CORE_LOG(CORE_LOG_LEVEL_DEBUG, NO_ERRNO, format, ##__VA_ARGS__)
 
 #define CORE_LOG_INFO(format, ...) \
-	_CORE_LOG(CORE_LOG_LEVEL_INFO, format, ##__VA_ARGS__)
+	_CORE_LOG(CORE_LOG_LEVEL_INFO, NO_ERRNO, format, ##__VA_ARGS__)
 
 #define CORE_LOG_NOTICE(format, ...) \
-	_CORE_LOG(CORE_LOG_LEVEL_NOTICE, format, ##__VA_ARGS__)
+	_CORE_LOG(CORE_LOG_LEVEL_NOTICE, NO_ERRNO, format, ##__VA_ARGS__)
 
 #define CORE_LOG_WARNING(format, ...) \
-	_CORE_LOG(CORE_LOG_LEVEL_WARNING, format, ##__VA_ARGS__)
+	_CORE_LOG(CORE_LOG_LEVEL_WARNING, NO_ERRNO, format, ##__VA_ARGS__)
 
 #define CORE_LOG_ERROR(format, ...) \
-	_CORE_LOG(CORE_LOG_LEVEL_ERROR, format, ##__VA_ARGS__)
+	_CORE_LOG(CORE_LOG_LEVEL_ERROR, NO_ERRNO, format, ##__VA_ARGS__)
 
 #define CORE_LOG_FATAL(format, ...) \
 	do { \
-		_CORE_LOG(CORE_LOG_LEVEL_FATAL, format, ##__VA_ARGS__); \
+		_CORE_LOG(CORE_LOG_LEVEL_FATAL, NO_ERRNO, \
+			format, ##__VA_ARGS__); \
 		abort(); \
 	} while (0)
 
 #define CORE_LOG_ALWAYS(format, ...) \
-	_CORE_LOG(CORE_LOG_LEVEL_ALWAYS, format, ##__VA_ARGS__)
+	_CORE_LOG(CORE_LOG_LEVEL_ALWAYS, NO_ERRNO, format, ##__VA_ARGS__)
 
 /*
  * 'With errno' macros' flavours. Append string describing the current errno
@@ -231,15 +204,10 @@ void core_log_to_last(const char *file_name, int line_no,
  */
 
 #define CORE_LOG_ERROR_LAST(format, ...) \
-	CORE_LOG_TO_LAST(format, ##__VA_ARGS__)
+	CORE_LOG_TO_LAST(NO_ERRNO, format, ##__VA_ARGS__)
 
 #define CORE_LOG_ERROR_W_ERRNO_LAST(format, ...) \
-	do { \
-		char buf[_CORE_LOG_MAX_ERRNO_MSG]; \
-		char *error_str; \
-		_CORE_LOG_STRERROR(buf, _CORE_LOG_MAX_ERRNO_MSG, &error_str); \
-		CORE_LOG_TO_LAST(format ": %s", ##__VA_ARGS__, error_str); \
-	} while (0)
+		CORE_LOG_TO_LAST(errno, format ": ", ##__VA_ARGS__);
 
 /* Aliases */
 

--- a/src/test/core_log/core_log.c
+++ b/src/test/core_log/core_log.c
@@ -100,8 +100,8 @@ static int Total_TLS_message_num;
  */
 #define TOTAL_TLS_MESSAGE_NUM_EXPECTED 311
 
-FUNC_MOCK(core_log_to_last, void, const char *file_name, int line_no,
-	const char *function_name, const char *message_format, ...)
+FUNC_MOCK(core_log_to_last, void, int errnum, const char *file_name,
+	int line_no, const char *function_name, const char *message_format, ...)
 	FUNC_MOCK_RUN_DEFAULT {
 		char buf[BIG_BUF_SIZE] = "";
 		va_list arg;

--- a/utils/call_stacks_analysis/README.md
+++ b/utils/call_stacks_analysis/README.md
@@ -15,7 +15,7 @@
 ./make_extra.py && \
 ./make_cflow.sh && \
 ./make_call_stacks.py --filter-api-file examples/api_filter.txt \
-    --filter-lower-limit 8192 --dump-all-stacks
+    --filter-lower-limit 11296 --dump-all-stacks
 ```
 
 If succesfull, it produces:


### PR DESCRIPTION
Move errno string generation into `core_log_va()` to decrease overall stack usage.
Original implementation increases max stack usage by 320 to 11376 bytes compared to 11056 before the new logging solution implementation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/6010)
<!-- Reviewable:end -->
