### PR TITLE
common: remove core_log_to_last

### DIFF
--- a/src/core/log.c
+++ b/src/core/log.c
@@ -214,16 +214,13 @@ core_log_va(char *buf, size_t buf_len, enum core_log_level level,
 	if (msg_len < 0)
 		goto end;
 
-	if (errnum != NO_ERRNO) {
+	if ((size_t)msg_len < buf_len - 1 && errnum != NO_ERRNO) {
+		/*
+		 * Ask for the error string right after the already printed
+		 * message.
+		 */
 		char *msg_ptr = buf + msg_len;
 		size_t buf_len_left = buf_len - (size_t)msg_len;
-
-		/* Check if the longest possible error string can fit */
-		if (buf_len_left < _CORE_LOG_MAX_ERRNO_MSG) {
-			goto end;
-		}
-
-		/* Ask for the error string */
 		/*
 		 * If it fails, the best thing to do is to at least pass
 		 * the log message as is.
@@ -236,13 +233,11 @@ core_log_va(char *buf, size_t buf_len, enum core_log_level level,
 	 * the CORE_LOG() macro it has to be done here again since it is not
 	 * performed in the case of the CORE_LOG_TO_LAST macro. Sorry.
 	 */
-	if (level > Core_log_threshold[CORE_LOG_THRESHOLD]) {
+	if (level > Core_log_threshold[CORE_LOG_THRESHOLD])
 		goto end;
-	}
 
-	if (0 == Core_log_function) {
+	if (0 == Core_log_function)
 		goto end;
-	}
 
 	((core_log_function *)Core_log_function)(Core_log_function_context,
 		level, file_name, line_no, function_name, buf);
@@ -257,8 +252,8 @@ core_log(enum core_log_level level, int errnum, const char *file_name,
 	int line_no, const char *function_name, const char *message_format, ...)
 {
 	char message[_CORE_LOG_MSG_MAXPRINT] = "";
-	va_list arg;
 
+	va_list arg;
 	va_start(arg, message_format);
 	core_log_va(message, sizeof(message), level, errnum, file_name,
 		line_no, function_name, message_format, arg);

--- a/src/core/log.c
+++ b/src/core/log.c
@@ -252,24 +252,17 @@ core_log(enum core_log_level level, int errnum, const char *file_name,
 	int line_no, const char *function_name, const char *message_format, ...)
 {
 	char message[_CORE_LOG_MSG_MAXPRINT] = "";
+	char *buf = message;
+	size_t buf_len = sizeof(message);
+	if (level == CORE_LOG_LEVEL_ERROR_LAST) {
+		level = CORE_LOG_LEVEL_ERROR;
+		buf = (char *)last_error_msg_get();
+		buf_len = CORE_LAST_ERROR_MSG_MAXPRINT;
+	}
 
 	va_list arg;
 	va_start(arg, message_format);
-	core_log_va(message, sizeof(message), level, errnum, file_name,
-		line_no, function_name, message_format, arg);
-	va_end(arg);
-}
-
-void
-core_log_to_last(int errnum, const char *file_name, int line_no,
-	const char *function_name, const char *message_format, ...)
-{
-	char *last_error = (char *)last_error_msg_get();
-	va_list arg;
-
-	va_start(arg, message_format);
-	core_log_va(last_error, CORE_LAST_ERROR_MSG_MAXPRINT,
-		CORE_LOG_LEVEL_ERROR, errnum, file_name, line_no,
+	core_log_va(buf, buf_len, level, errnum, file_name, line_no,
 		function_name, message_format, arg);
 	va_end(arg);
 }

--- a/src/core/log_internal.h
+++ b/src/core/log_internal.h
@@ -39,6 +39,9 @@ enum core_log_level {
 	CORE_LOG_LEVEL_MAX
 };
 
+#define CORE_LOG_LEVEL_ERROR_LAST ((enum core_log_level) \
+	(CORE_LOG_LEVEL_ERROR + CORE_LOG_LEVEL_MAX))
+
 enum core_log_threshold {
 	/*
 	 * the main threshold level - the logging messages above this level
@@ -130,10 +133,6 @@ void core_log(enum core_log_level level, int errnum, const char *file_name,
 	int line_no, const char *function_name,
 	const char *message_format, ...);
 
-/* Only error messages can last. So, no level has to be specified. */
-void core_log_to_last(int errnum, const char *file_name, int line_no,
-	const char *function_name, const char *message_format, ...);
-
 #define _CORE_LOG(level, errnum, format, ...) \
 	do { \
 		if (level <= Core_log_threshold[CORE_LOG_THRESHOLD]) { \
@@ -147,8 +146,8 @@ void core_log_to_last(int errnum, const char *file_name, int line_no,
  * Since the log message has to be generated anyway.
  */
 #define CORE_LOG_TO_LAST(errnum, format, ...) \
-	core_log_to_last(errnum, __FILE__, __LINE__, __func__, \
-		format, ##__VA_ARGS__)
+	core_log(CORE_LOG_LEVEL_ERROR_LAST, errnum, __FILE__, __LINE__, \
+		__func__, format, ##__VA_ARGS__)
 
 /* The value fine-tuned to accommodate all possible errno message strings. */
 #define _CORE_LOG_MAX_ERRNO_MSG 50


### PR DESCRIPTION
- Minor fixes to core_log_va()
- Remove core_log_to_last() and keep only one way to use core_log_va() from core_log() (with new invisible level).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/6030)
<!-- Reviewable:end -->
