### PR TITLE
common: improve the PMEM RAS workflow output

### DIFF
--- a/.github/workflows/pmem_ras.yml
+++ b/.github/workflows/pmem_ras.yml
@@ -42,7 +42,13 @@ jobs:
       - name: Clone the git repo
         uses: actions/checkout@v4
 
-      # Variables, such as $ras_runner are set on the controller platform as environment variables.
+      # Variables, such as $ras_runner are set on the controller platform
+      # as environment variables.
       - name: Prepare and run RAS Linux tests via ansible-playbook
         working-directory: ${{ env.WORKDIR }}
-        run: ansible-playbook -i $ras_runner, run-ras-linux.yml -e "host=all ansible_user=$ras_user"
+        env:
+          # Increases human readability in case of a failure
+          ANSIBLE_STDOUT_CALLBACK: yaml
+        run: >
+          ansible-playbook -i $ras_runner, run-ras-linux.yml
+          -e "host=all ansible_user=$ras_user"

--- a/utils/gha-runners/run-ras-linux.yml
+++ b/utils/gha-runners/run-ras-linux.yml
@@ -97,7 +97,7 @@
 
   tasks:
 
-# pmdk-tests requires cmake for building
+    # pmdk-tests requires cmake for building
     - name: "Ensure cmake availability in the system"
       package:
         state: present
@@ -205,17 +205,32 @@
             cmd: "make -j install prefix={{ pmdk_install_dir_path }}"
             chdir: "{{ repo.pmdk.target_dir }}"
             executable: "{{ bash_path }}"
+          register: output
 
-        - name: "Configure & build pmdk-tests"
+        - name: "Build PMDK - output"
+          debug:
+            msg: |
+              ::group::Build PMDK
+              {{ output.stderr_lines | to_nice_yaml }}
+              {{ output.stdout_lines | to_nice_yaml }}
+              ::endgroup::
+
+        - name: "Build pmdk-tests"
           shell:
-            cmd: "{{ item }}"
+            cmd: "cmake '{{ repo.pmdk_tests.target_dir }}' && make -j"
             chdir: "{{ pmdk_tests_build_dir_path }}"
             executable: "{{ bash_path }}"
           environment:
             PKG_CONFIG_PATH: "{{ pmdk_install_dir_path }}/lib/pkgconfig/"
-          with_items:
-            - "cmake '{{ repo.pmdk_tests.target_dir }}'"
-            - "make -j"
+          register: output
+
+        - name: "Build pmdk-tests - output"
+          debug:
+            msg: |
+              ::group::Build pmdk-tests
+              {{ output.stderr_lines | to_nice_yaml }}
+              {{ output.stdout_lines | to_nice_yaml }}
+              ::endgroup::
 
         - name: "Create template for config.xml file"
           lineinfile:
@@ -240,7 +255,7 @@
               - mountPoint: /mnt/{{item}}
           with_items: "{{ uuids }}"
 
-        - name: "Run the first phase of tests"
+        - name: "Phase 1 - run tests"
           shell:
             cmd: PATH=$PATH:{{ pmdk_install_dir_path }}/bin ./UNSAFE_SHUTDOWN_LOCAL 1 inject all --gtest_output=xml:{{ logs_dir_path }}/phase1.xml
             chdir: "{{ pmdk_tests_build_dir_path }}"
@@ -248,10 +263,10 @@
           environment:
             LD_LIBRARY_PATH: "{{ pmdk_install_dir_path }}/lib/"
           register: phase_1
-          ignore_errors: true
 
-        - name: "Print phase I output"
-          debug: var=phase_1
+        - name: "Phase 1 - output"
+          debug:
+            var: phase_1
 
         - name: "Flush filesystems before power cycle"
           shell: "sync"
@@ -282,7 +297,7 @@
             - "{{ uuids }}"
             - "{{ pmem_devices }}"
 
-        - name: "Run the second phase of tests"
+        - name: "Phase 2 - run tests"
           shell:
             cmd: PATH=$PATH:{{ pmdk_install_dir_path }}/bin ./UNSAFE_SHUTDOWN_LOCAL 2 cleanup all --gtest_output=xml:{{ logs_dir_path }}/phase2.xml
             chdir: "{{ pmdk_tests_build_dir_path }}"
@@ -290,10 +305,10 @@
           environment:
             LD_LIBRARY_PATH: "{{ pmdk_install_dir_path }}/lib/"
           register: phase_2
-          ignore_errors: true
 
-        - name: "Print phase II output"
-          debug: var=phase_2
+        - name: "Phase 2 - output"
+          debug:
+            var: phase_2
 
       # 'always' section makes sure that the temporary files are deleted regardless of the results.
       always:


### PR DESCRIPTION
- on failure JSON -> YAML (as it is more human-readable)
- print the PMDK and pmdk-tests build outputs unconditionally but groupped so it won't consume too much vertical space.
- remove all ignore_erros: true so no error is ignored

Preview: https://github.com/pmem/pmdk/actions/runs/9992769191/job/27618560250 (🔴 is 🆗 in this case ONLY 😉 )

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/6103)
<!-- Reviewable:end -->
