### PR TITLE
Update scan_codeql.yml

### DIFF
--- a/.github/workflows/scan_codeql.yml
+++ b/.github/workflows/scan_codeql.yml
@@ -4,15 +4,16 @@ name: CodeQL
 on:
   workflow_call:
 
-permissions:
-  actions: read
-  contents: read
-  security-events: write
+permissions: read-all
 
 jobs:
   codeql:
     name: CodeQL
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     steps:
     - name: Clone the git repo


### PR DESCRIPTION
OpenSSF Scorecard requires top level permissions to be at most read-all.  Moved the existing top level permissions which contain a write down to actual job and set the top level permissions.