### PR TITLE
common: Zomzog/changelog-checker executed only for PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,8 @@ jobs:
         # Skip for pmem/pmdk/master and stable-* branches
         if: |
           !(github.repository == 'pmem/pmdk' &&
-            (github.ref_name == 'master' || startsWith(github.ref_name, 'stable-')))
+            (github.ref_name == 'master' || startsWith(github.ref_name, 'stable-'))) &&
+            github.event_name == 'pull_request'
         uses: Zomzog/changelog-checker@09cfe9ad3618dcbfdba261adce0c41904cabb8c4 # v1.3.0
         with:
           fileName: ChangeLog


### PR DESCRIPTION
`Zomzog/changelog-checker` action can only be run on PR, otherwise the action fails E.g. when the Main workflow is run manually.

Please take a look at: https://github.com/grom72/pmdk/actions/runs/11526775592/job/32091465108#step:3:9

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/6128)
<!-- Reviewable:end -->
