### PR TITLE
common: run coverage scan in paralel w/ Ubuntu build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,6 @@ jobs:
     name: Ubuntu
 
   coverage_scan:
-    needs: call-ubuntu
+    needs: [src_checkers, basic_build]
     uses: ./.github/workflows/scan_coverage.yml
     name: Coverage


### PR DESCRIPTION
To get all results in a shorter time
Failed coverage scan does not stop Ubuntu build:
https://github.com/pmem/pmdk/actions/runs/8019036765

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/6025)
<!-- Reviewable:end -->
