### PR TITLE
common: update actions/checkout to v4

### DIFF
--- a/.github/workflows/docker_rebuild.yml
+++ b/.github/workflows/docker_rebuild.yml
@@ -37,7 +37,7 @@ jobs:
           - {OS: ubuntu, OS_VER: 22.04}
     steps:
       - name: Clone the git repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
   
       - name: Rebuild the image
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       issues: read
     steps:
       - name: Clone the git repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # required for `make check-license` to work properly
           fetch-depth: 50
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the git repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: sudo apt-get -y install pandoc

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,7 @@ jobs:
         TEST_BUILD: [debug, nondebug]
     steps:
       - name: Clone the git repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 50
 
@@ -66,7 +66,7 @@ jobs:
                 ]
     steps:
       - name: Clone the git repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 50
 

--- a/.github/workflows/pmem.io_doc_update.yml
+++ b/.github/workflows/pmem.io_doc_update.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the git repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: sudo apt-get install libndctl-dev libdaxctl-dev pandoc

--- a/.github/workflows/pmem_ras.yml
+++ b/.github/workflows/pmem_ras.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Clone the git repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Variables, such as $ras_runner are hidden on the controller platform as environmental variables.
       # 'sed' command is used to filter out IP addresses from the ansible output, it will show up as the 'ras_runner' instead.

--- a/.github/workflows/pmem_test_matrix.yml
+++ b/.github/workflows/pmem_test_matrix.yml
@@ -29,7 +29,7 @@ jobs:
         build: [debug, nondebug]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Test prepare
         uses: ./.github/actions/pmem_test_prepare

--- a/.github/workflows/pmem_tests.yml
+++ b/.github/workflows/pmem_tests.yml
@@ -48,7 +48,7 @@ jobs:
         build: [static_debug, static_nondebug]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Test prepare
         uses: ./.github/actions/pmem_test_prepare
@@ -67,7 +67,7 @@ jobs:
     runs-on: [self-hosted, rhel]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Test prepare
         uses: ./.github/actions/pmem_test_prepare
@@ -90,7 +90,7 @@ jobs:
     runs-on: [self-hosted, rhel]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Test prepare
         uses: ./.github/actions/pmem_test_prepare

--- a/.github/workflows/scan_bandit.yml
+++ b/.github/workflows/scan_bandit.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the git repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Bandit
         run: sudo apt-get -y install bandit

--- a/.github/workflows/scan_codeql.yml
+++ b/.github/workflows/scan_codeql.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Clone the git repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install pmem/valgrind (including dependencies)
       run: |

--- a/.github/workflows/scan_coverage.yml
+++ b/.github/workflows/scan_coverage.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the git repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Pull the image
         run: cd $WORKDIR && ./pull-or-rebuild-image.sh

--- a/.github/workflows/scan_coverity.yml
+++ b/.github/workflows/scan_coverity.yml
@@ -30,7 +30,7 @@ jobs:
         CONFIG: ["OS=ubuntu OS_VER=22.04"]
     steps:
       - name: Clone the git repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Pull or rebuild the image
         run: cd $WORKDIR && ${{ matrix.CONFIG }} ./pull-or-rebuild-image.sh

--- a/.github/workflows/scan_documentation.yml
+++ b/.github/workflows/scan_documentation.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Clone the git repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install required packages
         run: |

--- a/.github/workflows/scan_log_calls.yml
+++ b/.github/workflows/scan_log_calls.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the git repo
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
 
       - name: Generate log calls' diff
         working-directory: ${{ env.WORKING_DIRECTORY }}

--- a/.github/workflows/scan_stack_usage.yml
+++ b/.github/workflows/scan_stack_usage.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the git repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: pmdk
 

--- a/.github/workflows/scan_ubsan.yml
+++ b/.github/workflows/scan_ubsan.yml
@@ -28,7 +28,7 @@ jobs:
         build: ['debug', 'nondebug']
     steps:
       - name: Clone the git repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Pull the image
         run: cd $WORKDIR && ./pull-or-rebuild-image.sh

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,7 +27,7 @@ jobs:
         TEST_BUILD: ['debug', 'nondebug']
     steps:
       - name: Clone the git repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 50
 


### PR DESCRIPTION
It seems the only thing changed between v3 and v4 is node20. v4.1.1 has been used in our ci before. It was unified to directly use v4 which will make our life easier since we would not need to update these workflows till v5.

Ref: https://github.com/actions/checkout/releases/tag/v4.0.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/6046)
<!-- Reviewable:end -->
