### PR TITLE
test: suppress ERROR messages when irrelevant to the test result

### DIFF
--- a/src/test/obj_tx_locks/TEST1
+++ b/src/test/obj_tx_locks/TEST1
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2015-2019, Intel Corporation
+# Copyright 2015-2024, Intel Corporation
 
 #
 # src/test/obj_tx_locks/TEST1 -- unit test for transaction locks
@@ -21,6 +21,6 @@ require_valgrind 3.10
 configure_valgrind drd force-enable
 setup
 
-expect_normal_exit ./obj_tx_locks$EXESUFFIX $DIR/testfile1 m
+expect_normal_exit ./obj_tx_locks$EXESUFFIX $DIR/testfile1 m 2>/dev/null
 
 pass

--- a/src/test/out_err_mt/TEST1
+++ b/src/test/out_err_mt/TEST1
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2015-2023, Intel Corporation
+# Copyright 2015-2024, Intel Corporation
 #
 
 #
@@ -26,7 +26,7 @@ unset PMEM_LOG_FILE
 unset PMEMOBJ_LOG_FILE
 unset PMEMPOOL_LOG_FILE
 
-expect_normal_exit ./out_err_mt$EXESUFFIX $DIR/testfile1
+expect_normal_exit ./out_err_mt$EXESUFFIX $DIR/testfile1 2>/dev/null
 
 check
 

--- a/src/test/out_err_mt/TEST2
+++ b/src/test/out_err_mt/TEST2
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2015-2023, Intel Corporation
+# Copyright 2015-2024, Intel Corporation
 #
 
 #
@@ -24,7 +24,7 @@ unset PMEMOBJ_LOG_LEVEL
 unset PMEM_LOG_FILE
 unset PMEMOBJ_LOG_FILE
 
-expect_normal_exit ./out_err_mt$EXESUFFIX $DIR/testfile1
+expect_normal_exit ./out_err_mt$EXESUFFIX $DIR/testfile1 2>/dev/null
 
 check
 

--- a/src/test/util_ctl/TEST0
+++ b/src/test/util_ctl/TEST0
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2023, Intel Corporation
+# Copyright 2016-2024, Intel Corporation
 
 . ../unittest/unittest.sh
 
@@ -10,6 +10,6 @@ set_test_labels fault_injection
 setup
 
 expect_normal_exit\
-	./util_ctl$EXESUFFIX $DIR/testconfig
+	./util_ctl$EXESUFFIX $DIR/testconfig 2>/dev/null
 
 pass

--- a/src/test/util_ctl/TEST1
+++ b/src/test/util_ctl/TEST1
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2023, Intel Corporation
+# Copyright 2016-2024, Intel Corporation
 
 . ../unittest/unittest.sh
 
@@ -12,6 +12,6 @@ configure_valgrind memcheck force-enable
 setup
 
 expect_normal_exit\
-	./util_ctl$EXESUFFIX $DIR/testconfig
+	./util_ctl$EXESUFFIX $DIR/testconfig 2>/dev/null
 
 pass


### PR DESCRIPTION
Suppress **\*ERROR\*** messages from stderr in tests that verify faulty situations based on function return value and errno value. These tests ignore stderr/stdout at all.
This is to avoid a lot of unnecessary messages on the screen during test execution.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/6063)
<!-- Reviewable:end -->
