### PR TITLE
common: exclude line_no from call_all.c.generated

### DIFF
--- a/.github/workflows/scan_log_calls.yml
+++ b/.github/workflows/scan_log_calls.yml
@@ -24,13 +24,16 @@ jobs:
           echo "length=$(cat log_calls.diff | wc -l)" >> $GITHUB_OUTPUT
         id: log_calls_diff
 
+      - name: Non-empty diff
+        if: steps.log_calls_diff.outputs.length != '0'
+        run: cat ${{ env.WORKING_DIRECTORY }}/log_calls.diff
+
       - name: Upload artifacts
         if: steps.log_calls_diff.outputs.length != '0'
         uses: actions/upload-artifact@v3
         with:
           name: log_calls_diff
-          path: |
-            ${{ env.WORKING_DIRECTORY }}/log_calls.diff
+          path: ${{ env.WORKING_DIRECTORY }}/log_calls.diff
 
       - name: Exit code
         run: |

--- a/src/test/core_log_max/call_all.c.generated
+++ b/src/test/core_log_max/call_all.c.generated
@@ -10,782 +10,782 @@ call_all_CORE_LOG_ERROR_LAST(void)
 void
 call_all_ERR_WO_ERRNO(void)
 {
-	// src/common/ctl.c:215
+	// src/common/ctl.c
 	ERR_WO_ERRNO("read queries require non-NULL argument");
-	// src/common/ctl.c:231
+	// src/common/ctl.c
 	ERR_WO_ERRNO("write queries require non-NULL argument");
-	// src/common/ctl.c:278
+	// src/common/ctl.c
 	ERR_WO_ERRNO("invalid query");
-	// src/common/ctl.c:302
+	// src/common/ctl.c
 	ERR_WO_ERRNO("invalid query entry point %s", _s);
-	// src/common/ctl.c:374
+	// src/common/ctl.c
 	ERR_WO_ERRNO("failed to parse query %s", _s);
-	// src/common/ctl.c:436
+	// src/common/ctl.c
 	ERR_WO_ERRNO("Config file too large");
-	// src/common/ctl.c:562
+	// src/common/ctl.c
 	ERR_WO_ERRNO("invalid destination size %zu", _zu);
-	// src/common/file.c:111
+	// src/common/file.c
 	ERR_WO_ERRNO("invalid (NULL) path");
-	// src/common/file.c:182
+	// src/common/file.c
 	ERR_WO_ERRNO("file size (%ld) too big to be represented in 64-bit signed integer", _ld);
-	// src/common/file.c:409
+	// src/common/file.c
 	ERR_WO_ERRNO("size %zu smaller than %zu", _zu, _zu);
-	// src/common/file.c:415
+	// src/common/file.c
 	ERR_WO_ERRNO("invalid size (%zu) for os_off_t", _zu);
-	// src/common/file.c:485
+	// src/common/file.c
 	ERR_WO_ERRNO("stat \"%s\": negative size", _s);
-	// src/common/file.c:491
+	// src/common/file.c
 	ERR_WO_ERRNO("size %zu smaller than %zu", _zu, _zu);
-	// src/common/mmap.c:287
+	// src/common/mmap.c
 	ERR_WO_ERRNO("duplicated persistent memory range; presumably unmapped with munmap() instead of pmem_unmap(): addr %p len %zu", _p, _zu);
-	// src/common/mmap.c:308
+	// src/common/mmap.c
 	ERR_WO_ERRNO("Cannot find DAX device region id");
-	// src/common/mmap.c:336
+	// src/common/mmap.c
 	ERR_WO_ERRNO("invalid munmap length, must be non-zero and page aligned");
-	// src/common/mmap_posix.c:90
+	// src/common/mmap_posix.c
 	ERR_WO_ERRNO("end of address space reached");
-	// src/common/pool_hdr.c:116
+	// src/common/pool_hdr.c
 	ERR_WO_ERRNO("invalid reserved values");
-	// src/common/pool_hdr.c:121
+	// src/common/pool_hdr.c
 	ERR_WO_ERRNO("invalid machine value");
-	// src/common/pool_hdr.c:126
+	// src/common/pool_hdr.c
 	ERR_WO_ERRNO("invalid data value");
-	// src/common/pool_hdr.c:131
+	// src/common/pool_hdr.c
 	ERR_WO_ERRNO("invalid machine_class value");
-	// src/common/pool_hdr.c:136
+	// src/common/pool_hdr.c
 	ERR_WO_ERRNO("invalid alignment_desc value");
-	// src/common/pool_hdr.c:173
+	// src/common/pool_hdr.c
 	ERR_WO_ERRNO("unsafe to continue due to unknown incompat features: %#x", _u);
-	// src/common/pool_hdr.c:182
+	// src/common/pool_hdr.c
 	ERR_WO_ERRNO("switching to read-only mode due to unknown ro_compat features: %#x", _u);
-	// src/common/set.c:1066
+	// src/common/set.c
 	ERR_WO_ERRNO("unable to load part %s", _s);
-	// src/common/set.c:1105
+	// src/common/set.c
 	ERR_WO_ERRNO("failed to load parts from directory %s", _s);
-	// src/common/set.c:1302
+	// src/common/set.c
 	ERR_WO_ERRNO("Remote replicas are no longer supported. This functionality is deprecated.");
-	// src/common/set.c:1339
+	// src/common/set.c
 	ERR_WO_ERRNO("%s [%s:%d]", _s, _s, _d);
-	// src/common/set.c:1357
+	// src/common/set.c
 	ERR_WO_ERRNO("cannot load part files from directories");
-	// src/common/set.c:1511
+	// src/common/set.c
 	ERR_WO_ERRNO("file size does not match config: %s, %zu != %zu", _s, _zu, _zu);
-	// src/common/set.c:1609
+	// src/common/set.c
 	ERR_WO_ERRNO("size must be zero for device dax");
-	// src/common/set.c:1643
+	// src/common/set.c
 	ERR_WO_ERRNO("file is not a poolset file and its size (%zu) is smaller than %zu", _zu, _zu);
-	// src/common/set.c:1680
+	// src/common/set.c
 	ERR_WO_ERRNO("poolset file options (%u) do not match incompat feature flags (%#x)", _u, _u);
-	// src/common/set.c:1708
+	// src/common/set.c
 	ERR_WO_ERRNO("Non-empty file detected");
-	// src/common/set.c:1816
+	// src/common/set.c
 	ERR_WO_ERRNO("invalid major version (0)");
-	// src/common/set.c:1823
+	// src/common/set.c
 	ERR_WO_ERRNO("wrong pool type: \"%.8s\"", _8s);
-	// src/common/set.c:1830
+	// src/common/set.c
 	ERR_WO_ERRNO("pool version %d (library expects %d)", _d, _d);
-	// src/common/set.c:1833
+	// src/common/set.c
 	ERR_WO_ERRNO("Please run the pmdk-convert utility to upgrade the pool.");
-	// src/common/set.c:1858
+	// src/common/set.c
 	ERR_WO_ERRNO("invalid checksum of pool header");
-	// src/common/set.c:1866
+	// src/common/set.c
 	ERR_WO_ERRNO("wrong architecture flags");
-	// src/common/set.c:1874
+	// src/common/set.c
 	ERR_WO_ERRNO("wrong pool set UUID");
-	// src/common/set.c:1884
+	// src/common/set.c
 	ERR_WO_ERRNO("wrong part UUID");
-	// src/common/set.c:1891
+	// src/common/set.c
 	ERR_WO_ERRNO("incompatible pool format");
-	// src/common/set.c:1900
+	// src/common/set.c
 	ERR_WO_ERRNO("incompatible feature flags");
-	// src/common/set.c:2253
+	// src/common/set.c
 	ERR_WO_ERRNO("cannot extend pool by 0 bytes");
-	// src/common/set.c:2258
+	// src/common/set.c
 	ERR_WO_ERRNO("extending the pool by appending parts with headers is not supported!");
-	// src/common/set.c:2266
+	// src/common/set.c
 	ERR_WO_ERRNO("exceeded reservation size");
-	// src/common/set.c:2275
+	// src/common/set.c
 	ERR_WO_ERRNO("unable to append a new part to the pool");
-	// src/common/set.c:2290
+	// src/common/set.c
 	ERR_WO_ERRNO("cannot open the new part");
-	// src/common/set.c:2300
+	// src/common/set.c
 	ERR_WO_ERRNO("cannot map the new part");
-	// src/common/set.c:2310
+	// src/common/set.c
 	ERR_WO_ERRNO("new part cannot be mapped with MAP_SYNC");
-	// src/common/set.c:2313
+	// src/common/set.c
 	ERR_WO_ERRNO("new part mapped with MAP_SYNC");
-	// src/common/set.c:2356
+	// src/common/set.c
 	ERR_WO_ERRNO("file contains bad blocks -- '%s'", _s);
-	// src/common/set.c:2390
+	// src/common/set.c
 	ERR_WO_ERRNO("file %s already exists", _s);
-	// src/common/set.c:2407
+	// src/common/set.c
 	ERR_WO_ERRNO("the NOHDRS poolset option is not supported for local poolsets");
-	// src/common/set.c:2414
+	// src/common/set.c
 	ERR_WO_ERRNO("pool attributes are not supported for poolsets without headers (with the NOHDRS option)");
-	// src/common/set.c:2421
+	// src/common/set.c
 	ERR_WO_ERRNO("directory based pools are not supported for poolsets with headers (without SINGLEHDR option)");
-	// src/common/set.c:2428
+	// src/common/set.c
 	ERR_WO_ERRNO("reservation pool size %zu smaller than %zu", _zu, _zu);
-	// src/common/set.c:2436
+	// src/common/set.c
 	ERR_WO_ERRNO("cannot create a new part in provided directories");
-	// src/common/set.c:2455
+	// src/common/set.c
 	ERR_WO_ERRNO("pool set contains bad blocks and cannot be created, run 'pmempool create --clear-bad-blocks' utility to clear bad blocks and create a pool");
-	// src/common/set.c:2463
+	// src/common/set.c
 	ERR_WO_ERRNO("net pool size %zu smaller than %zu", _zu, _zu);
-	// src/common/set.c:2470
+	// src/common/set.c
 	ERR_WO_ERRNO("replication not supported");
-	// src/common/set.c:257
+	// src/common/set.c
 	ERR_WO_ERRNO("unable to map at requested address %p", _p);
-	// src/common/set.c:2633
+	// src/common/set.c
 	ERR_WO_ERRNO("pool mapping failed - address space reservation too small");
-	// src/common/set.c:2806
+	// src/common/set.c
 	ERR_WO_ERRNO("wrong replica UUID");
-	// src/common/set.c:2862
+	// src/common/set.c
 	ERR_WO_ERRNO("device dax cannot be mapped privately");
-	// src/common/set.c:2877
+	// src/common/set.c
 	ERR_WO_ERRNO("error: a bad block recovery file exists, run 'pmempool sync --bad-blocks' utility to try to recover the pool");
-	// src/common/set.c:2900
+	// src/common/set.c
 	ERR_WO_ERRNO("pool set contains bad blocks and cannot be opened, run 'pmempool sync --bad-blocks' utility to try to recover the pool");
-	// src/common/set.c:3018
+	// src/common/set.c
 	ERR_WO_ERRNO("device dax cannot be mapped privately");
-	// src/common/set.c:3038
+	// src/common/set.c
 	ERR_WO_ERRNO("error: a bad block recovery file exists, run 'pmempool sync --bad-blocks' utility to try to recover the pool");
-	// src/common/set.c:3064
+	// src/common/set.c
 	ERR_WO_ERRNO("pool set contains bad blocks and cannot be opened, run 'pmempool sync --bad-blocks' utility to try to recover the pool -- '%s'", _s);
-	// src/common/set.c:3215
+	// src/common/set.c
 	ERR_WO_ERRNO("util_poolset_parse failed -- '%s'", _s);
-	// src/common/set.c:476
+	// src/common/set.c
 	ERR_WO_ERRNO("size autodetection is supported only for device dax");
-	// src/common/set.c:732
+	// src/common/set.c
 	ERR_WO_ERRNO("cannot mix directories and files in a set");
-	// src/common/set.c:758
+	// src/common/set.c
 	ERR_WO_ERRNO("cannot mix directories and files in a set");
-	// src/common/set.c:768
+	// src/common/set.c
 	ERR_WO_ERRNO("cannot resolve realpath of new directory");
-	// src/common/set.c:780
+	// src/common/set.c
 	ERR_WO_ERRNO("cannot use the same directory twice");
-	// src/common/set.c:877
+	// src/common/set.c
 	ERR_WO_ERRNO("replica #%u part %u %smapped with MAP_SYNC", _u, _u, _s);
-	// src/common/set.c:887
+	// src/common/set.c
 	ERR_WO_ERRNO("replica #%u part %u header %smapped with MAP_SYNC", _u, _u, _s);
-	// src/common/set.c:916
+	// src/common/set.c
 	ERR_WO_ERRNO("either all the parts must be Device DAX or none");
-	// src/common/set.c:926
+	// src/common/set.c
 	ERR_WO_ERRNO("Multiple DAX devices with alignment other than 4KB. Use the SINGLEHDR poolset option.");
-	// src/common/set.c:945
+	// src/common/set.c
 	ERR_WO_ERRNO("both SINGLEHDR and NOHDR poolset options used at the same time");
-	// src/common/set_badblocks.c:120
+	// src/common/set_badblocks.c
 	ERR_WO_ERRNO("clearing bad blocks in the pool file failed -- '%s'", _s);
-	// src/common/set_badblocks.c:46
+	// src/common/set_badblocks.c
 	ERR_WO_ERRNO("checking the pool file for bad blocks failed -- '%s'", _s);
-	// src/common/set_badblocks.c:53
+	// src/common/set_badblocks.c
 	ERR_WO_ERRNO("part file contains bad blocks -- '%s'", _s);
-	// src/common/shutdown_state.c:101
+	// src/common/shutdown_state.c
 	ERR_WO_ERRNO("cannot read uuid of %d", _d);
-	// src/common/shutdown_state.c:232
+	// src/common/shutdown_state.c
 	ERR_WO_ERRNO("an ADR failure was detected, the pool might be corrupted");
-	// src/common/shutdown_state.c:77
+	// src/common/shutdown_state.c
 	ERR_WO_ERRNO("Cannot read unsafe shutdown count. For more information please check https://github.com/pmem/pmdk/issues/4207");
-	// src/common/shutdown_state.c:87
+	// src/common/shutdown_state.c
 	ERR_WO_ERRNO("cannot read uuid of %d", _d);
-	// src/libpmem/libpmem.c:56
+	// src/libpmem/libpmem.c
 	ERR_WO_ERRNO("libpmem major version mismatch (need %u, found %u)", _u, _u);
-	// src/libpmem/libpmem.c:63
+	// src/libpmem/libpmem.c
 	ERR_WO_ERRNO("libpmem minor version mismatch (need %u, found %u)", _u, _u);
-	// src/libpmem/pmem.c:413
+	// src/libpmem/pmem.c
 	ERR_WO_ERRNO("invalid flag specified %x", _u);
-	// src/libpmem/pmem.c:420
+	// src/libpmem/pmem.c
 	ERR_WO_ERRNO("flag unsupported for Device DAX %x", _u);
-	// src/libpmem/pmem.c:429
+	// src/libpmem/pmem.c
 	ERR_WO_ERRNO("unable to read Device DAX size");
-	// src/libpmem/pmem.c:434
+	// src/libpmem/pmem.c
 	ERR_WO_ERRNO("Device DAX length must be either 0 or the exact size of the device: %zu", _zu);
-	// src/libpmem/pmem.c:446
+	// src/libpmem/pmem.c
 	ERR_WO_ERRNO("invalid file length %zu", _zu);
-	// src/libpmem/pmem.c:457
+	// src/libpmem/pmem.c
 	ERR_WO_ERRNO("non-zero 'len' not allowed without PMEM_FILE_CREATE");
-	// src/libpmem/pmem.c:464
+	// src/libpmem/pmem.c
 	ERR_WO_ERRNO("zero 'len' not allowed with PMEM_FILE_CREATE");
-	// src/libpmem/pmem.c:470
+	// src/libpmem/pmem.c
 	ERR_WO_ERRNO("PMEM_FILE_TMPFILE not allowed without PMEM_FILE_CREATE");
-	// src/libpmem/pmem.c:513
+	// src/libpmem/pmem.c
 	ERR_WO_ERRNO("stat %s: negative size", _s);
-	// src/libpmem/pmem.c:588
+	// src/libpmem/pmem.c
 	ERR_WO_ERRNO("invalid flags 0x%x", _u);
-	// src/libpmem/pmem.c:619
+	// src/libpmem/pmem.c
 	ERR_WO_ERRNO("invalid flags 0x%x", _u);
-	// src/libpmem/pmem.c:651
+	// src/libpmem/pmem.c
 	ERR_WO_ERRNO("invalid flags 0x%x", _u);
-	// src/libpmemobj/alloc_class.c:231
+	// src/libpmemobj/alloc_class.c
 	ERR_WO_ERRNO("unable to register allocation class");
-	// src/libpmemobj/heap.c:1051
+	// src/libpmemobj/heap.c
 	ERR_WO_ERRNO("lost runtime tracking info of %u run due to OOM", _u);
-	// src/libpmemobj/heap.c:1167
+	// src/libpmemobj/heap.c
 	ERR_WO_ERRNO("lost runtime tracking info of %u run due to OOM", _u);
-	// src/libpmemobj/heap.c:1410
+	// src/libpmemobj/heap.c
 	ERR_WO_ERRNO("at least one automatic arena must exist");
-	// src/libpmemobj/heap.c:1605
+	// src/libpmemobj/heap.c
 	ERR_WO_ERRNO("mapped region smaller than the heap size");
-	// src/libpmemobj/heap.c:1787
+	// src/libpmemobj/heap.c
 	ERR_WO_ERRNO("heap: invalid header's checksum");
-	// src/libpmemobj/heap.c:1792
+	// src/libpmemobj/heap.c
 	ERR_WO_ERRNO("heap: invalid signature");
-	// src/libpmemobj/heap.c:1810
+	// src/libpmemobj/heap.c
 	ERR_WO_ERRNO("heap: invalid zone size");
-	// src/libpmemobj/heap.c:1825
+	// src/libpmemobj/heap.c
 	ERR_WO_ERRNO("heap: invalid chunk type");
-	// src/libpmemobj/heap.c:1830
+	// src/libpmemobj/heap.c
 	ERR_WO_ERRNO("heap: unknown chunk type");
-	// src/libpmemobj/heap.c:1835
+	// src/libpmemobj/heap.c
 	ERR_WO_ERRNO("heap: invalid chunk flags");
-	// src/libpmemobj/heap.c:1852
+	// src/libpmemobj/heap.c
 	ERR_WO_ERRNO("heap: invalid zone magic");
-	// src/libpmemobj/heap.c:1868
+	// src/libpmemobj/heap.c
 	ERR_WO_ERRNO("heap: chunk sizes mismatch");
-	// src/libpmemobj/heap.c:1884
+	// src/libpmemobj/heap.c
 	ERR_WO_ERRNO("heap: invalid heap size");
-	// src/libpmemobj/heap.c:768
+	// src/libpmemobj/heap.c
 	ERR_WO_ERRNO("lost runtime tracking info of %u run due to OOM", _u);
-	// src/libpmemobj/libpmemobj.c:52
+	// src/libpmemobj/libpmemobj.c
 	ERR_WO_ERRNO("libpmemobj major version mismatch (need %u, found %u)", _u, _u);
-	// src/libpmemobj/libpmemobj.c:59
+	// src/libpmemobj/libpmemobj.c
 	ERR_WO_ERRNO("libpmemobj minor version mismatch (need %u, found %u)", _u, _u);
-	// src/libpmemobj/memops.c:575
+	// src/libpmemobj/memops.c
 	ERR_WO_ERRNO("Capacity insufficient");
-	// src/libpmemobj/memops.c:586
+	// src/libpmemobj/memops.c
 	ERR_WO_ERRNO("Buffer currently used");
-	// src/libpmemobj/memops.c:691
+	// src/libpmemobj/memops.c
 	ERR_WO_ERRNO("no extend function present");
-	// src/libpmemobj/obj.c:1036
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("%s variable must be a positive integer", _s);
-	// src/libpmemobj/obj.c:1065
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("Layout too long");
-	// src/libpmemobj/obj.c:1114
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("initialization of replica #%u failed", _u);
-	// src/libpmemobj/obj.c:1134
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("pool initialization failed");
-	// src/libpmemobj/obj.c:1184
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("invalid run_id %lu", _lu);
-	// src/libpmemobj/obj.c:1246
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("read-only mode is not supported");
-	// src/libpmemobj/obj.c:1279
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("initialization of replica #%u failed", _u);
-	// src/libpmemobj/obj.c:1319
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("inconsistent replica #%u", _u);
-	// src/libpmemobj/obj.c:1405
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("pool initialization failed");
-	// src/libpmemobj/obj.c:1537
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("critnib_remove for pools_ht");
-	// src/libpmemobj/obj.c:1541
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("critnib_remove for pools_tree");
-	// src/libpmemobj/obj.c:1724
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("requested size too large");
-	// src/libpmemobj/obj.c:1767
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("allocation with size 0");
-	// src/libpmemobj/obj.c:1798
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("allocation with size 0");
-	// src/libpmemobj/obj.c:1804
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("unknown flags 0x%lx", _lu);
-	// src/libpmemobj/obj.c:1843
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("allocation with size 0");
-	// src/libpmemobj/obj.c:1921
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("requested size too large");
-	// src/libpmemobj/obj.c:2298
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("invalid flags 0x%x", _u);
-	// src/libpmemobj/obj.c:2316
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("invalid flags 0x%x", _u);
-	// src/libpmemobj/obj.c:2418
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("requested size too large");
-	// src/libpmemobj/obj.c:2424
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("requested size cannot equals zero");
-	// src/libpmemobj/obj.c:2560
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("unknown flags 0x%lx", _lu);
-	// src/libpmemobj/obj.c:2669
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("Not all PMEMoids belong to the provided pool");
-	// src/libpmemobj/obj.c:2739
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("requested size too large");
-	// src/libpmemobj/obj.c:773
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("invalid checksum of pool descriptor");
-	// src/libpmemobj/obj.c:780
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("wrong layout (\"%s\"), pool created with layout \"%s\"", _s, _s);
-	// src/libpmemobj/obj.c:788
+	// src/libpmemobj/obj.c
 	ERR_WO_ERRNO("unaligned heap: off %lu", _lu);
-	// src/libpmemobj/palloc.c:196
+	// src/libpmemobj/palloc.c
 	ERR_WO_ERRNO("no allocation class for size %lu bytes", _lu);
-	// src/libpmemobj/palloc.c:211
+	// src/libpmemobj/palloc.c
 	ERR_WO_ERRNO("allocation class not suitable for size %lu bytes", _lu);
-	// src/libpmemobj/palloc.c:275
+	// src/libpmemobj/palloc.c
 	ERR_WO_ERRNO("invalid operation or heap corruption");
-	// src/libpmemobj/pmalloc.c:237
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("unit size must be evenly divisible by alignment");
-	// src/libpmemobj/pmalloc.c:243
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("alignment cannot be larger than 2 megabytes");
-	// src/libpmemobj/pmalloc.c:261
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("invalid header type");
-	// src/libpmemobj/pmalloc.c:268
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("no available free allocation class identifier");
-	// src/libpmemobj/pmalloc.c:278
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("class id outside of the allowed range");
-	// src/libpmemobj/pmalloc.c:286
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("attempted to overwrite an allocation class");
-	// src/libpmemobj/pmalloc.c:344
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("invalid header type");
-	// src/libpmemobj/pmalloc.c:369
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("class id outside of the allowed range");
-	// src/libpmemobj/pmalloc.c:380
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("class with the given id does not exist");
-	// src/libpmemobj/pmalloc.c:459
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("incorrect size for extend, must be larger than %lu", _lu);
-	// src/libpmemobj/pmalloc.c:511
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("incorrect grow size, must be 0 or larger than %lu", _lu);
-	// src/libpmemobj/pmalloc.c:576
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("cannot change max arena number");
-	// src/libpmemobj/pmalloc.c:642
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("arena id outside of the allowed range: <1,%u>", _u);
-	// src/libpmemobj/pmalloc.c:680
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("arena id outside of the allowed range: <1,%u>", _u);
-	// src/libpmemobj/pmalloc.c:687
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("incorrect arena state, must be 0 or 1");
-	// src/libpmemobj/pmalloc.c:719
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("arena id outside of the allowed range: <1,%u>", _u);
-	// src/libpmemobj/pmalloc.c:767
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("arena id outside of the allowed range: <1,%u>", _u);
-	// src/libpmemobj/pmalloc.c:919
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("invalid arena assignment type");
-	// src/libpmemobj/pmalloc.c:969
+	// src/libpmemobj/pmalloc.c
 	ERR_WO_ERRNO("number of default arenas can't be 0");
-	// src/libpmemobj/stats.c:74
+	// src/libpmemobj/stats.c
 	ERR_WO_ERRNO("invalid enable type");
-	// src/libpmemobj/sync.c:43
+	// src/libpmemobj/sync.c
 	ERR_WO_ERRNO("error initializing lock");
-	// src/libpmemobj/sync.c:50
+	// src/libpmemobj/sync.c
 	ERR_WO_ERRNO("error setting lock runid");
-	// src/libpmemobj/tx.c:1236
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("snapshot size too large");
-	// src/libpmemobj/tx.c:1243
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("object outside of heap");
-	// src/libpmemobj/tx.c:1383
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("out of memory");
-	// src/libpmemobj/tx.c:1410
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("object outside of pool");
-	// src/libpmemobj/tx.c:1448
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("unknown flags 0x%lx", _lu);
-	// src/libpmemobj/tx.c:1456
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("object outside of pool");
-	// src/libpmemobj/tx.c:1493
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("invalid pool uuid");
-	// src/libpmemobj/tx.c:1531
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("unknown flags 0x%lx", _lu);
-	// src/libpmemobj/tx.c:1539
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("invalid pool uuid");
-	// src/libpmemobj/tx.c:1576
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("allocation with size 0");
-	// src/libpmemobj/tx.c:1607
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("allocation with size 0");
-	// src/libpmemobj/tx.c:1638
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("allocation with size 0");
-	// src/libpmemobj/tx.c:1645
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("unknown flags 0x%lx", _lu);
-	// src/libpmemobj/tx.c:1714
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("unknown flags 0x%lx", _lu);
-	// src/libpmemobj/tx.c:1722
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("cannot duplicate NULL string");
-	// src/libpmemobj/tx.c:1772
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("unknown flags 0x%lx", _lu);
-	// src/libpmemobj/tx.c:1780
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("cannot duplicate NULL string");
-	// src/libpmemobj/tx.c:1831
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("unknown flags 0x%lx", _lu);
-	// src/libpmemobj/tx.c:1842
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("invalid pool uuid");
-	// src/libpmemobj/tx.c:1914
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("unknown flags 0x%lx", _lu);
-	// src/libpmemobj/tx.c:1959
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("unknown flags 0x%lx", _lu);
-	// src/libpmemobj/tx.c:2208
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("invalid cache size, must be between 0 and max alloc size");
-	// src/libpmemobj/tx.c:2232
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("tx.cache.threshold parameter is deprecated");
-	// src/libpmemobj/tx.c:2247
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("tx.cache.threshold parameter is deprecated");
-	// src/libpmemobj/tx.c:513
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("Unrecognized lock type");
-	// src/libpmemobj/tx.c:550
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("Unrecognized lock type");
-	// src/libpmemobj/tx.c:588
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("requested size too large");
-	// src/libpmemobj/tx.c:617
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("out of memory");
-	// src/libpmemobj/tx.c:633
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("requested size too large");
-	// src/libpmemobj/tx.c:647
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("pmemobj_tx_free failed");
-	// src/libpmemobj/tx.c:665
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("pmemobj_tx_free failed");
-	// src/libpmemobj/tx.c:682
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("Buffer from a different pool");
-	// src/libpmemobj/tx.c:739
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("nested transaction for different pool");
-	// src/libpmemobj/tx.c:865
+	// src/libpmemobj/tx.c
 	ERR_WO_ERRNO("unknown flags 0x%lx", _lu);
-	// src/libpmemobj/ulog.c:245
+	// src/libpmemobj/ulog.c
 	ERR_WO_ERRNO("cannot auto reserve next ulog");
-	// src/tools/pmempool/output.c:779
+	// src/tools/pmempool/output.c
 	ERR_WO_ERRNO("snprintf for incompat features: %d", _d);
 }
 
 void
 call_all_CORE_LOG_WARNING(void)
 {
-	// src/common/file.c:263
+	// src/common/file.c
 	CORE_LOG_WARNING("requested size of write goes beyond the file length, %zu > %zu", _zu, _zu);
-	// src/common/file.c:326
+	// src/common/file.c
 	CORE_LOG_WARNING("requested size of write goes beyond the file length, %zu > %zu", _zu, _zu);
-	// src/common/file.c:380
+	// src/common/file.c
 	CORE_LOG_WARNING("requested size of read goes beyond the file length, %zu > %zu", _zu, _zu);
-	// src/common/mmap.c:54
+	// src/common/mmap.c
 	CORE_LOG_WARNING("Invalid PMEM_MMAP_HINT");
-	// src/common/mmap.c:56
+	// src/common/mmap.c
 	CORE_LOG_WARNING("No /proc, PMEM_MMAP_HINT ignored");
-	// src/common/set.c:2002
+	// src/common/set.c
 	CORE_LOG_WARNING("usable space mapping failed - part #%d - retrying", _d);
-	// src/common/set.c:2649
+	// src/common/set.c
 	CORE_LOG_WARNING("usable space mapping failed - part #%d - retrying", _d);
-	// src/common/set.c:2897
+	// src/common/set.c
 	CORE_LOG_WARNING("pool set contains bad blocks, ignoring");
-	// src/common/set.c:2955
+	// src/common/set.c
 	CORE_LOG_WARNING("cannot open the part -- \"%s\"", _s);
-	// src/common/set.c:3060
+	// src/common/set.c
 	CORE_LOG_WARNING("pool set contains bad blocks, ignoring -- '%s'", _s);
-	// src/common/set.c:428
+	// src/common/set.c
 	CORE_LOG_WARNING("file permissions changed during pool initialization, file: %s (%o)", _s, _u);
-	// src/common/shutdown_state.c:206
+	// src/common/shutdown_state.c
 	CORE_LOG_WARNING("incorrect checksum - SDS will be reinitialized");
-	// src/common/shutdown_state.c:219
+	// src/common/shutdown_state.c
 	CORE_LOG_WARNING("the pool was not closed - SDS will be reinitialized");
-	// src/common/shutdown_state.c:226
+	// src/common/shutdown_state.c
 	CORE_LOG_WARNING("an ADR failure was detected but the pool was closed - SDS will be reinitialized");
-	// src/libpmemobj/heap.c:1192
+	// src/libpmemobj/heap.c
 	CORE_LOG_WARNING("failed to allocate memory block runtime tracking info");
-	// src/libpmemobj/heap.c:1204
+	// src/libpmemobj/heap.c
 	CORE_LOG_WARNING("failed to allocate memory block runtime tracking info");
-	// src/libpmemobj/memops.c:352
+	// src/libpmemobj/memops.c
 	CORE_LOG_WARNING("out of memory - unable to track entries");
-	// src/libpmemobj/palloc.c:307
+	// src/libpmemobj/palloc.c
 	CORE_LOG_WARNING("unable to track runtime chunk state");
 }
 
 void
 call_all_CORE_LOG_ERROR(void)
 {
-	// src/common/bad_blocks.c:152
+	// src/common/bad_blocks.c
 	CORE_LOG_ERROR("pmem2_badblock_context_new failed -- %s", _s);
-	// src/common/bad_blocks.c:161
+	// src/common/bad_blocks.c
 	CORE_LOG_ERROR("pmem2_badblock_clear -- %s", _s);
-	// src/common/bad_blocks.c:210
+	// src/common/bad_blocks.c
 	CORE_LOG_ERROR("pmem2_badblock_context_new failed -- %s", _s);
-	// src/common/bad_blocks.c:217
+	// src/common/bad_blocks.c
 	CORE_LOG_ERROR("pmem2_badblock_clear -- %s", _s);
-	// src/common/bad_blocks.c:255
+	// src/common/bad_blocks.c
 	CORE_LOG_ERROR("counting bad blocks failed -- '%s'", _s);
-	// src/common/bad_blocks.c:260
+	// src/common/bad_blocks.c
 	CORE_LOG_ERROR("pool file '%s' contains %li bad block(s)", _s, _d);
-	// src/common/ctl.c:238
+	// src/common/ctl.c
 	CORE_LOG_ERROR("Invalid arguments");
-	// src/common/file.c:212
+	// src/common/file.c
 	CORE_LOG_ERROR("cannot determine file length \"%s\"", _s);
-	// src/common/file.c:218
+	// src/common/file.c
 	CORE_LOG_ERROR("failed to map entire file \"%s\"", _s);
-	// src/common/file.c:250
+	// src/common/file.c
 	CORE_LOG_ERROR("cannot determine file length \"%s\"", _s);
-	// src/common/file.c:256
+	// src/common/file.c
 	CORE_LOG_ERROR("offset beyond file length, %ju > %ju", _ju, _ju);
-	// src/common/file.c:272
+	// src/common/file.c
 	CORE_LOG_ERROR("failed to map entire file \"%s\"", _s);
-	// src/common/file.c:307
+	// src/common/file.c
 	CORE_LOG_ERROR("failed to open file \"%s\"", _s);
-	// src/common/file.c:320
+	// src/common/file.c
 	CORE_LOG_ERROR("cannot determine file length \"%s\"", _s);
-	// src/common/file.c:335
+	// src/common/file.c
 	CORE_LOG_ERROR("failed to map entire file \"%s\"", _s);
-	// src/common/file.c:361
+	// src/common/file.c
 	CORE_LOG_ERROR("failed to open file \"%s\"", _s);
-	// src/common/file.c:374
+	// src/common/file.c
 	CORE_LOG_ERROR("cannot determine file length \"%s\"", _s);
-	// src/common/file.c:389
+	// src/common/file.c
 	CORE_LOG_ERROR("failed to map entire file \"%s\"", _s);
-	// src/common/file.c:547
+	// src/common/file.c
 	CORE_LOG_ERROR("failed to open file \"%s\"", _s);
-	// src/common/file_posix.c:115
+	// src/common/file_posix.c
 	CORE_LOG_ERROR("Cannot open file %s", _s);
-	// src/common/mmap.c:94
+	// src/common/mmap.c
 	CORE_LOG_ERROR("cannot find a contiguous region of given size");
-	// src/common/os_deep_linux.c:127
+	// src/common/os_deep_linux.c
 	CORE_LOG_ERROR("pmem_msync(%p, %lu)", _p, _lu);
-	// src/common/os_deep_linux.c:156
+	// src/common/os_deep_linux.c
 	CORE_LOG_ERROR("deep_flush not supported");
-	// src/common/os_deep_linux.c:159
+	// src/common/os_deep_linux.c
 	CORE_LOG_ERROR("invalid dax_region id %u", _u);
-	// src/common/os_deep_linux.c:166
+	// src/common/os_deep_linux.c
 	CORE_LOG_ERROR("pmem2_deep_flush_write(%u)", _u);
-	// src/common/os_deep_linux.c:175
+	// src/common/os_deep_linux.c
 	CORE_LOG_ERROR("pmem_msync(%p, %lu)", _p, _lu);
-	// src/common/os_deep_linux.c:38
+	// src/common/os_deep_linux.c
 	CORE_LOG_ERROR("deep_flush not supported");
-	// src/common/os_deep_linux.c:42
+	// src/common/os_deep_linux.c
 	CORE_LOG_ERROR("cannot write to deep_flush in region %u", _u);
-	// src/common/set.c:1053
+	// src/common/set.c
 	CORE_LOG_ERROR("cannot read size of file (%s) in a poolset directory", _s);
-	// src/common/set.c:1484
+	// src/common/set.c
 	CORE_LOG_ERROR("failed to create file: %s", _s);
-	// src/common/set.c:1494
+	// src/common/set.c
 	CORE_LOG_ERROR("failed to open file: %s", _s);
-	// src/common/set.c:183
+	// src/common/set.c
 	CORE_LOG_ERROR("cannot find a contiguous region of given size");
-	// src/common/set.c:1964
+	// src/common/set.c
 	CORE_LOG_ERROR("cannot find a contiguous region of given size");
-	// src/common/set.c:1972
+	// src/common/set.c
 	CORE_LOG_ERROR("pool mapping failed - replica #%u part #0", _u);
-	// src/common/set.c:2016
+	// src/common/set.c
 	CORE_LOG_ERROR("usable space mapping failed - part #%d", _d);
-	// src/common/set.c:2085
+	// src/common/set.c
 	CORE_LOG_ERROR("header mapping failed - part #%d", _d);
-	// src/common/set.c:2093
+	// src/common/set.c
 	CORE_LOG_ERROR("header creation failed - part #%d", _d);
-	// src/common/set.c:2130
+	// src/common/set.c
 	CORE_LOG_ERROR("replica #%u map failed", _u);
-	// src/common/set.c:2139
+	// src/common/set.c
 	CORE_LOG_ERROR("replica #%u headers initialization failed", _u);
-	// src/common/set.c:2398
+	// src/common/set.c
 	CORE_LOG_ERROR("cannot create pool set -- '%s'", _s);
-	// src/common/set.c:2445
+	// src/common/set.c
 	CORE_LOG_ERROR("failed to check pool set for bad blocks -- '%s'", _s);
-	// src/common/set.c:2485
+	// src/common/set.c
 	CORE_LOG_ERROR("cannot generate pool set UUID");
-	// src/common/set.c:2497
+	// src/common/set.c
 	CORE_LOG_ERROR("cannot generate pool set part UUID");
-	// src/common/set.c:2524
+	// src/common/set.c
 	CORE_LOG_ERROR("replica #%u creation failed", _u);
-	// src/common/set.c:2591
+	// src/common/set.c
 	CORE_LOG_ERROR("cannot find a contiguous region of given size");
-	// src/common/set.c:2601
+	// src/common/set.c
 	CORE_LOG_ERROR("pool mapping failed - replica #%u part #0", _u);
-	// src/common/set.c:2615
+	// src/common/set.c
 	CORE_LOG_ERROR("header mapping failed - part #%d", _d);
-	// src/common/set.c:2662
+	// src/common/set.c
 	CORE_LOG_ERROR("usable space mapping failed - part #%d", _d);
-	// src/common/set.c:2793
+	// src/common/set.c
 	CORE_LOG_ERROR("header check failed - part #%d", _d);
-	// src/common/set.c:2823
+	// src/common/set.c
 	CORE_LOG_ERROR("ADR failure detected");
-	// src/common/set.c:2883
+	// src/common/set.c
 	CORE_LOG_ERROR("an error occurred when checking whether recovery file exists.");
-	// src/common/set.c:2890
+	// src/common/set.c
 	CORE_LOG_ERROR("failed to check pool set for bad blocks");
-	// src/common/set.c:2916
+	// src/common/set.c
 	CORE_LOG_ERROR("replica #%u open failed", _u);
-	// src/common/set.c:2963
+	// src/common/set.c
 	CORE_LOG_ERROR("header mapping failed -- \"%s\"", _s);
-	// src/common/set.c:3007
+	// src/common/set.c
 	CORE_LOG_ERROR("cannot open pool set -- '%s'", _s);
-	// src/common/set.c:3030
+	// src/common/set.c
 	CORE_LOG_ERROR("reading compat features failed");
-	// src/common/set.c:3045
+	// src/common/set.c
 	CORE_LOG_ERROR("an error occurred when checking whether recovery file exists.");
-	// src/common/set.c:3052
+	// src/common/set.c
 	CORE_LOG_ERROR("failed to check pool set for bad blocks -- '%s'", _s);
-	// src/common/set.c:3079
+	// src/common/set.c
 	CORE_LOG_ERROR("replica #%u open failed", _u);
-	// src/common/set.c:3316
+	// src/common/set.c
 	CORE_LOG_ERROR("os_part_deep_common(%p, %p, %lu)", _p, _p, _lu);
-	// src/common/set.c:343
+	// src/common/set.c
 	CORE_LOG_ERROR("replica open failed: replica %u", _u);
-	// src/common/set_badblocks.c:213
+	// src/common/set_badblocks.c
 	CORE_LOG_ERROR("allocating name of bad block recovery file failed");
-	// src/common/set_badblocks.c:86
+	// src/common/set_badblocks.c
 	CORE_LOG_ERROR("%i pool file(s) contain bad blocks", _d);
-	// src/common/shutdown_state.c:80
+	// src/common/shutdown_state.c
 	CORE_LOG_ERROR("cannot read unsafe shutdown count for %d", _d);
-	// src/common/uuid.c:24
+	// src/common/uuid.c
 	CORE_LOG_ERROR("invalid buffer for uuid string");
-	// src/common/uuid.c:29
+	// src/common/uuid.c
 	CORE_LOG_ERROR("invalid uuid structure");
-	// src/common/uuid.c:42
+	// src/common/uuid.c
 	CORE_LOG_ERROR("snprintf(uuid): %d", _d);
-	// src/common/uuid.c:60
+	// src/common/uuid.c
 	CORE_LOG_ERROR("invalid uuid string");
-	// src/common/uuid.c:66
+	// src/common/uuid.c
 	CORE_LOG_ERROR("invalid uuid string");
-	// src/common/uuid.c:79
+	// src/common/uuid.c
 	CORE_LOG_ERROR("sscanf(uuid)");
-	// src/common/uuid_linux.c:31
+	// src/common/uuid_linux.c
 	CORE_LOG_ERROR("open(uuid)");
-	// src/common/uuid_linux.c:37
+	// src/common/uuid_linux.c
 	CORE_LOG_ERROR("read(uuid)");
-	// src/core/util_posix.c:52
+	// src/core/util_posix.c
 	CORE_LOG_ERROR("stat failed for %s", _s);
-	// src/core/util_posix.c:62
+	// src/core/util_posix.c
 	CORE_LOG_ERROR("stat failed for %s", _s);
-	// src/libpmem/pmem.c:480
+	// src/libpmem/pmem.c
 	CORE_LOG_ERROR("failed to create temporary file at \"%s\"", _s);
-	// src/libpmem/pmem_posix.c:61
+	// src/libpmem/pmem_posix.c
 	CORE_LOG_ERROR("can't track mapped region");
-	// src/libpmemobj/heap.c:1327
+	// src/libpmemobj/heap.c
 	CORE_LOG_ERROR("cannot decrease max number of arenas");
-	// src/libpmemobj/lane.c:417
+	// src/libpmemobj/lane.c
 	CORE_LOG_ERROR("lane %lu internal redo failed: %d", _lu, _d);
-	// src/libpmemobj/list.c:564
+	// src/libpmemobj/list.c
 	CORE_LOG_ERROR("pmemobj_mutex_lock failed");
-	// src/libpmemobj/list.c:603
+	// src/libpmemobj/list.c
 	CORE_LOG_ERROR("pmemobj_mutex_lock failed");
-	// src/libpmemobj/list.c:731
+	// src/libpmemobj/list.c
 	CORE_LOG_ERROR("pmemobj_mutex_lock failed");
-	// src/libpmemobj/list.c:765
+	// src/libpmemobj/list.c
 	CORE_LOG_ERROR("pmemobj_mutex_lock failed");
-	// src/libpmemobj/list.c:842
+	// src/libpmemobj/list.c
 	CORE_LOG_ERROR("list_mutexes_lock failed");
-	// src/libpmemobj/obj.c:105
+	// src/libpmemobj/obj.c
 	CORE_LOG_ERROR("unable to parse config stored in %s environment variable", _s);
-	// src/libpmemobj/obj.c:1090
+	// src/libpmemobj/obj.c
 	CORE_LOG_ERROR("cannot create pool or pool set");
-	// src/libpmemobj/obj.c:1127
+	// src/libpmemobj/obj.c
 	CORE_LOG_ERROR("creation of pool descriptor failed");
-	// src/libpmemobj/obj.c:116
+	// src/libpmemobj/obj.c
 	CORE_LOG_ERROR("unable to parse config stored in %s file (from %s environment variable)", _s, _s);
-	// src/libpmemobj/obj.c:1189
+	// src/libpmemobj/obj.c
 	CORE_LOG_ERROR("lane_check");
-	// src/libpmemobj/obj.c:1198
+	// src/libpmemobj/obj.c
 	CORE_LOG_ERROR("heap_check");
-	// src/libpmemobj/obj.c:1238
+	// src/libpmemobj/obj.c
 	CORE_LOG_ERROR("cannot open pool or pool set");
-	// src/libpmemobj/obj.c:1375
+	// src/libpmemobj/obj.c
 	CORE_LOG_ERROR("descriptor check of replica #%u failed", _u);
-	// src/libpmemobj/obj.c:2438
+	// src/libpmemobj/obj.c
 	CORE_LOG_ERROR("obj_realloc_root failed");
-	// src/libpmemobj/obj.c:90
+	// src/libpmemobj/obj.c
 	CORE_LOG_ERROR("ctl_new");
-	// src/tools/pmempool/common.c:1307
+	// src/tools/pmempool/common.c
 	CORE_LOG_ERROR("cannot open pool set -- '%s'", _s);
 }
 
 void
 call_all_CORE_LOG_FATAL(void)
 {
-	// src/common/set.c:221
+	// src/common/set.c
 	CORE_LOG_FATAL("munmap: %s", _s);
-	// src/common/set.c:2220
+	// src/common/set.c
 	CORE_LOG_FATAL("cannot add a new part to the replica info");
-	// src/common/util_pmem.h:30
+	// src/common/util_pmem.h
 	CORE_LOG_FATAL("pmem_msync");
-	// src/core/alloc.c:62
+	// src/core/alloc.c
 	CORE_LOG_FATAL("unknown allocation type");
-	// src/core/core_assert.h:39
+	// src/core/core_assert.h
 	CORE_LOG_FATAL("assertion failure: %s", _s);
-	// src/core/core_assert.h:45
+	// src/core/core_assert.h
 	CORE_LOG_FATAL("assertion failure: %s (%s = %s)", _s, _s, _s);
-	// src/core/last_error_msg.c:37
+	// src/core/last_error_msg.c
 	CORE_LOG_FATAL("os_thread_key_create");
-	// src/core/last_error_msg.c:78
+	// src/core/last_error_msg.c
 	CORE_LOG_FATAL("os_tls_set");
-	// src/core/out.c:147
+	// src/core/out.c
 	CORE_LOG_FATAL("Cannot set log threshold");
-	// src/core/out.c:154
+	// src/core/out.c
 	CORE_LOG_FATAL("Cannot set legacy log function");
-	// src/core/sys_util.h:108
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_rwlock_init");
-	// src/core/sys_util.h:123
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_rwlock_rdlock");
-	// src/core/sys_util.h:138
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_rwlock_wrlock");
-	// src/core/sys_util.h:153
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_rwlock_unlock");
-	// src/core/sys_util.h:168
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_rwlock_destroy");
-	// src/core/sys_util.h:197
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_spin_destroy");
-	// src/core/sys_util.h:211
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_spin_lock");
-	// src/core/sys_util.h:226
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_spin_unlock");
-	// src/core/sys_util.h:239
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_semaphore_init");
-	// src/core/sys_util.h:249
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_semaphore_destroy");
-	// src/core/sys_util.h:266
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_semaphore_wait");
-	// src/core/sys_util.h:282
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_semaphore_trywait");
-	// src/core/sys_util.h:294
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_semaphore_post");
-	// src/core/sys_util.h:301
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_cond_init");
-	// src/core/sys_util.h:308
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_cond_destroy");
-	// src/core/sys_util.h:31
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_mutex_init");
-	// src/core/sys_util.h:46
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_mutex_destroy");
-	// src/core/sys_util.h:61
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_mutex_lock");
-	// src/core/sys_util.h:77
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_mutex_trylock");
-	// src/core/sys_util.h:93
+	// src/core/sys_util.h
 	CORE_LOG_FATAL("os_mutex_unlock");
-	// src/libpmem/pmem.c:362
+	// src/libpmem/pmem.c
 	CORE_LOG_FATAL("util_bool_compare_and_swap32");
-	// src/libpmem/pmem.c:915
+	// src/libpmem/pmem.c
 	CORE_LOG_FATAL("invalid flush function address");
-	// src/libpmemobj/lane.c:105
+	// src/libpmemobj/lane.c
 	CORE_LOG_FATAL("os_tls_key_create");
-	// src/libpmemobj/lane.c:43
+	// src/libpmemobj/lane.c
 	CORE_LOG_FATAL("critnib_new");
-	// src/libpmemobj/lane.c:483
+	// src/libpmemobj/lane.c
 	CORE_LOG_FATAL("Malloc");
-	// src/libpmemobj/lane.c:499
+	// src/libpmemobj/lane.c
 	CORE_LOG_FATAL("critnib_insert");
-	// src/libpmemobj/lane.c:555
+	// src/libpmemobj/lane.c
 	CORE_LOG_FATAL("lane_release");
-	// src/libpmemobj/lane.c:560
+	// src/libpmemobj/lane.c
 	CORE_LOG_FATAL("util_bool_compare_and_swap64");
-	// src/libpmemobj/lane.c:80
+	// src/libpmemobj/lane.c
 	CORE_LOG_FATAL("os_tls_set");
-	// src/libpmemobj/memblock.c:1106
+	// src/libpmemobj/memblock.c
 	CORE_LOG_FATAL("failed to initialize valgrind state");
-	// src/libpmemobj/memblock.c:1146
+	// src/libpmemobj/memblock.c
 	CORE_LOG_FATAL("failed to initialize valgrind state");
-	// src/libpmemobj/memblock.c:1466
+	// src/libpmemobj/memblock.c
 	CORE_LOG_FATAL("possible zone chunks metadata corruption");
-	// src/libpmemobj/obj.c:148
+	// src/libpmemobj/obj.c
 	CORE_LOG_FATAL("critnib_new for pools_ht");
-	// src/libpmemobj/obj.c:156
+	// src/libpmemobj/obj.c
 	CORE_LOG_FATAL("critnib_new for pools_tree");
-	// src/libpmemobj/obj.c:211
+	// src/libpmemobj/obj.c
 	CORE_LOG_FATAL("error: %s", _s);
-	// src/libpmemobj/obj.c:252
+	// src/libpmemobj/obj.c
 	CORE_LOG_FATAL("pmem_msync");
-	// src/libpmemobj/palloc.c:304
+	// src/libpmemobj/palloc.c
 	CORE_LOG_FATAL("duplicate runtime chunk state, possible double free");
-	// src/libpmemobj/sync.h:102
+	// src/libpmemobj/sync.h
 	CORE_LOG_FATAL("pmemobj_mutex_unlock");
-	// src/libpmemobj/sync.h:87
+	// src/libpmemobj/sync.h
 	CORE_LOG_FATAL("pmemobj_mutex_lock");
-	// src/libpmemobj/tx.c:1049
+	// src/libpmemobj/tx.c
 	CORE_LOG_FATAL("pmemobj_tx_end called without pmemobj_tx_commit");
-	// src/libpmemobj/tx.c:1053
+	// src/libpmemobj/tx.c
 	CORE_LOG_FATAL("pmemobj_tx_end called without pmemobj_tx_begin");
-	// src/libpmemobj/tx.c:161
+	// src/libpmemobj/tx.c
 	CORE_LOG_FATAL("%s called outside of transaction", _s);
-	// src/libpmemobj/tx.c:272
+	// src/libpmemobj/tx.c
 	CORE_LOG_FATAL("Malloc");
-	// src/libpmemobj/tx.c:284
+	// src/libpmemobj/tx.c
 	CORE_LOG_FATAL("Malloc");
-	// src/libpmemobj/tx.c:321
+	// src/libpmemobj/tx.c
 	CORE_LOG_FATAL("Malloc");
-	// src/libpmemobj/tx.c:574
+	// src/libpmemobj/tx.c
 	CORE_LOG_FATAL("invalid state of ranges tree");
-	// src/libpmemobj/tx.c:769
+	// src/libpmemobj/tx.c
 	CORE_LOG_FATAL("Invalid stage %d to begin new transaction", _d);
-	// src/libpmemobj/tx.c:807
+	// src/libpmemobj/tx.c
 	CORE_LOG_FATAL("transaction callback is already set, old %p new %p old_arg %p new_arg %p", _p, _p, _p, _p);
 }
 
@@ -799,304 +799,304 @@ void
 call_all_ERR_W_ERRNO(int errnum)
 {
 	errno = errnum;
-	// src/common/bad_blocks.c:142
+	// src/common/bad_blocks.c
 	ERR_W_ERRNO("open %s", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/bad_blocks.c:200
+	// src/common/bad_blocks.c
 	ERR_W_ERRNO("open %s", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/bad_blocks.c:63
+	// src/common/bad_blocks.c
 	ERR_W_ERRNO("open %s", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/ctl.c:132
+	// src/common/ctl.c
 	ERR_W_ERRNO("Malloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/ctl.c:142
+	// src/common/ctl.c
 	ERR_W_ERRNO("strtok_r");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/ctl.c:400
+	// src/common/ctl.c
 	ERR_W_ERRNO("Strdup");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/ctl.c:445
+	// src/common/ctl.c
 	ERR_W_ERRNO("Zalloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/ctl.c:479
+	// src/common/ctl.c
 	ERR_W_ERRNO("Zalloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/file.c:126
+	// src/common/file.c
 	ERR_W_ERRNO("stat");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/file.c:143
+	// src/common/file.c
 	ERR_W_ERRNO("open");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/file.c:206
+	// src/common/file.c
 	ERR_W_ERRNO("open \"%s\"", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/file.c:244
+	// src/common/file.c
 	ERR_W_ERRNO("open \"%s\"", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/file.c:40
+	// src/common/file.c
 	ERR_W_ERRNO("os_access \"%s\"", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/file.c:430
+	// src/common/file.c
 	ERR_W_ERRNO("open \"%s\"", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/file.c:435
+	// src/common/file.c
 	ERR_W_ERRNO("posix_fallocate \"%s\", %zu", _s, _zu);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/file.c:440
+	// src/common/file.c
 	ERR_W_ERRNO("flock \"%s\"", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/file.c:469
+	// src/common/file.c
 	ERR_W_ERRNO("open \"%s\"", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/file.c:474
+	// src/common/file.c
 	ERR_W_ERRNO("flock \"%s\"", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/file.c:507
+	// src/common/file.c
 	ERR_W_ERRNO("flock unlock");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/file.c:94
+	// src/common/file.c
 	ERR_W_ERRNO("fstat");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/file_posix.c:158
+	// src/common/file_posix.c
 	ERR_W_ERRNO("stat \"%s\"", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/mmap.c:104
+	// src/common/mmap.c
 	ERR_W_ERRNO("mmap %zu bytes", _zu);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/mmap.c:126
+	// src/common/mmap.c
 	ERR_W_ERRNO("munmap");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/mmap.c:155
+	// src/common/mmap.c
 	ERR_W_ERRNO("mprotect: PROT_READ");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/mmap.c:184
+	// src/common/mmap.c
 	ERR_W_ERRNO("mprotect: PROT_READ|PROT_WRITE");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/mmap.c:213
+	// src/common/mmap.c
 	ERR_W_ERRNO("mprotect: PROT_NONE");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/mmap.c:297
+	// src/common/mmap.c
 	ERR_W_ERRNO("Malloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/mmap.c:360
+	// src/common/mmap.c
 	ERR_W_ERRNO("Malloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/mmap.c:375
+	// src/common/mmap.c
 	ERR_W_ERRNO("Malloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/mmap_posix.c:141
+	// src/common/mmap_posix.c
 	ERR_W_ERRNO("mmap MAP_ANONYMOUS");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/mmap_posix.c:43
+	// src/common/mmap_posix.c
 	ERR_W_ERRNO("%s", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:1027
+	// src/common/set.c
 	ERR_W_ERRNO("fs_new: \"%s\"", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:1060
+	// src/common/set.c
 	ERR_W_ERRNO("Strdup");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:1139
+	// src/common/set.c
 	ERR_W_ERRNO("no directories in replica");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:1156
+	// src/common/set.c
 	ERR_W_ERRNO("Malloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:1196
+	// src/common/set.c
 	ERR_W_ERRNO("lseek %d", _d);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:1202
+	// src/common/set.c
 	ERR_W_ERRNO("dup");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:1208
+	// src/common/set.c
 	ERR_W_ERRNO("fdopen %d", _d);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:1219
+	// src/common/set.c
 	ERR_W_ERRNO("Reading poolset file");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:1226
+	// src/common/set.c
 	ERR_W_ERRNO("Malloc for pool set");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:1232
+	// src/common/set.c
 	ERR_W_ERRNO("Strdup");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:1404
+	// src/common/set.c
 	ERR_W_ERRNO("Malloc for pool set");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:1410
+	// src/common/set.c
 	ERR_W_ERRNO("Strdup");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:1419
+	// src/common/set.c
 	ERR_W_ERRNO("Malloc for pool set replica");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:1503
+	// src/common/set.c
 	ERR_W_ERRNO("posix_fallocate \"%s\", %zu", _s, _zu);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:1573
+	// src/common/set.c
 	ERR_W_ERRNO("open: path \"%s\"", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:1632
+	// src/common/set.c
 	ERR_W_ERRNO("read %d", _d);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:1756
+	// src/common/set.c
 	ERR_W_ERRNO("fstat");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:195
+	// src/common/set.c
 	ERR_W_ERRNO("mmap: %s", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:2212
+	// src/common/set.c
 	ERR_W_ERRNO("Malloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:252
+	// src/common/set.c
 	ERR_W_ERRNO("mmap: %s", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:283
+	// src/common/set.c
 	ERR_W_ERRNO("munmap: %s", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:3013
+	// src/common/set.c
 	ERR_W_ERRNO("no parts in replicas");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:3144
+	// src/common/set.c
 	ERR_W_ERRNO("read");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:3208
+	// src/common/set.c
 	ERR_W_ERRNO("open: path \"%s\"", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:369
+	// src/common/set.c
 	ERR_W_ERRNO("unlink %s failed (part %u, replica %u)", _s, _u, _u);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:422
+	// src/common/set.c
 	ERR_W_ERRNO("fstat %d %s", _d, _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:435
+	// src/common/set.c
 	ERR_W_ERRNO("chmod %u/%u/%s", _u, _u, _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:518
+	// src/common/set.c
 	ERR_W_ERRNO("Strdup");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:622
+	// src/common/set.c
 	ERR_W_ERRNO("Strdup");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:648
+	// src/common/set.c
 	ERR_W_ERRNO("Realloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:841
+	// src/common/set.c
 	ERR_W_ERRNO("Realloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set.c:849
+	// src/common/set.c
 	ERR_W_ERRNO("Zalloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/set_badblocks.c:171
+	// src/common/set_badblocks.c
 	ERR_W_ERRNO("Malloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/shutdown_state.c:95
+	// src/common/shutdown_state.c
 	ERR_W_ERRNO("Zalloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/vec.h:62
+	// src/common/vec.h
 	ERR_W_ERRNO("Realloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/vecq.h:68
+	// src/common/vecq.h
 	ERR_W_ERRNO("Realloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/out.c:104
+	// src/core/out.c
 	ERR_W_ERRNO("snprintf");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/ravl.c:167
+	// src/core/ravl.c
 	ERR_W_ERRNO("Malloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/ravl.c:51
+	// src/core/ravl.c
 	ERR_W_ERRNO("Malloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:181
+	// src/core/sys_util.h
 	ERR_W_ERRNO("os_spin_init");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/util_posix.c:138
+	// src/core/util_posix.c
 	ERR_W_ERRNO("open");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/util_posix.c:49
+	// src/core/util_posix.c
 	ERR_W_ERRNO("stat failed for %s", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/core/util_posix.c:59
+	// src/core/util_posix.c
 	ERR_W_ERRNO("stat failed for %s", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/core/util_posix.c:99
+	// src/core/util_posix.c
 	ERR_W_ERRNO("mkstemp");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmem/pmem.c:280
+	// src/libpmem/pmem.c
 	ERR_W_ERRNO("msync");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmem/pmem.c:487
+	// src/libpmem/pmem.c
 	ERR_W_ERRNO("open %s", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmem/pmem.c:500
+	// src/libpmem/pmem.c
 	ERR_W_ERRNO("ftruncate");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmem/pmem.c:506
+	// src/libpmem/pmem.c
 	ERR_W_ERRNO("posix_fallocate");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/critnib.c:279
+	// src/libpmemobj/critnib.c
 	ERR_W_ERRNO("Malloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/critnib.c:316
+	// src/libpmemobj/critnib.c
 	ERR_W_ERRNO("Malloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/heap.c:187
+	// src/libpmemobj/heap.c
 	ERR_W_ERRNO("heap: arena malloc error");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/lane.c:267
+	// src/libpmemobj/lane.c
 	ERR_W_ERRNO("Malloc of volatile lanes");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/lane.c:276
+	// src/libpmemobj/lane.c
 	ERR_W_ERRNO("Malloc for lane locks");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/lane.c:289
+	// src/libpmemobj/lane.c
 	ERR_W_ERRNO("lane_init");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/list.c:473
+	// src/libpmemobj/list.c
 	ERR_W_ERRNO("palloc_reserve");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/memops.c:116
+	// src/libpmemobj/memops.c
 	ERR_W_ERRNO("Zalloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/memops.c:177
+	// src/libpmemobj/memops.c
 	ERR_W_ERRNO("Zalloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/memops.c:90
+	// src/libpmemobj/memops.c
 	ERR_W_ERRNO("Zalloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/obj.c:662
+	// src/libpmemobj/obj.c
 	ERR_W_ERRNO("lane_boot");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/obj.c:667
+	// src/libpmemobj/obj.c
 	ERR_W_ERRNO("lane_recover_and_section_boot");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/obj.c:725
+	// src/libpmemobj/obj.c
 	ERR_W_ERRNO("palloc_init");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/obj.c:964
+	// src/libpmemobj/obj.c
 	ERR_W_ERRNO("critnib_insert to pools_ht");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/obj.c:969
+	// src/libpmemobj/obj.c
 	ERR_W_ERRNO("critnib_insert to pools_tree");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/obj.c:984
+	// src/libpmemobj/obj.c
 	ERR_W_ERRNO("ravl_new_sized");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/stats.c:124
+	// src/libpmemobj/stats.c
 	ERR_W_ERRNO("Malloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/tx.c:499
+	// src/libpmemobj/tx.c
 	ERR_W_ERRNO("pmemobj_mutex_lock");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/tx.c:508
+	// src/libpmemobj/tx.c
 	ERR_W_ERRNO("pmemobj_rwlock_wrlock");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/tx.c:776
+	// src/libpmemobj/tx.c
 	ERR_W_ERRNO("Malloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/tx.c:945
+	// src/libpmemobj/tx.c
 	ERR_W_ERRNO("explicit transaction abort");
 	UT_ASSERTeq(errno, errnum);
 }
@@ -1105,7 +1105,7 @@ void
 call_all_CORE_LOG_WARNING_W_ERRNO(int errnum)
 {
 	errno = errnum;
-	// src/common/set.c:2955
+	// src/common/set.c
 	CORE_LOG_WARNING_W_ERRNO("cannot open the part -- \"%s\"", _s);
 	UT_ASSERTeq(errno, errnum);
 }
@@ -1114,25 +1114,25 @@ void
 call_all_CORE_LOG_ERROR_W_ERRNO(int errnum)
 {
 	errno = errnum;
-	// src/common/os_deep_linux.c:156
+	// src/common/os_deep_linux.c
 	CORE_LOG_ERROR_W_ERRNO("deep_flush not supported");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/os_deep_linux.c:38
+	// src/common/os_deep_linux.c
 	CORE_LOG_ERROR_W_ERRNO("deep_flush not supported");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/uuid_linux.c:31
+	// src/common/uuid_linux.c
 	CORE_LOG_ERROR_W_ERRNO("open(uuid)");
 	UT_ASSERTeq(errno, errnum);
-	// src/common/uuid_linux.c:37
+	// src/common/uuid_linux.c
 	CORE_LOG_ERROR_W_ERRNO("read(uuid)");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/obj.c:1189
+	// src/libpmemobj/obj.c
 	CORE_LOG_ERROR_W_ERRNO("lane_check");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/obj.c:1198
+	// src/libpmemobj/obj.c
 	CORE_LOG_ERROR_W_ERRNO("heap_check");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/obj.c:90
+	// src/libpmemobj/obj.c
 	CORE_LOG_ERROR_W_ERRNO("ctl_new");
 	UT_ASSERTeq(errno, errnum);
 }
@@ -1141,106 +1141,106 @@ void
 call_all_CORE_LOG_FATAL_W_ERRNO(int errnum)
 {
 	errno = errnum;
-	// src/common/set.c:221
+	// src/common/set.c
 	CORE_LOG_FATAL_W_ERRNO("munmap: %s", _s);
 	UT_ASSERTeq(errno, errnum);
-	// src/common/util_pmem.h:30
+	// src/common/util_pmem.h
 	CORE_LOG_FATAL_W_ERRNO("pmem_msync");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/last_error_msg.c:37
+	// src/core/last_error_msg.c
 	CORE_LOG_FATAL_W_ERRNO("os_thread_key_create");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/last_error_msg.c:78
+	// src/core/last_error_msg.c
 	CORE_LOG_FATAL_W_ERRNO("os_tls_set");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:108
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_rwlock_init");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:123
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_rwlock_rdlock");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:138
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_rwlock_wrlock");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:153
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_rwlock_unlock");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:168
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_rwlock_destroy");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:197
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_spin_destroy");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:211
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_spin_lock");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:226
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_spin_unlock");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:239
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_semaphore_init");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:249
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_semaphore_destroy");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:266
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_semaphore_wait");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:282
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_semaphore_trywait");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:294
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_semaphore_post");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:301
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_cond_init");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:308
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_cond_destroy");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:31
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_mutex_init");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:46
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_mutex_destroy");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:61
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_mutex_lock");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:77
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_mutex_trylock");
 	UT_ASSERTeq(errno, errnum);
-	// src/core/sys_util.h:93
+	// src/core/sys_util.h
 	CORE_LOG_FATAL_W_ERRNO("os_mutex_unlock");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/lane.c:105
+	// src/libpmemobj/lane.c
 	CORE_LOG_FATAL_W_ERRNO("os_tls_key_create");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/lane.c:80
+	// src/libpmemobj/lane.c
 	CORE_LOG_FATAL_W_ERRNO("os_tls_set");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/obj.c:148
+	// src/libpmemobj/obj.c
 	CORE_LOG_FATAL_W_ERRNO("critnib_new for pools_ht");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/obj.c:156
+	// src/libpmemobj/obj.c
 	CORE_LOG_FATAL_W_ERRNO("critnib_new for pools_tree");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/obj.c:252
+	// src/libpmemobj/obj.c
 	CORE_LOG_FATAL_W_ERRNO("pmem_msync");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/sync.h:102
+	// src/libpmemobj/sync.h
 	CORE_LOG_FATAL_W_ERRNO("pmemobj_mutex_unlock");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/sync.h:87
+	// src/libpmemobj/sync.h
 	CORE_LOG_FATAL_W_ERRNO("pmemobj_mutex_lock");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/tx.c:272
+	// src/libpmemobj/tx.c
 	CORE_LOG_FATAL_W_ERRNO("Malloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/tx.c:284
+	// src/libpmemobj/tx.c
 	CORE_LOG_FATAL_W_ERRNO("Malloc");
 	UT_ASSERTeq(errno, errnum);
-	// src/libpmemobj/tx.c:321
+	// src/libpmemobj/tx.c
 	CORE_LOG_FATAL_W_ERRNO("Malloc");
 	UT_ASSERTeq(errno, errnum);
 }

--- a/utils/call_stacks_analysis/log_call_all_generate.py
+++ b/utils/call_stacks_analysis/log_call_all_generate.py
@@ -116,7 +116,7 @@ def extract_all_calls(func: str) -> List[Dict]:
                 code = extract_append_code(file, int(line_no), code)
             call = {
                 'file': file,
-                'line': line_no,
+                'line_no': line_no,
                 'code': code
             }
             calls.append(call)
@@ -124,7 +124,7 @@ def extract_all_calls(func: str) -> List[Dict]:
             bad_line('An unexpected line format', line)
     # sort calls by file and line
     def key_func(a: Dict) -> str:
-        return a['file'] + a['line']
+        return a['file'] + a['line_no']
     calls.sort(key=key_func)
     print(f'[{func}] total: {total}, included: {len(calls)}')
     return calls
@@ -369,7 +369,7 @@ def generate_call(file, func: str, call: Dict) -> str:
         args = ', ' + ', '.join(call['args'])
     else:
         args = ''
-    file.write(f'\t// src/{call["file"]}:{call["line"]}\n')
+    file.write(f'\t// src/{call["file"]}\n')
     file.write(f'\t{func}("{call["format_string"]}"{args});\n')
 
 def generate_func_with_errno(func: str, calls: List[Dict]) -> None:


### PR DESCRIPTION
Exclude line number from `call_all.c.generated to`
[log_calls_diff.zip](https://github.com/pmem/pmdk/files/14382080/log_calls_diff.zip)
 avoid false Log call Scans GHA results because of changing the place where `CORE_LOG...()` is used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/6022)
<!-- Reviewable:end -->
