### PR TITLE
common: pmem2_badblock_next is replaced by pmem2_badblock_next_internal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Before contributing please remember to run:
 ```
 
 This will check all C/C++ files in the tree for style issues. To check C++
-files you have to have clang-format version 9.0, otherwise they will be
+files you have to have clang-format version 14.0, otherwise they will be
 skipped. If you want to run this target automatically at build time, you can
 pass CSTYLEON=1 to make. If you want cstyle to be run, but not fail the build,
 pass CSTYLEON=2 to make.

--- a/src/common.inc
+++ b/src/common.inc
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2014-2023, Intel Corporation
+# Copyright 2025, Hewlett Packard Enterprise Development LP
 #
 # src/common.inc -- common Makefile rules for PMDK
 #
@@ -39,8 +40,8 @@ $(error Cannot evaluate version)
 endif
 
 ifeq ($(CLANG_FORMAT),)
-ifeq ($(shell command -v clang-format-9 > /dev/null && echo y || echo n), y)
-export CLANG_FORMAT ?= clang-format-9
+ifeq ($(shell command -v clang-format-14 > /dev/null && echo y || echo n), y)
+export CLANG_FORMAT ?= clang-format-14
 else
 export CLANG_FORMAT ?= clang-format
 endif

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright 2014-2024, Intel Corporation */
+/* Copyright 2025, Hewlett Packard Enterprise Development LP */
 /*
  * Copyright (c) 2016-2020, Microsoft Corporation. All rights reserved.
  *
@@ -330,6 +331,17 @@ char *util_concat_str(const char *s1, const char *s2);
 #define SUPPRESS_ARG_7(X, ...) SUPPRESS_ARG_1(X); SUPPRESS_ARG_6(__VA_ARGS__)
 #define SUPPRESS_ARG_8(X, ...) SUPPRESS_ARG_1(X); SUPPRESS_ARG_7(__VA_ARGS__)
 #define SUPPRESS_ARG_9(X, ...) SUPPRESS_ARG_1(X); SUPPRESS_ARG_8(__VA_ARGS__)
+
+/* tell clang to ignore the "cast-function-type-strict" warning */
+#if __clang__
+#define CLANG_IGNORE_CAST_FUNCTION_TYPE_STRICT_WARNING(exp) \
+	_Pragma("clang diagnostic push") \
+	_Pragma("clang diagnostic ignored \"-Wcast-function-type-strict\"") \
+	exp; \
+	_Pragma("clang diagnostic pop")
+#else
+#define CLANG_IGNORE_CAST_FUNCTION_TYPE_STRICT_WARNING(exp) exp
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/libpmem/libpmem.c
+++ b/src/libpmem/libpmem.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2014-2024, Intel Corporation */
+/* Copyright 2025, Hewlett Packard Enterprise Development LP */
 
 /*
  * libpmem.c -- pmem entry points for libpmem
@@ -128,6 +129,8 @@ pmem_log_get_threshold(enum pmem_log_threshold threshold,
 int
 pmem_log_set_function(pmem_log_function *log_function)
 {
-	int ret = core_log_set_function((core_log_function *)log_function);
+	int ret = EFAULT;
+	CLANG_IGNORE_CAST_FUNCTION_TYPE_STRICT_WARNING(
+		ret = core_log_set_function((core_log_function *)log_function));
 	return core_log_error_translate(ret);
 }

--- a/src/libpmemobj/lane.c
+++ b/src/libpmemobj/lane.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2015-2024, Intel Corporation */
+/* Copyright 2025, Hewlett Packard Enterprise Development LP */
 
 /*
  * lane.c -- lane implementation
@@ -215,17 +216,17 @@ lane_init(PMEMobjpool *pop, struct lane *lane, struct lane_layout *layout)
 	if (lane->internal == NULL)
 		goto error_internal_new;
 
-	lane->external = operation_new((struct ulog *)&layout->external,
-		LANE_REDO_EXTERNAL_SIZE,
-		lane_redo_extend, (ulog_free_fn)pfree, &pop->p_ops,
-		LOG_TYPE_REDO);
+	CLANG_IGNORE_CAST_FUNCTION_TYPE_STRICT_WARNING(
+		lane->external = operation_new((struct ulog *)&layout->external,
+			LANE_REDO_EXTERNAL_SIZE, lane_redo_extend,
+			(ulog_free_fn)pfree, &pop->p_ops, LOG_TYPE_REDO));
 	if (lane->external == NULL)
 		goto error_external_new;
 
-	lane->undo = operation_new((struct ulog *)&layout->undo,
-		LANE_UNDO_SIZE,
-		lane_undo_extend, (ulog_free_fn)pfree, &pop->p_ops,
-		LOG_TYPE_UNDO);
+	CLANG_IGNORE_CAST_FUNCTION_TYPE_STRICT_WARNING(
+		lane->undo = operation_new((struct ulog *)&layout->undo,
+			LANE_UNDO_SIZE, lane_undo_extend, (ulog_free_fn)pfree,
+			&pop->p_ops, LOG_TYPE_UNDO));
 	if (lane->undo == NULL)
 		goto error_undo_new;
 

--- a/src/libpmemobj/obj_log.c
+++ b/src/libpmemobj/obj_log.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2024, Intel Corporation */
+/* Copyright 2025, Hewlett Packard Enterprise Development LP */
 
 /*
  * obj_log.c -- the public interface to control the logging output
@@ -40,6 +41,8 @@ pmemobj_log_get_threshold(enum pmemobj_log_threshold threshold,
 int
 pmemobj_log_set_function(pmemobj_log_function *log_function)
 {
-	int ret = core_log_set_function((core_log_function *)log_function);
+	int ret = EFAULT;
+	CLANG_IGNORE_CAST_FUNCTION_TYPE_STRICT_WARNING(
+		ret = core_log_set_function((core_log_function *)log_function));
 	return core_log_error_translate(ret);
 }

--- a/src/test/ctl_prefault/ctl_prefault.c
+++ b/src/test/ctl_prefault/ctl_prefault.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2018-2023, Intel Corporation */
+/* Copyright 2025, Hewlett Packard Enterprise Development LP */
 
 /*
  * ctl_prefault.c -- tests for the ctl entry points: prefault
@@ -119,7 +120,9 @@ main(int argc, char *argv[])
 	int prefault = atoi(argv[2]);
 	int open = atoi(argv[3]);
 
-	prefault_fun(prefault, (fun)pmemobj_ctl_get, (fun)pmemobj_ctl_set);
+	CLANG_IGNORE_CAST_FUNCTION_TYPE_STRICT_WARNING(
+		prefault_fun(prefault, (fun)pmemobj_ctl_get,
+			(fun)pmemobj_ctl_set));
 	test_obj(path, open);
 
 	DONE(NULL);

--- a/src/test/obj_memops/obj_memops.c
+++ b/src/test/obj_memops/obj_memops.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2018-2023, Intel Corporation */
+/* Copyright 2025, Hewlett Packard Enterprise Development LP */
 
 /*
  * obj_memops.c -- basic memory operations tests
@@ -161,10 +162,11 @@ test_same_twice(struct operation_context *ctx, struct test_object *object)
 static void
 test_redo(PMEMobjpool *pop, struct test_object *object)
 {
-	struct operation_context *ctx = operation_new(
-		(struct ulog *)&object->redo, TEST_ENTRIES,
-		pmalloc_redo_extend, (ulog_free_fn)pfree,
-		&pop->p_ops, LOG_TYPE_REDO);
+	struct operation_context *ctx = NULL;
+	CLANG_IGNORE_CAST_FUNCTION_TYPE_STRICT_WARNING(
+		ctx = operation_new((struct ulog *)&object->redo, TEST_ENTRIES,
+			pmalloc_redo_extend, (ulog_free_fn)pfree, &pop->p_ops,
+			LOG_TYPE_REDO));
 
 	/*
 	 * Keep this test first.
@@ -620,10 +622,11 @@ static void
 test_redo_cleanup_same_size(PMEMobjpool *pop, struct test_object *object)
 {
 #define ULOG_SIZE 1024
-	struct operation_context *ctx = operation_new(
-		(struct ulog *)&object->redo, TEST_ENTRIES,
-		pmalloc_redo_extend, (ulog_free_fn)pfree,
-		&pop->p_ops, LOG_TYPE_REDO);
+	struct operation_context *ctx = NULL;
+	CLANG_IGNORE_CAST_FUNCTION_TYPE_STRICT_WARNING(
+		ctx = operation_new((struct ulog *)&object->redo, TEST_ENTRIES,
+			pmalloc_redo_extend, (ulog_free_fn)pfree, &pop->p_ops,
+			LOG_TYPE_REDO));
 
 	int ret = pmalloc(pop, &object->redo.next, ULOG_SIZE, 0, 0);
 	UT_ASSERTeq(ret, 0);
@@ -648,10 +651,11 @@ test_redo_cleanup_same_size(PMEMobjpool *pop, struct test_object *object)
 static void
 test_undo(PMEMobjpool *pop, struct test_object *object)
 {
-	struct operation_context *ctx = operation_new(
-		(struct ulog *)&object->undo, TEST_ENTRIES,
-		pmalloc_redo_extend, (ulog_free_fn)pfree,
-		&pop->p_ops, LOG_TYPE_UNDO);
+	struct operation_context *ctx = NULL;
+	CLANG_IGNORE_CAST_FUNCTION_TYPE_STRICT_WARNING(
+		ctx = operation_new((struct ulog *)&object->undo, TEST_ENTRIES,
+			pmalloc_redo_extend, (ulog_free_fn)pfree, &pop->p_ops,
+			LOG_TYPE_UNDO));
 
 	test_undo_small_single_copy(ctx, object);
 	test_undo_small_single_set(ctx, object);

--- a/utils/call_stacks_analysis/white_list.json
+++ b/utils/call_stacks_analysis/white_list.json
@@ -55,6 +55,7 @@
         "stats_enabled_parser",
 
         "__comment: libpmem2 only",
+        "pmem2_badblock_next",
         "pmem2_config_delete",
         "pmem2_config_init",
         "pmem2_config_new",

--- a/utils/style_check.sh
+++ b/utils/style_check.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2016-2023, Intel Corporation
+# Copyright 2025, Hewlett Packard Enterprise Development LP
 #
 # utils/style_check.sh -- common style checking script
 #
@@ -15,8 +16,8 @@ CHECK_TYPE=$1
 # When updating, please search for all references to "clang-format" and update
 # them as well; at this time these are CONTRIBUTING.md src/common.inc and
 # docker images.
-[ -z "$clang_format_bin" ] && which clang-format-9 >/dev/null &&
-	clang_format_bin=clang-format-9
+[ -z "$clang_format_bin" ] && which clang-format-14 >/dev/null &&
+	clang_format_bin=clang-format-14
 [ -z "$clang_format_bin" ] && which clang-format >/dev/null &&
 	clang_format_bin=clang-format
 [ -z "$clang_format_bin" ] && clang_format_bin=clang-format


### PR DESCRIPTION
pmem2_badblock_next is no longer used as libpmem uses pmem2_badblock_next_internal.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk/6133)
<!-- Reviewable:end -->
