### PR TITLE
common: start PMem tests at 6:00 pm to get results early next day

### DIFF
--- a/.github/workflows/pmem_tests.yml
+++ b/.github/workflows/pmem_tests.yml
@@ -6,8 +6,8 @@ name: PMEM tests
 on:
   workflow_dispatch:
   schedule:
-    # run this job at 00:00 UTC every day
-    - cron:  '0 0 * * *'
+    # run this job at 18:00 UTC every day
+    - cron:  '0 18 * * *'
 
 jobs:
   # Test the default build with the basic test suite.


### PR DESCRIPTION
PMem tests required about 14h30m for execution.
With execution started at noon results are practically available at the end of working day.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/6023)
<!-- Reviewable:end -->
