### PR TITLE
common: ansible_user support in ansible scripts

### DIFF
--- a/utils/ansible/README.md
+++ b/utils/ansible/README.md
@@ -111,6 +111,11 @@ ansible-playbook -i $TARGET_IP, configure-self-hosted-runner.yml --extra-vars \
 
 # Provisioning from the target platform itself
 It is possible to run playbooks directly on the target platform.
+In this case, you have to always pass `ansible_user=pmdkuser` as an additional
+variable since the playbooks are fine-tuned for remote execution and assume
+the `ansible_user` variable is defined. When running on a remote target the
+connection plugin does it for you.
+
 To run playbooks inside the platform please comment out the line:
 ```
 - hosts: "{{ host }}"
@@ -123,18 +128,18 @@ uncomment the following two:
 and run commands as follows e.g.
 ```sh
 export SETUP_SCRIPT= # opensuse-setup.yml or rockylinux-setup.yml
-sudo ansible-playbook $SETUP_SCRIPT --extra-vars "testUser=pmdkuser"
+sudo ansible-playbook $SETUP_SCRIPT --extra-vars "ansible_user=pmdkuser"
 ```
 **Note**: If a reboot is necessary, as described above, perform it manually and
 rerun the playbook without in question.
 
 And next log in as `pmdkuser`:
 ```sh
-ansible-playbook configure-pmem.yml --extra-vars "newRegions=true"
+ansible-playbook configure-pmem.yml --extra-vars "ansible_user=pmdkuser newRegions=true"
 # you will have to perform a reboot manually
 sudo reboot
 # and re-run the playbook without newRegions=true to finalize the setup
-ansible-playbook configure-pmem.yml
+ansible-playbook configure-pmem.yml --extra-vars "ansible_user=pmdkuser"
 ```
 
 # Example - GitHub self-hosted runner setup
@@ -167,19 +172,19 @@ Log in as `pmdkuser` and execute:
 ```sh
 # as pmdkuser
 cd pmdk/utils/ansible
-ansible-playbook configure-pmem.yml --extra-vars "newRegions=true"
+ansible-playbook configure-pmem.yml --extra-vars "ansible_user=pmdkuser newRegions=true"
 sudo reboot
 # ...
 cd pmdk/utils/ansible
 # note - no newRegions=true when running the playbook after the reboot
-ansible-playbook configure-pmem.yml
+ansible-playbook configure-pmem.yml --extra-vars "ansible_user=pmdkuser"
 
 export GHA_TOKEN= # GitHub token generated for a new self-hosted runner
 export HOST_NAME=`hostname`
 export LABELS=rhel
 export VARS_GHA=http_proxy=http://proxy-dmz.{XXX}.com:911,https_proxy=http://proxy-dmz.{XXX}.com:912
 ansible-playbook configure-self-hosted-runner.yml -extra-vars \
-"runner_name=$HOST_NAME labels=$LABELS token=$GHA_TOKEN vars_gha=$VARS_GHA"
+"ansible_user=pmdkuser runner_name=$HOST_NAME labels=$LABELS token=$GHA_TOKEN vars_gha=$VARS_GHA"
 cd
 rm -rf pmdk
 ```
@@ -207,19 +212,19 @@ Log in as `pmdkuser` and execute:
 ```sh
 # as pmdkuser:
 cd pmdk/utils/ansible
-ansible-playbook configure-pmem.yml --extra-vars "newRegions=true"
+ansible-playbook configure-pmem.yml --extra-vars "ansible_user=pmdkuser newRegions=true"
 sudo reboot
 # ...
 cd pmdk/utils/ansible
 # note - no newRegions=true when running the playbook after the reboot
-ansible-playbook configure-pmem.yml
+ansible-playbook configure-pmem.yml --extra-vars "ansible_user=pmdkuser"
 
 export GHA_TOKEN= # GitHub token generated for a new self-hosted runner
 export HOST_NAME=`hostname`
 export LABELS=opensuse
 export VARS_GHA=http_proxy=http://proxy-dmz.{XXX}.com:911,https_proxy=http://proxy-dmz.{XXX}.com:912
 ansible-playbook configure-self-hosted-runner.yml -extra-vars \
-"runner_name=$HOST_NAME labels=$LABELS token=$GHA_TOKEN vars_gha=$VARS_GHA"
+"ansible_user=pmdkuser runner_name=$HOST_NAME labels=$LABELS token=$GHA_TOKEN vars_gha=$VARS_GHA"
 cd
 rm -rf pmdk
 ```

--- a/utils/ansible/README.md
+++ b/utils/ansible/README.md
@@ -46,7 +46,7 @@ export SETUP_SCRIPT= # opensuse-setup.yml or rockylinux-setup.yml
 
 ansible-playbook -i $TARGET_IP, $SETUP_SCRIPT \
   --extra-vars "host=all ansible_user=root ansible_password=$ROOT_PASSWORD \
-  testUser=pmdkuser testUserPass=pmdkpass"
+  new_user=pmdkuser new_user_pass=pmdkpass"
 ```
 **Note**: If the Linux kernel is outdated, `opensuse-setup.yml` and
 `rockylinux-setup.yml` playbooks will reboot the target platform.
@@ -128,7 +128,7 @@ uncomment the following two:
 and run commands as follows e.g.
 ```sh
 export SETUP_SCRIPT= # opensuse-setup.yml or rockylinux-setup.yml
-sudo ansible-playbook $SETUP_SCRIPT --extra-vars "ansible_user=pmdkuser"
+sudo ansible-playbook $SETUP_SCRIPT --extra-vars "new_user=pmdkuser"
 ```
 **Note**: If a reboot is necessary, as described above, perform it manually and
 rerun the playbook without in question.
@@ -161,12 +161,12 @@ Update playbooks to be used directly on the target as described [above](#provisi
 and execute:
 ```sh
 # as root:
-ansible-playbook rockylinux-setup.yml --extra-vars "testUser=pmdkuser testUserPass=pmdkpass"
+ansible-playbook rockylinux-setup.yml --extra-vars "new_user=pmdkuser new_user_pass=pmdkpass"
 # reboot shall be performed only if the playbook requests to do it.
 reboot
 # ...
 cd pmdk/utils/ansible
-ansible-playbook rockylinux-setup.yml --extra-vars "testUser=pmdkuser testUserPass=pmdkpass"
+ansible-playbook rockylinux-setup.yml --extra-vars "new_user=pmdkuser new_user_pass=pmdkpass"
 ```
 Log in as `pmdkuser` and execute:
 ```sh
@@ -201,12 +201,12 @@ Update playbooks to be used directly on the target as described [above](#provisi
 and execute:
 ```sh
 # as root:
-ansible-playbook opensuse-setup.yml --extra-vars "testUser=pmdkuser testUserPass=pmdkpass"
+ansible-playbook opensuse-setup.yml --extra-vars "new_user=pmdkuser new_user_pass=pmdkpass"
 # reboot shall be performed only if the playbook requests to do it.
 reboot
 # ...
 cd pmdk/utils/ansible
-ansible-playbook opensuse-setup.yml --extra-vars "testUser=pmdkuser testUserPass=pmdkpass"
+ansible-playbook opensuse-setup.yml --extra-vars "new_user=pmdkuser new_user_pass=pmdkpass"
 ```
 Log in as `pmdkuser` and execute:
 ```sh

--- a/utils/ansible/configure-pmem.yml
+++ b/utils/ansible/configure-pmem.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2023, Intel Corporation
+# Copyright 2023-2024, Intel Corporation
 
 # This playbook is designed to configure regions and namespaces on DIMMs
 # so users can execute tests later. Playbook usage is described in
@@ -33,9 +33,9 @@
 # - hosts: localhost
 #   connection: local
 # c) setup PMem for the first time (establish regions):
-# ansible-playbook configure-pmem.yml --extra-vars "newRegions=true"
+# ansible-playbook configure-pmem.yml --extra-vars "ansible_user=pmdkuser newRegions=true"
 # d) setup PMem if it already has been initialized before:
-# ansible-playbook configure-pmem.yml
+# ansible-playbook configure-pmem.yml --extra-vars "ansible_user=pmdkuser"
 #
 
 - hosts: "{{ host }}"

--- a/utils/ansible/configure-pmem.yml
+++ b/utils/ansible/configure-pmem.yml
@@ -28,7 +28,7 @@
 #
 # 2) locally
 # For a playbook to be used on a local server please log in as pmdkuser:
-# a) comment out the first command: # -hosts: "{{ host }}"
+# a) comment out the first command: # - hosts: "{{ host }}"
 # b) uncomment the next two lines:
 # - hosts: localhost
 #   connection: local

--- a/utils/ansible/configure-self-hosted-runner.yml
+++ b/utils/ansible/configure-self-hosted-runner.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2023, Intel Corporation
+# Copyright 2023-2024, Intel Corporation
 
 # This playbook is designed to add a new self-hosted runner to pmem/pmdk.
 # Examples below show how to use this file:
@@ -26,7 +26,7 @@
 # export LABELS= # rhel or opensuse
 # export VARS_GHA=http_proxy=http://proxy-dmz.{XXX}.com:911,https_proxy=http://proxy-dmz.{XXX}.com:912
 # ansible-playbook configure-self-hosted-runner.yml --extra-vars \
-#   "runner_name=$HOST_NAME labels=$LABELS vars_gha=$VARS_GHA token=$GHA_TOKEN"
+#   "ansible_user=pmdkuser runner_name=$HOST_NAME labels=$LABELS vars_gha=$VARS_GHA token=$GHA_TOKEN"
 #
 
 #

--- a/utils/ansible/configure-self-hosted-runner.yml
+++ b/utils/ansible/configure-self-hosted-runner.yml
@@ -16,7 +16,7 @@
 #
 # 2) locally
 # For a playbook to be used on a local server please log in as pmdkuser:
-# a) comment out the first command: # -hosts: "{{ host }}"
+# a) comment out the first command: # - hosts: "{{ host }}"
 # b) uncomment the next two lines:
 # - hosts: localhost
 #   connection: local

--- a/utils/ansible/opensuse-setup.yml
+++ b/utils/ansible/opensuse-setup.yml
@@ -5,6 +5,17 @@
 # OpenSUSE to execute tests.
 # The playbook description and how to use it are available
 # in the README.md file.
+#
+# Below is an example of how to use this file localy:
+#
+# a) comment out the first command:
+# -hosts: "{{ host }}"
+# b) uncomment the next two lines:
+# - hosts: localhost
+#   connection: local
+# and run commands as follows e.g.
+# sudo ansible-playbook opensuse-setup.yml
+#
 
 - hosts: "{{ host }}"
 # - hosts: localhost

--- a/utils/ansible/opensuse-setup.yml
+++ b/utils/ansible/opensuse-setup.yml
@@ -6,10 +6,10 @@
 # The playbook description and how to use it are available
 # in the README.md file.
 #
-# Below is an example of how to use this file localy:
+# Below is an example of how to use this file locally:
 #
 # a) comment out the first command:
-# -hosts: "{{ host }}"
+# - hosts: "{{ host }}"
 # b) uncomment the next two lines:
 # - hosts: localhost
 #   connection: local
@@ -21,8 +21,8 @@
 # - hosts: localhost
 #   connection: local
   vars:
-    testUser: null
-    testUserPass: pmdkpass
+    new_user: null
+    new_user_pass: pmdkpass
 
   tasks:
     - name: Update kernel packages
@@ -173,8 +173,8 @@
     - name: Add new user
       shell: |
         #!/usr/bin/env bash
-        export USER={{ testUser }}
-        export USERPASS={{ testUserPass }}
+        export USER={{ new_user }}
+        export USERPASS={{ new_user_pass }}
         useradd -m $USER
         export PFILE=./password
         echo $USERPASS > $PFILE
@@ -184,7 +184,7 @@
         sed -i 's/# %wheel/%wheel/g' /etc/sudoers
         groupadd wheel
         gpasswd wheel -a $USER
-      when: testUser != None
+      when: new_user != None
 
     - name: Set variable OS
       env:

--- a/utils/ansible/rockylinux-setup.yml
+++ b/utils/ansible/rockylinux-setup.yml
@@ -6,10 +6,10 @@
 # The playbook description and how to use it are available
 # in the README.md file.
 #
-# Below is an example of how to use this file localy:
+# Below is an example of how to use this file locally:
 #
 # a) comment out the first command:
-# -hosts: "{{ host }}"
+# - hosts: "{{ host }}"
 # b) uncomment the next two lines:
 # - hosts: localhost
 #   connection: local
@@ -21,8 +21,8 @@
 # - hosts: localhost
 #   connection: local
   vars:
-    testUser: null
-    testUserPass: pmdkpass
+    new_user: null
+    new_user_pass: pmdkpass
 
   tasks:
     - name: Update kernel packages
@@ -168,13 +168,13 @@
     - name: Add new user
       shell: |
         #!/usr/bin/env bash
-        export USER={{ testUser }}
-        export USERPASS={{ testUserPass }}
+        export USER={{ new_user }}
+        export USERPASS={{ new_user_pass }}
         useradd -m $USER
         echo $USERPASS | passwd $USER --stdin
         gpasswd wheel -a $USER
         echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-      when: testUser != none
+      when: new_user != none
 
     - name: Set variable OS
       env:

--- a/utils/ansible/rockylinux-setup.yml
+++ b/utils/ansible/rockylinux-setup.yml
@@ -5,6 +5,17 @@
 # configure Rocky Linux to execute tests.
 # The playbook description and how to use it are available
 # in the README.md file.
+#
+# Below is an example of how to use this file localy:
+#
+# a) comment out the first command:
+# -hosts: "{{ host }}"
+# b) uncomment the next two lines:
+# - hosts: localhost
+#   connection: local
+# and run commands as follows e.g.
+# sudo ansible-playbook rockylinux-setup.yml
+#
 
 - hosts: "{{ host }}"
 # - hosts: localhost

--- a/utils/ansible/update-os.yml
+++ b/utils/ansible/update-os.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2023, Intel Corporation
+# Copyright 2023-2024, Intel Corporation
 
 # This playbook is designed to update all installed packages at
 # Rocky Linux / OpenSUSE and reboot the platform if required.
@@ -7,7 +7,7 @@
 # in the README.md file.
 #
 # Note: This playbook is designed to work as a composite action during test preparation steps.
-# Local usage will fail the playbook run.
+# Local usage might cause an immediate system reboot.
 
 - hosts: localhost
   connection: local


### PR DESCRIPTION
- `ansible_user` is undefined on  a localhost with a local connection and needs to be always passed with `--extra-vars`
https://radeksprta.eu/posts/ansible_user-is-undefined-on-localhost/
- several minor cleanups of Ansible scripts' documentation
- rename the `testUser` to a `new_user`

This PR is a replacement for #5955.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/6055)
<!-- Reviewable:end -->
