### PR TITLE
common: fix coverity issue 1976787

### DIFF
--- a/src/core/out.h
+++ b/src/core/out.h
@@ -53,7 +53,9 @@ out_log_discard(const char *file, int line, const char *func, int level,
 } while (0)
 
 #else
-#define LOG(level, ...) SUPPRESS_UNUSED(__VA_ARGS__)
+#define LOG(level, ...) do { \
+		SUPPRESS_UNUSED(__VA_ARGS__); \
+	} while (0)
 #endif
 
 void out_init(const char *log_prefix, const char *log_level_var,

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -319,7 +319,7 @@ char *util_concat_str(const char *s1, const char *s2);
 #define GLUE_I(A, B) A##B
 
 /* macro for suppresing errors from unused variables (up to 9) */
-#define SUPPRESS_UNUSED(...)\
+#define SUPPRESS_UNUSED(...) \
 	GLUE(SUPPRESS_ARG_, COUNT(__VA_ARGS__))(__VA_ARGS__)
 #define SUPPRESS_ARG_1(X) (void) (X)
 #define SUPPRESS_ARG_2(X, ...) SUPPRESS_ARG_1(X); SUPPRESS_ARG_1(__VA_ARGS__)


### PR DESCRIPTION
Adapt the `LOG()` macro for proper usage in the context of the `if()` statement without brackets {} in the release build.
https://coverityent.devtools.intel.com/prod8/#/project-view/26102/10909?selectedIssue=1976787