### PR TITLE
common: log uses unsigned instead of int for line_no as it is done in DAOS/vos

### DIFF
--- a/doc/libpmemobj/pmemobj_log_set_function.3.md
+++ b/doc/libpmemobj/pmemobj_log_set_function.3.md
@@ -34,7 +34,7 @@ header: "pmemobj API version 2.3"
 	typedef void pmemobj_log_function(
 		enum pmemobj_log_level level,
 		const char *file_name,
-		const int line_no,
+		unsigned line_no,
 		const char *function_name,
 		const char *message);
 

--- a/src/core/log.c
+++ b/src/core/log.c
@@ -176,7 +176,7 @@ _core_log_get_threshold_internal()
 
 static void inline
 core_log_va(char *buf, size_t buf_len, enum core_log_level level,
-	int errnum, const char *file_name, int line_no,
+	int errnum, const char *file_name, unsigned line_no,
 	const char *function_name, const char *message_format, va_list arg)
 {
 	int msg_len = vsnprintf(buf, buf_len, message_format, arg);
@@ -217,7 +217,8 @@ end:
 
 void
 core_log(enum core_log_level level, int errnum, const char *file_name,
-	int line_no, const char *function_name, const char *message_format, ...)
+	unsigned line_no, const char *function_name, const char *message_format,
+	...)
 {
 	char message[_CORE_LOG_MSG_MAXPRINT] = "";
 	char *buf = message;

--- a/src/core/log_default.c
+++ b/src/core/log_default.c
@@ -99,7 +99,7 @@ err_message:
  */
 void
 core_log_default_function(enum core_log_level level, const char *file_name,
-	const int line_no, const char *function_name, const char *message)
+	unsigned line_no, const char *function_name, const char *message)
 {
 	char file_info_buffer[256] = "";
 	const char *file_info = file_info_buffer;
@@ -116,7 +116,7 @@ core_log_default_function(enum core_log_level level, const char *file_name,
 			base_file_name++;
 
 		if (snprintf(file_info_buffer, sizeof(file_info_buffer),
-				"%s: %3d: %s: ", base_file_name, line_no,
+				"%s: %3u: %s: ", base_file_name, line_no,
 				function_name) < 0) {
 			file_info = file_info_error;
 		}

--- a/src/core/log_default.h
+++ b/src/core/log_default.h
@@ -9,7 +9,7 @@
 #define CORE_LOG_DEFAULT_H
 
 void core_log_default_function(enum core_log_level level, const char *file_name,
-	const int line_no, const char *function_name, const char *message);
+	unsigned line_no, const char *function_name, const char *message);
 
 void core_log_default_init(void);
 

--- a/src/core/log_internal.h
+++ b/src/core/log_internal.h
@@ -73,7 +73,7 @@ typedef void core_log_function(
 	/* name of the source file where the message coming from */
 	const char *file_name,
 	/* the source file line where the message coming from */
-	const int line_no,
+	unsigned line_no,
 	/* the function name where the message coming from */
 	const char *function_name,
 	/* message */
@@ -109,8 +109,8 @@ core_log_error_translate(int ret)
 #define NO_ERRNO (-1)
 
 void core_log(enum core_log_level level, int errnum, const char *file_name,
-	int line_no, const char *function_name,
-	const char *message_format, ...);
+	unsigned line_no, const char *function_name, const char *message_format,
+	...);
 
 #define _CORE_LOG(level, errnum, format, ...) \
 	do { \

--- a/src/core/out.c
+++ b/src/core/out.c
@@ -53,7 +53,7 @@ static const int core_log_level_to_level[CORE_LOG_LEVEL_MAX] = {
 
 static void
 out_legacy(enum core_log_level core_level, const char *file_name,
-	const int line_no, const char *function_name, const char *message)
+	unsigned line_no, const char *function_name, const char *message)
 {
 	int level = core_log_level_to_level[core_level];
 	out_log(file_name, line_no, function_name, level, "%s", message);
@@ -247,7 +247,7 @@ out_snprintf(char *str, size_t size, const char *format, ...)
  * out_common -- common output code, all output goes through here
  */
 static void
-out_common(const char *file, int line, const char *func, int level,
+out_common(const char *file, unsigned line, const char *func, int level,
 		const char *suffix, const char *fmt, va_list ap)
 {
 	int oerrno = errno;
@@ -262,7 +262,7 @@ out_common(const char *file, int line, const char *func, int level,
 		if (f)
 			file = f + 1;
 		ret = out_snprintf(&buf[cc], MAXPRINT - cc,
-				"<%s>: <%d> [%s:%d %s] ",
+				"<%s>: <%d> [%s:%u %s] ",
 				Log_prefix, level, file, line, func);
 		if (ret < 0) {
 			out_print_func("out_snprintf failed");
@@ -301,7 +301,7 @@ end:
  * out_log_va/out_log -- output a log line if Log_level >= level
  */
 static void
-out_log_va(const char *file, int line, const char *func, int level,
+out_log_va(const char *file, unsigned line, const char *func, int level,
 		const char *fmt, va_list ap)
 {
 	if (Log_level < level)
@@ -310,7 +310,7 @@ out_log_va(const char *file, int line, const char *func, int level,
 }
 
 void
-out_log(const char *file, int line, const char *func, int level,
+out_log(const char *file, unsigned line, const char *func, int level,
 		const char *fmt, ...)
 {
 	va_list ap;

--- a/src/core/out.h
+++ b/src/core/out.h
@@ -33,7 +33,7 @@ extern "C" {
 #else
 
 static __attribute__((always_inline)) inline void
-out_log_discard(const char *file, int line, const char *func, int level,
+out_log_discard(const char *file, unsigned line, const char *func, int level,
 		const char *fmt, ...)
 {
 	/* suppress unused-parameter errors */
@@ -70,8 +70,8 @@ void out_init(const char *log_prefix, const char *log_level_var,
 void out_fini(void);
 
 #ifdef DEBUG
-void out_log(const char *file, int line, const char *func, int level,
-	const char *fmt, ...) FORMAT_PRINTF(5, 6);
+void out_log(const char *file, unsigned line, const char *func,
+	int level, const char *fmt, ...) FORMAT_PRINTF(5, 6);
 #endif
 
 #ifdef __cplusplus

--- a/src/include/libpmem.h
+++ b/src/include/libpmem.h
@@ -151,7 +151,7 @@ typedef void pmem_log_function(
 	/* name of the source file where the message coming from */
 	const char *file_name,
 	/* the source file line where the message coming from */
-	const int line_no,
+	unsigned line_no,
 	/* the function name where the message coming from */
 	const char *function_name,
 	/* message */

--- a/src/include/libpmemobj/log.h
+++ b/src/include/libpmemobj/log.h
@@ -72,7 +72,7 @@ typedef void pmemobj_log_function(
 	/* name of the source file where the message coming from */
 	const char *file_name,
 	/* the source file line where the message coming from */
-	const int line_no,
+	unsigned line_no,
 	/* the function name where the message coming from */
 	const char *function_name,
 	/* message */

--- a/src/test/core_log/core_log_common.c
+++ b/src/test/core_log/core_log_common.c
@@ -64,7 +64,7 @@ FUNC_MOCK_RUN_DEFAULT {
 FUNC_MOCK_END
 
 FUNC_MOCK_NONSTATIC(core_log_default_function, void, enum core_log_level level,
-	const char *file_name, const int line_no, const char *function_name,
+	const char *file_name, unsigned line_no, const char *function_name,
 	const char *message)
 	FUNC_MOCK_RUN(VALIDATED_CALL) {
 		UT_ASSERTeq(level, Log_function_.exp_level);
@@ -85,7 +85,7 @@ FUNC_MOCK_RUN_DEFAULT {
 FUNC_MOCK_END
 
 FUNC_MOCK_NONSTATIC(custom_log_function, void, enum core_log_level level,
-	const char *file_name, const int line_no, const char *function_name,
+	const char *file_name, unsigned line_no, const char *function_name,
 	const char *message)
 	FUNC_MOCK_RUN(VALIDATED_CALL) {
 		UT_ASSERTeq(level, Log_function_.exp_level);
@@ -107,7 +107,7 @@ FUNC_MOCK_END
 
 void
 custom_log_function(enum core_log_level level, const char *file_name,
-	const int line_no, const char *function_name, const char *message)
+	unsigned line_no, const char *function_name, const char *message)
 {
 	SUPPRESS_UNUSED(level, file_name, line_no, function_name, message);
 }

--- a/src/test/core_log/core_log_common.h
+++ b/src/test/core_log/core_log_common.h
@@ -64,4 +64,4 @@ void test_log_function_call_helper(enum core_log_level level,
 	bool call_log_function);
 
 void custom_log_function(enum core_log_level level, const char *file_name,
-	const int line_no, const char *function_name, const char *message);
+	unsigned line_no, const char *function_name, const char *message);

--- a/src/test/core_log_default_function/core_log_default_function.c
+++ b/src/test/core_log_default_function/core_log_default_function.c
@@ -80,10 +80,10 @@ FUNC_MOCK(snprintf, int, char *__restrict __s, size_t __maxlen,
 	FUNC_MOCK_RUN(0) {
 		va_list arg;
 		va_start(arg, __format);
-		UT_ASSERTstreq(__format, "%s: %3d: %s: ");
+		UT_ASSERTstreq(__format, "%s: %3u: %s: ");
 		char *file_name = va_arg(arg, char *);
 		UT_ASSERTstreq(file_name, Snprintf.exp_file_name);
-		int line_no = va_arg(arg, int);
+		unsigned line_no = va_arg(arg, unsigned);
 		UT_ASSERTeq(line_no, LINE_NO);
 		char *function_name = va_arg(arg, char *);
 		UT_ASSERTstreq(function_name, FUNCTION_NAME);

--- a/src/test/core_log_function_mt/core_log_function_mt.c
+++ b/src/test/core_log_function_mt/core_log_function_mt.c
@@ -23,7 +23,7 @@
 
 #define LOG_FUNC(FUNC_NAME) \
 static void \
-FUNC_NAME(enum core_log_level level, const char *file_name, const int line_no, \
+FUNC_NAME(enum core_log_level level, const char *file_name, unsigned line_no, \
 	const char *function_name, const char *message) \
 { \
 	SUPPRESS_UNUSED(level, file_name, line_no, function_name, message); \

--- a/src/test/core_log_internal/core_log_internal.c
+++ b/src/test/core_log_internal/core_log_internal.c
@@ -40,13 +40,13 @@ static struct {
 	enum core_log_level level;
 	int errnum;
 	const char *file_name;
-	int line_no;
+	unsigned line_no;
 	const char *function_name;
 	const char *message_format;
 } Core_log_context;
 
 FUNC_MOCK(core_log, void, enum core_log_level level, int errnum,
-	const char *file_name, int line_no, const char *function_name,
+	const char *file_name, unsigned line_no, const char *function_name,
 	const char *message_format, ...)
 FUNC_MOCK_RUN_DEFAULT {
 	Core_log_no_of_calls++;

--- a/src/test/core_log_max/core_log_max.c
+++ b/src/test/core_log_max/core_log_max.c
@@ -125,7 +125,7 @@ static int Total_message_num = 0;
 static char The_longest_message[BIG_BUF_SIZE];
 
 FUNC_MOCK(core_log, void, enum core_log_level level, int errnum,
-	const char *file_name, int line_no, const char *function_name,
+	const char *file_name, unsigned line_no, const char *function_name,
 	const char *message_format, ...)
 	FUNC_MOCK_RUN_DEFAULT {
 		char buf[BIG_BUF_SIZE] = "";


### PR DESCRIPTION
To make PMDK logging system compatible with DAOS/vos logging.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/6064)
<!-- Reviewable:end -->
